### PR TITLE
[TTNN] Stateful op-model constraints in the L1 spill optimizer (reland of #9069)

### DIFF
--- a/.github/test_scripts/op_model.sh
+++ b/.github/test_scripts/op_model.sh
@@ -15,6 +15,8 @@ echo "Running op-model test MockDevice"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice
 echo "Running op-model tripwire tests"
 $BUILD_DIR/test/unittests/OpModel/TTNN/Lib/TestOpModelLibTripwires
+echo "Running allocator-backed stateful L1 spill tests"
+$BUILD_DIR/test/unittests/Optimizer/L1SpillManagementMockAllocatorTests
 
 echo
 echo "Run Optimizer Models Perf Tests"

--- a/docs/src/ttnn-op-constraints.md
+++ b/docs/src/ttnn-op-constraints.md
@@ -7,6 +7,12 @@ The TTNN Op Model Interface provides two key APIs for analyzing and optimizing o
 - **`getOpConstraints`**: Returns constraint information including memory requirements, layout compatibility, and operation feasibility
 - **`getOpRuntime`**: Returns performance metrics including execution time estimates
 
+`getOpConstraints` has a single entry point per layer whose trailing argument
+selects one of two *flavours*: a cached, nothing-is-allocated **stateless**
+query, or an allocator-backed **stateful** query that evaluates the op on top of
+the allocations already live in L1. See
+[The Stateful (Build-From-Records) Path](#the-stateful-build-from-records-path).
+
 These APIs enable the compiler to make informed decisions about operation placement, memory allocation, and performance optimization.
 
 This guide walks you through best practices for implementing these APIs. It will cover the following steps:
@@ -17,8 +23,9 @@ This guide walks you through best practices for implementing these APIs. It will
    - [Step 2: Add Core Model Implementation](#step-2-add-core-model-implementation)
    - [Step 3: Add Unit Tests](#step-3-add-unit-tests)
    - [Step 4: Add Integration Tests](#step-4-add-integration-tests)
-3. [Key Considerations](#key-considerations)
-4. [Example: Complete Implementation](#example-complete-implementation)
+3. [The Stateful (Build-From-Records) Path](#the-stateful-build-from-records-path)
+4. [Key Considerations](#key-considerations)
+5. [Example: Complete Implementation](#example-complete-implementation)
 
 
 ## Architecture
@@ -62,63 +69,90 @@ consistency and functional correctness.
 
 ### Step 1: Implement Operation-Specific Methods
 
-Add your operation's implementation in `lib/Dialect/TTNN/IR/TTNNOpModelInterface.cpp`:
+Add your operation's implementation in
+`lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp`:
 
 ```cpp
 //===----------------------------------------------------------------------===//
 // YourOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-YourOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> YourOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   // You can extract all input tensors' layouts from `inputs`.
   // Other configurations can also be extracted from `opConfig`.
   // All inputs/attrs can be extracted from YourOp's member functions.
   // This layer is usually a wrapper to extract the op's necessary inputs/attrs
   // and pass those information to TTNNOpModel.h.
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<YourOp>::getOpConstraints, *this,
-      deviceGrid, /* other parameters */);
+  //
+  // `liveRecords` is threaded straight through, untouched and uninspected:
+  // detail::constraintsDispatch owns the stateless-vs-stateful decision.
+  return detail::constraintsDispatch(*this, liveRecords,
+                                     /* op-model query parameters */);
 }
 
 llvm::Expected<size_t>
 YourOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
-  // Similar to the previous function.
+  // Similar to the previous function; runtime queries are always stateless.
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<YourOp>::getOpRuntime, *this,
       /* other parameters */);
 }
 ```
 
-Note: The codebase provides several template helpers for common operation patterns:
+The signature is fixed by the single `getOpConstraints` interface method in
+`include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td`, which ODS
+declares inside every non-`OpModelExempt` op class. A new op must define exactly
+that 3-argument form — a 2-argument definition will not bind. (A 2-argument
+convenience overload exists, but only on the `OpModel` *interface handle*, for
+callers that want a plain stateless query.)
+
+#### Why `constraintsDispatch` and not a direct cached call
+
+`detail::constraintsDispatch` (defined near the top of
+`TTNNOpModelInterface.cpp`) is the single choke point for the cache decision:
+
+- A **stateful** query (engaged `liveRecords`) must **bypass** the constraint
+  cache. The cache key is the op plus its layout/shape arguments; the live
+  allocation set is deliberately *not* part of it, so a cached stateful result
+  would be a fit decision taken under a different live set — a stale-fit bug.
+- The op-model entry's `initialState` parameter is *defaulted*, and a default
+  argument does not survive the function-pointer conversion that
+  `getOrCompute`'s `is_invocable` guard performs. The dispatcher's stateless
+  branch therefore binds `/*initialState=*/nullptr` inside a lambda, which also
+  keeps the hashed cache key at exactly the query arguments.
+
+Note: The codebase provides several template helpers for common operation
+patterns. Each takes and forwards `liveRecords`:
 
 #### Unary Operations
 ```cpp
 // For simple unary operations (like ReluOp, SqrtOp, etc.)
-return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 return detail::getUnaryOpRuntime(*this, inputs, opConfig);
 ```
 
 #### Binary Operations
 ```cpp
 // For binary element-wise operations (like AddOp, MultiplyOp, etc.)
-return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 return detail::getBinaryOpRuntime(*this, inputs, opConfig);
 ```
 
 #### Ternary Operations
 ```cpp
 // For ternary operations (like WhereOp)
-return detail::getTernaryOpConstraints(*this, inputs, opConfig);
+return detail::getTernaryOpConstraints(*this, inputs, opConfig, liveRecords);
 return detail::getTernaryOpRuntime(*this, inputs, opConfig);
 ```
 
 #### Reduction Operations
 ```cpp
 // For reduction operations (like SumOp, MeanOp, etc.)
-return detail::getReductionOpConstraints(*this, inputs, opConfig);
+return detail::getReductionOpConstraints(*this, inputs, opConfig, liveRecords);
 return detail::getReductionOpRuntime(*this, inputs, opConfig);
 ```
 
@@ -130,9 +164,9 @@ Add the core implementation in `include/ttmlir/OpModel/TTNN/TTNNOpModel.h`:
 template <>
 struct OpModel<YourOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(ttcore::GridAttr deviceGrid,
-                   // ... operation-specific parameters ...
-                   TTNNLayoutAttr outputLayout);
+  getOpConstraints(// ... operation-specific parameters ...
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(// ... operation-specific parameters  ...
@@ -140,15 +174,21 @@ struct OpModel<YourOp> {
 };
 ```
 
+The trailing `initialState` is the op-model-layer half of the selector, and it
+is *defaulted*: `nullptr` means the stateless query, non-null means the stateful
+one. Because it is defaulted, existing call sites that pass no state keep
+compiling and get the stateless behaviour. The convention is spelled out in the
+comment block above `template <typename OpTy> struct OpModel;` in
+`TTNNOpModel.h`.
+
 And the corresponding implementation in `lib/OpModel/TTNN/TTNNOpModel.cpp`:
 
 ```cpp
 llvm::Expected<OpConstraints>
 OpModel<YourOp>::getOpConstraints(
-    ttcore::GridAttr deviceGrid,
     // operation-specific parameters
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
   #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -159,28 +199,42 @@ OpModel<YourOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
-  // 2. Create query closure
+  // 2. Convert the raw state pointer to the optional tt-metal wants.
+  //    tt-mlir carries the selector as a raw pointer so the default
+  //    argument works and the type can stay incomplete in the header.
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  // 3. Create query closure
   // Here the ultimate goal is to enable the optimizer to call the
   // invoke method of the op in tt-metal. This is achieved through
-  // creating a lambda that calls `query_op_constraints` which
-  // receives 3 arguments:
+  // creating a lambda that calls
+  // `query_op_constraints_with_optional_state` which receives:
   //   1. An op (eg. ::ttnn::yourOp). This is the op's backend
   //      found under tt-metal/src/tt-metal/ttnn/. The op usually
   //      has an 'invoke' method.
   //   2. The device,
-  //   3. A variadic number of inputs that are converted to match
+  //   3. The optional allocator state. tt-metal dispatches on it:
+  //      nullopt -> the stateless query, a value -> the
+  //      build-from-records query.
+  //   4. A variadic number of inputs that are converted to match
   //      the metal's definitions. The order and the types of these
   //      inputs are expected to match the invoke function of the
   //      op in metal.
   auto yourOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::yourOp, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::yourOp, device, initialStateOpt, inputSpec,
         /* other converted parameters */);
   };
 
-  // 3. Call getOpConstraints and pass the callable.
-  return operation::getOpConstraints(inputLayout.getContext(), deviceGrid,
-                                     yourOpQuery);
+  // 4. Unwrap the response. Use getOpConstraintsWithState for the
+  //    state-carrying QueryOutput shape returned by the macro above.
+  //    (Stateless-only families that still call QUERY_OP_CONSTRAINTS
+  //    use operation::getOpConstraints instead; the two differ only in
+  //    the tt-metal response shape they unwrap.)
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              yourOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -258,7 +312,8 @@ TEST_F(OpModelBase, YourOpInterface) {
   auto constraintsExp = getOpConstraints(yourOp.getOperation());
   if (constraintsExp) {
       auto l1 = constraintsExp.get();
-      const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] = l1;
+      const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                   outputAllocations] = l1;
       EXPECT_EQ(cbSize, /* some expected value */);
       EXPECT_EQ(l1PeakSize, /* some expected value */);
       EXPECT_EQ(totalPeakSize, /* some expected value */);
@@ -299,12 +354,13 @@ protected:
     TTNNLayoutAttr inputLayout = createLayout(inputTensor);
     TTNNLayoutAttr outputLayout = createLayout(outputTensor);
 
+    // No state argument: the defaulted nullptr makes this a stateless query.
     auto constraintsExp = OpModel<OpTy>::getOpConstraints(
-        CreateWorkerGrid(), /* pass the params according to TTNNOpModel.h interface */, outputLayout);
+        /* pass the params according to TTNNOpModel.h interface */, outputLayout);
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedResult.expectedLegal);
     if (expectedResult.expectedLegal) {
-      const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
-          constraintsExp.get();
+      const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                  outputAllocations] = constraintsExp.get();
       EXPECT_EQ(cbSize, expectedResult.expectedCbSize);
       EXPECT_EQ(l1PeakSize, expectedResult.expectedL1PeakSize);
       EXPECT_EQ(totalPeakSize, expectedResult.expectedTotalPeakSize);
@@ -339,6 +395,123 @@ INSTANTIATE_TEST_SUITE_P(
     ));
 ```
 
+## The Stateful (Build-From-Records) Path
+
+There is exactly **one** `getOpConstraints` per layer. Which behaviour you get is
+decided entirely by whether the caller passed allocator state:
+
+```
+                       ReluOp::getOpConstraints(inputs, config, liveRecords)
+                                        ▼
+                       detail::getUnaryOpConstraints(...)
+                                        ▼
+                       detail::constraintsDispatch(op, liveRecords, args...)
+                                        │
+              ┌─────────────────────────┴─────────────────────────┐
+      liveRecords == nullopt                            liveRecords engaged
+              │                                                   │
+   opConstraintsCache().getOrCompute                 buildInitialState(*liveRecords)
+   (lambda binds initialState = nullptr)             → non-null MockAllocatorState
+              │                                       (cache is BYPASSED)
+              └───────────────► OpModel<ReluOp>::getOpConstraints(
+                                    ..., const MockAllocatorState *initialState)
+                                        ▼
+                    query_op_constraints_with_optional_state(...)
+```
+
+### The selector is tri-state
+
+`liveRecords` is a `std::optional<llvm::ArrayRef<OpModelAllocationRecord>>`, and
+the dispatcher tests **the optional's engagement, never its size**:
+
+| `liveRecords` | flavour | cached? | tt-metal run mode | `outputAllocations` | peak-byte check in validation |
+|---|---|---|---|---|---|
+| `std::nullopt` | stateless | **yes** | `NO_DISPATCH` only | empty | **enforced** |
+| engaged, **empty** | **stateful** | no | phase-1 `NO_DISPATCH` + phase-2 `NORMAL` | populated | skipped |
+| engaged, non-empty | stateful | no | phase-1 `NO_DISPATCH` + phase-2 `NORMAL` | populated | skipped |
+
+Rows 2 and 3 are the same row. **Never key the selector on
+`liveRecords.empty()`.** The L1 spill pass's record set starts out empty, and the
+only producer of records is a stateful query. If an empty-but-engaged live set
+were treated as stateless, the first op of every run would report no
+allocations, so the second op would also see an empty set, and so on — the
+feature would degrade to stateless permanently and silently, with every test
+still passing. This is why `op_model::buildInitialState({})` deliberately
+returns a **non-null** state, and why the same contract is restated in the
+`.td` method description, in `constraintsDispatch`, in `TTNNOpModel.h`/`.cpp`,
+and on the stateful `validateOperation` overload.
+
+### Threading `liveRecords` vs. passing it through unnamed
+
+When adding an op, pick one of two shapes:
+
+**Stateful** — the op has a real op-model query, so give its op-model entry a
+trailing `const MockAllocatorState *initialState = nullptr` and thread the
+caller's records straight through. `ReluOp` is the canonical example
+(`TTNNOpModelInterface.cpp`):
+
+```cpp
+llvm::Expected<op_model::OpConstraints> ReluOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
+}
+```
+
+**Intentionally stateless** — the op is a creation/bookkeeping op with no L1
+buffer worth tracking, or its op-model backend has no `initialState` parameter
+yet. Take the parameter **unnamed** and call the cache directly:
+
+```cpp
+llvm::Expected<op_model::OpConstraints> EmptyOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  // ...
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<EmptyOp>::getOpConstraints, *this,
+      /* parameters */);
+}
+```
+
+The unnamed parameter is the convention that says *this op deliberately discards
+the caller's state*. It is safe, not buggy: such an op is modeled exactly as it
+was before this feature, just less fragmentation-aware if it appears in the
+spill window. Because the signature no longer distinguishes the two, the policy
+comment block at the top of `TTNNOpModelInterface.cpp` enumerates every
+intentionally-stateless op and the reason for it — **add your op there if you
+choose this shape**, so a later reader can tell "intentionally stateless" from
+"accidentally forgot". `grep -n '/\*liveRecords\*/'` finds them in code.
+
+Migrating a blocked op later means adding the `initialState` parameter at the
+op-model layer first, then switching the body to `detail::constraintsDispatch`.
+That changes nothing for stateless callers.
+
+### How the L1 spill pass uses it
+
+`MockAllocatorL1Tracker::validate` (`lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`,
+driven by `GreedyL1SpillManagement.cpp`) flattens its per-value live-record map
+into a flat `ArrayRef` and passes it to the stateful `validateOperation`
+overload — which is what makes the query stateful, even on the first op where
+the set is empty. tt-metal applies the state, allocates the outputs for real,
+and the resulting `OpConstraints::outputAllocations` are stashed and then fed
+back into the tracker's record set (`addTensor`), so the next op's query sees the
+previous op's real addresses. Ops that produce no records simply contribute
+nothing to the state.
+
+On the validation side, `statefulQuery` is **derived** from the same optional
+(`/*statefulQuery=*/liveRecords.has_value()` in
+`lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp`) rather than passed
+alongside it, so the two can never disagree. That flag gates the scalar
+peak-byte check: the stateless path enforces
+`overallPeakL1Usage + additionalL1Usage <= getUsableL1PerCore`, because nothing
+was allocated and that comparison is the only thing keeping the beam search off
+illegal L1 layouts. The stateful path skips it — tt-metal's real allocator
+decides fit/fragmentation/CB-clash, and `MockAllocatorL1Tracker` enforces the
+optimizer's own (lower) byte ceiling on top. The two checks are complementary,
+not duplicated.
+
 ## Key Considerations
 
 ### Operations Not Supported by OpModel
@@ -362,31 +535,41 @@ We're keeping track of ops that lack OpModel support in
 [this issue](https://github.com/tenstorrent/tt-mlir/issues/4392).
 Please either update the issue or add comments to it when exempting an op.
 
-### Device Grid Validation
+### Device Grid
 
-Validate the device worker grid before proceeding using the
-`ASSIGN_OR_RETURN` macro (defined in `ttmlir/OpModel/TTNN/TTNNOpModel.h`)
-combined with `detail::getValidatedDeviceGrid`:
-
-```cpp
-ASSIGN_OR_RETURN(ttcore::GridAttr deviceGrid,
-    detail::getValidatedDeviceGrid(op.getOperation()));
-```
+The worker grid is not threaded in from the IR: `operation::getOpConstraints`
+/ `operation::getOpConstraintsWithState` source it from the open device
+(`SingletonDeviceContext::getInstance().getComputeGridShape()`) when building
+the output layouts. The two are equivalent — the system desc that produced the
+IR's `DeviceAttr` is itself derived from that grid — so op-model entries take no
+`deviceGrid` parameter.
 
 ### Caching
 
 Use the provided caching mechanisms for computations:
 
 ```cpp
-// For getOpConstraints:
+// For getOpConstraints: go through the dispatcher, which caches the
+// stateless flavour and deliberately bypasses the cache for the stateful one.
+return detail::constraintsDispatch(*this, liveRecords, /* parameters */);
+
+// For an intentionally stateless op (unnamed liveRecords), call the cache
+// directly:
 return opConstraintsCache().getOrCompute(
     op_model::OpModel<YourOp>::getOpConstraints, *this,
     /* parameters */);
+
 // For getOpRuntime:
 return opRuntimeCache().getOrCompute(
     op_model::OpModel<YourOp>::getOpRuntime, *this,
     /* parameters */);
 ```
+
+Stateful constraint queries are **deliberately uncached**. The cache key is the
+op plus its layout/shape arguments and does *not* include the live allocation
+set, so caching a stateful result would hand back a fit decision computed under
+some other live set. Never add `liveRecords` to the key either — the records
+change on essentially every query, so it would only pollute the cache.
 
 ### Check Metal Backend Availability
 
@@ -410,10 +593,11 @@ Here's a complete example for a hypothetical `CustomUnaryOp`:
 
 ```cpp
 // In TTNNOpModelInterface.cpp
-llvm::Expected<op_model::OpConstraints>
-CustomUnaryOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> CustomUnaryOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>

--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -43,7 +43,7 @@ struct SumL1MemoryTracker {
 
   /// Bypass input-overlap accounting and call the backend (or hook) with an
   /// explicit additionalL1Usage. Used by consumer-reshard probes and DRAM
-  /// CB re-queries inside L1SpillManagement — those call sites already know
+  /// CB re-queries inside L1SpillManagementBase — those call sites already know
   /// the L1 pressure they want to express.
   op_constraint_validation::ValidationResult validateBackendDirect(
       Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
@@ -169,7 +169,93 @@ private:
   llvm::DenseMap<uint64_t, AliasGroup> aliasGroups;
 };
 
-/// L1SpillManagement enforces L1 budget constraints using farthest-last-use
+/// L1 memory tracker backed by tt-metal's stateful op-constraints query.
+///
+/// Holds only the set of currently-live L1 allocation records (no address
+/// simulation). validate() flattens the live records into the op-model's
+/// stateful query, so fit / fragmentation / placement / CB-clash are all
+/// modeled by tt-metal's real allocator. Records are keyed by the producing
+/// Value; a view op's output aliases its source's buffer via `aliasOf` /
+/// `aliasRefcount` (record-level aliasing, no addresses), so it never adds a
+/// second record and the buffer stays live until the last aliaser dies.
+struct MockAllocatorL1Tracker {
+  using RecordVec = llvm::SmallVector<op_model::OpModelAllocationRecord>;
+
+  /// Backend validator hook (test-only). Same shape as SumL1MemoryTracker's:
+  /// when set, every validate()/validateBackendDirect() call forwards to it.
+  using BackendValidatorFn =
+      std::function<op_constraint_validation::ValidationResult(
+          Operation *, llvm::ArrayRef<TTNNLayoutAttr>, const OpConfig &,
+          uint64_t /*additionalL1*/)>;
+  BackendValidatorFn backendValidator;
+
+  /// Currently-live L1 allocations, keyed by the owning Value (an alias does
+  /// NOT get its own entry). Flattened into each validate()'s initial state.
+  llvm::DenseMap<Value, RecordVec> liveRecords;
+
+  /// Records produced by the most recent successful validate(), keyed by op,
+  /// awaiting association with result Values at addTensor time. `mutable` so
+  /// the const validate() can populate it.
+  mutable llvm::DenseMap<Operation *, RecordVec> pendingRecords;
+
+  /// Maps a view-op output (aliaser) to the canonical Value that owns the
+  /// shared buffer's record.
+  llvm::DenseMap<Value, Value> aliasOf;
+
+  /// Per-owner count of live aliasers (including the owner itself). The owner's
+  /// record is dropped from liveRecords when this reaches zero.
+  llvm::DenseMap<Value, unsigned> aliasRefcount;
+
+  /// Optimizer per-core L1 budget (a ~0.95 cap minus reserved L1 — tighter than
+  /// the device's physical L1 that the query models). validate() enforces it as
+  /// a byte ceiling on top of the query so the optimizer keeps its headroom.
+  uint64_t l1Budget = 0;
+
+  void init(uint64_t l1BudgetPerCore);
+
+  /// Stateful fit decision: flatten liveRecords (deduped by owner) into the
+  /// op-model's stateful query and stash the resulting per-output records for
+  /// association at addTensor time.
+  op_constraint_validation::ValidationResult
+  validate(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+           const OpConfig &config) const;
+
+  /// Query a single op in isolation with an explicit additionalL1Usage (no live
+  /// records). Used by the eviction path's consumer-reshard probes.
+  op_constraint_validation::ValidationResult validateBackendDirect(
+      Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+      const OpConfig &config, uint64_t additionalL1Usage) const;
+
+  /// Associate `result`'s allocation record from the pending stash (positional:
+  /// i-th tensor result <-> i-th output-buffer record). No-op if the op
+  /// produced no records. `l1SizePerCore` is unused (records carry sizes) and
+  /// kept only for interface parity with SumL1MemoryTracker.
+  void addTensor(Value result, uint64_t l1SizePerCore);
+
+  /// Record `out` as an alias of `src`'s buffer: bump the owner's refcount and
+  /// add no new record.
+  void addTensorAlias(Value out, Value src);
+
+  /// Drop `result` from the live set (dead or spilled to DRAM): decrement its
+  /// owner's refcount and erase the record when it reaches zero.
+  void removeTensor(Value result);
+  void removeTensorFromSizes(Value result);
+
+  bool hasTensor(Value result) const;
+  uint64_t getTensorSize(Value result) const;
+  uint64_t getOccupiedL1() const;
+
+  /// Replay checkpoint: the live record set + alias bookkeeping.
+  struct Snapshot {
+    llvm::DenseMap<Value, RecordVec> liveRecords;
+    llvm::DenseMap<Value, Value> aliasOf;
+    llvm::DenseMap<Value, unsigned> aliasRefcount;
+  };
+  Snapshot takeSnapshot() const;
+  void restoreSnapshot(const Snapshot &snapshot);
+};
+
+/// L1SpillManagementBase enforces L1 budget constraints using farthest-last-use
 /// eviction with validation-based budget enforcement.
 /// Each op is re-validated during the sweep using validateOperation() with
 /// the sum of live tensor L1 sizes as additionalL1Usage. When validation
@@ -182,11 +268,13 @@ private:
 /// - Inserts ToMemoryConfigOp after spilled ops (L1 -> DRAM)
 /// - Reconnects uses to read from spilled tensor
 template <typename MemoryTracker = SumL1MemoryTracker>
-class L1SpillManagement {
+class L1SpillManagementBase {
 public:
-  L1SpillManagement(func::FuncOp func, ttcore::GridAttr deviceGrid,
-                    uint64_t l1BudgetPerCore,
-                    std::unique_ptr<L1SpillObserver> observer = nullptr);
+  L1SpillManagementBase(func::FuncOp func, ttcore::GridAttr deviceGrid,
+                        uint64_t l1BudgetPerCore,
+                        std::unique_ptr<L1SpillObserver> observer = nullptr);
+
+  virtual ~L1SpillManagementBase() = default;
 
   /// Run farthest-last-use eviction with validation-based enforcement and apply
   /// spills directly to the IR.
@@ -205,7 +293,7 @@ public:
   /// does not fail the pass).
   bool hasFailed() const { return compilationFailed; }
 
-private:
+protected:
   func::FuncOp func;
   ttcore::GridAttr deviceGrid;
   uint64_t l1BudgetPerCore;
@@ -229,9 +317,39 @@ private:
       return a.first < b.first; // max-heap: higher lastUse = higher priority
     }
   };
-  std::priority_queue<LiveEntry, std::vector<LiveEntry>, LiveEntryCompare>
-      liveSet;
+  using LiveSet =
+      std::priority_queue<LiveEntry, std::vector<LiveEntry>, LiveEntryCompare>;
+  LiveSet liveSet;
   llvm::DenseSet<Value> liveValues;
+
+  /// Full sweep state captured before processing a schedule position, so the
+  /// stateful eviction (StatefulL1SpillManagement) can rewind and re-run the
+  /// forward sweep from there. Bundles the tracker snapshot with the FLU heap
+  /// and live-value set (which are not cheaply re-derivable once eviction has
+  /// changed the L1-resident set).
+  struct SweepCheckpoint {
+    typename MemoryTracker::Snapshot tracker;
+    llvm::DenseSet<Value> liveValues;
+    LiveSet liveSet;
+  };
+  /// Per-position sweep checkpoints (stateful path only; keyed by schedule
+  /// pos).
+  llvm::DenseMap<int64_t, SweepCheckpoint> sweepCheckpoints;
+
+  /// When set by the stateful recoverFromOOM, run() restores the checkpoint at
+  /// this position and re-runs the sweep from it.
+  std::optional<int64_t> pendingRewindTo;
+
+  /// True for spill strategies that rebuild allocator state by rewinding and
+  /// re-running the forward sweep (StatefulL1SpillManagement) rather than the
+  /// address-sim event-log replay. Gates checkpoint capture + rewind wiring so
+  /// the Sum/address-sim path stays byte-identical.
+  virtual bool usesRewindEviction() const { return false; }
+
+  /// Capture / restore the full sweep state (tracker snapshot + liveValues +
+  /// liveSet) at a schedule position. Used by the rewind eviction.
+  void captureCheckpoint(int64_t pos);
+  void restoreCheckpoint(int64_t pos);
 
   /// Event log entry for address reconstruction. Records every L1 allocation
   /// and deallocation in schedule order so that eviction can replay the full
@@ -276,13 +394,6 @@ private:
   /// placed; false means a still-live tensor has no contiguous fit
   /// (fragmentation).
   bool markEvictedAndRebuild(Value victim, size_t &campaignMin);
-
-  /// Restore the snapshot at `startIdx` and replay every non-skipped event in
-  /// [startIdx, end) top-down first-fit. Pre-checks `wouldAllocateAt` before
-  /// each fresh allocation so `allocateAddress`'s hard contract holds, and
-  /// returns false at the first no-fit (a still-live tensor has no contiguous
-  /// slot). Returns true iff every still-live tensor was placed.
-  bool replayFrom(size_t startIdx);
 
   /// Insert event at pos in l1EventLog and shift all allocEventIndex entries
   /// and addressSnapshots keys >= pos by 1, preserving the index invariants.
@@ -364,44 +475,40 @@ private:
   /// Remove result tensors whose last use was the previous position.
   void processDeadTensors(int64_t pos, const ScheduleData &data);
 
-  /// Check if the op's CB region (growing bottom-up) would overlap with any
-  /// live tensor or the speculative output tensor based on simulated L1
-  /// addresses. Uses min(speculativeOutputAddr, lowestOccupiedAddress) as
-  /// the effective lowest tensor address.
-  /// See: https://github.com/tenstorrent/tt-mlir/issues/7396
-  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
-                              uint64_t speculativeOutputAddr);
+protected:
+  // --- Strategy hooks. Implemented by AddressSimSpillManagement (address-sim)
+  //     and StatefulL1SpillManagement (captured allocator state). ---
 
-  /// Output cannot fit contiguously in the free list. Evict farthest-last-use
-  /// tensors until the output fits, then re-validate. Returns L1 bytes to add
-  /// to live set (0 if demoted to DRAM).
-  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
-                       uint64_t outputL1Size);
+  /// Place a successfully-validated op's output. Returns the L1 size to add to
+  /// the live set (0 = demoted to DRAM).
+  virtual uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) = 0;
 
-  /// CB fragmentation recovery: evict tensors in the CB danger zone,
-  /// re-validate, or demote output to DRAM. Returns L1 bytes to add to live
-  /// set (0 if demoted).
-  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
-                               uint64_t cbPeakUsage, uint64_t outputL1Size);
-
-  /// Run contiguous-fit and CB-fragmentation checks on a validated op's
-  /// output. Returns the (possibly updated) L1 size to add to the live set,
-  /// or 0 if the output was demoted to DRAM.
-  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
-                        uint64_t cbPeakUsage, uint64_t l1Size);
-
-  /// True when `op` is a view-eligible reshape whose source operand is still
-  /// resident in L1. Its output will alias the source's existing slot
-  /// (addTensorAtAddress) instead of carving a fresh one, so it consumes no
-  /// additional L1 and the fit / CB-overlap checks must not treat it as a
-  /// new allocation.
-  bool willAliasSourceInL1(Operation *op) const;
-
-  /// OOM recovery: evict farthest-last-use tensors or demote self to DRAM.
-  void handleOOM(Operation *op, int64_t pos,
+  /// Recover from an OOM validation result (evict live tensors or demote self
+  /// to DRAM).
+  virtual void
+  recoverFromOOM(Operation *op, int64_t pos,
                  llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
-                 std::function<void(uint64_t)> addResultsToLiveSet);
+                 std::function<void(uint64_t)> addResultsToLiveSet) = 0;
 
+  /// Commit one result tensor into the live set: log the alloc event, add it to
+  /// the tracker (alias-or-fresh), and push it onto the FLU heap.
+  virtual void commitAllocation(Value val, uint64_t perResultL1,
+                                ScheduleData &data) = 0;
+
+  /// Handle an L1-output op that cannot be validated (a pre-decomposition
+  /// ToLayoutOp). Address-sim runs a fit check; the stateful path defers to the
+  /// consuming op's query.
+  virtual void handleUnvalidatedL1Output(Operation *op, int64_t pos,
+                                         ScheduleData &data,
+                                         uint64_t derivedL1) = 0;
+
+  /// Rebuild live-set state after an eviction marks events skipped, replaying
+  /// from `startIdx`. Returns true iff every still-live tensor was placed.
+  virtual bool replayFrom(size_t startIdx) = 0;
+
+protected:
   /// Evict all live L1 tensors. Used when encountering ops without OpModel
   /// support — since we cannot know their L1 requirements, the only safe
   /// choice is a full flush. Spill ops are inserted right before triggerOp
@@ -409,17 +516,10 @@ private:
   void evictAllFromL1(int64_t pos, ScheduleData &data,
                       Operation *triggerOp = nullptr);
 
-  /// Evict live tensors (farthest-last-use first) until no tensor's simulated
-  /// address falls below the cushioned CB threshold. Replaces the former
-  /// evictTensorsBelow, which was incorrect after address rebuild (addresses
-  /// shift, making the threshold check stale).
-  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
-                         ScheduleData &data);
-
   /// Evict tensors (farthest-last-use first) until shouldStop() returns true
   /// or the live set is empty. Returns true if shouldStop was satisfied.
-  /// After each eviction, rebuilds address simulation and inserts reshards
-  /// for already-processed consumers.
+  /// After each eviction, rebuilds tracker state (via the replayFrom hook) and
+  /// inserts reshards for already-processed consumers.
   bool evictUntil(int64_t pos, ScheduleData &data,
                   std::function<bool()> shouldStop);
 
@@ -442,22 +542,126 @@ private:
   void insertReshardForConsumer(Operation *consumer, unsigned operandIdx,
                                 TTNNLayoutAttr originalL1Layout);
 
-  /// After demoting an op's output to DRAM, re-query op_model for the DRAM
-  /// config's cbPeakUsage and evict any live tensors that fall within the
-  /// (potentially larger) static CB region.  When output switches from
-  /// L1-sharded to DRAM, the output CB flips from globally_allocated (aliased
-  /// to the shard, not in the static CB region) to locally_allocated (bottom-up
-  /// in the static CB region), which can significantly increase the CB
-  /// footprint.
-  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
-
   /// Collect downstream consumers of an op, following through spill ops.
   static llvm::SmallVector<Operation *>
   collectDownstreamConsumers(Operation *changed);
 };
 
-// Explicit instantiation declaration (definition in .cpp).
-extern template class L1SpillManagement<SumL1MemoryTracker>;
+// Explicit instantiation declarations (definitions in .cpp).
+extern template class L1SpillManagementBase<SumL1MemoryTracker>;
+extern template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+
+/// Address-sim strategy: implements the spill hooks with the simulated top-down
+/// first-fit allocator (SumL1MemoryTracker's address model) and the
+/// contiguous-fit / CB-overlap fragmentation checks. Shared by the legacy Sum
+/// path and (transitionally) the Mock path until the stateful path lands.
+template <typename MemoryTracker>
+class AddressSimSpillManagement : public L1SpillManagementBase<MemoryTracker> {
+public:
+  using L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase;
+
+protected:
+  using Base = L1SpillManagementBase<MemoryTracker>;
+  using typename Base::L1Event;
+  using typename Base::ScheduleData;
+  // Base state + generic helpers the address-sim strategy reuses. (Dependent
+  // base: member names must be brought into scope explicitly.)
+  using Base::addressSnapshots;
+  using Base::allocEventIndex;
+  using Base::applyOutputConfig;
+  using Base::cbFragCushion;
+  using Base::collectDownstreamConsumers;
+  using Base::compilationFailed;
+  using Base::demoteToDram;
+  using Base::evictFarthestUse;
+  using Base::evictUntil;
+  using Base::evictValue;
+  using Base::extractOpConfigFromIR;
+  using Base::insertedReshardValues;
+  using Base::insertEventIntoLog;
+  using Base::insertReshardForConsumer;
+  using Base::insertReshardIntoSchedule;
+  using Base::l1BudgetPerCore;
+  using Base::l1EventLog;
+  using Base::liveSet;
+  using Base::liveValues;
+  using Base::markEvictedAndRebuild;
+  using Base::memoryTracker;
+  using Base::observer_;
+  using Base::spillToDram;
+
+  // Strategy hooks (address-sim implementations).
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
+
+  // Address-simulation fit / fragmentation / CB-overlap helpers.
+  uint64_t ensureFitsL1(Operation *op, int64_t pos, ScheduleData &data,
+                        uint64_t cbPeakUsage, uint64_t l1Size);
+  uint64_t handleNoFit(Operation *op, int64_t pos, ScheduleData &data,
+                       uint64_t outputL1Size);
+  uint64_t handleFragmentation(Operation *op, int64_t pos, ScheduleData &data,
+                               uint64_t cbPeakUsage, uint64_t outputL1Size);
+  bool wouldCBsOverlapTensors(Operation *op, int64_t pos, uint64_t cbPeakUsage,
+                              uint64_t speculativeOutputAddr);
+  bool willAliasSourceInL1(Operation *op) const;
+  void handleOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet);
+  void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
+                         ScheduleData &data);
+  void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
+};
+
+extern template class AddressSimSpillManagement<SumL1MemoryTracker>;
+
+/// Legacy spill manager: scalar-sum tracker + simulated top-down first-fit
+/// address model. Selected when `use-mock-allocator-state=false`.
+class SumL1SpillManagement final
+    : public AddressSimSpillManagement<SumL1MemoryTracker> {
+public:
+  using AddressSimSpillManagement<
+      SumL1MemoryTracker>::AddressSimSpillManagement;
+};
+
+/// Stateful spill manager: fit / fragmentation / placement / CB-clash are all
+/// answered by tt-metal's captured allocator state (no address simulation).
+/// Selected by default (`use-mock-allocator-state=true`). Eviction drops the
+/// victim's records and replays the surviving allocation history through the
+/// op-model, so the allocator re-flows addresses under the victim-free history
+/// (a stored record cannot simply be dropped: with_allocations pins buffers at
+/// their recorded addresses). The base is a non-dependent type here, so base
+/// members are reachable without using-declarations.
+class StatefulL1SpillManagement final
+    : public L1SpillManagementBase<MockAllocatorL1Tracker> {
+public:
+  using L1SpillManagementBase<MockAllocatorL1Tracker>::L1SpillManagementBase;
+
+protected:
+  bool usesRewindEviction() const override { return true; }
+
+  uint64_t placeValidatedOutput(
+      Operation *op, int64_t pos, ScheduleData &data,
+      const op_constraint_validation::ValidationResult &result) override;
+  void
+  recoverFromOOM(Operation *op, int64_t pos,
+                 llvm::ArrayRef<OpResult> tensorResults, ScheduleData &data,
+                 std::function<void(uint64_t)> addResultsToLiveSet) override;
+  void commitAllocation(Value val, uint64_t perResultL1,
+                        ScheduleData &data) override;
+  void handleUnvalidatedL1Output(Operation *op, int64_t pos, ScheduleData &data,
+                                 uint64_t derivedL1) override;
+  bool replayFrom(size_t startIdx) override;
+};
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -76,6 +76,24 @@ struct SliceRuleBook : OpRuleBook {
 /// condition in tt-metal's reshape.cpp.
 bool canReshapeBeView(Operation *op);
 
+/// True if a `ttnn.pad` returns its input as a view (all-zero padding, same
+/// shape, or the TILE fast-path). Mirrors tt-metal's pad.cpp.
+bool canPadBeView(Operation *op);
+
+/// True if a `ttnn.repeat` with an all-ones repetition returns its input as a
+/// view. Mirrors tt-metal's repeat.cpp:196.
+bool canRepeatBeView(Operation *op);
+
+/// True if a `ttnn.permute` is a no-op (is_permute_nop) whose output memory
+/// config matches its input, so tt-metal returns the input as a view. Mirrors
+/// tt-metal's permute.cpp is_permute_nop.
+bool canPermuteBeView(Operation *op);
+
+/// True if `op` is realized by tt-metal as an input-aliasing (zero-copy) view:
+/// any of the per-op view predicates above. Used by the L1 spill pass to alias
+/// the op onto its source's L1 slot instead of tracking a fresh allocation.
+bool isAliasingViewOp(Operation *op);
+
 /// ReshapeOp, PermuteOp: reject width-sharded inputs, no reshards.
 /// View-eligible reshapes use NULL hint only (inherit input memory config).
 /// Non-view reshapes use non-sharded output hints.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -52,16 +52,6 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -91,13 +81,6 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
       // i.e. this to_layout actually performs a dtype conversion as part of
       // the layout change.
       bool hasDtypeChange();
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -118,15 +101,6 @@ def TTNN_TypecastOp : TTNN_Op<"typecast"> {
     let hasFolder = 1;
     let hasCanonicalizeMethod = 1;
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 }
 
 def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
@@ -142,15 +116,6 @@ def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 }
 
 def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
@@ -192,16 +157,6 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
       }]>
     ];
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints). Declared on the base so
-      // the out-of-line defs in the interface impl bind for every member.
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
@@ -220,14 +175,6 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
         return
           wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints). Declared on the base so
-      // the out-of-line defs in the interface impl bind for every member.
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -293,13 +240,6 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
           wa::TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
                                                                         inputs);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -366,13 +306,6 @@ def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createErfOpOperandsWorkarounds(getInput().getType());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let description = [{
@@ -433,13 +366,6 @@ def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
           wa::TTNNOperandsWorkaroundsFactory::createUnaryBitwiseOpOperandsWorkarounds(
               this->getOperation());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -774,18 +700,12 @@ def TTNN_LogicalLeftShiftOp: TTNN_ElementwiseBinaryCompositeOp<"logical_left_shi
   }];
 
   // Per-op extraClassDeclaration replaces the composite base's, so re-declare
-  // getOperandsWorkarounds here alongside the stateful constraint-query
-  // override (default delegates to the stateless getOpConstraints).
+  // getOperandsWorkarounds here.
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return
         wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
     }
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -895,16 +815,6 @@ def TTNN_PowScalarOp : TTNN_ElementwiseBinaryCompositeScalarOp<"pow_scalar"> {
     Restriction: TTNN API supports exponent ≥ 0 only.
   }];
 
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
-
   let hasVerifier = 1;
 }
 
@@ -963,24 +873,14 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
     }]>
   ];
 
-  // NOTE: getOpConstraintsWithState is declared HERE on the base (not per-op)
-  // and cascades to every member (Sum/Mean/Max/Min). A per-op
-  // extraClassDeclaration would SHADOW this base block and silently drop
-  // getOperandsWorkarounds (the si32->f32 reduction cast) -- see
-  // https://github.com/tenstorrent/tt-mlir/issues/8279. All base members are
-  // migrated (define getOpConstraintsWithState in TTNNOpModelInterface.cpp).
+  // NOTE: a per-op extraClassDeclaration would SHADOW this base block and
+  // silently drop getOperandsWorkarounds (the si32->f32 reduction cast) -- see
+  // https://github.com/tenstorrent/tt-mlir/issues/8279.
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return
         wa::TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(*this);
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1069,13 +969,6 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
           createArgMaxOpOperandsWorkarounds();
     }
 
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let results = (outs AnyRankedTensor:$result);
@@ -1115,13 +1008,6 @@ def TTNN_ProdOp : TTNN_Op<"prod"> {
         wa::TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds();
     }
 
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1142,13 +1028,6 @@ def TTNN_EmbeddingOp : TTNN_Op<"embedding"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1170,13 +1049,6 @@ def TTNN_UpdateCacheOp : TTNN_InplaceOp<"update_cache"> {
         RankedTensorType updateIndexType = getUpdateIndex().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(updateIndexType);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
   let hasVerifier = 1;
@@ -1203,13 +1075,6 @@ def TTNN_PagedUpdateCacheOp : TTNN_InplaceOp<"paged_update_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(this->getOperation());
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1224,16 +1089,6 @@ def TTNN_FillCacheOp : TTNN_InplaceOp<"fill_cache"> {
   let arguments = (ins Arg<AnyRankedTensor, "cache tensor", [MemWrite]>:$cache,
                        AnyRankedTensor:$input,
                        I32Attr:$batch_offset);
-
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 
   let hasVerifier = 1;
 }
@@ -1253,13 +1108,6 @@ def TTNN_PagedFillCacheOp : TTNN_InplaceOp<"paged_fill_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFillCacheOpOperandsWorkarounds(getOperation());
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1281,13 +1129,6 @@ def TTNN_EmbeddingBackwardOp : TTNN_Op<"embedding_bw"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingBackwardOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1316,15 +1157,6 @@ def TTNN_CumSumOp : TTNN_Op<"cumsum"> {
 
   let results = (outs AnyRankedTensor:$result);
 
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 }
 
 def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
@@ -1350,15 +1182,6 @@ def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
 
   let results = (outs AnyRankedTensor:$result);
 
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 }
 
 def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
@@ -1372,16 +1195,6 @@ def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
     let arguments = (ins AnyRankedTensor:$input);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1400,16 +1213,6 @@ def TTNN_NLPConcatHeadsDecodeOp: TTNN_Op<"nlp_concat_heads_decode"> {
                          UI32Attr:$num_heads);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1431,16 +1234,6 @@ def TTNN_SplitQueryKeyValueAndSplitHeadsOp: TTNN_Op<"split_query_key_value_and_s
     let results = (outs AnyRankedTensor:$query,
                         AnyRankedTensor:$key,
                         AnyRankedTensor:$value);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1473,16 +1266,6 @@ def TTNN_SoftmaxOp : TTNN_Op<"softmax", [TTNN_ComputeKernelConfigOpInterface]> {
               /*compute_config=*/nullptr);
       }]>
     ];
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1518,13 +1301,6 @@ def TTNN_SortOp : TTNN_Op<"sort"> {
       return
         wa::TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(*this);
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1541,16 +1317,6 @@ def TTNN_TransposeOp : TTNN_Op<"transpose"> {
                          SI32Attr:$dim1);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1574,16 +1340,6 @@ def TTNN_RepeatInterleaveOp : TTNN_Op<"repeat_interleave"> {
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -1597,16 +1353,6 @@ def TTNN_ConcatOp : TTNN_Op<"concat"> {
                          SI32Attr:$dim);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1632,13 +1378,6 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape"> {
         RankedTensorType inputType = getInput().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(inputType);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -1656,16 +1395,6 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
                          TTNN_ShapeAttr:$repeat_dims);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -1700,13 +1429,6 @@ def TTNN_PadOp: TTNN_Op<"pad"> {
         wa::TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
                                                     input, layoutAttr, padding);
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 }
 
@@ -1730,13 +1452,6 @@ def TTNN_SliceStaticOp: TTNN_Op<"slice_static"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceStaticOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1763,13 +1478,6 @@ def TTNN_SliceDynamicOp: TTNN_Op<"slice_dynamic"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceDynamicOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1815,16 +1523,6 @@ def TTNN_LinearOp : TTNN_Op<"linear", [TTNN_ComputeKernelConfigOpInterface]> {
       }]>
     ];
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -1860,17 +1558,6 @@ def TTNN_MatmulOp : TTNN_Op<"matmul", [TTNN_ComputeKernelConfigOpInterface]> {
     let hasVerifier = 1;
     let hasCanonicalizer = 1;
 
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints). Declared here so the
-    // out-of-line MatmulOp::getOpConstraintsWithState in the interface impl
-    // binds and hides the trait default.
-    let extraClassDeclaration = [{
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
@@ -2182,13 +1869,6 @@ def TTNN_PrepareMoEComputeW0W1WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW0W1WeightsOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2217,13 +1897,6 @@ def TTNN_PrepareMoEComputeW2WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW2WeightsOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2310,16 +1983,6 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -2347,16 +2010,6 @@ def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias", [TTNN_ComputeKerne
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -2411,16 +2064,6 @@ def TTNN_PrepareConvTranspose2dWeightsOp : TTNN_Op<"prepare_conv_transpose2d_wei
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -2448,16 +2091,6 @@ def TTNN_PrepareConvTranspose2dBiasOp : TTNN_Op<"prepare_conv_transpose2d_bias",
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -2621,13 +2254,6 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -2721,13 +2347,6 @@ def TTNN_Conv3dOp : TTNN_Op<"conv3d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConv3dOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -2816,13 +2435,6 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d", [TTNN_ComputeKernelConf
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -2867,13 +2479,6 @@ def TTNN_AvgPool2dOp : TTNN_Op<"avg_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2905,13 +2510,6 @@ def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2946,13 +2544,6 @@ def TTNN_MaxPool2dWithIndicesOp : TTNN_Op<"max_pool2d_with_indices"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DWithIndicesOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2986,16 +2577,6 @@ def TTNN_BatchNormInferenceOp : TTNN_Op<"batch_norm_inference", [AttrSizedOperan
       }]>
     ];
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -3028,16 +2609,6 @@ def TTNN_BatchNormTrainingOp : TTNN_Op<"batch_norm_training", [AttrSizedOperandS
       }]>
     ];
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -3069,16 +2640,6 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_Compute
               epsilon, /*compute_config=*/nullptr);
       }]>
     ];
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -3246,16 +2807,6 @@ def TTNN_RMSNormPreAllGatherOp :  TTNN_Op<"rms_norm_pre_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -3317,16 +2868,6 @@ def TTNN_LayerNormOp : TTNN_Op<"layer_norm", [AttrSizedOperandSegments]> {
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -3357,16 +2898,6 @@ def TTNN_LayerNormPreAllGatherOp : TTNN_Op<"layer_norm_pre_all_gather",
                          OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -3402,16 +2933,6 @@ def TTNN_LayerNormPostAllGatherOp : TTNN_Op<"layer_norm_post_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -3439,13 +2960,6 @@ def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments]> {
             createGroupNormOpOperandsWorkarounds(this->getOperation());
       }
 
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -3471,16 +2985,6 @@ def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar"> {
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 
 }
@@ -3504,16 +3008,6 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
                        AnyRankedTensor:$max);
 
   let results = (outs AnyRankedTensor:$result);
-
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 
 }
 
@@ -3713,13 +3207,6 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasCanonicalizer = 1;
@@ -3775,13 +3262,6 @@ def TTNN_ScatterOp : TTNN_Op<"scatter">{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScatterOpOperandsWorkarounds(getOperation());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -3810,13 +3290,6 @@ def TTNN_GatherOp : TTNN_Op<"gather"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createGatherOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 }
 
@@ -3913,15 +3386,6 @@ def TTNN_MeshPartitionOp: TTNN_Op<"mesh_partition"> {
                        SI32Attr:$dim,
                        OptionalAttr<UI32Attr>:$cluster_axis);
   let results = (outs AnyRankedTensor:$result);
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
   let hasVerifier = 1;
 }
 
@@ -3954,13 +3418,6 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
             getInput().getType()
           );
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasFolder = 1;
@@ -3991,13 +3448,6 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds();
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4112,16 +3562,6 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
                          OptionalAttr<TTCore_DataTypeAttr>:$output_dtype);
 
     let results = (outs AnyRankedTensor:$result);
-
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
 
     let hasVerifier = 1;
 }
@@ -4364,16 +3804,6 @@ def TTNN_RotaryEmbeddingLlamaOp : TTNN_Op<"rotary_embedding_llama", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
-    let extraClassDeclaration = [{
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
-    }];
-
     let hasVerifier = 1;
 }
 
@@ -4405,13 +3835,6 @@ def TTNN_RotaryEmbeddingOp : TTNN_Op<"rotary_embedding", [TTNN_ComputeKernelConf
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createRotaryEmbeddingOpOperandsWorkarounds(*this);
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4427,16 +3850,6 @@ def TTNN_NLPConcatHeadsOp : TTNN_Op<"nlp_concat_heads"> {
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
-
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 
   let hasVerifier = 1;
 }
@@ -4476,16 +3889,6 @@ def NLPCreateQKVHeadsDecodeOp : TTNN_Op<"nlp_create_qkv_heads_decode"> {
   let results = (outs AnyRankedTensor:$query,
                       AnyRankedTensor:$key,
                       AnyRankedTensor:$value);
-
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 
   let hasVerifier = 1;
 }
@@ -4558,13 +3961,6 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4594,13 +3990,6 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4634,13 +4023,6 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createChunkedScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4679,13 +4061,6 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFlashMultiLatentAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4735,13 +4110,6 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4788,13 +4156,6 @@ def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegme
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createFlashMlaPrefillOpOperandsWorkarounds(getOperation());
       }
-      // Override the OpModel interface's stateful constraint query (default
-      // delegates to the stateless getOpConstraints).
-      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-      getOpConstraintsWithState(
-          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4877,16 +4238,6 @@ def TTNN_GlobalAvgPool2dOp: TTNN_Op<"global_avg_pool2d">{
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
-
-  let extraClassDeclaration = [{
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
-  }];
 
   let hasVerifier = 1;
 }
@@ -5022,13 +4373,6 @@ def TTNN_SamplingOp : TTNN_Op<"sampling"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds();
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -5056,13 +4400,6 @@ def TTNN_TopKOp : TTNN_Op<"topk"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKOpOperandsWorkarounds(*this);
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -5100,13 +4437,6 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKRouterGptOpOperandsWorkarounds();
     }
-    // Override the OpModel interface's stateful constraint query (default
-    // delegates to the stateless getOpConstraints).
-    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
-    getOpConstraintsWithState(
-        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
-        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
-            liveRecords);
   }];
 
   let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -52,6 +52,16 @@ def TTNN_ToMemoryConfigOp : TTNN_Op<"to_memory_config"> {
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -81,6 +91,13 @@ def TTNN_ToLayoutOp : TTNN_Op<"to_layout", [TTNN_LayoutOpInterface]> {
       // i.e. this to_layout actually performs a dtype conversion as part of
       // the layout change.
       bool hasDtypeChange();
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -100,6 +117,16 @@ def TTNN_TypecastOp : TTNN_Op<"typecast"> {
 
     let hasFolder = 1;
     let hasCanonicalizeMethod = 1;
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
@@ -114,6 +141,16 @@ def TTNN_BitcastConvertOp : TTNN_Op<"bitcast_convert"> {
 
     let arguments = (ins AnyRankedTensor:$input);
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 def TTNN_ToDeviceOp : TTNN_Op<"to_device", [OpModelExempt]> {
@@ -154,6 +191,17 @@ class TTNN_ElementwiseUnaryOp<string mnemonic, list<Trait> traits = []> :
         build($_builder, $_state, {input.getType()}, input);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints). Declared on the base so
+      // the out-of-line defs in the interface impl bind for every member.
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 
 class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
@@ -172,6 +220,14 @@ class TTNN_ElementwiseBinaryOp<string mnemonic, list<Trait> traits = []> :
         return
           wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints). Declared on the base so
+      // the out-of-line defs in the interface impl bind for every member.
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -237,6 +293,13 @@ def TTNN_WhereOp : TTNN_ElementwiseTernaryOp<"where"> {
           wa::TTNNOperandsWorkaroundsFactory::createWhereOpOperandsWorkarounds(
                                                                         inputs);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -303,6 +366,13 @@ def TTNN_ErfOp : TTNN_ElementwiseUnaryOp<"erf"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createErfOpOperandsWorkarounds(getInput().getType());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let description = [{
@@ -363,6 +433,13 @@ def TTNN_BitwiseNotOp : TTNN_ElementwiseUnaryOp<"bitwise_not"> {
           wa::TTNNOperandsWorkaroundsFactory::createUnaryBitwiseOpOperandsWorkarounds(
               this->getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -695,6 +772,22 @@ def TTNN_LogicalLeftShiftOp: TTNN_ElementwiseBinaryCompositeOp<"logical_left_shi
     on the elements of the first tensor by the corresponding shift amounts in the
     second tensor.
   }];
+
+  // Per-op extraClassDeclaration replaces the composite base's, so re-declare
+  // getOperandsWorkarounds here alongside the stateful constraint-query
+  // override (default delegates to the stateless getOpConstraints).
+  let extraClassDeclaration = [{
+    wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+      return
+        wa::TTNNOperandsWorkaroundsFactory::createBinaryOpOperandsWorkarounds(*this);
+    }
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
+
   let hasVerifier = 1;
 }
 
@@ -799,7 +892,17 @@ def TTNN_PowScalarOp : TTNN_ElementwiseBinaryCompositeScalarOp<"pow_scalar"> {
     // Output tensor: [4.0, 9.0, 16.0, 25.0]
     ```
 
-    Restriction: TTNN API supports expoenent ≥ 0 only.
+    Restriction: TTNN API supports exponent ≥ 0 only.
+  }];
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -860,11 +963,24 @@ class TTNN_ReductionOp<string mnemonic, list<Trait> traits = []> : TTNN_Op<mnemo
     }]>
   ];
 
+  // NOTE: getOpConstraintsWithState is declared HERE on the base (not per-op)
+  // and cascades to every member (Sum/Mean/Max/Min). A per-op
+  // extraClassDeclaration would SHADOW this base block and silently drop
+  // getOperandsWorkarounds (the si32->f32 reduction cast) -- see
+  // https://github.com/tenstorrent/tt-mlir/issues/8279. All base members are
+  // migrated (define getOpConstraintsWithState in TTNNOpModelInterface.cpp).
   let extraClassDeclaration = [{
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return
         wa::TTNNOperandsWorkaroundsFactory::createReductionOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -952,6 +1068,14 @@ def TTNN_ArgMaxOp : TTNN_Op<"argmax"> {
       return wa::TTNNOperandsWorkaroundsFactory::
           createArgMaxOpOperandsWorkarounds();
     }
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let results = (outs AnyRankedTensor:$result);
@@ -990,6 +1114,14 @@ def TTNN_ProdOp : TTNN_Op<"prod"> {
       return
         wa::TTNNOperandsWorkaroundsFactory::createReduceProdOpOperandsWorkarounds();
     }
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1010,6 +1142,13 @@ def TTNN_EmbeddingOp : TTNN_Op<"embedding"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1031,6 +1170,13 @@ def TTNN_UpdateCacheOp : TTNN_InplaceOp<"update_cache"> {
         RankedTensorType updateIndexType = getUpdateIndex().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createUpdateCacheOpOperandsWorkarounds(updateIndexType);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
   let hasVerifier = 1;
@@ -1057,6 +1203,13 @@ def TTNN_PagedUpdateCacheOp : TTNN_InplaceOp<"paged_update_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedUpdateCacheOpOperandsWorkarounds(this->getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1071,6 +1224,16 @@ def TTNN_FillCacheOp : TTNN_InplaceOp<"fill_cache"> {
   let arguments = (ins Arg<AnyRankedTensor, "cache tensor", [MemWrite]>:$cache,
                        AnyRankedTensor:$input,
                        I32Attr:$batch_offset);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -1090,6 +1253,13 @@ def TTNN_PagedFillCacheOp : TTNN_InplaceOp<"paged_fill_cache"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFillCacheOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1111,6 +1281,13 @@ def TTNN_EmbeddingBackwardOp : TTNN_Op<"embedding_bw"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createEmbeddingBackwardOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1138,6 +1315,16 @@ def TTNN_CumSumOp : TTNN_Op<"cumsum"> {
                        SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 }
 
 def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
@@ -1162,6 +1349,16 @@ def TTNN_CumProdOp : TTNN_Op<"cumprod"> {
                        SI32Attr:$dim);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 }
 
 def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
@@ -1175,6 +1372,16 @@ def TTNN_ConcatenateHeadsOp: TTNN_Op<"concatenate_heads"> {
     let arguments = (ins AnyRankedTensor:$input);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1193,6 +1400,16 @@ def TTNN_NLPConcatHeadsDecodeOp: TTNN_Op<"nlp_concat_heads_decode"> {
                          UI32Attr:$num_heads);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1214,6 +1431,16 @@ def TTNN_SplitQueryKeyValueAndSplitHeadsOp: TTNN_Op<"split_query_key_value_and_s
     let results = (outs AnyRankedTensor:$query,
                         AnyRankedTensor:$key,
                         AnyRankedTensor:$value);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1246,6 +1473,16 @@ def TTNN_SoftmaxOp : TTNN_Op<"softmax", [TTNN_ComputeKernelConfigOpInterface]> {
               /*compute_config=*/nullptr);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1281,6 +1518,13 @@ def TTNN_SortOp : TTNN_Op<"sort"> {
       return
         wa::TTNNOperandsWorkaroundsFactory::createSortOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -1297,6 +1541,16 @@ def TTNN_TransposeOp : TTNN_Op<"transpose"> {
                          SI32Attr:$dim1);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1320,6 +1574,16 @@ def TTNN_RepeatInterleaveOp : TTNN_Op<"repeat_interleave"> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1333,6 +1597,16 @@ def TTNN_ConcatOp : TTNN_Op<"concat"> {
                          SI32Attr:$dim);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1358,6 +1632,13 @@ def TTNN_ReshapeOp : TTNN_Op<"reshape"> {
         RankedTensorType inputType = getInput().getType();
         return wa::TTNNOperandsWorkaroundsFactory::createReshapeOpOperandsWorkarounds(inputType);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -1375,6 +1656,16 @@ def TTNN_RepeatOp : TTNN_Op<"repeat"> {
                          TTNN_ShapeAttr:$repeat_dims);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -1409,6 +1700,13 @@ def TTNN_PadOp: TTNN_Op<"pad"> {
         wa::TTNNOperandsWorkaroundsFactory::createPadOpOperandsWorkarounds(
                                                     input, layoutAttr, padding);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 }
 
@@ -1432,6 +1730,13 @@ def TTNN_SliceStaticOp: TTNN_Op<"slice_static"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceStaticOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1458,6 +1763,13 @@ def TTNN_SliceDynamicOp: TTNN_Op<"slice_dynamic"> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createSliceDynamicOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1503,6 +1815,16 @@ def TTNN_LinearOp : TTNN_Op<"linear", [TTNN_ComputeKernelConfigOpInterface]> {
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1537,6 +1859,18 @@ def TTNN_MatmulOp : TTNN_Op<"matmul", [TTNN_ComputeKernelConfigOpInterface]> {
 
     let hasVerifier = 1;
     let hasCanonicalizer = 1;
+
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints). Declared here so the
+    // out-of-line MatmulOp::getOpConstraintsWithState in the interface impl
+    // binds and hides the trait default.
+    let extraClassDeclaration = [{
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 }
 // ANCHOR_END: adding_an_op_matmul_ttnn
 
@@ -1848,6 +2182,13 @@ def TTNN_PrepareMoEComputeW0W1WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW0W1WeightsOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1876,6 +2217,13 @@ def TTNN_PrepareMoEComputeW2WeightsOp :
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPrepareMoEComputeW2WeightsOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -1962,6 +2310,16 @@ def TTNN_PrepareConv2dWeightsOp : TTNN_Op<"prepare_conv2d_weights", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -1989,6 +2347,16 @@ def TTNN_PrepareConv2dBiasOp : TTNN_Op<"prepare_conv2d_bias", [TTNN_ComputeKerne
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2043,6 +2411,16 @@ def TTNN_PrepareConvTranspose2dWeightsOp : TTNN_Op<"prepare_conv_transpose2d_wei
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2070,6 +2448,16 @@ def TTNN_PrepareConvTranspose2dBiasOp : TTNN_Op<"prepare_conv_transpose2d_bias",
                          OptionalAttr<TTNN_Conv2dSliceConfigAttr>:$conv2d_slice_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2233,6 +2621,13 @@ def TTNN_Conv2dOp : TTNN_Op<"conv2d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2326,6 +2721,13 @@ def TTNN_Conv3dOp : TTNN_Op<"conv3d", [TTNN_ComputeKernelConfigOpInterface]> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConv3dOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2414,6 +2816,13 @@ def TTNN_ConvTranspose2dOp : TTNN_Op<"conv_transpose2d", [TTNN_ComputeKernelConf
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConvOpOperandsWorkarounds(*this);
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -2458,6 +2867,13 @@ def TTNN_AvgPool2dOp : TTNN_Op<"avg_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2489,6 +2905,13 @@ def TTNN_MaxPool2dOp : TTNN_Op<"max_pool2d"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2523,6 +2946,13 @@ def TTNN_MaxPool2dWithIndicesOp : TTNN_Op<"max_pool2d_with_indices"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createPool2DWithIndicesOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2556,6 +2986,16 @@ def TTNN_BatchNormInferenceOp : TTNN_Op<"batch_norm_inference", [AttrSizedOperan
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2588,6 +3028,16 @@ def TTNN_BatchNormTrainingOp : TTNN_Op<"batch_norm_training", [AttrSizedOperandS
       }]>
     ];
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2619,6 +3069,16 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_Compute
               epsilon, /*compute_config=*/nullptr);
       }]>
     ];
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2786,6 +3246,16 @@ def TTNN_RMSNormPreAllGatherOp :  TTNN_Op<"rms_norm_pre_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2847,6 +3317,16 @@ def TTNN_LayerNormOp : TTNN_Op<"layer_norm", [AttrSizedOperandSegments]> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2877,6 +3357,16 @@ def TTNN_LayerNormPreAllGatherOp : TTNN_Op<"layer_norm_pre_all_gather",
                          OptionalAttr<TTNN_LayerNormShardedMultiCoreProgramConfigAttr>:$program_config);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -2912,6 +3402,16 @@ def TTNN_LayerNormPostAllGatherOp : TTNN_Op<"layer_norm_post_all_gather",
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -2938,6 +3438,14 @@ def TTNN_GroupNormOp : TTNN_Op<"group_norm", [AttrSizedOperandSegments]> {
         return wa::TTNNOperandsWorkaroundsFactory::
             createGroupNormOpOperandsWorkarounds(this->getOperation());
       }
+
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -2963,6 +3471,16 @@ def TTNN_ClampScalarOp : TTNN_Op<"clamp_scalar"> {
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 
 }
@@ -2986,6 +3504,16 @@ def TTNN_ClampTensorOp : TTNN_Op<"clamp_tensor"> {
                        AnyRankedTensor:$max);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
 }
 
@@ -3185,6 +3713,13 @@ def TTNN_ConstantOp : TTNN_CreationOp<"constant", [AllShapesMatch<["value", "res
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createConstantOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasCanonicalizer = 1;
@@ -3240,6 +3775,13 @@ def TTNN_ScatterOp : TTNN_Op<"scatter">{
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScatterOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -3268,6 +3810,13 @@ def TTNN_GatherOp : TTNN_Op<"gather"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createGatherOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 }
 
@@ -3364,6 +3913,15 @@ def TTNN_MeshPartitionOp: TTNN_Op<"mesh_partition"> {
                        SI32Attr:$dim,
                        OptionalAttr<UI32Attr>:$cluster_axis);
   let results = (outs AnyRankedTensor:$result);
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
   let hasVerifier = 1;
 }
 
@@ -3396,6 +3954,13 @@ def TTNN_PermuteOp : TTNN_Op<"permute"> {
             getInput().getType()
           );
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasFolder = 1;
@@ -3426,6 +3991,13 @@ def TTNN_UpsampleOp : TTNN_Op<"upsample"> {
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createUpsampleOpOperandsWorkarounds();
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -3540,6 +4112,16 @@ def TTNN_RequantizeOp : TTNN_Op<"requantize"> {
                          OptionalAttr<TTCore_DataTypeAttr>:$output_dtype);
 
     let results = (outs AnyRankedTensor:$result);
+
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
 
     let hasVerifier = 1;
 }
@@ -3782,6 +4364,16 @@ def TTNN_RotaryEmbeddingLlamaOp : TTNN_Op<"rotary_embedding_llama", [TTNN_Comput
 
     let results = (outs AnyRankedTensor:$result);
 
+    let extraClassDeclaration = [{
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
+    }];
+
     let hasVerifier = 1;
 }
 
@@ -3813,6 +4405,13 @@ def TTNN_RotaryEmbeddingOp : TTNN_Op<"rotary_embedding", [TTNN_ComputeKernelConf
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createRotaryEmbeddingOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -3828,6 +4427,16 @@ def TTNN_NLPConcatHeadsOp : TTNN_Op<"nlp_concat_heads"> {
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -3867,6 +4476,16 @@ def NLPCreateQKVHeadsDecodeOp : TTNN_Op<"nlp_create_qkv_heads_decode"> {
   let results = (outs AnyRankedTensor:$query,
                       AnyRankedTensor:$key,
                       AnyRankedTensor:$value);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -3939,6 +4558,13 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -3968,6 +4594,13 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedScaledDotProductAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4001,6 +4634,13 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createChunkedScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4039,6 +4679,13 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createPagedFlashMultiLatentAttentionDecodeOpOperandsWorkarounds(getOperation());
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4088,6 +4735,13 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createScaledDotProductAttentionOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4134,6 +4788,13 @@ def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegme
       wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
         return wa::TTNNOperandsWorkaroundsFactory::createFlashMlaPrefillOpOperandsWorkarounds(getOperation());
       }
+      // Override the OpModel interface's stateful constraint query (default
+      // delegates to the stateless getOpConstraints).
+      llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+      getOpConstraintsWithState(
+          const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+              liveRecords);
     }];
 
     let hasVerifier = 1;
@@ -4216,6 +4877,16 @@ def TTNN_GlobalAvgPool2dOp: TTNN_Op<"global_avg_pool2d">{
   let arguments = (ins AnyRankedTensor:$input);
 
   let results = (outs AnyRankedTensor:$result);
+
+  let extraClassDeclaration = [{
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
+  }];
 
   let hasVerifier = 1;
 }
@@ -4351,6 +5022,13 @@ def TTNN_SamplingOp : TTNN_Op<"sampling"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createSamplingOpOperandsWorkarounds();
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4378,6 +5056,13 @@ def TTNN_TopKOp : TTNN_Op<"topk"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKOpOperandsWorkarounds(*this);
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;
@@ -4415,6 +5100,13 @@ def TTNN_TopKRouterGptOp : TTNN_Op<"topk_router_gpt"> {
     wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
       return wa::TTNNOperandsWorkaroundsFactory::createTopKRouterGptOpOperandsWorkarounds();
     }
+    // Override the OpModel interface's stateful constraint query (default
+    // delegates to the stateless getOpConstraints).
+    llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+    getOpConstraintsWithState(
+        const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &config,
+        llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>
+            liveRecords);
   }];
 
   let hasVerifier = 1;

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
@@ -41,6 +41,23 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
             /*methodBody=*/"",
             /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
+        InterfaceMethod<
+            /*desc=*/[{
+                Stateful variant of getOpConstraints used by the L1 spill path.
+                `liveRecords` describes the allocations already live in L1 (a
+                build-from-records snapshot); the op is evaluated on top of that
+                state via a query that bypasses the op-model constraint cache.
+                The default implementation ignores the state and delegates to the
+                (cached) stateless getOpConstraints, so ops become state-aware by
+                overriding this method. Passing an empty `liveRecords` is
+                equivalent to the stateless query.
+            }],
+            /*retTy=*/"llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>",
+            /*methodName=*/"getOpConstraintsWithState",
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config, "llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>":$liveRecords),
+            /*methodBody=*/"",
+            /*defaultImplementation=*/"return $_op.getOpConstraints(inputs, config);"
+        >,
         ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
+++ b/include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td
@@ -34,31 +34,44 @@ def TTNN_OpModelInterface : OpInterface<"OpModel"> {
                    - The fourth value is the actual TTNNLayoutAttr of the output tensor, as returned by the operation. For
                      some operations this may be different from the requested output layout
                 If the op is illegal, returns an Error with a string describing the failure.
+
+                `liveRecords` selects the query flavour and is TRI-STATE -- do not
+                collapse it to "is the record set empty":
+                   - std::nullopt: stateless query. Nothing is allocated
+                     (NO_DISPATCH), `outputAllocations` comes back empty, and the
+                     result is cached by the op-model constraint cache.
+                   - engaged, EVEN IF EMPTY: stateful query. The records describe
+                     the allocations already live in L1; the op is evaluated on
+                     top of that state by a query that really allocates, reports
+                     per-output `outputAllocations`, and bypasses the cache (the
+                     live set is deliberately not part of the cache key). An
+                     empty-but-engaged live set is a real state the L1 spill path
+                     depends on: it is how the record set bootstraps off the
+                     first op, so treating it as stateless would silently degrade
+                     the whole feature.
+                Use the 2-argument overload below for a plain stateless query.
             }],
             /*retTy=*/"llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>",
             /*methodName=*/"getOpConstraints",
-            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config),
+            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config, "std::optional<llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>>":$liveRecords),
             /*methodBody=*/"",
             /*defaultImplementation=*/"return llvm::createStringError(\"Not Implemented\");"
         >,
-        InterfaceMethod<
-            /*desc=*/[{
-                Stateful variant of getOpConstraints used by the L1 spill path.
-                `liveRecords` describes the allocations already live in L1 (a
-                build-from-records snapshot); the op is evaluated on top of that
-                state via a query that bypasses the op-model constraint cache.
-                The default implementation ignores the state and delegates to the
-                (cached) stateless getOpConstraints, so ops become state-aware by
-                overriding this method. Passing an empty `liveRecords` is
-                equivalent to the stateless query.
-            }],
-            /*retTy=*/"llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>",
-            /*methodName=*/"getOpConstraintsWithState",
-            /*args=*/(ins "const std::vector<TTNNLayoutAttr>&":$inputs, "const OpConfig&":$config, "llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>":$liveRecords),
-            /*methodBody=*/"",
-            /*defaultImplementation=*/"return $_op.getOpConstraints(inputs, config);"
-        >,
         ];
+
+    // Declared on the interface class only (NOT extraSharedClassDeclaration):
+    // ODS declares the 3-argument getOpConstraints inside every implementing op
+    // class, which would hide a 2-argument overload inherited from the Trait.
+    // Every caller of the convenience form goes through an interface handle.
+    let extraClassDeclaration = [{
+        // Convenience overload for a stateless constraint query; equivalent to
+        // passing std::nullopt.
+        llvm::Expected<mlir::tt::ttnn::op_model::OpConstraints>
+        getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &config) {
+          return getOpConstraints(inputs, config, /*liveRecords=*/std::nullopt);
+        }
+    }];
 }
 
 #endif // TTMLIR_DIALECT_TTNN_INTERFACES_TTNNOPMODELINTERFACE_TD

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -529,6 +529,15 @@ struct TTIRToTTNNCommonPipelineOptions
       llvm::cl::desc("Output directory for decision trace JSON files."),
       llvm::cl::init("ttrt-artifacts/decision_trace")};
 
+  // Greedy L1 spill: use the stateful (tt-metal MockAllocatorState-backed)
+  // memory tracker vs the scalar-heuristic tracker. Exposed here so it can be
+  // toggled without a rebuild (e.g. for stateful-vs-scalar A/B).
+  Option<bool> useMockAllocatorState{
+      *this, "use-mock-allocator-state",
+      llvm::cl::desc("Greedy L1 spill: use the stateful allocator-backed L1 "
+                     "tracker (true) vs the scalar-heuristic tracker (false)."),
+      llvm::cl::init(true)};
+
   // Enable per-op compile-time statistics from the greedy optimizer.
   Option<bool> enableCompileTimeStats{
       *this, "enable-compile-time-stats",

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -853,6 +853,10 @@ def TTNNGreedyL1SpillManagement : Pass<"ttnn-greedy-l1-spill-management", "::mli
     Option<"decisionTraceDir", "decision-trace-dir", "std::string",
            "\"ttrt-artifacts/decision_trace\"",
            "Directory for decision trace JSON output.">,
+    Option<"useMockAllocatorState", "use-mock-allocator-state", "bool", "true",
+           "Use tt-metal's stateful op-constraints query (MockAllocatorL1Tracker) "
+           "for fragmentation-accurate L1 fit decisions. When false, use the "
+           "scalar additional-L1 + CB-cushion tracker (SumL1MemoryTracker).">,
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -50,6 +50,11 @@ struct ValidationResult {
   // CB peak L1 usage from op_model. Only valid if Success.
   uint64_t cbPeakUsage = 0;
 
+  // Per-output allocation records from a stateful (build-from-records) query.
+  // Empty on the stateless path. The L1 spill path keeps these for still-live
+  // tensors and rebuilds allocator state from them.
+  llvm::SmallVector<op_model::OpModelAllocationRecord> outputAllocations;
+
   // Error message if status != Success.
   std::string errorMessage;
 
@@ -146,6 +151,16 @@ ValidationResult validateOperation(Operation *op,
                                    llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                                    const OpConfig &config,
                                    uint64_t additionalL1Usage = 0);
+
+// Stateful (build-from-records) validation for the L1 spill path. Routes to the
+// uncached getOpConstraintsWithState, evaluating the op against `liveRecords`
+// (the allocations already live in L1). An empty liveRecords is equivalent to
+// the stateless query.
+ValidationResult
+validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                  const OpConfig &config,
+                  llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords,
+                  uint64_t additionalL1Usage = 0);
 
 // Test multiple attributes with all layouts.
 // op: Operation to validate.

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -177,14 +177,14 @@ validateWithMultipleAttributes(Operation *op,
                                llvm::ArrayRef<OpConfig> opConfigs,
                                llvm::ArrayRef<OpConfig> referenceConfigs);
 
-// Validate an OpConstraints result against the L1 memory budget derived from
-// the given context operation (used to look up device attributes and module-
-// level tensorL1UsageCap).  This is the shared L1 budget check used by both
-// the Operation*-based validateOperation and the template overload below.
-ValidationResult
-checkConstraintsResult(Operation *contextOp,
-                       llvm::Expected<op_model::OpConstraints> constraints,
-                       uint64_t additionalL1Usage = 0);
+// Validate an OpConstraints result against the L1 budget (looked up from
+// |contextOp|'s device/module attributes). |statefulQuery| skips the peak-usage
+// byte check: on the stateful path tt-metal itself checks fit, while the
+// stateless path has to check it here. The byte budget is enforced by
+// MockAllocatorL1Tracker::validate.
+ValidationResult checkConstraintsResult(
+    Operation *contextOp, llvm::Expected<op_model::OpConstraints> constraints,
+    uint64_t additionalL1Usage = 0, bool statefulQuery = false);
 
 // Op-less validation: calls OpModel<OpType>::getOpConstraints directly with
 // the forwarded arguments, then validates the result against the L1 memory

--- a/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
+++ b/include/ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h
@@ -152,10 +152,13 @@ ValidationResult validateOperation(Operation *op,
                                    const OpConfig &config,
                                    uint64_t additionalL1Usage = 0);
 
-// Stateful (build-from-records) validation for the L1 spill path. Routes to the
-// uncached getOpConstraintsWithState, evaluating the op against `liveRecords`
-// (the allocations already live in L1). An empty liveRecords is equivalent to
-// the stateless query.
+// Stateful (build-from-records) validation for the L1 spill path. Issues an
+// uncached getOpConstraints query that evaluates the op against `liveRecords`
+// (the allocations already live in L1) and reports outputAllocations. Selecting
+// this overload -- not the contents of `liveRecords` -- is what makes the query
+// stateful: an EMPTY liveRecords is still a stateful query, which is how the
+// spill path bootstraps its record set off the first op. Use the overload above
+// for a stateless query.
 ValidationResult
 validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                   const OpConfig &config,
@@ -190,7 +193,8 @@ ValidationResult checkConstraintsResult(
 // the forwarded arguments, then validates the result against the L1 memory
 // budget.  |contextOp| is any operation in the module (e.g. the consumer) and
 // is used only to look up device/module attributes — it is NOT the operation
-// being validated.
+// being validated. Stateless by construction: no allocator state is forwarded,
+// so getOpConstraints takes its defaulted null state.
 template <typename OpType, typename... Args>
 ValidationResult validateOperation(Operation *contextOp,
                                    uint64_t additionalL1Usage, Args &&...args) {

--- a/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
@@ -11,6 +11,17 @@
 
 namespace mlir::tt::ttnn::op_model {
 
+// tt-mlir-side mirror of tt-metal's experimental::AllocationRecord. Kept as a
+// plain POD of dialect/scalar types so this broadly-included header stays free
+// of any tt-metalium include (which would pull a global ::tt into every
+// translation unit). Conversion to/from the metal type happens behind the
+// op-model boundary in TTNNOpModel.cpp.
+struct OpModelAllocationRecord {
+  tt::ttnn::BufferType bufferType = tt::ttnn::BufferType::L1;
+  uint64_t address = 0;
+  uint64_t sizePerBank = 0;
+};
+
 /*
  * OpConstraints struct is used to store the constraints of an operation.
  * It is returned by the getOpConstraints method of the OpModel interface.
@@ -27,20 +38,26 @@ struct OpConstraints {
   llvm::SmallVector<tt::ttnn::TTNNLayoutAttr>
       outputLayouts; // Layouts of all output tensors (one layout per output
                      // tensor)
+  // Per-output-buffer allocation records produced by a stateful
+  // (build-from-records) query. Empty on the stateless path. The L1 spill path
+  // keeps these for still-live tensors and rebuilds allocator state from them.
+  llvm::SmallVector<OpModelAllocationRecord> outputAllocations;
   // ---------------------------------------------------------------------------
   // Parameterized constructor, should be used in most cases
   OpConstraints(size_t cbPeak, size_t tensorPeak, size_t peakMemory,
                 size_t outputBuffer,
-                llvm::SmallVector<tt::ttnn::TTNNLayoutAttr> layouts)
+                llvm::SmallVector<tt::ttnn::TTNNLayoutAttr> layouts,
+                llvm::SmallVector<OpModelAllocationRecord> allocations = {})
       : cbL1PeakSize(cbPeak), tensorL1PeakSize(tensorPeak),
         peakL1MemorySize(peakMemory), outputL1BufferSize(outputBuffer),
-        outputLayouts(std::move(layouts)) {}
+        outputLayouts(std::move(layouts)),
+        outputAllocations(std::move(allocations)) {}
   // ---------------------------------------------------------------------------
   // Default constructor, should be used only when the default value is intended
   // to be used, eg. when TTMLIR_ENABLE_OPMODEL is not defined.
   OpConstraints()
       : cbL1PeakSize(0), tensorL1PeakSize(0), peakL1MemorySize(0),
-        outputL1BufferSize(0), outputLayouts({}) {}
+        outputL1BufferSize(0), outputLayouts({}), outputAllocations({}) {}
 };
 
 } // namespace mlir::tt::ttnn::op_model

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -502,7 +502,8 @@ struct QuantizationOpModel {
       llvm::ArrayRef<int64_t> scaleShape, TTNNLayoutAttr scaleLayout,
       llvm::ArrayRef<int64_t> zeroPointShape, TTNNLayoutAttr zeroPointLayout,
       std::optional<int32_t> axis, std::optional<ttcore::DataType> outputDtype,
-      TTNNLayoutAttr outputLayout);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1437,7 +1438,8 @@ struct OpModel<Conv1dOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -1004,7 +1004,8 @@ struct OpModel<IndexerScoreDsaOp> {
       llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
       llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
       llvm::ArrayRef<int64_t> weightsShape, TTNNLayoutAttr weightsLayout,
-      uint32_t chunkStartIdx, TTNNLayoutAttr outputLayout);
+      uint32_t chunkStartIdx, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -56,10 +56,16 @@ namespace mlir::tt::ttnn::op_model {
 using MockAllocatorState = ::tt::tt_metal::experimental::MockAllocatorState;
 
 // Build a MockAllocatorState representing the given live allocations, for the
-// stateful (build-from-records) constraint query. Returns null when
-// `liveRecords` is empty (equivalent to a stateless query). Confines all
-// tt-metalium interaction (extract + with_allocations + record conversion) to
-// the op-model boundary; callers pass/receive the opaque handle only.
+// stateful (build-from-records) constraint query. Confines all tt-metalium
+// interaction (extract + with_allocations + record conversion) to the op-model
+// boundary; callers pass/receive the opaque handle only.
+//
+// Returns a NON-NULL state even for an empty `liveRecords`: an empty state
+// gives the same fit decision as the stateless query, but it routes through the
+// stateful query branch, which is the only branch that reports
+// output_allocations. The spill path bootstraps its record set from those, so
+// returning null here would permanently degrade it to stateless behavior (see
+// the rationale at the definition).
 std::shared_ptr<MockAllocatorState>
 buildInitialState(llvm::ArrayRef<OpModelAllocationRecord> liveRecords);
 
@@ -77,6 +83,29 @@ bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  TTNNLayoutAttr layout,
                                  ttcore::GridAttr maxGrid);
 
+//===----------------------------------------------------------------------===//
+// Op-model constraint queries
+//
+// Every family below exposes ONE constraint entry point, `getOpConstraints`,
+// whose trailing `initialState` parameter selects the query flavour:
+//
+//   * `nullptr` (the default) -- stateless query. tt-metal runs
+//     query_op_constraints under NO_DISPATCH: nothing is allocated,
+//     `outputAllocations` comes back empty, and the result is a pure function
+//     of the remaining arguments, so the interface layer caches it.
+//   * non-null -- stateful (build-from-records) query. tt-metal applies the
+//     state, then runs a NORMAL-mode capture that really allocates, so the
+//     result reflects actual L1 placement/fragmentation and reports per-output
+//     `outputAllocations`. Depends on the live set, hence never cached.
+//
+// Build the state with `buildInitialState` above; note that an empty record set
+// still yields a non-null (i.e. stateful) state on purpose.
+//
+// The families that predate the stateful spill path (creation ops,
+// quantization, Conv1d, ...) simply have no `initialState` parameter: they are
+// stateless-only, and the interface layer passes no state for them.
+//===----------------------------------------------------------------------===//
+
 template <typename OpTy>
 struct OpModel;
 
@@ -86,17 +115,10 @@ struct OpModel;
 
 template <typename OpT>
 struct UnaryEltwiseOpModel {
-  // Cache-facing (stateless) entry. Signature is kept exactly as the cache's
-  // getOrCompute invokes it (by function pointer), so it must not grow params.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
-  // initialState may be null (equivalent to the stateless query).
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -105,15 +127,10 @@ struct UnaryEltwiseOpModel {
 
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
-  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  // Stateful entry (L1 spill path); bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -223,11 +240,8 @@ template <>
 struct OpModel<SigmoidOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -243,13 +257,8 @@ struct OpModel<LeakyReluOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::APFloat slope,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
-                            TTNNLayoutAttr inputLayout, llvm::APFloat slope,
-                            TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -263,18 +272,11 @@ struct OpModel<LeakyReluOp> {
 
 template <typename OpT>
 struct BinaryEltwiseOpModel {
-  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
-
-  // Stateful entry (L1 spill path); bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
-      const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -284,18 +286,11 @@ struct BinaryEltwiseOpModel {
 
 template <typename OpT>
 struct BinaryCompositeOpModel {
-  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
-
-  // Stateful entry (L1 spill path); bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
-      const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -383,13 +378,8 @@ struct OpModel<GeluBackwardOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      std::string approximate, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       std::string approximate, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -403,19 +393,12 @@ struct OpModel<GeluBackwardOp> {
 
 template <typename OpT>
 struct TernaryEltwiseOpModel {
-  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
-      TTNNLayoutAttr outputLayout);
-
-  // Stateful entry (L1 spill path); bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -433,18 +416,12 @@ struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 template <typename OpT>
 struct ReductionOpModel {
-  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-                   TTNNLayoutAttr outputLayout);
-
-  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -473,12 +450,8 @@ struct OpModel<ArgMaxOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
-                   bool keepDim, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   bool keepDim, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -496,12 +469,8 @@ struct OpModel<ProdOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
-                   bool keepDim, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   bool keepDim, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -559,17 +528,8 @@ struct OpModel<RequantizeOp> {
       TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
       TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
       TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
-      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
-      llvm::ArrayRef<int64_t> inZeroPointShape,
-      TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
-      TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
-      TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -590,13 +550,8 @@ struct OpModel<SoftmaxOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dimArg,
-                   bool numericStable, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
-                            TTNNLayoutAttr inputLayout, const int dimArg,
-                            bool numericStable, TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   bool numericStable, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -616,14 +571,8 @@ struct OpModel<ScatterOp> {
       llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
       llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
       int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
-      llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-      int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -641,12 +590,8 @@ template <>
 struct OpModel<ReshapeOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -664,13 +609,8 @@ struct OpModel<SliceStaticOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
                    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
-      llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -689,14 +629,8 @@ struct OpModel<SliceDynamicOp> {
       llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
       llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
       std::optional<llvm::SmallVector<int64_t>> step,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
-      llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
-      std::optional<llvm::SmallVector<int64_t>> step,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -715,12 +649,8 @@ struct OpModel<BitcastConvertOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -737,12 +667,8 @@ struct OpModel<TypecastOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -758,12 +684,8 @@ template <>
 struct OpModel<ToLayoutOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -779,11 +701,8 @@ template <>
 struct OpModel<ToMemoryConfigOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -799,13 +718,8 @@ struct OpModel<ConcatOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
                    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-                            std::vector<TTNNLayoutAttr> inputLayouts,
-                            const int dim, TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
@@ -822,13 +736,8 @@ struct OpModel<TransposeOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
-                            TTNNLayoutAttr inputLayout, const int dim0,
-                            const int dim1, TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -846,12 +755,8 @@ struct OpModel<CumSumOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int32_t dim,
                    std::optional<ttcore::DataType> dtype,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      const int32_t dim, std::optional<ttcore::DataType> dtype,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -869,12 +774,8 @@ struct OpModel<CumProdOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int32_t dim,
                    std::optional<ttcore::DataType> dtype,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      const int32_t dim, std::optional<ttcore::DataType> dtype,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -890,11 +791,8 @@ template <>
 struct OpModel<ConcatenateHeadsOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -919,21 +817,8 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
                    std::optional<TTNNLayoutAttr> attentionSinkLayout,
                    std::optional<llvm::APFloat> scale,
                    std::optional<SDPAProgramConfigAttr> programConfig,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-      std::optional<TTNNLayoutAttr> curPosTensorLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-      std::optional<TTNNLayoutAttr> attentionSinkLayout,
-      std::optional<llvm::APFloat> scale,
-      std::optional<SDPAProgramConfigAttr> programConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -968,23 +853,8 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<llvm::APFloat> scale,
       std::optional<uint32_t> slidingWindowSize,
       std::optional<SDPAProgramConfigAttr> programConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-      std::optional<TTNNLayoutAttr> curPosTensorLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-      std::optional<TTNNLayoutAttr> attentionSinkLayout,
-      std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize,
-      std::optional<SDPAProgramConfigAttr> programConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -1021,22 +891,8 @@ struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
       std::optional<TTNNLayoutAttr> curPosTensorLayout,
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
-      std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      std::optional<llvm::ArrayRef<int64_t>> valueShape,
-      std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
-      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-      std::optional<TTNNLayoutAttr> curPosTensorLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-      std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -1067,17 +923,8 @@ struct OpModel<ChunkedScaledDotProductAttentionOp> {
       llvm::ArrayRef<int64_t> chunkStartIdxShape,
       TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
       std::optional<SDPAProgramConfigAttr> programConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-      llvm::ArrayRef<int64_t> chunkStartIdxShape,
-      TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
-      std::optional<SDPAProgramConfigAttr> programConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -1104,19 +951,8 @@ struct OpModel<ScaledDotProductAttentionOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
       std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
       std::optional<llvm::APFloat> scale,
-      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-      std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
-      std::optional<llvm::APFloat> scale,
       std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -1144,17 +980,8 @@ struct OpModel<FlashMlaPrefillOp> {
       std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
       std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
       bool isCausal, std::optional<llvm::APFloat> scale,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-      std::optional<llvm::ArrayRef<int64_t>> valueShape,
-      std::optional<TTNNLayoutAttr> valueLayout,
-      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-      std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
-      bool isCausal, std::optional<llvm::APFloat> scale,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -1197,15 +1024,8 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
       llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
       llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
       llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
-      bool isDecodeMode, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
-      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-      llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
       bool isDecodeMode, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1227,14 +1047,8 @@ struct OpModel<RotaryEmbeddingOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> cosShape,
                    TTNNLayoutAttr cosLayout, llvm::ArrayRef<int64_t> sinShape,
                    TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
-      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-      std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1254,15 +1068,8 @@ struct OpModel<NLPCreateQKVHeadsDecodeOp> {
       std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
       std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
       std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
-      std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
-      std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
-      std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
       std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1284,14 +1091,8 @@ struct OpModel<SplitQueryKeyValueAndSplitHeadsOp> {
                    std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
                    std::optional<TTNNLayoutAttr> inputKVLayout,
                    uint32_t numHeads, std::optional<uint32_t> numKVHeads,
-                   bool transposeKey, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
-      std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
-      std::optional<uint32_t> numKVHeads, bool transposeKey,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   bool transposeKey, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1309,11 +1110,8 @@ template <>
 struct OpModel<NLPConcatHeadsOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1328,13 +1126,8 @@ struct OpModel<NLPConcatHeadsDecodeOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, uint32_t headDim,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
-                            TTNNLayoutAttr inputLayout, uint32_t headDim,
-                            TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1351,12 +1144,8 @@ struct OpModel<RepeatInterleaveOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const unsigned int repeats,
-                   const int dim, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   const int dim, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1374,12 +1163,8 @@ struct OpModel<RepeatOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> repeats,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1397,12 +1182,8 @@ struct OpModel<PadOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int32_t> padding,
                    llvm::APFloat padValue, bool multicore,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1419,12 +1200,8 @@ struct OpModel<SortOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int dim, bool descending,
-                   bool stable, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
-      bool descending, bool stable, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   bool stable, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1443,14 +1220,8 @@ struct OpModel<TopKRouterGptOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
-      uint32_t numExperts, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
       uint32_t numExperts, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1474,18 +1245,8 @@ struct OpModel<LinearOp> {
       std::optional<llvm::StringRef> activation,
       std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-          std::nullopt);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
-      bool transposeA, bool transposeB,
-      std::optional<llvm::StringRef> activation,
-      std::optional<mlir::Attribute> programConfigAttr,
-      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
-      const MockAllocatorState *initialState);
+          std::nullopt,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -1501,7 +1262,6 @@ struct OpModel<LinearOp> {
 
 template <>
 struct OpModel<MatmulOp> {
-  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -1509,17 +1269,8 @@ struct OpModel<MatmulOp> {
       std::optional<llvm::StringRef> activation = std::nullopt,
       std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-          std::nullopt);
-
-  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-      TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
-      std::optional<llvm::StringRef> activation,
-      std::optional<mlir::Attribute> programConfigAttr,
-      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
-      const MockAllocatorState *initialState);
+          std::nullopt,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -1547,13 +1298,8 @@ struct OpModel<FillCacheOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      uint32_t batchOffset, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       uint32_t batchOffset, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1572,14 +1318,8 @@ struct OpModel<UpdateCacheOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> updateIndexShape,
       TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> updateIndexShape,
-      TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1602,16 +1342,8 @@ struct OpModel<PagedUpdateCacheOp> {
       TTNNLayoutAttr updateIndexLayout,
       std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
       std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> updateIndexShape,
-      TTNNLayoutAttr updateIndexLayout,
-      std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
-      std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1634,16 +1366,8 @@ struct OpModel<PagedFillCacheOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
       std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
-      std::optional<TTNNLayoutAttr> batchIdxLayout,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-      std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
       std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1673,21 +1397,8 @@ struct OpModel<Conv2dOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
-      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-      std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1761,22 +1472,8 @@ struct OpModel<Conv3dOp> {
       std::optional<ttcore::DataTypeAttr> outputDtype,
       std::optional<Conv3dConfigAttr> conv3dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-      uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
-      uint32_t input_height, uint32_t input_width,
-      llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, uint32_t groups,
-      llvm::StringRef padding_mode,
-      std::optional<ttcore::DataTypeAttr> outputDtype,
-      std::optional<Conv3dConfigAttr> conv3dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1811,20 +1508,8 @@ struct OpModel<ConvTranspose2dOp> {
       llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
       uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
-      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
-      uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1859,22 +1544,8 @@ struct OpModel<PrepareConv2dWeightsOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
-      MemoryConfigAttr inputMemConfig,
-      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
-      int32_t inChannels, int32_t outChannels, int32_t batchSize,
-      int32_t inputHeight, int32_t inputWidth,
-      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-      bool hasBias, int32_t groups, ttcore::DataType inputDtype,
-      std::optional<ttcore::DataType> outputDtype,
-      std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1894,20 +1565,8 @@ struct OpModel<PrepareConv2dBiasOp> {
       ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
-      MemoryConfigAttr inputMemConfig,
-      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
-      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
-      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, int32_t groups,
-      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-      std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1929,22 +1588,8 @@ struct OpModel<PrepareConvTranspose2dWeightsOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
-      MemoryConfigAttr inputMemConfig,
-      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
-      int32_t inChannels, int32_t outChannels, int32_t batchSize,
-      int32_t inputHeight, int32_t inputWidth,
-      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
-      llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
-      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-      std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1965,21 +1610,8 @@ struct OpModel<PrepareConvTranspose2dBiasOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
-      MemoryConfigAttr inputMemConfig,
-      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
-      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
-      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, int32_t groups,
-      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-      std::optional<Conv2dConfigAttr> conv2dConfig,
-      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1995,16 +1627,8 @@ struct OpModel<PrepareMoEComputeW0W1WeightsOp> {
                    std::optional<TTNNLayoutAttr> bias0Layout,
                    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
                    std::optional<TTNNLayoutAttr> bias1Layout,
-                   uint32_t hiddenSize, uint32_t intermediateSize);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
-      llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
-      std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
-      std::optional<TTNNLayoutAttr> bias0Layout,
-      std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
-      std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-      uint32_t intermediateSize, const MockAllocatorState *initialState);
+                   uint32_t hiddenSize, uint32_t intermediateSize,
+                   const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -2017,13 +1641,8 @@ struct OpModel<PrepareMoEComputeW2WeightsOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
                    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
                    std::optional<TTNNLayoutAttr> bias2Layout,
-                   uint32_t hiddenSize, uint32_t intermediateSize);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
-      std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
-      std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-      uint32_t intermediateSize, const MockAllocatorState *initialState);
+                   uint32_t hiddenSize, uint32_t intermediateSize,
+                   const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -2039,16 +1658,8 @@ struct OpModel<MaxPool2dOp> {
       llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
       llvm::ArrayRef<int32_t> dilation, bool ceilMode,
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
-      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2074,17 +1685,8 @@ struct OpModel<MaxPool2dWithIndicesOp> {
       llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
       llvm::ArrayRef<int32_t> dilation, bool ceilMode,
       bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
-      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
-      bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
       std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2110,16 +1712,8 @@ struct OpModel<AvgPool2dOp> {
       llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
       llvm::ArrayRef<int32_t> dilation, bool ceilMode,
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
-      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2140,12 +1734,8 @@ template <>
 struct OpModel<GlobalAvgPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2170,19 +1760,8 @@ struct OpModel<BatchNormInferenceOp> {
                    std::optional<TTNNLayoutAttr> weightLayout,
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout,
-                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
-      std::optional<TTNNLayoutAttr> runningMeanLayout,
-      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
-      std::optional<TTNNLayoutAttr> runningVarLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2213,20 +1792,8 @@ struct OpModel<BatchNormTrainingOp> {
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      llvm::APFloat momentum, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
-      std::optional<TTNNLayoutAttr> runningMeanLayout,
-      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
-      std::optional<TTNNLayoutAttr> runningVarLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       llvm::APFloat momentum, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2255,17 +1822,8 @@ struct OpModel<RMSNormOp> {
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       TTNNLayoutAttr outputLayout,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-          std::nullopt);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      TTNNLayoutAttr outputLayout,
-      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
-      const MockAllocatorState *initialState);
+          std::nullopt,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2289,14 +1847,8 @@ struct OpModel<RMSNormPreAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-      std::optional<TTNNLayoutAttr> residualInputLayout,
-      std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2319,15 +1871,8 @@ struct OpModel<LayerNormOp> {
                    std::optional<TTNNLayoutAttr> weightLayout,
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout,
-                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2350,16 +1895,8 @@ struct OpModel<LayerNormPreAllGatherOp> {
       std::optional<TTNNLayoutAttr> residualInputLayout,
       std::optional<llvm::ArrayRef<int64_t>> recipShape,
       std::optional<TTNNLayoutAttr> recipLayout,
-      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-      std::optional<TTNNLayoutAttr> residualInputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> recipShape,
-      std::optional<TTNNLayoutAttr> recipLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2384,16 +1921,8 @@ struct OpModel<LayerNormPostAllGatherOp> {
       std::optional<TTNNLayoutAttr> weightLayout,
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2420,18 +1949,8 @@ struct OpModel<GroupNormOp> {
                    std::optional<TTNNLayoutAttr> weightLayout,
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
-      std::optional<TTNNLayoutAttr> inputMaskLayout,
-      std::optional<llvm::ArrayRef<int64_t>> weightShape,
-      std::optional<TTNNLayoutAttr> weightLayout,
-      std::optional<llvm::ArrayRef<int64_t>> biasShape,
-      std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-      llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2453,13 +1972,8 @@ struct OpModel<ClampScalarOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute min,
-                   mlir::Attribute max, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
-                            TTNNLayoutAttr inputLayout, mlir::Attribute min,
-                            mlir::Attribute max, TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+                   mlir::Attribute max, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -2478,13 +1992,8 @@ struct OpModel<ClampTensorOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> minShape,
                    TTNNLayoutAttr minLayout, llvm::ArrayRef<int64_t> maxShape,
-                   TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
-      llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2503,12 +2012,8 @@ struct OpModel<PermuteOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2525,12 +2030,8 @@ struct OpModel<PowScalarOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute exponent,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -2547,12 +2048,8 @@ struct OpModel<UpsampleOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
-                   llvm::StringRef mode, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      mlir::Attribute scaleFactor, llvm::StringRef mode,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   llvm::StringRef mode, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -2571,12 +2068,8 @@ struct OpModel<EmbeddingOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    llvm::ArrayRef<int64_t> weightShape,
-                   TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2594,13 +2087,8 @@ struct OpModel<EmbeddingBackwardOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
-      TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-      llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2618,13 +2106,8 @@ struct OpModel<GatherOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
-      int32_t dim, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
       int32_t dim, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2676,12 +2159,8 @@ struct OpModel<mlir::tt::ttnn::FullOp> {
 template <>
 struct OpModel<ConstantOp> {
   static llvm::Expected<OpConstraints>
-  getOpConstraints(mlir::ElementsAttr value, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints>
-  getOpConstraintsWithState(mlir::ElementsAttr value,
-                            TTNNLayoutAttr outputLayout,
-                            const MockAllocatorState *initialState);
+  getOpConstraints(mlir::ElementsAttr value, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 };
 
 //===----------------------------------------------------------------------===//
@@ -2739,12 +2218,8 @@ struct OpModel<TopKOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int k, int dim, bool largest,
-                   bool sorted, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int k,
-      int dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
-      const MockAllocatorState *initialState);
+                   bool sorted, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout, int k,
@@ -2766,17 +2241,8 @@ struct OpModel<SamplingOp> {
                    llvm::ArrayRef<int64_t> kShape, TTNNLayoutAttr kLayout,
                    llvm::ArrayRef<int64_t> pShape, TTNNLayoutAttr pLayout,
                    llvm::ArrayRef<int64_t> tempShape, TTNNLayoutAttr tempLayout,
-                   std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputValuesShape,
-      TTNNLayoutAttr inputValuesLayout,
-      llvm::ArrayRef<int64_t> inputIndicesShape,
-      TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
-      TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
-      TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
-      TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputValuesShape,
@@ -2799,12 +2265,8 @@ struct OpModel<MeshPartitionOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int32_t dim,
                    std::optional<uint32_t> clusterAxis,
-                   TTNNLayoutAttr outputLayout);
-
-  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
-      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-      int32_t dim, std::optional<uint32_t> clusterAxis,
-      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -12,6 +12,9 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/Error.h"
 
+#include <memory>
+#include <optional>
+
 // Unwrap an llvm::Expected<T> expression: on success assign the value to `lhs`,
 // on failure propagate the error by returning it from the enclosing function.
 //
@@ -38,7 +41,36 @@
   _Pragma("clang diagnostic pop")
 // clang-format on
 
+// Forward declaration only. The full definition lives in tt-metalium
+// (experimental/mock_device/mock_allocator.hpp) and is only available when
+// TTMLIR_ENABLE_OPMODEL is defined. Declared here (rather than in the broadly
+// included TTNNOpConstraints.h) so the global ::tt name it introduces stays out
+// of translation units that do `using namespace mlir` and reference an
+// unqualified `tt` (which would otherwise become ambiguous with mlir::tt).
+namespace tt::tt_metal::experimental {
+class MockAllocatorState;
+} // namespace tt::tt_metal::experimental
+
 namespace mlir::tt::ttnn::op_model {
+
+using MockAllocatorState = ::tt::tt_metal::experimental::MockAllocatorState;
+
+// Build a MockAllocatorState representing the given live allocations, for the
+// stateful (build-from-records) constraint query. Returns null when
+// `liveRecords` is empty (equivalent to a stateless query). Confines all
+// tt-metalium interaction (extract + with_allocations + record conversion) to
+// the op-model boundary; callers pass/receive the opaque handle only.
+std::shared_ptr<MockAllocatorState>
+buildInitialState(llvm::ArrayRef<OpModelAllocationRecord> liveRecords);
+
+// Snapshot / restore the mock device's allocator state around a batch of
+// stateful spill queries. Those queries mutate the SHARED mock device and do
+// not restore it, which corrupts later stateless op-model queries (wrong
+// conv2d config, spurious pool/conv global-CB failures). Call snapshot before
+// the spill pass runs and restore after, so the device is byte-identical to
+// before -- matching what the stateless (scalar-spill) path leaves.
+void snapshotMockAllocatorState();
+void restoreMockAllocatorState();
 
 // Checks if the tensor layout is legal for the given tensor shape.
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
@@ -54,9 +86,17 @@ struct OpModel;
 
 template <typename OpT>
 struct UnaryEltwiseOpModel {
+  // Cache-facing (stateless) entry. Signature is kept exactly as the cache's
+  // getOrCompute invokes it (by function pointer), so it must not grow params.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  // initialState may be null (equivalent to the stateless query).
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -65,9 +105,15 @@ struct UnaryEltwiseOpModel {
 
 template <typename OpT>
 struct UnaryEltwiseWithFastApproxModeOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -179,6 +225,10 @@ struct OpModel<SigmoidOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -195,6 +245,12 @@ struct OpModel<LeakyReluOp> {
                    TTNNLayoutAttr inputLayout, llvm::APFloat slope,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, llvm::APFloat slope,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              llvm::APFloat slope,
@@ -207,10 +263,18 @@ struct OpModel<LeakyReluOp> {
 
 template <typename OpT>
 struct BinaryEltwiseOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -220,10 +284,18 @@ struct BinaryEltwiseOpModel {
 
 template <typename OpT>
 struct BinaryCompositeOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr = nullptr);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -313,6 +385,12 @@ struct OpModel<GeluBackwardOp> {
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       std::string approximate, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::string approximate, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
                llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -325,11 +403,19 @@ struct OpModel<GeluBackwardOp> {
 
 template <typename OpT>
 struct TernaryEltwiseOpModel {
+  // Cache-facing stateless entry (forwards to the stateful body with null).
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
       llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
       TTNNLayoutAttr outputLayout);
+
+  // Stateful entry (L1 spill path); bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -347,11 +433,18 @@ struct OpModel<WhereOp> : TernaryEltwiseOpModel<WhereOp> {};
 
 template <typename OpT>
 struct ReductionOpModel {
+  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout,
                    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
                    TTNNLayoutAttr outputLayout);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -382,6 +475,11 @@ struct OpModel<ArgMaxOp> {
                    TTNNLayoutAttr inputLayout, std::optional<int32_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              std::optional<int32_t> dim,
@@ -399,6 +497,11 @@ struct OpModel<ProdOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, std::optional<int64_t> dim,
                    bool keepDim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -458,6 +561,16 @@ struct OpModel<RequantizeOp> {
       TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+      llvm::ArrayRef<int64_t> inZeroPointShape,
+      TTNNLayoutAttr inZeroPointLayout, llvm::ArrayRef<int64_t> outScaleShape,
+      TTNNLayoutAttr outScaleLayout, llvm::ArrayRef<int64_t> outZeroPointShape,
+      TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
+      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
@@ -479,6 +592,12 @@ struct OpModel<SoftmaxOp> {
                    TTNNLayoutAttr inputLayout, const int dimArg,
                    bool numericStable, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, const int dimArg,
+                            bool numericStable, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              const int dimArg,
@@ -499,6 +618,13 @@ struct OpModel<ScatterOp> {
       int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+      int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
@@ -517,6 +643,11 @@ struct OpModel<ReshapeOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> outputShape,
@@ -534,6 +665,12 @@ struct OpModel<SliceStaticOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> begins,
                    llvm::ArrayRef<int64_t> ends, llvm::ArrayRef<int64_t> step,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+      llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -554,6 +691,13 @@ struct OpModel<SliceDynamicOp> {
       std::optional<llvm::SmallVector<int64_t>> step,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+      llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+      std::optional<llvm::SmallVector<int64_t>> step,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
@@ -573,6 +717,11 @@ struct OpModel<BitcastConvertOp> {
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              ttcore::DataTypeAttr dtype,
@@ -590,6 +739,11 @@ struct OpModel<TypecastOp> {
                    TTNNLayoutAttr inputLayout, ttcore::DataTypeAttr dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              ttcore::DataTypeAttr dtype,
@@ -605,6 +759,11 @@ struct OpModel<ToLayoutOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -622,6 +781,10 @@ struct OpModel<ToMemoryConfigOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -637,6 +800,12 @@ struct OpModel<ConcatOp> {
   getOpConstraints(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
                    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+                            std::vector<TTNNLayoutAttr> inputLayouts,
+                            const int dim, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(std::vector<llvm::ArrayRef<int64_t>> inputShapes,
@@ -654,6 +823,12 @@ struct OpModel<TransposeOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const int dim0, const int dim1,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, const int dim0,
+                            const int dim1, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -673,6 +848,11 @@ struct OpModel<CumSumOp> {
                    std::optional<ttcore::DataType> dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const int32_t dim, std::optional<ttcore::DataType> dtype,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                const int32_t dim, std::optional<ttcore::DataType> dtype,
@@ -691,6 +871,11 @@ struct OpModel<CumProdOp> {
                    std::optional<ttcore::DataType> dtype,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const int32_t dim, std::optional<ttcore::DataType> dtype,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                const int32_t dim, std::optional<ttcore::DataType> dtype,
@@ -706,6 +891,10 @@ struct OpModel<ConcatenateHeadsOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -731,6 +920,20 @@ struct OpModel<ScaledDotProductAttentionDecodeOp> {
                    std::optional<llvm::APFloat> scale,
                    std::optional<SDPAProgramConfigAttr> programConfig,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -766,6 +969,22 @@ struct OpModel<PagedScaledDotProductAttentionDecodeOp> {
       std::optional<uint32_t> slidingWindowSize,
       std::optional<SDPAProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale,
+      std::optional<uint32_t> slidingWindowSize,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -804,6 +1023,21 @@ struct OpModel<PagedFlashMultiLatentAttentionDecodeOp> {
       std::optional<TTNNLayoutAttr> attentionSinkLayout,
       std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      std::optional<llvm::ArrayRef<int64_t>> valueShape,
+      std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+      std::optional<TTNNLayoutAttr> curPosTensorLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout,
+      std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
                llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
@@ -835,6 +1069,16 @@ struct OpModel<ChunkedScaledDotProductAttentionOp> {
       std::optional<SDPAProgramConfigAttr> programConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      llvm::ArrayRef<int64_t> chunkStartIdxShape,
+      TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+      std::optional<SDPAProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
       llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
@@ -861,6 +1105,18 @@ struct OpModel<ScaledDotProductAttentionOp> {
       std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
       std::optional<llvm::APFloat> scale,
       std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+      std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
+      std::optional<llvm::APFloat> scale,
+      std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -889,6 +1145,16 @@ struct OpModel<FlashMlaPrefillOp> {
       std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
       bool isCausal, std::optional<llvm::APFloat> scale,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      std::optional<llvm::ArrayRef<int64_t>> valueShape,
+      std::optional<TTNNLayoutAttr> valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
+      bool isCausal, std::optional<llvm::APFloat> scale,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
@@ -933,6 +1199,14 @@ struct OpModel<RotaryEmbeddingLlamaOp> {
       llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
       bool isDecodeMode, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+      bool isDecodeMode, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
@@ -955,6 +1229,13 @@ struct OpModel<RotaryEmbeddingOp> {
                    TTNNLayoutAttr sinLayout, std::optional<uint32_t> tokenIndex,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+      llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+      std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
@@ -974,6 +1255,14 @@ struct OpModel<NLPCreateQKVHeadsDecodeOp> {
       std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
       std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
       std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
+      std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
+      std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
+      std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -997,6 +1286,13 @@ struct OpModel<SplitQueryKeyValueAndSplitHeadsOp> {
                    uint32_t numHeads, std::optional<uint32_t> numKVHeads,
                    bool transposeKey, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
+      std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
+      std::optional<uint32_t> numKVHeads, bool transposeKey,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
@@ -1015,6 +1311,10 @@ struct OpModel<NLPConcatHeadsOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              TTNNLayoutAttr outputLayout);
@@ -1029,6 +1329,12 @@ struct OpModel<NLPConcatHeadsDecodeOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, uint32_t headDim,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, uint32_t headDim,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1046,6 +1352,11 @@ struct OpModel<RepeatInterleaveOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, const unsigned int repeats,
                    const int dim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1065,6 +1376,11 @@ struct OpModel<RepeatOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> repeats,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              llvm::ArrayRef<int64_t> repeats,
@@ -1083,6 +1399,11 @@ struct OpModel<PadOp> {
                    llvm::APFloat padValue, bool multicore,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue,
@@ -1099,6 +1420,11 @@ struct OpModel<SortOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, int dim, bool descending,
                    bool stable, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
+      bool descending, bool stable, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1118,6 +1444,13 @@ struct OpModel<TopKRouterGptOp> {
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
       llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
       uint32_t numExperts, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+      uint32_t numExperts, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1143,6 +1476,17 @@ struct OpModel<LinearOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+      bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
                llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -1157,6 +1501,7 @@ struct OpModel<LinearOp> {
 
 template <>
 struct OpModel<MatmulOp> {
+  // Cache-facing (stateless) entry; signature unchanged for getOrCompute.
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
       llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -1165,6 +1510,16 @@ struct OpModel<MatmulOp> {
       std::optional<mlir::Attribute> programConfigAttr = std::nullopt,
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
+
+  // Stateful entry used by the L1 spill path; bypasses the op-model cache.
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+      llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+      TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+      std::optional<llvm::StringRef> activation,
+      std::optional<mlir::Attribute> programConfigAttr,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
@@ -1194,6 +1549,12 @@ struct OpModel<FillCacheOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       uint32_t batchOffset, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
                llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1212,6 +1573,13 @@ struct OpModel<UpdateCacheOp> {
       llvm::ArrayRef<int64_t> updateIndexShape,
       TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
+      TTNNLayoutAttr updateIndexLayout, uint32_t batchOffset,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1236,6 +1604,15 @@ struct OpModel<PagedUpdateCacheOp> {
       std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> updateIndexShape,
+      TTNNLayoutAttr updateIndexLayout,
+      std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
+      std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
                llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1259,6 +1636,14 @@ struct OpModel<PagedFillCacheOp> {
       std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
       std::optional<TTNNLayoutAttr> batchIdxLayout,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+      std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
+      std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
@@ -1289,6 +1674,20 @@ struct OpModel<Conv2dOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1364,6 +1763,21 @@ struct OpModel<Conv3dOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
+      uint32_t input_height, uint32_t input_width,
+      llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, uint32_t groups,
+      llvm::StringRef padding_mode,
+      std::optional<ttcore::DataTypeAttr> outputDtype,
+      std::optional<Conv3dConfigAttr> conv3dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1399,6 +1813,19 @@ struct OpModel<ConvTranspose2dOp> {
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+      uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+      uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+      uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1433,6 +1860,21 @@ struct OpModel<PrepareConv2dWeightsOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
+      int32_t inChannels, int32_t outChannels, int32_t batchSize,
+      int32_t inputHeight, int32_t inputWidth,
+      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+      bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+      std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1453,6 +1895,19 @@ struct OpModel<PrepareConv2dBiasOp> {
       std::optional<Conv2dConfigAttr> conv2dConfig,
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
+      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
+      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1475,6 +1930,21 @@ struct OpModel<PrepareConvTranspose2dWeightsOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, llvm::StringRef weightsFormat,
+      int32_t inChannels, int32_t outChannels, int32_t batchSize,
+      int32_t inputHeight, int32_t inputWidth,
+      llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+      llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+      llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1496,6 +1966,20 @@ struct OpModel<PrepareConvTranspose2dBiasOp> {
       std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
       std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+      MemoryConfigAttr inputMemConfig,
+      ::mlir::tt::ttnn::Layout inputTensorLayout, int32_t inChannels,
+      int32_t outChannels, int32_t batchSize, int32_t inputHeight,
+      int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, int32_t groups,
+      ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+      std::optional<Conv2dConfigAttr> conv2dConfig,
+      std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+      std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1512,6 +1996,15 @@ struct OpModel<PrepareMoEComputeW0W1WeightsOp> {
                    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
                    std::optional<TTNNLayoutAttr> bias1Layout,
                    uint32_t hiddenSize, uint32_t intermediateSize);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
+      llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
+      std::optional<TTNNLayoutAttr> bias0Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
+      std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
+      uint32_t intermediateSize, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1525,6 +2018,12 @@ struct OpModel<PrepareMoEComputeW2WeightsOp> {
                    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
                    std::optional<TTNNLayoutAttr> bias2Layout,
                    uint32_t hiddenSize, uint32_t intermediateSize);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
+      std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
+      std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
+      uint32_t intermediateSize, const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -1541,6 +2040,15 @@ struct OpModel<MaxPool2dOp> {
       llvm::ArrayRef<int32_t> dilation, bool ceilMode,
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1568,6 +2076,16 @@ struct OpModel<MaxPool2dWithIndicesOp> {
       bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
       std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, bool deallocateInput, bool returnIndices,
+      std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
@@ -1594,6 +2112,15 @@ struct OpModel<AvgPool2dOp> {
       bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+      int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+      llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+      llvm::ArrayRef<int32_t> dilation, bool ceilMode,
+      bool reallocateHaloOutput, std::optional<bool> configTensorsInDram,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
@@ -1614,6 +2141,11 @@ struct OpModel<GlobalAvgPool2dOp> {
   static llvm::Expected<OpConstraints> getOpConstraints(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1639,6 +2171,18 @@ struct OpModel<BatchNormInferenceOp> {
                    std::optional<llvm::ArrayRef<int64_t>> biasShape,
                    std::optional<TTNNLayoutAttr> biasLayout,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+      std::optional<TTNNLayoutAttr> runningMeanLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+      std::optional<TTNNLayoutAttr> runningVarLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1671,6 +2215,19 @@ struct OpModel<BatchNormTrainingOp> {
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       llvm::APFloat momentum, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+      std::optional<TTNNLayoutAttr> runningMeanLayout,
+      std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+      std::optional<TTNNLayoutAttr> runningVarLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      llvm::APFloat momentum, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
@@ -1700,6 +2257,16 @@ struct OpModel<RMSNormOp> {
       std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
           std::nullopt);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout,
+      std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       std::optional<llvm::ArrayRef<int64_t>> weightShape,
@@ -1724,6 +2291,13 @@ struct OpModel<RMSNormPreAllGatherOp> {
       std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
@@ -1747,6 +2321,14 @@ struct OpModel<LayerNormOp> {
                    std::optional<TTNNLayoutAttr> biasLayout,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> weightShape,
@@ -1769,6 +2351,15 @@ struct OpModel<LayerNormPreAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> recipShape,
       std::optional<TTNNLayoutAttr> recipLayout,
       std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+      std::optional<TTNNLayoutAttr> residualInputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> recipShape,
+      std::optional<TTNNLayoutAttr> recipLayout,
+      std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1794,6 +2385,15 @@ struct OpModel<LayerNormPostAllGatherOp> {
       std::optional<llvm::ArrayRef<int64_t>> biasShape,
       std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
       TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1822,6 +2422,17 @@ struct OpModel<GroupNormOp> {
                    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
                    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+      std::optional<TTNNLayoutAttr> inputMaskLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> biasShape,
+      std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+      llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
@@ -1844,6 +2455,12 @@ struct OpModel<ClampScalarOp> {
                    TTNNLayoutAttr inputLayout, mlir::Attribute min,
                    mlir::Attribute max, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(llvm::ArrayRef<int64_t> inputShape,
+                            TTNNLayoutAttr inputLayout, mlir::Attribute min,
+                            mlir::Attribute max, TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              mlir::Attribute min,
@@ -1862,6 +2479,12 @@ struct OpModel<ClampTensorOp> {
                    TTNNLayoutAttr inputLayout, llvm::ArrayRef<int64_t> minShape,
                    TTNNLayoutAttr minLayout, llvm::ArrayRef<int64_t> maxShape,
                    TTNNLayoutAttr maxLayout, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
+      llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -1882,6 +2505,11 @@ struct OpModel<PermuteOp> {
                    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
@@ -1899,6 +2527,11 @@ struct OpModel<PowScalarOp> {
                    TTNNLayoutAttr inputLayout, mlir::Attribute exponent,
                    TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
                                              mlir::Attribute exponent,
@@ -1915,6 +2548,11 @@ struct OpModel<UpsampleOp> {
   getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                    TTNNLayoutAttr inputLayout, mlir::Attribute scaleFactor,
                    llvm::StringRef mode, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      mlir::Attribute scaleFactor, llvm::StringRef mode,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout,
@@ -1935,6 +2573,11 @@ struct OpModel<EmbeddingOp> {
                    llvm::ArrayRef<int64_t> weightShape,
                    TTNNLayoutAttr weightLayout, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1953,6 +2596,12 @@ struct OpModel<EmbeddingBackwardOp> {
       llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
       TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+      llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
                llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
@@ -1970,6 +2619,12 @@ struct OpModel<GatherOp> {
       llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
       llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
       int32_t dim, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+      int32_t dim, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
@@ -2022,6 +2677,11 @@ template <>
 struct OpModel<ConstantOp> {
   static llvm::Expected<OpConstraints>
   getOpConstraints(mlir::ElementsAttr value, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints>
+  getOpConstraintsWithState(mlir::ElementsAttr value,
+                            TTNNLayoutAttr outputLayout,
+                            const MockAllocatorState *initialState);
 };
 
 //===----------------------------------------------------------------------===//
@@ -2081,6 +2741,11 @@ struct OpModel<TopKOp> {
                    TTNNLayoutAttr inputLayout, int k, int dim, bool largest,
                    bool sorted, TTNNLayoutAttr outputLayout);
 
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int k,
+      int dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState);
+
   static llvm::Expected<size_t> getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
                                              TTNNLayoutAttr inputLayout, int k,
                                              int dim, bool largest, bool sorted,
@@ -2102,6 +2767,16 @@ struct OpModel<SamplingOp> {
                    llvm::ArrayRef<int64_t> pShape, TTNNLayoutAttr pLayout,
                    llvm::ArrayRef<int64_t> tempShape, TTNNLayoutAttr tempLayout,
                    std::optional<uint32_t> seed, TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputValuesShape,
+      TTNNLayoutAttr inputValuesLayout,
+      llvm::ArrayRef<int64_t> inputIndicesShape,
+      TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+      TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+      TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+      TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputValuesShape,
@@ -2125,6 +2800,11 @@ struct OpModel<MeshPartitionOp> {
                    TTNNLayoutAttr inputLayout, int32_t dim,
                    std::optional<uint32_t> clusterAxis,
                    TTNNLayoutAttr outputLayout);
+
+  static llvm::Expected<OpConstraints> getOpConstraintsWithState(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t dim, std::optional<uint32_t> clusterAxis,
+      TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -1971,8 +1971,10 @@ MockAllocatorL1Tracker::validate(Operation *op,
   // Flatten the currently-live L1 allocations into the stateful query's initial
   // state. Aliases share their owner's record (no separate entry), so there is
   // no duplication. additionalL1Usage is 0: the live set is encoded in the
-  // records. Ops that don't override the stateful interface method fall back to
-  // the (cached) stateless query and return no records.
+  // records. Note that `flat` is empty on the first op of a run -- that is
+  // still a STATEFUL query (this overload selects the flavour), which is how
+  // the record set below bootstraps. Ops that are intentionally stateless
+  // ignore the records and return none.
   llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
   for (const auto &entry : liveRecords) {
     flat.append(entry.second.begin(), entry.second.end());

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -266,11 +266,11 @@ SumL1MemoryTracker::wouldAllocateAt(uint64_t l1SizePerCore) const {
 }
 
 //===----------------------------------------------------------------------===//
-// L1SpillManagement
+// L1SpillManagementBase
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-L1SpillManagement<MemoryTracker>::L1SpillManagement(
+L1SpillManagementBase<MemoryTracker>::L1SpillManagementBase(
     func::FuncOp func, ttcore::GridAttr deviceGrid, uint64_t l1BudgetPerCore,
     std::unique_ptr<L1SpillObserver> observer)
     : func(func), deviceGrid(deviceGrid), l1BudgetPerCore(l1BudgetPerCore),
@@ -290,7 +290,7 @@ L1SpillManagement<MemoryTracker>::L1SpillManagement(
 
 template <typename MemoryTracker>
 OpConfig
-L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
+L1SpillManagementBase<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
   if (op->getNumResults() == 0) {
     return OpConfig{};
   }
@@ -336,7 +336,7 @@ L1SpillManagement<MemoryTracker>::extractOpConfigFromIR(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
+Value L1SpillManagementBase<MemoryTracker>::evictFarthestUse() {
   while (!liveSet.empty()) {
     auto [lastUse, candidateVal] = liveSet.top();
     liveSet.pop();
@@ -363,7 +363,7 @@ Value L1SpillManagement<MemoryTracker>::evictFarthestUse() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::applyOutputConfig(
+void L1SpillManagementBase<MemoryTracker>::applyOutputConfig(
     Operation *op, const op_constraint_validation::ValidationResult &result) {
   TTNNLayoutAttr chosenLayout = result.getFirstActualOutputLayout();
   if (!chosenLayout) {
@@ -404,7 +404,7 @@ void L1SpillManagement<MemoryTracker>::applyOutputConfig(
 
 template <typename MemoryTracker>
 llvm::SmallVector<Operation *>
-L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
+L1SpillManagementBase<MemoryTracker>::collectDownstreamConsumers(
     Operation *changed) {
   // After spillToDram, a result may have a ToMemoryConfigOp user (spill op).
   // Follow through spill ops to find the actual downstream consumers.
@@ -428,7 +428,7 @@ L1SpillManagement<MemoryTracker>::collectDownstreamConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::revalidateConsumers(
+void L1SpillManagementBase<MemoryTracker>::revalidateConsumers(
     Operation *changedOp, int64_t currentPos,
     const llvm::DenseMap<Operation *, int64_t> &positionMap) {
   // Worklist of ops whose output changed — seed with the victim/changed op.
@@ -507,8 +507,8 @@ void L1SpillManagement<MemoryTracker>::revalidateConsumers(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-typename L1SpillManagement<MemoryTracker>::ScheduleData
-L1SpillManagement<MemoryTracker>::buildScheduleData() {
+typename L1SpillManagementBase<MemoryTracker>::ScheduleData
+L1SpillManagementBase<MemoryTracker>::buildScheduleData() {
   ScheduleData data;
 
   // Build schedule (ops in IR order = topological order). Include sink ops
@@ -546,7 +546,7 @@ L1SpillManagement<MemoryTracker>::buildScheduleData() {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::processDeadTensors(
+void L1SpillManagementBase<MemoryTracker>::processDeadTensors(
     int64_t pos, const ScheduleData &data) {
   auto it = data.deathSchedule.find(pos - 1);
   if (it == data.deathSchedule.end()) {
@@ -571,23 +571,75 @@ void L1SpillManagement<MemoryTracker>::processDeadTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::willAliasSourceInL1(
+bool AddressSimSpillManagement<MemoryTracker>::willAliasSourceInL1(
     Operation *op) const {
-  // canReshapeBeView already guarantees op is a ReshapeOp with operand(0).
-  // Use hasTensorAddress (not hasTensor): aliasing calls allocateAddressAt,
-  // which requires the source to occupy a simulated address slot. A tensor
-  // can be size-tracked but not address-tracked (e.g. zero-size or no-fit),
-  // in which case it cannot be aliased. This matches the replay path.
-  return canReshapeBeView(op) &&
+  // isAliasingViewOp guarantees op is a view op (reshape/pad/repeat/permute)
+  // that aliases its input operand(0). Use hasTensorAddress (not hasTensor):
+  // aliasing calls allocateAddressAt, which requires the source to occupy a
+  // simulated address slot. A tensor can be size-tracked but not
+  // address-tracked (e.g. zero-size or no-fit), in which case it cannot be
+  // aliased. This matches the replay path.
+  return isAliasingViewOp(op) &&
          memoryTracker.hasTensorAddress(op->getOperand(0));
 }
 
+//===----------------------------------------------------------------------===//
+// Hooks (default = address-sim path)
+//===----------------------------------------------------------------------===//
+
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
-                                                        int64_t pos,
-                                                        ScheduleData &data,
-                                                        uint64_t cbPeakUsage,
-                                                        uint64_t l1Size) {
+uint64_t AddressSimSpillManagement<MemoryTracker>::placeValidatedOutput(
+    Operation *op, int64_t pos, ScheduleData &data,
+    const op_constraint_validation::ValidationResult &result) {
+  return ensureFitsL1(op, pos, data, result.cbPeakUsage, result.outputL1Usage);
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::handleUnvalidatedL1Output(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t derivedL1) {
+  // Pre-decomposition ToLayoutOp: no validation result, so CB peak is 0. Run
+  // the contiguous-fit check to make room if needed.
+  ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
+    ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
+  handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::commitAllocation(
+    Value val, uint64_t perResultL1, ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // Snapshot before allocation and record event for replay.
+  allocEventIndex[val] = l1EventLog.size();
+  addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
+  l1EventLog.push_back({L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
+
+  // View-eligible reshape: alias src's buffer instead of carving a fresh slot.
+  // Must stay in sync with the willAliasSourceInL1 short-circuit in
+  // ensureFitsL1.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && willAliasSourceInL1(defOp)) {
+    memoryTracker.addTensorAtAddress(val, perResultL1, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
+template <typename MemoryTracker>
+uint64_t AddressSimSpillManagement<MemoryTracker>::ensureFitsL1(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
+    uint64_t l1Size) {
   // A view-eligible reshape aliases its source's existing L1 slot
   // (addResultsToLiveSet uses addTensorAtAddress), so it consumes no fresh
   // L1. Skip the fit / CB-overlap checks that assume a new allocation —
@@ -620,7 +672,7 @@ uint64_t L1SpillManagement<MemoryTracker>::ensureFitsL1(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::handleOOM(
+void AddressSimSpillManagement<MemoryTracker>::handleOOM(
     Operation *op, int64_t pos, llvm::ArrayRef<OpResult> tensorResults,
     ScheduleData &data, std::function<void(uint64_t)> addResultsToLiveSet) {
   observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
@@ -689,8 +741,8 @@ void L1SpillManagement<MemoryTracker>::handleOOM(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
-                                                          L1Event event) {
+void L1SpillManagementBase<MemoryTracker>::insertEventIntoLog(size_t pos,
+                                                              L1Event event) {
   // Insert the event and shift every index >= pos in both index structures
   // so the invariant "addressSnapshots[i] = state before event i" and
   // "allocEventIndex[v] = i <=> l1EventLog[i] is v's kAlloc" are preserved.
@@ -713,7 +765,7 @@ void L1SpillManagement<MemoryTracker>::insertEventIntoLog(size_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
+bool L1SpillManagementBase<MemoryTracker>::markEvictedAndRebuild(
     Value victim, size_t &campaignMin) {
   // O(1) lookup of victim's alloc event.
   auto idxIt = allocEventIndex.find(victim);
@@ -748,7 +800,7 @@ bool L1SpillManagement<MemoryTracker>::markEvictedAndRebuild(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
+bool AddressSimSpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
   auto snapIt = addressSnapshots.find(startIdx);
   assert(snapIt != addressSnapshots.end() &&
          "snapshot not found for replay start index");
@@ -765,11 +817,11 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
       continue;
     }
     addressSnapshots[i] = memoryTracker.takeSnapshot();
-    // View-eligible reshape: alias if src is still address-tracked in this
-    // replay (consumes no fresh L1), otherwise fresh-allocate (the
-    // counterfactual when src was evicted to DRAM).
+    // View-eligible op (reshape/pad/repeat/permute): alias if src is still
+    // address-tracked in this replay (consumes no fresh L1), otherwise
+    // fresh-allocate (the counterfactual when src was evicted to DRAM).
     Operation *defOp = l1EventLog[i].tensor.getDefiningOp();
-    if (defOp && canReshapeBeView(defOp) &&
+    if (defOp && isAliasingViewOp(defOp) &&
         memoryTracker.hasTensorAddress(defOp->getOperand(0))) {
       memoryTracker.allocateAddressAt(l1EventLog[i].tensor,
                                       defOp->getOperand(0));
@@ -796,7 +848,7 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictValue(
+bool L1SpillManagementBase<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
     Operation *skipReshardConsumer) {
   liveValues.erase(victim);
@@ -815,6 +867,26 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
 
   spillToDram(victim);
   memoryTracker.removeTensorFromSizes(victim);
+
+  // Rewind (stateful) path: the address-sim path frees the victim by marking
+  // its alloc event skipped in the replay; the rewind re-run has no such skip
+  // and re-processes the victim's op, which still produces L1. After the spill
+  // the victim's only remaining L1 use is the to_memory_config inserted right
+  // after it, so shorten its tracked lifetime to its own position — the re-run
+  // then frees it immediately (processDeadTensors) instead of keeping it live
+  // to its original far-future last use, which is what actually frees L1 for
+  // the op that triggered this eviction.
+  if (usesRewindEviction() && victimOp) {
+    int64_t victimPos = data.positionMap.lookup(victimOp);
+    auto luIt = data.lastUsePositions.find(victim);
+    if (luIt != data.lastUsePositions.end() && luIt->second != victimPos) {
+      auto &oldBucket = data.deathSchedule[luIt->second];
+      oldBucket.erase(std::remove(oldBucket.begin(), oldBucket.end(), victim),
+                      oldBucket.end());
+    }
+    data.lastUsePositions[victim] = victimPos;
+    data.deathSchedule[victimPos].push_back(victim);
+  }
 
   // Restore the original L1-sharded layout for consumers that need it:
   // - Past consumers (pos < currentPos): always restore. They were already
@@ -917,7 +989,9 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
                       originalL1Layout,
                       ttmlir::utils::volume(originalL1Layout.getGridShape()));
 
-        if (isPastConsumer) {
+        if (isPastConsumer && !usesRewindEviction()) {
+          // Address-sim path: bracket the reshard's transient occupation in the
+          // event log so replayFrom accounts for it.
           // Find the consumer's first and last output alloc event indices so
           // we can bracket the reshard's transient occupation in the log.
           size_t firstAllocIdx = std::numeric_limits<size_t>::max();
@@ -952,9 +1026,12 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
                  {L1Event::kAlloc, reshardResult, reshardSizePerCore, false}});
           }
         } else {
-          // Insert the reshard into the schedule so the forward sweep processes
-          // it naturally, adding it to liveValues and the tracker. Each
-          // insertion shifts the consumer right by one, so advance consumerPos.
+          // Future consumer, OR any consumer on the stateful rewind path:
+          // insert the reshard into the schedule so the (re-run) forward sweep
+          // processes it as an ordinary op — querying and tracking its L1
+          // buffer in schedule order. This is why the stateful path never
+          // leaves a reshard untracked (RCA #2). Each insertion shifts the
+          // consumer right by one, so advance consumerPos.
           insertReshardIntoSchedule(reshardOp, reshardResult,
                                     reshardSizePerCore, consumerPos, data);
           ++consumerPos;
@@ -963,8 +1040,16 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
     }
   }
 
-  // Apply transient event insertions largest-position-first so earlier
-  // positions are not invalidated by later insertions.
+  // Stateful (rewind) path: allocator state is rebuilt by the rewind + re-run
+  // of the forward sweep driven by recoverFromOOM. No event-log replay here,
+  // and all reshards were routed into the schedule above.
+  if (usesRewindEviction()) {
+    return true;
+  }
+
+  // Address-sim path: apply transient event insertions largest-position-first
+  // so earlier positions are not invalidated by later insertions, then rebuild
+  // via the first-fit replay.
   llvm::sort(transientInsertions,
              [](const TransientInsertion &a, const TransientInsertion &b) {
                return a.pos > b.pos;
@@ -981,7 +1066,7 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
+void L1SpillManagementBase<MemoryTracker>::insertReshardIntoSchedule(
     Operation *reshardOp, Value reshardResult, uint64_t reshardSizePerCore,
     int64_t consumerPos, ScheduleData &data) {
   // Register so evictFarthestUse and sibling eviction guards know not to
@@ -1018,10 +1103,22 @@ void L1SpillManagement<MemoryTracker>::insertReshardIntoSchedule(
   }
   newDeathSchedule[reshardLastUse].push_back(reshardResult);
   data.deathSchedule = std::move(newDeathSchedule);
+
+  // Keep position-keyed sweep checkpoints (stateful rewind path) aligned across
+  // the insertion: keys >= consumerPos shift by +1, mirroring positionMap.
+  // Empty (a no-op) on the Sum path, which does not capture checkpoints.
+  if (!sweepCheckpoints.empty()) {
+    llvm::DenseMap<int64_t, SweepCheckpoint> shifted;
+    shifted.reserve(sweepCheckpoints.size());
+    for (auto &[k, cp] : sweepCheckpoints) {
+      shifted[k >= consumerPos ? k + 1 : k] = std::move(cp);
+    }
+    sweepCheckpoints = std::move(shifted);
+  }
 }
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::evictUntil(
+bool L1SpillManagementBase<MemoryTracker>::evictUntil(
     int64_t pos, ScheduleData &data, std::function<bool()> shouldStop) {
   // Helper: true if every remaining live value is a non-evictable inserted
   // reshard. Avoids exhausting the liveSet heap through stale entries when
@@ -1059,7 +1156,8 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
   if (!rebuildPlacedAll) {
     Operation *blockedOp = data.schedule[pos];
     blockedOp->emitError(
-        "L1SpillManagement: a live tensor has no contiguous L1 placement even "
+        "L1SpillManagementBase: a live tensor has no contiguous L1 placement "
+        "even "
         "after evicting every spillable tensor (fragmentation: a non-evictable "
         "inserted reshard or irreducible working set cannot be relocated)");
     compilationFailed = true;
@@ -1074,10 +1172,8 @@ bool L1SpillManagement<MemoryTracker>::evictUntil(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
-                                                       int64_t pos,
-                                                       ScheduleData &data,
-                                                       uint64_t outputL1Size) {
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(
+    Operation *op, int64_t pos, ScheduleData &data, uint64_t outputL1Size) {
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    NO_FIT: output {0} bytes can't fit contiguously, evicting",
                outputL1Size);
@@ -1127,7 +1223,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleNoFit(Operation *op,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
+uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     Operation *op, int64_t pos, ScheduleData &data, uint64_t cbPeakUsage,
     uint64_t outputL1Size) {
   // Add the same safety cushion as wouldCBsOverlapTensors to account for
@@ -1221,7 +1317,8 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
     }
     if (!fitsAfterSiblingSpill) {
       op->emitError(
-          "L1SpillManagement: sibling-operand spill left a live tensor with no "
+          "L1SpillManagementBase: sibling-operand spill left a live tensor "
+          "with no "
           "contiguous L1 placement (fragmentation cannot be resolved by "
           "demoting this op)");
       compilationFailed = true;
@@ -1241,7 +1338,7 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
+bool AddressSimSpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
     Operation *op, int64_t pos, uint64_t cbPeakUsage,
     uint64_t speculativeOutputAddr) {
   // Check if the op's CB region (growing bottom-up from base) would overlap
@@ -1292,7 +1389,26 @@ bool L1SpillManagement<MemoryTracker>::wouldCBsOverlapTensors(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::run() {
+void L1SpillManagementBase<MemoryTracker>::captureCheckpoint(int64_t pos) {
+  SweepCheckpoint cp;
+  cp.tracker = memoryTracker.takeSnapshot();
+  cp.liveValues = liveValues;
+  cp.liveSet = liveSet;
+  sweepCheckpoints[pos] = std::move(cp);
+}
+
+template <typename MemoryTracker>
+void L1SpillManagementBase<MemoryTracker>::restoreCheckpoint(int64_t pos) {
+  auto it = sweepCheckpoints.find(pos);
+  assert(it != sweepCheckpoints.end() &&
+         "no sweep checkpoint at rewind position");
+  memoryTracker.restoreSnapshot(it->second.tracker);
+  liveValues = it->second.liveValues;
+  liveSet = it->second.liveSet;
+}
+
+template <typename MemoryTracker>
+void L1SpillManagementBase<MemoryTracker>::run() {
   ScheduleData data = buildScheduleData();
 
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1306,6 +1422,13 @@ void L1SpillManagement<MemoryTracker>::run() {
 
   [[maybe_unused]] int64_t spillCount = 0;
 
+  // Rewind budget (stateful path): each eviction permanently moves a value from
+  // L1 to DRAM, so rewinds are bounded by the L1-resident count (<= schedule
+  // size). The generous cap is a runaway backstop, not a real limit.
+  int64_t rewindCount = 0;
+  const int64_t kMaxRewinds =
+      4 * static_cast<int64_t>(data.schedule.size()) + 64;
+
   // Farthest-last-use eviction sweep with validation-based enforcement.
   for (int64_t pos = 0; pos < static_cast<int64_t>(data.schedule.size());
        ++pos) {
@@ -1315,6 +1438,13 @@ void L1SpillManagement<MemoryTracker>::run() {
       break;
     }
     Operation *op = data.schedule[pos];
+
+    // Snapshot the full sweep state entering this position so the stateful
+    // eviction can rewind here and re-run the forward sweep. No-op for the
+    // address-sim path.
+    if (usesRewindEviction()) {
+      captureCheckpoint(pos);
+    }
 
     // Eviction can insert a reshard for `op`, shifting `op` past `pos`. Rewind
     // to the first inserted reshard (always at `pos`) so the sweep processes it
@@ -1366,7 +1496,7 @@ void L1SpillManagement<MemoryTracker>::run() {
                      memoryTracker.getOccupiedL1(), l1BudgetPerCore);
         // CBPeakUsage fixed to 0 as we have no validation result for ToLayoutOp
         // itself which is yet to be decomposed.
-        ensureFitsL1(op, pos, data, /*cbPeakUsage=*/0, derivedL1);
+        handleUnvalidatedL1Output(op, pos, data, derivedL1);
       }
 
       // Regardless of whether the ToLayoutOp's output is L1 or DRAM, we have no
@@ -1419,30 +1549,7 @@ void L1SpillManagement<MemoryTracker>::run() {
       uint64_t perResultL1 =
           numTensorResults > 0 ? totalL1 / numTensorResults : 0;
       for (auto r : tensorResults) {
-        Value val = r;
-        auto luIt = data.lastUsePositions.find(val);
-        assert(luIt != data.lastUsePositions.end() &&
-               "scheduled value missing its lastUsePositions entry");
-        int64_t resultLastUse = luIt->second;
-        // Snapshot before allocation and record event for replay.
-        allocEventIndex[val] = l1EventLog.size();
-        addressSnapshots[l1EventLog.size()] = memoryTracker.takeSnapshot();
-        l1EventLog.push_back(
-            {L1Event::kAlloc, val, perResultL1, /*skipped=*/false});
-
-        // View-eligible reshape: alias src's buffer instead of carving a
-        // fresh slot. See `addTensorAtAddress`. Must stay in sync with the
-        // willAliasSourceInL1 short-circuit in ensureFitsL1.
-        Operation *defOp = val.getDefiningOp();
-        if (defOp && willAliasSourceInL1(defOp)) {
-          memoryTracker.addTensorAtAddress(val, perResultL1,
-                                           defOp->getOperand(0));
-        } else {
-          memoryTracker.addTensor(val, perResultL1);
-        }
-
-        liveValues.insert(val);
-        liveSet.push({resultLastUse, val});
+        commitAllocation(r, perResultL1, data);
       }
     };
 
@@ -1467,14 +1574,13 @@ void L1SpillManagement<MemoryTracker>::run() {
     }
 
     if (result.isSuccess()) {
-      uint64_t l1Size = result.outputL1Usage;
-
       TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                    "    VALIDATION SUCCESS: op {0}, "
                    "cbPeakUsage={1}, outputL1={2} bytes",
-                   ttmlir::opToString(op), result.cbPeakUsage, l1Size);
+                   ttmlir::opToString(op), result.cbPeakUsage,
+                   result.outputL1Usage);
 
-      l1Size = ensureFitsL1(op, pos, data, result.cbPeakUsage, l1Size);
+      uint64_t l1Size = placeValidatedOutput(op, pos, data, result);
       if (rewindIfScheduleShifted()) {
         continue;
       }
@@ -1507,7 +1613,39 @@ void L1SpillManagement<MemoryTracker>::run() {
       continue;
     }
 
-    handleOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    recoverFromOOM(op, pos, tensorResults, data, addResultsToLiveSet);
+    // Stateful eviction requests a rewind: restore the full sweep state at the
+    // victim's position and re-run the forward sweep from there (the victim now
+    // reads DRAM, inserted reshards are ordinary schedule ops, and this op is
+    // re-reached and re-validated against the freed state). Inert on the Sum
+    // path (never sets pendingRewindTo).
+    if (pendingRewindTo) {
+      int64_t r = *pendingRewindTo;
+      pendingRewindTo.reset();
+      restoreCheckpoint(r);
+      // Drop stale checkpoints past the rewind point; the re-run recaptures
+      // them at each position it re-processes, so no checkpoint older than the
+      // current pass is ever restored.
+      llvm::SmallVector<int64_t> stale;
+      for (const auto &kv : sweepCheckpoints) {
+        if (kv.first > r) {
+          stale.push_back(kv.first);
+        }
+      }
+      for (int64_t k : stale) {
+        sweepCheckpoints.erase(k);
+      }
+      // Safety net: each eviction permanently moves one value from L1 to DRAM,
+      // so the total number of rewinds is bounded by the L1-resident tensor
+      // count. A runaway means a logic error (a re-added victim, a rewind that
+      // makes no progress); fail loudly rather than spin.
+      if (++rewindCount > kMaxRewinds) {
+        llvm_unreachable(
+            "stateful spill: rewind budget exceeded (no progress)");
+      }
+      pos = r - 1; // ++pos brings the sweep to r
+      continue;
+    }
     if (rewindIfScheduleShifted()) {
       continue;
     }
@@ -1530,7 +1668,7 @@ void L1SpillManagement<MemoryTracker>::run() {
 
 template <typename MemoryTracker>
 llvm::DenseMap<Value, int64_t>
-L1SpillManagement<MemoryTracker>::computeLastUsePositions(
+L1SpillManagementBase<MemoryTracker>::computeLastUsePositions(
     const llvm::SmallVector<Operation *> &schedule) {
   // Build position map.
   llvm::DenseMap<Operation *, int64_t> positionMap;
@@ -1571,7 +1709,7 @@ L1SpillManagement<MemoryTracker>::computeLastUsePositions(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
+void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
   for (auto opResult : op->getResults()) {
     auto tensorType = mlir::dyn_cast<RankedTensorType>(opResult.getType());
     if (!tensorType) {
@@ -1601,9 +1739,8 @@ void L1SpillManagement<MemoryTracker>::demoteToDram(Operation *op) {
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
-                                                      ScheduleData &data,
-                                                      Operation *triggerOp) {
+void L1SpillManagementBase<MemoryTracker>::evictAllFromL1(
+    int64_t pos, ScheduleData &data, Operation *triggerOp) {
   llvm::SmallVector<Operation *> evictedOps;
   for (Value victim : liveValues) {
     uint64_t freedBytes = memoryTracker.getTensorSize(victim);
@@ -1640,7 +1777,7 @@ void L1SpillManagement<MemoryTracker>::evictAllFromL1(int64_t pos,
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
+void AddressSimSpillManagement<MemoryTracker>::evictForCBOverlap(
     uint64_t cushionedCBUsage, int64_t pos, ScheduleData &data) {
   evictUntil(pos, data, [&]() {
     return cushionedCBUsage <= memoryTracker.getLowestOccupiedAddress();
@@ -1652,7 +1789,7 @@ void L1SpillManagement<MemoryTracker>::evictForCBOverlap(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
+void AddressSimSpillManagement<MemoryTracker>::evictForDramCBGrowth(
     Operation *op, int64_t pos, ScheduleData &data) {
 
   auto inputLayouts = utils::extractInputLayouts(op);
@@ -1660,10 +1797,22 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
   auto result = memoryTracker.validateBackendDirect(op, inputLayouts, config,
                                                     /*additionalL1Usage=*/0);
   if (!result.isSuccess()) {
-    op->emitError("L1SpillManagement: DRAM output config failed validation "
-                  "after demotion (")
-        << result.errorMessage << "); this indicates a compiler bug";
-    compilationFailed = true;
+    // The op's demoted (DRAM-interleaved) output config does not validate given
+    // its current inputs. This is expected for layout-constrained ops: e.g.
+    // ttnn.typecast requires input and output memory layouts to match
+    // (typecast_device_op.cpp), so a DRAM-interleaved output paired with a
+    // still-sharded L1 input is rejected. Such an op cannot be CB-managed by
+    // demoting its output. Rather than abort the whole pass, leave the op as-is
+    // and let the downstream OperationValidationAndFallback pass reconcile the
+    // layout -- the same recovery the pass gets when this op-model error is
+    // classified as a plain backend error. Aborting here instead regresses
+    // models whose CB-vs-L1 clash lands on such an op
+    // (https://github.com/tenstorrent/tt-mlir/issues/9064).
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    DRAM_CB_SKIP: {0} DRAM-output config failed validation "
+                 "after demotion ({1}); leaving op for downstream layout fixup",
+                 op->getName(),
+                 ttmlir::utils::firstNLines(result.errorMessage, 1));
     return;
   }
   if (result.cbPeakUsage == 0) {
@@ -1687,7 +1836,7 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
   // rather than emit IR that overflows L1 at runtime.
   if (!liveValues.empty() &&
       dramCBCushioned > memoryTracker.getLowestOccupiedAddress()) {
-    op->emitError("L1SpillManagement: ")
+    op->emitError("L1SpillManagementBase: ")
         << op->getName()
         << " requires an L1 input restored by an inserted reshard, but its "
            "circular-buffer region overlaps that reshard's L1 slot and the "
@@ -1702,19 +1851,19 @@ void L1SpillManagement<MemoryTracker>::evictForDramCBGrowth(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDram(Value result) {
+void L1SpillManagementBase<MemoryTracker>::spillToDram(Value result) {
   spillToDramImpl(result, /*insertBefore=*/nullptr);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramBeforeTrigger(
+void L1SpillManagementBase<MemoryTracker>::spillToDramBeforeTrigger(
     Value result, Operation *triggerOp) {
   assert(triggerOp && "spillToDramBeforeTrigger requires a non-null trigger");
   spillToDramImpl(result, triggerOp);
 }
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::spillToDramImpl(
+void L1SpillManagementBase<MemoryTracker>::spillToDramImpl(
     Value result, Operation *insertBefore) {
   Operation *defOp = result.getDefiningOp();
   RankedTensorType tensorType = mlir::cast<RankedTensorType>(result.getType());
@@ -1776,7 +1925,7 @@ void L1SpillManagement<MemoryTracker>::spillToDramImpl(
 //===----------------------------------------------------------------------===//
 
 template <typename MemoryTracker>
-void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
+void L1SpillManagementBase<MemoryTracker>::insertReshardForConsumer(
     Operation *consumer, unsigned operandIdx, TTNNLayoutAttr originalL1Layout) {
   Value spillOutput = consumer->getOperand(operandIdx);
   auto spillTensorType = mlir::cast<RankedTensorType>(spillOutput.getType());
@@ -1807,9 +1956,291 @@ void L1SpillManagement<MemoryTracker>::insertReshardForConsumer(
 }
 
 //===----------------------------------------------------------------------===//
+// MockAllocatorL1Tracker
+//===----------------------------------------------------------------------===//
+
+op_constraint_validation::ValidationResult
+MockAllocatorL1Tracker::validate(Operation *op,
+                                 llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                                 const OpConfig &config) const {
+  // Test-only hook takes precedence and is state-agnostic.
+  if (backendValidator) {
+    return backendValidator(op, inputLayouts, config, /*additionalL1Usage=*/0);
+  }
+
+  // Flatten the currently-live L1 allocations into the stateful query's initial
+  // state. Aliases share their owner's record (no separate entry), so there is
+  // no duplication. additionalL1Usage is 0: the live set is encoded in the
+  // records. Ops that don't override the stateful interface method fall back to
+  // the (cached) stateless query and return no records.
+  llvm::SmallVector<op_model::OpModelAllocationRecord> flat;
+  for (const auto &entry : liveRecords) {
+    flat.append(entry.second.begin(), entry.second.end());
+  }
+
+  op_constraint_validation::ValidationResult result =
+      op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                  flat,
+                                                  /*additionalL1Usage=*/0);
+
+  if (result.isSuccess()) {
+    // The query decides fit / fragmentation / CB-clash on the device's physical
+    // L1, but the optimizer budget reserves headroom below that (a ~0.95 cap
+    // minus reserved). Enforce that byte ceiling here so the optimizer does not
+    // pack up to the full device L1: projected peak = currently-live L1 (which
+    // includes this op's inputs) + this op's output.
+    uint64_t projected = getOccupiedL1() + result.outputL1Usage;
+    if (l1Budget > 0 && projected > l1Budget) {
+      return op_constraint_validation::ValidationResult::outOfMemoryError(
+          "stateful: projected L1 (" + std::to_string(projected) +
+          "B) exceeds optimizer budget (" + std::to_string(l1Budget) + "B)");
+    }
+    // Stash this op's output records for association at addTensor time.
+    if (!result.outputAllocations.empty()) {
+      pendingRecords[op] = RecordVec(result.outputAllocations.begin(),
+                                     result.outputAllocations.end());
+    }
+  }
+  return result;
+}
+
+op_constraint_validation::ValidationResult
+MockAllocatorL1Tracker::validateBackendDirect(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage) const {
+  if (backendValidator) {
+    return backendValidator(op, inputLayouts, config, additionalL1Usage);
+  }
+  return op_constraint_validation::validateOperation(op, inputLayouts, config,
+                                                     additionalL1Usage);
+}
+
+void MockAllocatorL1Tracker::init(uint64_t l1BudgetPerCore) {
+  l1Budget = l1BudgetPerCore;
+  liveRecords.clear();
+  pendingRecords.clear();
+  aliasOf.clear();
+  aliasRefcount.clear();
+}
+
+void MockAllocatorL1Tracker::addTensor(Value result,
+                                       uint64_t /*l1SizePerCore*/) {
+  // Associate the pending record for this result (positional: i-th tensor
+  // result <-> i-th output-buffer record). Ops that produced no records (not
+  // migrated to the stateful path) simply contribute nothing to the state.
+  Operation *op = result.getDefiningOp();
+  if (!op) {
+    return;
+  }
+  auto it = pendingRecords.find(op);
+  if (it == pendingRecords.end()) {
+    return;
+  }
+  const unsigned idx = mlir::cast<OpResult>(result).getResultNumber();
+  if (idx < it->second.size()) {
+    liveRecords[result] = RecordVec{it->second[idx]};
+    aliasOf[result] = result;
+    aliasRefcount[result] = 1;
+  }
+  // The pending stash for `op` is only needed to associate its records to its
+  // tensor results, which happens right after the validate() that produced it
+  // (both the forward-sweep commit and the revalidation cascade call validate()
+  // immediately before addTensor()). Drop the entry once the op's last tensor
+  // result has been associated so pendingRecords does not accumulate a stale
+  // entry per op visited over the pass. Results are committed in ascending
+  // order in both paths, so once the highest-numbered tensor result is reached
+  // every earlier result of this op has already been associated, and no further
+  // addTensor() for `op` runs before its next validate() re-stashes -- so this
+  // never orphans an association.
+  bool isLastTensorResult = true;
+  for (unsigned i = idx + 1, e = op->getNumResults(); i < e; ++i) {
+    if (mlir::isa<RankedTensorType>(op->getResult(i).getType())) {
+      isLastTensorResult = false;
+      break;
+    }
+  }
+  if (isLastTensorResult) {
+    pendingRecords.erase(it);
+  }
+}
+
+void MockAllocatorL1Tracker::addTensorAlias(Value out, Value src) {
+  // A view op's output shares src's buffer: add no new record, just bump the
+  // owner's live-aliaser refcount so the record survives until the last
+  // aliaser dies.
+  auto ownerIt = aliasOf.find(src);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : src;
+  aliasOf[out] = owner;
+  ++aliasRefcount[owner];
+}
+
+void MockAllocatorL1Tracker::removeTensor(Value result) {
+  auto ownerIt = aliasOf.find(result);
+  if (ownerIt == aliasOf.end()) {
+    // Untracked (op produced no records). Nothing to drop.
+    liveRecords.erase(result);
+    return;
+  }
+  Value owner = ownerIt->second;
+  aliasOf.erase(ownerIt);
+  auto rcIt = aliasRefcount.find(owner);
+  if (rcIt != aliasRefcount.end() && --rcIt->second == 0) {
+    aliasRefcount.erase(rcIt);
+    liveRecords.erase(owner);
+  }
+}
+
+void MockAllocatorL1Tracker::removeTensorFromSizes(Value result) {
+  // Records are the only size state, so the eviction spill path is identical to
+  // removeTensor.
+  removeTensor(result);
+}
+
+bool MockAllocatorL1Tracker::hasTensor(Value result) const {
+  return aliasOf.count(result) > 0;
+}
+
+uint64_t MockAllocatorL1Tracker::getTensorSize(Value result) const {
+  auto ownerIt = aliasOf.find(result);
+  Value owner = ownerIt != aliasOf.end() ? ownerIt->second : result;
+  auto it = liveRecords.find(owner);
+  if (it == liveRecords.end()) {
+    return 0;
+  }
+  uint64_t total = 0;
+  for (const auto &rec : it->second) {
+    if (rec.bufferType == BufferType::L1) {
+      total += rec.sizePerBank;
+    }
+  }
+  return total;
+}
+
+uint64_t MockAllocatorL1Tracker::getOccupiedL1() const {
+  uint64_t total = 0;
+  for (const auto &entry : liveRecords) {
+    for (const auto &rec : entry.second) {
+      if (rec.bufferType == BufferType::L1) {
+        total += rec.sizePerBank;
+      }
+    }
+  }
+  return total;
+}
+
+MockAllocatorL1Tracker::Snapshot MockAllocatorL1Tracker::takeSnapshot() const {
+  return Snapshot{liveRecords, aliasOf, aliasRefcount};
+}
+
+void MockAllocatorL1Tracker::restoreSnapshot(const Snapshot &snapshot) {
+  liveRecords = snapshot.liveRecords;
+  aliasOf = snapshot.aliasOf;
+  aliasRefcount = snapshot.aliasRefcount;
+}
+
+//===----------------------------------------------------------------------===//
+// StatefulL1SpillManagement (captured allocator state)
+//===----------------------------------------------------------------------===//
+
+uint64_t StatefulL1SpillManagement::placeValidatedOutput(
+    Operation *, int64_t, ScheduleData &,
+    const op_constraint_validation::ValidationResult &result) {
+  // Fit / fragmentation / CB-overlap are all answered by the stateful query, so
+  // a validated output is committed at its reported L1 size with no extra
+  // checks.
+  return result.outputL1Usage;
+}
+
+void StatefulL1SpillManagement::handleUnvalidatedL1Output(Operation *, int64_t,
+                                                          ScheduleData &,
+                                                          uint64_t) {
+  // Pre-decomposition ToLayoutOp: no query, and (as in the address-sim path) it
+  // is kept out of liveValues. Any real OOM surfaces at the consuming op's
+  // stateful query, so there is nothing to do here.
+}
+
+void StatefulL1SpillManagement::commitAllocation(Value val,
+                                                 uint64_t perResultL1,
+                                                 ScheduleData &data) {
+  auto luIt = data.lastUsePositions.find(val);
+  assert(luIt != data.lastUsePositions.end() &&
+         "scheduled value missing its lastUsePositions entry");
+  int64_t resultLastUse = luIt->second;
+
+  // No event log here: the stateful path rebuilds state by rewinding and
+  // re-running the sweep (per-position checkpoints), not via event-log replay.
+
+  // View-eligible op whose source is still L1-resident: alias its buffer (no
+  // new record). Otherwise associate this result's own output record.
+  Operation *defOp = val.getDefiningOp();
+  if (defOp && isAliasingViewOp(defOp) &&
+      memoryTracker.hasTensor(defOp->getOperand(0))) {
+    memoryTracker.addTensorAlias(val, defOp->getOperand(0));
+  } else {
+    memoryTracker.addTensor(val, perResultL1);
+  }
+
+  liveValues.insert(val);
+  liveSet.push({resultLastUse, val});
+}
+
+void StatefulL1SpillManagement::recoverFromOOM(
+    Operation *op, int64_t pos, llvm::ArrayRef<OpResult> /*tensorResults*/,
+    ScheduleData &data, std::function<void(uint64_t)> /*addResultsToLiveSet*/) {
+  observer_->onOOM(op, pos, memoryTracker.getOccupiedL1());
+
+  // Evict ONE farthest-last-use victim, then rewind and re-run the forward
+  // sweep. evictValue spills the victim to DRAM and routes its consumers'
+  // reshards into the schedule; the rewind (pendingRewindTo, honored by run())
+  // restores the checkpoint before the victim's allocation and re-runs the
+  // sweep from there. The victim re-processes as a briefly-live L1 buffer that
+  // is freed immediately (its shortened lifetime), the reshards process as
+  // ordinary schedule ops, and this op is re-reached and re-validated against
+  // the freed state. If it still OOMs, recoverFromOOM fires again for the next
+  // victim -- one eviction per rewind, monotonically shrinking the L1 working
+  // set. There is no separate replay: eviction reuses the one placement
+  // algorithm (the forward sweep), so it cannot diverge from it.
+  Value victim = evictFarthestUse();
+  if (!victim) {
+    // Nothing evictable remains (only non-evictable reshards / an irreducible,
+    // genuinely-unplaceable working set). Degrade gracefully: demote this op's
+    // output to DRAM and continue, rather than failing the pass.
+    observer_->onSelfSpill(op, pos);
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "    DEMOTE SELF (stateful): {0} unplaceable after draining L1",
+        ttmlir::opToString(op));
+    demoteToDram(op);
+    return; // no rewind; sweep advances to pos+1
+  }
+
+  Operation *victimOp = victim.getDefiningOp();
+  size_t unusedCampaign = SIZE_MAX;
+  evictValue(victim, pos, data, unusedCampaign);
+
+  // Rewind to the victim's own allocation position. Reshards insert at consumer
+  // positions (> victimPos, since a consumer follows its producer), so
+  // victimPos is the earliest position affected by this eviction. Re-read
+  // positionMap in case insertions shifted it (they should not, being after
+  // victimPos).
+  int64_t victimPos = data.positionMap.lookup(victimOp);
+  pendingRewindTo = victimPos;
+}
+
+bool StatefulL1SpillManagement::replayFrom(size_t /*startIdx*/) {
+  // The stateful path rebuilds allocator state by rewinding and re-running the
+  // forward sweep (see recoverFromOOM), not via event-log replay. evictValue
+  // never calls markEvictedAndRebuild on this path, so this override is
+  // unreachable; it exists only to satisfy the pure-virtual base declaration.
+  llvm_unreachable("StatefulL1SpillManagement uses rewind, not replayFrom");
+}
+
+//===----------------------------------------------------------------------===//
 // Explicit template instantiation
 //===----------------------------------------------------------------------===//
 
-template class L1SpillManagement<SumL1MemoryTracker>;
+template class L1SpillManagementBase<SumL1MemoryTracker>;
+template class L1SpillManagementBase<MockAllocatorL1Tracker>;
+template class AddressSimSpillManagement<SumL1MemoryTracker>;
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -258,6 +258,171 @@ bool canReshapeBeView(Operation *op) {
   return true;
 }
 
+//===----------------------------------------------------------------------===//
+// View-op detection (input-aliasing / zero-copy ops)
+//
+// These predicates mirror tt-metal's decision to return the input tensor (or a
+// view built at the input's address) instead of allocating a fresh output.
+// The L1 spill pass uses `isAliasingViewOp` to alias such an op onto its
+// source's L1 slot (see MockAllocatorL1Tracker / addTensorAtAddress) rather
+// than tracking a fresh allocation. Under the stateful op-model query, an
+// aliasing op's output is reported at the weightless input's address 0, which
+// is not a re-installable allocation -- so mis-tracking it crashes
+// `with_allocations` (issue
+// https://github.com/tenstorrent/tt-mlir/issues/9054). Each predicate is
+// guarded by a tripwire unit test asserting that an op it classifies as a view
+// really does return address 0 from the mock op-model; if tt-metal drifts, the
+// tripwire fails and the predicate must be revisited.
+//===----------------------------------------------------------------------===//
+
+/// Check if a `ttnn.pad` returns its input as a view (no new allocation).
+/// Mirrors ttnn::pad: all-zero padding (pad.cpp:451), on-device same shape
+/// (pad.cpp:128), and the TILE fast-path where the padding stays within the
+/// existing tile padding so the tiled buffer is unchanged (pad.cpp:383).
+bool canPadBeView(Operation *op) {
+  auto pad = mlir::dyn_cast<PadOp>(op);
+  if (!pad) {
+    return false;
+  }
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!inputType || !outputType) {
+    return false;
+  }
+  llvm::ArrayRef<int32_t> padding = pad.getPadding(); // [lo0,hi0,lo1,hi1,...]
+
+  // (A) All-zero padding is a strict no-op regardless of layout/shape.
+  if (llvm::all_of(padding, [](int32_t p) { return p == 0; })) {
+    return true;
+  }
+
+  llvm::ArrayRef<int64_t> inShape = inputType.getShape();
+  llvm::ArrayRef<int64_t> outShape = outputType.getShape();
+  if (inShape.size() != outShape.size() || inShape.empty()) {
+    return false;
+  }
+
+  // (B) Same logical shape -> ttnn::pad returns the input.
+  if (inShape == outShape) {
+    return true;
+  }
+
+  // (C) TILE fast-path: only reachable for tiled layout, with zero front
+  // (before) padding, when the change is confined within the tile padding so
+  // the tiled (padded) buffer is byte-identical -- then ttnn::pad returns a
+  // view at the input's address. tt-metal's condition (pad.cpp:383):
+  //   !pad_upper_dims && padded[-1] unchanged && padded[-2] unchanged.
+  auto inputLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  if (!inputLayout || !inputLayout.isTiled()) {
+    return false;
+  }
+  // Front (low) padding must be zero on every dim (tt-metal TT_FATALs
+  // otherwise; certainly not a view).
+  for (size_t d = 0; d < padding.size() / 2; ++d) {
+    if (padding[2 * d] != 0) {
+      return false;
+    }
+  }
+  // Upper dims (everything but the last two) must be unchanged.
+  for (size_t i = 0; i + 2 < inShape.size(); ++i) {
+    if (inShape[i] != outShape[i]) {
+      return false;
+    }
+  }
+  auto roundUpTo = [](int64_t x, int64_t t) {
+    return llvm::divideCeil(x, t) * t;
+  };
+  int64_t inLast = inShape.back(), outLast = outShape.back();
+  int64_t inSecondLast = inShape[inShape.size() - 2];
+  int64_t outSecondLast = outShape[outShape.size() - 2];
+  return roundUpTo(inLast, TILE_WIDTH) == roundUpTo(outLast, TILE_WIDTH) &&
+         roundUpTo(inSecondLast, TILE_HEIGHT) ==
+             roundUpTo(outSecondLast, TILE_HEIGHT);
+}
+
+/// Check if a `ttnn.repeat` returns its input as a view: an all-ones
+/// repetition is a strict no-op (repeat.cpp:196 `return input_tensor`).
+bool canRepeatBeView(Operation *op) {
+  auto repeat = mlir::dyn_cast<RepeatOp>(op);
+  if (!repeat) {
+    return false;
+  }
+  llvm::ArrayRef<int64_t> repeatDims = repeat.getRepeatDims().getShape();
+  return llvm::all_of(repeatDims, [](int64_t r) { return r == 1; });
+}
+
+/// Check if a `ttnn.permute` is a no-op view. Mirrors tt-metal's
+/// `is_permute_nop` (permute.cpp:158): rank<=1, identity permutation, or a
+/// permutation that only moves size-1 dims (layout-aware: TILE fixes the last
+/// two dims, ROW_MAJOR the last). Permute-nop returns
+/// `to_memory_config(input, requested)`, so it aliases the input only when the
+/// requested (output) memory config equals the input's -- hence the extra
+/// buffer-type + memory-layout equality check.
+bool canPermuteBeView(Operation *op) {
+  auto permute = mlir::dyn_cast<PermuteOp>(op);
+  if (!permute) {
+    return false;
+  }
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  if (!inputType || !outputType) {
+    return false;
+  }
+  llvm::ArrayRef<int64_t> dims = permute.getPermutation();
+  llvm::ArrayRef<int64_t> shape = inputType.getShape();
+  const int64_t rank = static_cast<int64_t>(shape.size());
+
+  bool isNop = false;
+  if (rank <= 1) {
+    isNop = true;
+  } else {
+    // Identity permutation.
+    bool identity = true;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (dims[i] != i) {
+        identity = false;
+        break;
+      }
+    }
+    auto inputLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+    bool tiled = inputLayout && inputLayout.isTiled();
+    // TILE: last two dims must stay; ROW_MAJOR: last dim must stay.
+    bool lastDimsFixed =
+        tiled ? (dims[rank - 1] == rank - 1 && dims[rank - 2] == rank - 2)
+              : (dims[rank - 1] == rank - 1);
+    // Only size-1 dims moved (and shape therefore unchanged).
+    bool onlySize1Moved = true;
+    for (int64_t i = 0; i < rank; ++i) {
+      if (i != dims[i] && shape[i] > 1) {
+        onlySize1Moved = false;
+        break;
+      }
+    }
+    isNop = identity || (lastDimsFixed && onlySize1Moved);
+  }
+  if (!isNop) {
+    return false;
+  }
+
+  // Aliases the input only if the output memory config matches the input's.
+  auto inLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
+  auto outLayout = mlir::dyn_cast<TTNNLayoutAttr>(outputType.getEncoding());
+  if (!inLayout || !outLayout) {
+    return false;
+  }
+  return inLayout.getBufferType() == outLayout.getBufferType() &&
+         inLayout.getMemLayoutOpt() == outLayout.getMemLayoutOpt();
+}
+
+bool isAliasingViewOp(Operation *op) {
+  return canReshapeBeView(op) || canPadBeView(op) || canRepeatBeView(op) ||
+         canPermuteBeView(op);
+}
+
 LayoutFilterFn
 ReshapeRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
   // Reshape/Permute: width-sharded inputs round-trip through interleaved

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -59,11 +59,6 @@ namespace mlir::tt::ttnn {
 //     DeallocateOp, D2MSubgraphOp, DropoutOp, PrepareConv3dWeightsOp.
 //   * MoeGptOp -- getOpConstraints is not implemented at all (no tt-metal
 //     definition); there is no query to hand a state to.
-//   * QuantizeOp, DequantizeOp, Conv1dOp -- compute ops that *would* benefit,
-//     but blocked one level down: their op_model::OpModel<> entry points have
-//     no `initialState` parameter and their queries use QUERY_OP_CONSTRAINTS
-//     rather than QUERY_OP_CONSTRAINTS_WITH_STATE. Migrating them is a backend
-//     change in lib/OpModel/TTNN/TTNNOpModel.cpp, not a thread-through here.
 // Migrating an op that is only blocked here means threading `liveRecords`
 // through instead (see ReluOp / ChunkedScaledDotProductAttentionOp for the
 // pattern), which changes no existing behavior for stateless callers.
@@ -402,18 +397,18 @@ getNamedFullOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getQuantizationOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> getQuantizationOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
   const auto inputShape = op.getInput().getType().getShape();
   const auto scaleShape = op.getScale().getType().getShape();
   const auto zeroPointShape = op.getZeroPoint().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      scaleShape, inputs[1], zeroPointShape, inputs[2], op.getAxis(),
-      op.getOutputDtype(), opConfig.outputLayout);
+  return constraintsDispatch(op, liveRecords, inputShape, inputs[0], scaleShape,
+                             inputs[1], zeroPointShape, inputs[2], op.getAxis(),
+                             op.getOutputDtype(), opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -3105,9 +3100,10 @@ ProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> QuantizeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getQuantizationOpConstraints(*this, inputs, opConfig);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getQuantizationOpConstraints(*this, inputs, opConfig,
+                                              liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -3122,9 +3118,10 @@ QuantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> DequantizeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getQuantizationOpConstraints(*this, inputs, opConfig);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getQuantizationOpConstraints(*this, inputs, opConfig,
+                                              liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -3647,8 +3644,8 @@ static Conv2dAttrs unpackConv1dAttrs(const OpConfig::OpSpecificAttrs &attrs,
 
 llvm::Expected<op_model::OpConstraints> Conv1dOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
   const auto inputShape = getInput().getType().getShape();
@@ -3662,11 +3659,11 @@ llvm::Expected<op_model::OpConstraints> Conv1dOp::getOpConstraints(
 
   Conv2dAttrs attr = unpackConv1dAttrs(opConfig.opSpecificAttrs, *this);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv1dOp>::getOpConstraints, getOperation(), inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputLength(), getKernelSize(),
-      getStride(), getPadding(), getDilation(), getGroups(), attr.conv2dConfig,
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], weightShape, inputs[1],
+      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
+      getInputLength(), getKernelSize(), getStride(), getPadding(),
+      getDilation(), getGroups(), attr.conv2dConfig,
       attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
       opConfig.outputLayout);
 }

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -31,6 +31,38 @@
 
 namespace mlir::tt::ttnn {
 
+//===----------------------------------------------------------------------===//
+// Stateful op-model migration policy (L1 spill)
+//
+// Ops that participate in the stateful, allocator-backed L1 spill pass override
+// the OpModel interface's getOpConstraintsWithState -- directly, via a per-op
+// extraClassDeclaration + out-of-line body, via a per-family helper macro
+// (e.g. TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE), or via a templated
+// *OpModel body. Every op that does NOT override it inherits the interface
+// default, which delegates to the stateless getOpConstraints
+// (buildInitialState({}) yields a null state -> plain stateless query). That
+// default is SAFE, not buggy: an unmigrated op is modeled exactly as before
+// this feature (no live-record state), never silently wrong -- only less
+// fragmentation-aware if it ever appears in the spill window.
+//
+// The ops below are INTENTIONALLY left on the stateless default as of this
+// change (they are creation / structural ops, or their stateful body has not
+// been needed by the models this pass targets). This list exists so future
+// readers can distinguish "intentionally stateless" from "accidentally
+// forgot" -- migrating any of them just means adding a
+// getOpConstraintsWithState override mirroring its stateless twin (see
+// ChunkedScaledDotProductAttentionOp for the pattern) and changes no existing
+// behavior:
+//   * Creation / no-activation-input ops: ArangeOp, EmptyOp, FullOp, OnesOp,
+//     ZerosOp, RandOp.
+//   * Structural / bookkeeping ops: AssignOp, DeallocateOp, D2MSubgraphOp,
+//     DropoutOp, PrepareConv3dWeightsOp.
+//   * Elementwise binary-composite / bitwise binaries: Atan2Op, MaximumOp,
+//     MinimumOp, PowTensorOp, RemainderOp, BitwiseAndOp, BitwiseOrOp,
+//     BitwiseXorOp.
+//   * QuantizeOp, DequantizeOp, Conv1dOp, MoeGptOp, TanhOp.
+//===----------------------------------------------------------------------===//
+
 namespace detail {
 
 char OpNotSupportedError::ID = 0;
@@ -124,17 +156,54 @@ convertOptionalArrayAttrToSmallVec(std::optional<mlir::ArrayAttr> arrayAttr) {
   return convertArrayAttrToSmallVec(arrayAttr.value());
 }
 
+// Centralizes the cache-vs-bypass decision for every constraints query.
+//
+// The opConstraintsCache key is the op plus its args; liveRecords are
+// deliberately NOT part of the key. A stateful query (state != nullptr)
+// therefore MUST bypass the cache -- otherwise it would return a fit decision
+// cached under a different (or empty) live set, i.e. a stale-fit result. A
+// stateless query (state == nullptr) goes through the cache exactly as before.
+// Every op interface body routes through here so this invariant lives in one
+// place. Args are taken by value: they are cheap (ArrayRef views, attrs) and
+// each branch consumes them at most once.
+template <typename OpT, typename... Args>
+llvm::Expected<op_model::OpConstraints>
+constraintsDispatch(OpT op, const op_model::MockAllocatorState *state,
+                    Args... args) {
+  if (state) {
+    return op_model::OpModel<OpT>::getOpConstraintsWithState(args..., state);
+  }
+  return opConstraintsCache().getOrCompute(
+      op_model::OpModel<OpT>::getOpConstraints, op, args...);
+}
+
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig) {
+getUnaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig,
+                        const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      opConfig.outputLayout);
+  return constraintsDispatch(op, state, inputShape, inputs[0],
+                             opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  return getUnaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getUnaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getUnaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -152,8 +221,9 @@ getUnaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig) {
+getBinaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                         const OpConfig &opConfig,
+                         const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = op.getLhs().getType().getShape();
@@ -164,9 +234,24 @@ getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
     opDtypeAttr = dtypeOp.getDtypeAttr();
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], opConfig.outputLayout, opDtypeAttr);
+  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
+                             inputs[1], opConfig.outputLayout, opDtypeAttr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig) {
+  return getBinaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getBinaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getBinaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -185,17 +270,34 @@ getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
+getTernaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig,
+                          const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 3);
 
   const auto inputShapeA = op.getFirst().getType().getShape();
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShapeA, inputs[0],
-      inputShapeB, inputs[1], inputShapeC, inputs[2], opConfig.outputLayout);
+  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
+                             inputs[1], inputShapeC, inputs[2],
+                             opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getTernaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getTernaryOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getTernaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -215,14 +317,31 @@ getTernaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
+getReductionConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig,
+                            const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  return getReductionConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getReductionOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getReductionConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -239,18 +358,35 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 
 template <typename OpT>
 llvm::Expected<op_model::OpConstraints>
-getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
+getPoolingConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig,
+                          const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
-      op.getConfigTensorsInDram(), opConfig.outputLayout);
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(), op.getConfigTensorsInDram(),
+      opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
+                        const OpConfig &opConfig) {
+  return getPoolingConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints> getPoolingOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getPoolingConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -270,21 +406,40 @@ getPoolingOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getMaxPool2dWithIndicesOpConstraints(OpT op,
-                                     const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> getMaxPool2dWithIndicesConstraintsImpl(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, inputShape, inputs[0],
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getChannels(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getDilation(), op.getCeilMode(), op.getReallocateHaloOutput(),
+  return constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
+      op.getPadding(), op.getDilation(), op.getCeilMode(),
+      op.getReallocateHaloOutput(),
       /*deallocate_input*/ false, /*return_indices*/ true,
       op.getConfigTensorsInDram(), opConfig.outputLayout);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getMaxPool2dWithIndicesOpConstraints(OpT op,
+                                     const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
+                                                /*state=*/nullptr);
+}
+
+template <typename OpT>
+llvm::Expected<op_model::OpConstraints>
+getMaxPool2dWithIndicesOpConstraintsWithState(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
+                                                initialState.get());
 }
 
 template <typename OpT>
@@ -367,6 +522,87 @@ llvm::Expected<size_t>
 ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
   return detail::getUnaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Elementwise-unary family: stateful getOpConstraintsWithState overrides.
+// Uniform members route through the stateful helper (both UnaryEltwiseOpModel
+// and UnaryEltwiseWithFastApproxModeOpModel have migrated op-model bodies).
+// ErfOp and BitwiseNotOp provide their own per-op extraClassDeclaration in
+// tablegen (which declares getOpConstraintsWithState there), so they are
+// defined here via the same helper macro.
+//===----------------------------------------------------------------------===//
+
+#define TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(OP)                        \
+  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
+      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
+      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
+    return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,     \
+                                                  liveRecords);                \
+  }
+
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AbsOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(BitwiseNotOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CbrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CeilOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CosOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ExpOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfcOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(NegOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReciprocalOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Relu6Op)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SinOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SqrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(RsqrtOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(HardsigmoidOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SiluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(MishOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AcosOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinhOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AtanOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Expm1Op)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(FloorOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(GeluOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(IsFiniteOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Log1pOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogicalNotOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SignOp)
+TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(TanOp)
+
+#undef TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE
+
+// SigmoidOp (bespoke op-model) has the standard unary
+// (inputShape, inputLayout, outputLayout) signature, so it routes through the
+// uniform stateful helper. LeakyReluOp carries an extra float parameter, so it
+// threads state through a bespoke query.
+llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                liveRecords);
+}
+
+static llvm::Expected<op_model::OpConstraints> leakyReluConstraintsImpl(
+    LeakyReluOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getParameter(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> LeakyReluOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return leakyReluConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -888,13 +1124,7 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LeakyReluOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getParameter(), opConfig.outputLayout);
+  return leakyReluConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
 }
 
 llvm::Expected<size_t>
@@ -923,6 +1153,64 @@ llvm::Expected<size_t>
 AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
   return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+//===----------------------------------------------------------------------===//
+// Elementwise-binary family: stateful getOpConstraintsWithState overrides.
+// Declared on the shared TTNN_ElementwiseBinaryOp base (extraClassDeclaration),
+// so every member defines it here. The uniform BinaryEltwiseOpModel members
+// route through the stateful helper; GeluBackwardOp (bespoke op-model, extra
+// approximate arg) is not yet state-aware and delegates to the stateless query.
+//===----------------------------------------------------------------------===//
+
+#define TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(OP)                       \
+  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
+      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
+      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
+    return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,    \
+                                                   liveRecords);               \
+  }
+
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(AddOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(DivideOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(MultiplyOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(SubtractOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(EqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(NotEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterThanOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessEqualOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessThanOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalAndOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalOrOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalXorOp)
+TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalRightShiftOp)
+
+#undef TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE
+
+// GeluBackwardOp shares the binary tablegen base but has a bespoke op-model
+// (extra `approximate` arg), so it threads state through a bespoke query.
+static llvm::Expected<op_model::OpConstraints> geluBackwardConstraintsImpl(
+    GeluBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = op.getLhs().getType().getShape();
+  const auto inputShapeB = op.getRhs().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      op.getApproximate().str(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+GeluBackwardOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
+                                     initialState.get());
 }
 
 //===----------------------------------------------------------------------===//
@@ -971,6 +1259,14 @@ llvm::Expected<size_t>
 LogicalLeftShiftOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
   return detail::getBinaryOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+LogicalLeftShiftOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                 liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1073,26 +1369,40 @@ BitwiseXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ScatterOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+scatterConstraintsImpl(ScatterOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto indexShape = op.getIndex().getType().getShape();
+  const auto sourceShape = op.getSource().getType().getShape();
+
+  std::optional<ttcore::ReduceTypeAttr> reduceType =
+      ttcore::ReduceTypeAttr::get(op.getContext(), ttcore::ReduceType::Invalid);
+  if (op.getScatterReduceType() != ttcore::ReduceType::Invalid) {
+    reduceType =
+        ttcore::ReduceTypeAttr::get(op.getContext(), op.getScatterReduceType());
+  }
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], indexShape, inputs[1], sourceShape,
+      inputs[2], op.getDim(), reduceType, opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return scatterConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  const auto sourceShape = getSource().getType().getShape();
-
-  std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
-  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
-    reduceType =
-        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
-  }
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScatterOp>::getOpConstraints, *this, inputShape,
-      inputs[0], indexShape, inputs[1], sourceShape, inputs[2], getDim(),
-      reduceType, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> ScatterOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return scatterConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1121,18 +1431,33 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+gatherConstraintsImpl(GatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto indexShape = op.getIndex().getType().getShape();
+  int32_t dim = op.getDim();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     indexShape, inputs[1], dim,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
+  return gatherConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto indexShape = getIndex().getType().getShape();
-  int32_t dim = getDim();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GatherOp>::getOpConstraints, *this, inputShape,
-      inputs[0], indexShape, inputs[1], dim, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> GatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return gatherConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1172,15 +1497,8 @@ Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 llvm::Expected<op_model::OpConstraints>
 GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = getLhs().getType().getShape();
-  const auto inputShapeB = getRhs().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GeluBackwardOp>::getOpConstraints, getOperation(),
-      inputShapeA, inputs[0], inputShapeB, inputs[1], getApproximate().str(),
-      opConfig.outputLayout);
+  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
+                                     /*state=*/nullptr);
 }
 
 llvm::Expected<size_t>
@@ -1236,16 +1554,29 @@ PowTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PowScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> powScalarConstraintsImpl(
+    PowScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getLhs().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRhs(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return powScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getLhs().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PowScalarOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getRhs(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> PowScalarOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return powScalarConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1436,6 +1767,13 @@ WhereOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getTernaryOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> WhereOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getTernaryOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MeanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -1450,6 +1788,13 @@ llvm::Expected<size_t>
 MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                      const OpConfig &opConfig) {
   return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> MeanOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1468,6 +1813,13 @@ MaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> MaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -1482,6 +1834,13 @@ llvm::Expected<size_t>
 MinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                     const OpConfig &opConfig) {
   return getReductionOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> MinOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1500,20 +1859,42 @@ SumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> SumOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
+                                            liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+softmaxConstraintsImpl(SoftmaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDimension(), op.getNumericStable(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return softmaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SoftmaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDimension(), getNumericStable(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> SoftmaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return softmaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1532,18 +1913,32 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ReshapeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+reshapeConstraintsImpl(ReshapeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  const auto outputShape = op.getResult().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputShape, opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return reshapeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  const auto outputShape = getResult().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ReshapeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputShape, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> ReshapeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return reshapeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1563,18 +1958,34 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceStaticOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> sliceStaticConstraintsImpl(
+    SliceStaticOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0],
+      detail::convertArrayAttrToSmallVec(op.getBegins()),
+      detail::convertArrayAttrToSmallVec(op.getEnds()),
+      detail::convertArrayAttrToSmallVec(op.getStep()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return sliceStaticConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceStaticOp>::getOpConstraints, *this, inputShape,
-      inputs[0], detail::convertArrayAttrToSmallVec(getBegins()),
-      detail::convertArrayAttrToSmallVec(getEnds()),
-      detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+SliceStaticOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return sliceStaticConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1595,20 +2006,36 @@ SliceStaticOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceDynamicOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> sliceDynamicConstraintsImpl(
+    SliceDynamicOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto beginsShape = op.getBegins().getType().getShape();
+  const auto endsShape = op.getEnds().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], beginsShape, inputs[1], endsShape,
+      inputs[2], detail::convertOptionalArrayAttrToSmallVec(op.getStep()),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                  const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
+                                     /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto beginsShape = getBegins().getType().getShape();
-  const auto endsShape = getEnds().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SliceDynamicOp>::getOpConstraints, *this, inputShape,
-      inputs[0], beginsShape, inputs[1], endsShape, inputs[2],
-      detail::convertOptionalArrayAttrToSmallVec(getStep()),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+SliceDynamicOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
+                                     initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1630,20 +2057,36 @@ SliceDynamicOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // BitcastConvertOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
+static llvm::Expected<op_model::OpConstraints> bitcastConvertConstraintsImpl(
+    BitcastConvertOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  ttcore::DataTypeAttr dtype =
+      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
+  assert(dtype && "BitcastConvertOp requires output dtype");
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
-  assert(dtype && "BitcastConvertOp requires output dtype");
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BitcastConvertOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dtype, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+BitcastConvertOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1666,25 +2109,38 @@ BitcastConvertOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TypecastOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> typecastConstraintsImpl(
+    TypecastOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   if (inputs[0].getBufferType() == BufferType::SystemMemory) {
     return issueErrorForGetOpConstraints(
-        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+        op.getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
   }
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
+      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
   assert(dtype && "TypecastOp requires output dtype");
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TypecastOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dtype, opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
+                                     opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return typecastConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> TypecastOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return typecastConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1712,29 +2168,42 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToLayoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> toLayoutConstraintsImpl(
+    ToLayoutOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
+  assert(opConfig.outputLayout.getLayout() == op.getLayoutAttr().getValue());
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   // Only signal a dtype conversion to the op model when this to_layout is
   // genuinely changing dtype. Use the resolved (candidate or intrinsic)
   // output dtype, and compare it against the input dtype.
   std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype =
-          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
+  if (ttcore::DataTypeAttr dtype = detail::resolveOutputDtype(
+          op.getOperation(), opConfig.outputLayout)) {
     if (dtype.getValue() != inputs[0].getDataType()) {
       outputDtype = dtype.getValue();
     }
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToLayoutOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputDtype, opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputDtype, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  return toLayoutConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> ToLayoutOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return toLayoutConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1763,21 +2232,37 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> toMemoryConfigConstraintsImpl(
+    ToMemoryConfigOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
   TTNNLayoutAttr outputLayout =
       opConfig.outputLayout
           ? opConfig.outputLayout
-          : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
+          : mlir::cast<TTNNLayoutAttr>(op.getResult().getType().getEncoding());
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ToMemoryConfigOp>::getOpConstraints, *this, inputShape,
-      inputs[0], outputLayout);
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ToMemoryConfigOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1801,21 +2286,35 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == getInputs().size());
+static llvm::Expected<op_model::OpConstraints>
+concatConstraintsImpl(ConcatOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == op.getInputs().size());
 
   std::vector<llvm::ArrayRef<int64_t>> inputShapes;
-  for (const Value &opInput : getInputs()) {
+  for (const Value &opInput : op.getInputs()) {
     mlir::RankedTensorType inputType =
         mlir::cast<mlir::RankedTensorType>(opInput.getType());
     inputShapes.push_back(inputType.getShape());
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConcatOp>::getOpConstraints, *this, inputShapes, inputs,
-      getDim(), opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, inputShapes, inputs,
+                                     op.getDim(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return concatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> ConcatOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return concatConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1839,16 +2338,30 @@ ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> transposeConstraintsImpl(
+    TransposeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim0(), op.getDim1(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return transposeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TransposeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim0(), getDim1(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> TransposeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return transposeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1867,17 +2380,31 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumSumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+cumSumConstraintsImpl(CumSumOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getDim(),
+      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return cumSumConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<CumSumOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> CumSumOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return cumSumConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1896,17 +2423,31 @@ CumSumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+cumProdConstraintsImpl(CumProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getDim(),
+      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 CumProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return cumProdConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<CumProdOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> CumProdOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return cumProdConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1925,16 +2466,32 @@ CumProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatenateHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> concatenateHeadsConstraintsImpl(
+    ConcatenateHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConcatenateHeadsOp>::getOpConstraints, *this,
-      inputShape, inputs[0], opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+ConcatenateHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2023,9 +2580,11 @@ unpackScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+scaledDotProductAttentionDecodeConstraintsImpl(
+    ScaledDotProductAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // Clang tidy falsley determines that the underling float data in the
   // llvm::APFloat is freed more than once as APFloat is passed by value and
   // then destroyed at the end of this function.
@@ -2040,12 +2599,11 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
          "4, 5, or 6 input tensors");
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
-      unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
+      unpackScaledDotProductAttentionDecodeArgs(inputs, op);
 
-  auto scale = getScale();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
+  auto scale = op.getScale();
+  return detail::constraintsDispatch(
+      op, state, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
       sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
       sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
       sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
@@ -2053,6 +2611,23 @@ ScaledDotProductAttentionDecodeOp::getOpConstraints(
       sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
       opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                        /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                        initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2158,9 +2733,11 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedScaledDotProductAttentionDecodeConstraintsImpl(
+    PagedScaledDotProductAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // See the comment in scaledDotProductAttentionDecodeOp::getOpConstraints for
   // an explanation of this lint suppression.
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
@@ -2169,12 +2746,10 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
          "7 input tensors");
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
-      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
+      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<
-          PagedScaledDotProductAttentionDecodeOp>::getOpConstraints,
-      *this, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
+  return detail::constraintsDispatch(
+      op, state, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
       pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout, pagedSdpaArgs.valueShape,
       pagedSdpaArgs.valueLayout, pagedSdpaArgs.pageTableShape,
       pagedSdpaArgs.pageTableLayout, pagedSdpaArgs.isCausal,
@@ -2184,6 +2759,23 @@ PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
       pagedSdpaArgs.programConfig, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2290,24 +2882,41 @@ unpackPagedFlashMultiLatentAttentionDecodeArgs(
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+    PagedFlashMultiLatentAttentionDecodeOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
-      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
+      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<
-          PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints,
-      *this, args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-      args.valueShape, args.valueLayout, args.headDimV, args.pageTableShape,
-      args.pageTableLayout, args.isCausal, args.attentionMaskShape,
-      args.attentionMaskLayout, args.curPosTensorShape, args.curPosTensorLayout,
-      args.attentionSinkShape, args.attentionSinkLayout, args.scale,
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      args.keyLayout, args.valueShape, args.valueLayout, args.headDimV,
+      args.pageTableShape, args.pageTableLayout, args.isCausal,
+      args.attentionMaskShape, args.attentionMaskLayout, args.curPosTensorShape,
+      args.curPosTensorLayout, args.attentionSinkShape,
+      args.attentionSinkLayout, args.scale, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFlashMultiLatentAttentionDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
@@ -2331,24 +2940,42 @@ llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
 // ChunkedScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ChunkedScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+chunkedScaledDotProductAttentionConstraintsImpl(
+    ChunkedScaledDotProductAttentionOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5 &&
          "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
          "(q, k, v, page_table, chunk_start_idx)");
 
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
-  const auto pageTableShape = getPageTable().getType().getShape();
-  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
+  const auto queryShape = op.getQuery().getType().getShape();
+  const auto keyShape = op.getKey().getType().getShape();
+  const auto valueShape = op.getValue().getType().getShape();
+  const auto pageTableShape = op.getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = op.getChunkStartIdx().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints,
-      *this, queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-      pageTableShape, inputs[3], chunkStartIdxShape, inputs[4], getScale(),
-      getProgramConfig(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
+      inputs[2], pageTableShape, inputs[3], chunkStartIdxShape, inputs[4],
+      op.getScale(), op.getProgramConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return chunkedScaledDotProductAttentionConstraintsImpl(
+      *this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return chunkedScaledDotProductAttentionConstraintsImpl(
+      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
@@ -2374,39 +3001,56 @@ llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
 // ScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+scaledDotProductAttentionConstraintsImpl(
+    ScaledDotProductAttentionOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 5 &&
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  const auto queryShape = getQuery().getType().getShape();
-  const auto keyShape = getKey().getType().getShape();
-  const auto valueShape = getValue().getType().getShape();
+  const auto queryShape = op.getQuery().getType().getShape();
+  const auto keyShape = op.getKey().getType().getShape();
+  const auto valueShape = op.getValue().getType().getShape();
 
   size_t idx = 3;
   const std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape =
-      getAttentionMask()
-          ? std::make_optional(getAttentionMask().getType().getShape())
+      op.getAttentionMask()
+          ? std::make_optional(op.getAttentionMask().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionMaskLayout =
-      getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      op.getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
   const std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape =
-      getAttentionSink()
-          ? std::make_optional(getAttentionSink().getType().getShape())
+      op.getAttentionSink()
+          ? std::make_optional(op.getAttentionSink().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionSinkLayout =
-      getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      op.getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
 
-  bool isCausal = getIsCausal();
+  bool isCausal = op.getIsCausal();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ScaledDotProductAttentionOp>::getOpConstraints, *this,
-      queryShape, inputs[0], keyShape, inputs[1], valueShape, inputs[2],
-      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
-      attentionSinkLayout, isCausal, getScale(), getSlidingWindowSize(),
+  return detail::constraintsDispatch(
+      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
+      inputs[2], attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+      attentionSinkLayout, isCausal, op.getScale(), op.getSlidingWindowSize(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
+                                                  /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
+                                                  initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
@@ -2491,21 +3135,37 @@ unpackFlashMlaPrefillArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints>
-FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> flashMlaPrefillConstraintsImpl(
+    FlashMlaPrefillOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 2 && inputs.size() <= 4 &&
          "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
          "(q, k, optional value, optional mask)");
 
-  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, *this);
+  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<FlashMlaPrefillOp>::getOpConstraints, *this,
-      args.queryShape, args.queryLayout, args.keyShape, args.keyLayout,
-      args.valueShape, args.valueLayout, args.attentionMaskShape,
-      args.attentionMaskLayout, args.headDimV, args.isCausal, getScale(),
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      args.keyLayout, args.valueShape, args.valueLayout,
+      args.attentionMaskShape, args.attentionMaskLayout, args.headDimV,
+      args.isCausal, op.getScale(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+FlashMlaPrefillOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2562,21 +3222,39 @@ IndexerScoreDsaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingLlamaOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+rotaryEmbeddingLlamaConstraintsImpl(RotaryEmbeddingLlamaOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 4);
+
+  auto inputShape = op.getInput().getType().getShape();
+  auto cosShape = op.getCosCache().getType().getShape();
+  auto sinShape = op.getSinCache().getType().getShape();
+  auto transMatShape = op.getTransMat().getType().getShape();
+  bool isDecodeMode = op.getIsDecodeMode();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
+      inputs[2], transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingLlamaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == 4);
+  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
+}
 
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto transMatShape = getTransMat().getType().getShape();
-  bool isDecodeMode = getIsDecodeMode();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints, *this,
-      inputShape, inputs[0], cosShape, inputs[1], sinShape, inputs[2],
-      transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+RotaryEmbeddingLlamaOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2600,20 +3278,36 @@ RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingOp - TTNN Op Model Interface
 //===-----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> rotaryEmbeddingConstraintsImpl(
+    RotaryEmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  auto inputShape = op.getInput().getType().getShape();
+  auto cosShape = op.getCosCache().getType().getShape();
+  auto sinShape = op.getSinCache().getType().getShape();
+  auto tokenIndex = op.getTokenIndex();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], cosShape,
+                                     inputs[1], sinShape, inputs[2], tokenIndex,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
+}
 
-  auto inputShape = getInput().getType().getShape();
-  auto cosShape = getCosCache().getType().getShape();
-  auto sinShape = getSinCache().getType().getShape();
-  auto tokenIndex = getTokenIndex();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RotaryEmbeddingOp>::getOpConstraints, *this, inputShape,
-      inputs[0], cosShape, inputs[1], sinShape, inputs[2], tokenIndex,
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+RotaryEmbeddingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2636,25 +3330,42 @@ RotaryEmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NLPCreateQKVHeadsDecodeOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-NLPCreateQKVHeadsDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+nLPCreateQKVHeadsDecodeConstraintsImpl(
+    NLPCreateQKVHeadsDecodeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (1 + (op.getBatchOffset() == nullptr ? 0 : 1)));
 
-  auto inputShape = getInput().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
   std::optional<TTNNLayoutAttr> batchOffsetEncoding;
   if (inputs.size() == 2) {
-    batchOffsetShape = getBatchOffset().getType().getShape();
+    batchOffsetShape = op.getBatchOffset().getType().getShape();
     batchOffsetEncoding = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints, *this,
-      inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
-      getNumHeads(), getNumKvHeads(), getOverlapQkCoregrid(), getSliceSize(),
-      opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
+      op.getNumHeads(), op.getNumKvHeads(), op.getOverlapQkCoregrid(),
+      op.getSliceSize(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+NLPCreateQKVHeadsDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+NLPCreateQKVHeadsDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                                initialState.get());
 }
 
 llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
@@ -2681,16 +3392,32 @@ llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
 // NLPConcatHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> nLPConcatHeadsConstraintsImpl(
+    NLPConcatHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                    const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
+}
 
-  auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPConcatHeadsOp>::getOpConstraints, *this, inputShape,
-      inputs[0], opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+NLPConcatHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2708,17 +3435,35 @@ NLPConcatHeadsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsDecodeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
+static llvm::Expected<op_model::OpConstraints>
+nLPConcatHeadsDecodeConstraintsImpl(NLPConcatHeadsDecodeOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  uint32_t numHeads = op.getNumHeads();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0], numHeads,
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  uint32_t numHeads = getNumHeads();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints, *this,
-      inputShape, inputs[0], numHeads, opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+NLPConcatHeadsDecodeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2736,26 +3481,45 @@ NLPConcatHeadsDecodeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // SplitQueryKeyValueAndSplitHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-llvm::Expected<op_model::OpConstraints>
-SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
+static llvm::Expected<op_model::OpConstraints>
+splitQueryKeyValueAndSplitHeadsConstraintsImpl(
+    SplitQueryKeyValueAndSplitHeadsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (1 + (op.getKvInputTensor() ? 1 : 0)));
 
-  auto inputShape = getInputTensor().getType().getShape();
+  auto inputShape = op.getInputTensor().getType().getShape();
 
   // Handle optional kv input tensor
   std::optional<llvm::ArrayRef<int64_t>> kvInputShape = std::nullopt;
   std::optional<TTNNLayoutAttr> kvInputLayout = std::nullopt;
 
-  if (getKvInputTensor()) {
-    kvInputShape = getKvInputTensor().getType().getShape();
+  if (op.getKvInputTensor()) {
+    kvInputShape = op.getKvInputTensor().getType().getShape();
     kvInputLayout = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints,
-      *this, inputShape, inputs[0], kvInputShape, kvInputLayout, getNumHeads(),
-      getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], kvInputShape, kvInputLayout,
+      op.getNumHeads(), op.getNumKvHeads(), op.getTransposeKey(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
+                                                        /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+SplitQueryKeyValueAndSplitHeadsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
+                                                        initialState.get());
 }
 
 llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
@@ -2779,16 +3543,33 @@ llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
 // RepeatInterleaveOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> repeatInterleaveConstraintsImpl(
+    RepeatInterleaveOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRepeats(), op.getDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                      const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RepeatInterleaveOp>::getOpConstraints, *this,
-      inputShape, inputs[0], getRepeats(), getDim(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+RepeatInterleaveOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2807,16 +3588,31 @@ RepeatInterleaveOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RepeatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+repeatConstraintsImpl(RepeatOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getRepeatDims().getShape(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return repeatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RepeatOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getRepeatDims().getShape(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> RepeatOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return repeatConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2835,16 +3631,31 @@ RepeatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PadOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+padConstraintsImpl(PadOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                   const OpConfig &opConfig,
+                   const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getPadding(), op.getValue(),
+      op.getUseMulticore(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                         const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return padConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PadOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getPadding(), getValue(), getUseMulticore(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> PadOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return padConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2863,16 +3674,31 @@ PadOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SortOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+sortConstraintsImpl(SortOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getDescending(),
+                                     op.getStable(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return sortConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<SortOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getDim(), getDescending(), getStable(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> SortOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return sortConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2891,16 +3717,31 @@ SortOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ArgMaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+argMaxConstraintsImpl(ArgMaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getKeepDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                            const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return argMaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ArgMaxOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), getKeepDim(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> ArgMaxOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return argMaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2919,16 +3760,31 @@ ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+prodConstraintsImpl(ProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDimArg(), op.getKeepDim(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return prodConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ProdOp>::getOpConstraints, *this, inputShape, inputs[0],
-      getDimArg(), getKeepDim(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> ProdOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prodConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2974,21 +3830,34 @@ DequantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RequantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> requantizeConstraintsImpl(
+    RequantizeOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 5);
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto inScaleShape = op.getInScale().getType().getShape();
+  const auto inZeroPointShape = op.getInZeroPoint().getType().getShape();
+  const auto outScaleShape = op.getOutScale().getType().getShape();
+  const auto outZeroPointShape = op.getOutZeroPoint().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], inScaleShape, inputs[1],
+      inZeroPointShape, inputs[2], outScaleShape, inputs[3], outZeroPointShape,
+      inputs[4], op.getAxis(), op.getOutputDtype(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                const OpConfig &opConfig) {
-  assert(inputs.size() == 5);
-  const auto inputShape = getInput().getType().getShape();
-  const auto inScaleShape = getInScale().getType().getShape();
-  const auto inZeroPointShape = getInZeroPoint().getType().getShape();
-  const auto outScaleShape = getOutScale().getType().getShape();
-  const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
+  return requantizeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RequantizeOp>::getOpConstraints, *this, inputShape,
-      inputs[0], inScaleShape, inputs[1], inZeroPointShape, inputs[2],
-      outScaleShape, inputs[3], outZeroPointShape, inputs[4], getAxis(),
-      getOutputDtype(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return requantizeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3039,35 +3908,49 @@ static MatmulAttrs unpackMatmulAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+linearConstraintsImpl(LinearOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
+  const auto inputShapeA = op.getA().getType().getShape();
+  const auto inputShapeB = op.getB().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
+      op.getActivation() ? std::make_optional(op.getActivation().value())
+                         : std::nullopt;
 
   // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LinearOp>::getOpConstraints, *this, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], biasShape, biasLayout,
-      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
-      attr.matmulProgramConfig, attr.computeKernelConfig);
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
+      biasLayout, opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(),
+      activation, attr.matmulProgramConfig, attr.computeKernelConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return linearConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> LinearOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return linearConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3096,27 +3979,41 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+matmulConstraintsImpl(MatmulOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA = getA().getType().getShape();
-  const auto inputShapeB = getB().getType().getShape();
+  const auto inputShapeA = op.getA().getType().getShape();
+  const auto inputShapeB = op.getB().getType().getShape();
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      getActivation() ? std::make_optional(getActivation().value())
-                      : std::nullopt;
+      op.getActivation() ? std::make_optional(op.getActivation().value())
+                         : std::nullopt;
 
   // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MatmulOp>::getOpConstraints, *this, inputShapeA,
-      inputs[0], inputShapeB, inputs[1], opConfig.outputLayout, getTransposeA(),
-      getTransposeB(), activation, attr.matmulProgramConfig,
-      attr.computeKernelConfig);
+  return detail::constraintsDispatch(
+      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(), activation,
+      attr.matmulProgramConfig, attr.computeKernelConfig);
+}
+
+llvm::Expected<op_model::OpConstraints>
+MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return matmulConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> MatmulOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return matmulConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3137,20 +4034,36 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> topKRouterGptConstraintsImpl(
+    TopKRouterGptOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+  const auto biasShape = op.getBias().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      inputs[2], static_cast<uint32_t>(op.getK()),
+      static_cast<uint32_t>(op.getNumExperts()), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
+                                      /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto biasShape = getBias().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<TopKRouterGptOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, inputs[2],
-      static_cast<uint32_t>(getK()), static_cast<uint32_t>(getNumExperts()),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+TopKRouterGptOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
+                                      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3191,26 +4104,44 @@ MoeGptOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareMoEComputeW0W1WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  const bool hasBias = getBias_0() != nullptr;
+static llvm::Expected<op_model::OpConstraints>
+prepareMoEComputeW0W1WeightsConstraintsImpl(
+    PrepareMoEComputeW0W1WeightsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
+  const bool hasBias = op.getBias_0() != nullptr;
   assert(inputs.size() == (hasBias ? 4u : 2u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias0Shape, bias1Shape;
   std::optional<TTNNLayoutAttr> bias0Layout, bias1Layout;
   if (hasBias) {
-    bias0Shape = getBias_0().getType().getShape();
-    bias1Shape = getBias_1().getType().getShape();
+    bias0Shape = op.getBias_0().getType().getShape();
+    bias1Shape = op.getBias_1().getType().getShape();
     bias0Layout = inputs[2];
     bias1Layout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints,
-      *this, getW0().getType().getShape(), inputs[0],
-      getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
-      bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize());
+  return detail::constraintsDispatch(
+      op, state, op.getW0().getType().getShape(), inputs[0],
+      op.getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
+      bias1Shape, bias1Layout, op.getHiddenSize(), op.getIntermediateSize());
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                     /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW0W1WeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                     initialState.get());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
@@ -3223,23 +4154,40 @@ llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
 // PrepareMoEComputeW2WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW2WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  const bool hasBias = getBias_2() != nullptr;
+static llvm::Expected<op_model::OpConstraints>
+prepareMoEComputeW2WeightsConstraintsImpl(
+    PrepareMoEComputeW2WeightsOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const bool hasBias = op.getBias_2() != nullptr;
   assert(inputs.size() == (hasBias ? 2u : 1u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias2Shape;
   std::optional<TTNNLayoutAttr> bias2Layout;
   if (hasBias) {
-    bias2Shape = getBias_2().getType().getShape();
+    bias2Shape = op.getBias_2().getType().getShape();
     bias2Layout = inputs[1];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints, *this,
-      getW2().getType().getShape(), inputs[0], bias2Shape, bias2Layout,
-      getHiddenSize(), getIntermediateSize());
+  return detail::constraintsDispatch(
+      op, state, op.getW2().getType().getShape(), inputs[0], bias2Shape,
+      bias2Layout, op.getHiddenSize(), op.getIntermediateSize());
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW2WeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                   /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW2WeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
+                                                   initialState.get());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(
@@ -3273,18 +4221,31 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> fillCacheConstraintsImpl(
+    FillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
+                                     inputShape, inputs[1], op.getBatchOffset(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
+  return fillCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<FillCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], getBatchOffset(),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> FillCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return fillCacheConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3304,19 +4265,34 @@ FillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpdateCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> updateCacheConstraintsImpl(
+    UpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape,
+      inputs[2], op.getBatchOffset(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return updateCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpdateCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      getBatchOffset(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+UpdateCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return updateCacheConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3333,26 +4309,43 @@ UpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getBatchOffset(), opConfig.outputLayout);
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> pagedUpdateCacheConstraintsImpl(
+    PagedUpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto updateIndexShape = getUpdateIndex().getType().getShape();
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> pageTableShape;
   std::optional<TTNNLayoutAttr> pageTableLayout;
-  if (getPageTable()) {
-    pageTableShape = getPageTable().getType().getShape();
+  if (op.getPageTable()) {
+    pageTableShape = op.getPageTable().getType().getShape();
     pageTableLayout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PagedUpdateCacheOp>::getOpConstraints, *this,
-      cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape, inputs[2],
-      pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
+  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
+                                     inputShape, inputs[1], updateIndexShape,
+                                     inputs[2], pageTableShape, pageTableLayout,
+                                     op.getShareCache(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                     const OpConfig &opConfig) {
+  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
+                                         /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedUpdateCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
+                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3376,26 +4369,42 @@ PagedUpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
 }
 
-llvm::Expected<op_model::OpConstraints>
-PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> pagedFillCacheConstraintsImpl(
+    PagedFillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = getCache().getType().getShape();
-  auto inputShape = getInput().getType().getShape();
-  auto pageTableShape = getPageTable().getType().getShape();
+  auto cacheShape = op.getCache().getType().getShape();
+  auto inputShape = op.getInput().getType().getShape();
+  auto pageTableShape = op.getPageTable().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> batchIdxShape;
   std::optional<TTNNLayoutAttr> batchIdxLayout;
-  if (getBatchIdxTensor()) {
-    batchIdxShape = getBatchIdxTensor().getType().getShape();
+  if (op.getBatchIdxTensor()) {
+    batchIdxShape = op.getBatchIdxTensor().getType().getShape();
     batchIdxLayout = inputs[3];
   }
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PagedFillCacheOp>::getOpConstraints, *this, cacheShape,
-      inputs[0], inputShape, inputs[1], pageTableShape, inputs[2],
-      batchIdxShape, batchIdxLayout, opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, cacheShape, inputs[0], inputShape, inputs[1], pageTableShape,
+      inputs[2], batchIdxShape, batchIdxLayout, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
+                                       /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PagedFillCacheOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
+                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3423,17 +4432,30 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SamplingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> samplingConstraintsImpl(
+    SamplingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 5);
+  return detail::constraintsDispatch(
+      op, state, op.getInputValues().getType().getShape(), inputs[0],
+      op.getInputIndices().getType().getShape(), inputs[1],
+      op.getK().getType().getShape(), inputs[2], op.getP().getType().getShape(),
+      inputs[3], op.getTemp().getType().getShape(), inputs[4], op.getSeed(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 5);
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<mlir::tt::ttnn::SamplingOp>::getOpConstraints, *this,
-      getInputValues().getType().getShape(), inputs[0],
-      getInputIndices().getType().getShape(), inputs[1],
-      getK().getType().getShape(), inputs[2], getP().getType().getShape(),
-      inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
-      opConfig.outputLayout);
+  return samplingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> SamplingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return samplingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3549,30 +4571,45 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+conv2dConstraintsImpl(Conv2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getDilation(), getGroups(),
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
+      op.getStride(), op.getPadding(), op.getDilation(), op.getGroups(),
       attr.conv2dConfig, attr.deviceComputeKernelConfig,
-      getConv2dSliceConfigAttr(), opConfig.outputLayout);
+      op.getConv2dSliceConfigAttr(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return conv2dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> Conv2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return conv2dConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3624,35 +4661,50 @@ static Conv3dAttrs unpackConv3dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints>
+conv3dConstraintsImpl(Conv3dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig,
+                      const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
   // tt-metal's conv3d kernel consumes the prepared 2D weight; the in-IR
   // weight may still be raw 5D (before TTNNPrepareConv3dWeights runs), so
   // pass the prepared shape/layout regardless of what's currently in IR.
-  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(&op);
   const auto weightShape = preparedWeight.getShape();
   auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<Conv3dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, weightLayout, biasShape, biasLayout,
-      getInChannels(), getOutChannels(), getBatchSize(), getInputDepth(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
-      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, weightLayout, biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputDepth(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getGroups(),
+      op.getPaddingMode(), op.getDtypeAttr(), attr.conv3dConfig,
+      attr.deviceComputeKernelConfig, opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                           const OpConfig &opConfig) {
+  return conv3dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> Conv3dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return conv3dConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3708,31 +4760,48 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                      std::nullopt};
 }
 
-llvm::Expected<op_model::OpConstraints>
-ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
+static llvm::Expected<op_model::OpConstraints> convTranspose2dConstraintsImpl(
+    ConvTranspose2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = getBias().getType().getShape();
+    biasShape = op.getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
   // If a conv config has been specified, use that. If not, read the op property
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConvTranspose2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], biasShape, biasLayout, getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
-      getDilation(), getGroups(), conv2dAttrs.conv2dConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
+      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
+      op.getStride(), op.getPadding(), op.getOutputPadding(), op.getDilation(),
+      op.getGroups(), conv2dAttrs.conv2dConfig, op.getConv2dSliceConfig(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig) {
+  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+ConvTranspose2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3766,24 +4835,43 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConv2dWeightsConstraintsImpl(PrepareConv2dWeightsOp op,
+                                    const std::vector<TTNNLayoutAttr> &inputs,
+                                    const OpConfig &opConfig,
+                                    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConv2dWeightsOp>::getOpConstraints, *this,
-      inputs[0], weightShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getWeightsFormat(), getInChannels(), getOutChannels(), getBatchSize(),
-      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
-      getPadding(), getDilation(), getHasBias(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
+      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
+      op.getDilation(), op.getHasBias(), op.getGroups(), op.getInputDtype(),
+      op.getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfigAttr(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                             /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dWeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3797,23 +4885,40 @@ PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> prepareConv2dBiasConstraintsImpl(
+    PrepareConv2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConv2dBiasOp>::getOpConstraints, *this,
-      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
       conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dBiasOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3846,25 +4951,43 @@ PrepareConv3dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConvTranspose2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConvTranspose2dWeightsConstraintsImpl(
+    PrepareConvTranspose2dWeightsOp op,
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints,
-      *this, inputs[0], weightShape, getInputMemoryConfig(),
-      getInputTensorLayout(), getWeightsFormat(), getInChannels(),
-      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
-      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
-      getDilation(), getHasBias(), getGroups(), getInputDtype(),
-      getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
-      getMirrorKernel(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
+      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
+      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
+      op.getOutputPadding(), op.getDilation(), op.getHasBias(), op.getGroups(),
+      op.getInputDtype(), op.getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfig(),
+      op.getMirrorKernel(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                                      /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dWeightsOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
+                                                      initialState.get());
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
@@ -3877,23 +5000,41 @@ llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
 // PrepareConvTranspose2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dBiasOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+prepareConvTranspose2dBiasConstraintsImpl(
+    PrepareConvTranspose2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
+      op.getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints, *this,
-      inputs[0], biasShape, getInputMemoryConfig(), getInputTensorLayout(),
-      getInChannels(), getOutChannels(), getBatchSize(), getInputHeight(),
-      getInputWidth(), getKernelSize(), getStride(), getPadding(),
-      getDilation(), getGroups(), getInputDtype(), getOutputDtype(),
+  return detail::constraintsDispatch(
+      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
+      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
+      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
       conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      getConv2dSliceConfig(), opConfig.outputLayout);
+      op.getConv2dSliceConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dBiasOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                                   /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dBiasOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
+                                                   initialState.get());
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(
@@ -3918,6 +5059,13 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints> MaxPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // MaxPool2dWithIndicesOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -3934,6 +5082,14 @@ MaxPool2dWithIndicesOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getMaxPool2dWithIndicesOpRuntime(*this, inputs, opConfig);
 }
 
+llvm::Expected<op_model::OpConstraints>
+MaxPool2dWithIndicesOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getMaxPool2dWithIndicesOpConstraintsWithState(
+      *this, inputs, opConfig, liveRecords);
+}
+
 //===----------------------------------------------------------------------===//
 // AvgPoo2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
@@ -3948,6 +5104,13 @@ llvm::Expected<size_t>
 AvgPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
+}
+
+llvm::Expected<op_model::OpConstraints> AvgPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
+                                                  liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -3983,24 +5146,41 @@ unpackBatchNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints>
+batchNormInferenceConstraintsImpl(BatchNormInferenceOp op,
+                                  const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig,
+                                  const op_model::MockAllocatorState *state) {
   assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
+  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BatchNormInferenceOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
+                                           /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BatchNormInferenceOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
+                                           initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4028,9 +5208,9 @@ BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BatchNormTrainingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
+static llvm::Expected<op_model::OpConstraints> batchNormTrainingConstraintsImpl(
+    BatchNormTrainingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
   assert((inputs.size() == 1 || inputs.size() == 5) &&
          "ttnn::batch_norm_training can either have 1 input tensor "
          "(representing the main input) or 5 input tensors (representing main "
@@ -4038,19 +5218,34 @@ BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
          "usage of this op with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  const auto inputShape = getInput().getType().getShape();
+  const auto inputShape = op.getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs =
-      unpackBatchNormOptionalArgs(inputs, *this);
+  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<BatchNormTrainingOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.runningMeanShape,
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), getMomentum(),
+      optionalArgs.biasLayout, op.getEpsilon(), op.getMomentum(),
       opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
+                                      const OpConfig &opConfig) {
+  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+BatchNormTrainingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4109,24 +5304,38 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+rMSNormConstraintsImpl(RMSNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, op);
+
+  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
+      op.getComputeConfigAttr() ? std::optional<DeviceComputeKernelConfigAttr>(
+                                      op.getComputeConfigAttr())
+                                : std::nullopt;
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout,
+      computeKernelConfig);
+}
+
 llvm::Expected<op_model::OpConstraints>
 RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
+  return rMSNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, *this);
-
-  std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-      getComputeConfigAttr()
-          ? std::optional<DeviceComputeKernelConfigAttr>(getComputeConfigAttr())
-          : std::nullopt;
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RMSNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout, computeKernelConfig);
+llvm::Expected<op_model::OpConstraints> RMSNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return rMSNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4173,19 +5382,37 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-
-  const auto inputShape = getInput().getType().getShape();
+static llvm::Expected<op_model::OpConstraints>
+rMSNormPreAllGatherConstraintsImpl(RMSNormPreAllGatherOp op,
+                                   const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig,
+                                   const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
 
   RMSNormPreAllGatherOptionalArgs optionalArgs =
-      unpackRMSNormPreAllGatherOptionalArgs(inputs, *this);
+      unpackRMSNormPreAllGatherOptionalArgs(inputs, op);
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<RMSNormPreAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      getUse_2dCoreGrid(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout,
+      dataTypeAttrToOptional(op.getDtypeAttr()), op.getUse_2dCoreGrid(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                            /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+RMSNormPreAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                            initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4235,20 +5462,31 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints> layerNormConstraintsImpl(
+    LayerNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  LayerNormOptionalArgs optionalArgs = unpackLayerNormOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
+  return layerNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormOptionalArgs optionalArgs =
-      unpackLayerNormOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> LayerNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return layerNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4298,21 +5536,37 @@ unpackLayerNormPreAllGatherOptionalArgs(
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+layerNormPreAllGatherConstraintsImpl(
+    LayerNormPreAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
+      optionalArgs.residualInputLayout, optionalArgs.recipShape,
+      optionalArgs.recipLayout, dataTypeAttrToOptional(op.getDtypeAttr()),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                              /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  LayerNormPreAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormPreAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, optionalArgs.recipShape,
-      optionalArgs.recipLayout, dataTypeAttrToOptional(getDtypeAttr()),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+LayerNormPreAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                              initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4363,21 +5617,38 @@ unpackLayerNormPostAllGatherOptionalArgs(
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints>
+layerNormPostAllGatherConstraintsImpl(
+    LayerNormPostAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto statsShape = op.getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], statsShape, inputs[1],
+      optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, op.getEpsilon(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                               /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto statsShape = getStats().getType().getShape();
-
-  LayerNormPostAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<LayerNormPostAllGatherOp>::getOpConstraints, *this,
-      inputShape, inputs[0], statsShape, inputs[1], optionalArgs.weightShape,
-      optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+LayerNormPostAllGatherOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
+                                               initialState.get());
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -4435,22 +5706,35 @@ unpackGroupNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
+static llvm::Expected<op_model::OpConstraints> groupNormConstraintsImpl(
+    GroupNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  GroupNormOptionalArgs optionalArgs = unpackGroupNormOptionalArgs(inputs, op);
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], optionalArgs.inputMaskShape,
+      optionalArgs.inputMaskLayout, optionalArgs.weightShape,
+      optionalArgs.weightLayout, optionalArgs.biasShape,
+      optionalArgs.biasLayout, op.getNumGroups(), op.getEpsilon(),
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(!inputs.empty() && "GroupNormOp requires at least input layout");
+  return groupNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  GroupNormOptionalArgs optionalArgs =
-      unpackGroupNormOptionalArgs(inputs, *this);
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GroupNormOp>::getOpConstraints, *this, inputShape,
-      inputs[0], optionalArgs.inputMaskShape, optionalArgs.inputMaskLayout,
-      optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, getNumGroups(),
-      getEpsilon(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> GroupNormOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return groupNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4474,16 +5758,32 @@ GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> clampScalarConstraintsImpl(
+    ClampScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getMinAttr(), op.getMaxAttr(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return clampScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampScalarOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getMinAttr(), getMaxAttr(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+ClampScalarOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return clampScalarConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4502,17 +5802,33 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> clampTensorConstraintsImpl(
+    ClampTensorOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      op, state, inputShape, inputs[0], op.getMin().getType().getShape(),
+      inputs[1], op.getMax().getType().getShape(), inputs[2],
+      opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                 const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return clampTensorConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ClampTensorOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getMin().getType().getShape(), inputs[1],
-      getMax().getType().getShape(), inputs[2], opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+ClampTensorOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return clampTensorConstraintsImpl(*this, inputs, opConfig,
+                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4532,16 +5848,31 @@ ClampTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PermuteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+permuteConstraintsImpl(PermuteOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                       const OpConfig &opConfig,
+                       const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getPermutation(), op.getPadValue(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                             const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return permuteConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<PermuteOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getPermutation(), getPadValue(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> PermuteOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return permuteConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4560,16 +5891,30 @@ PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpsampleOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> upsampleConstraintsImpl(
+    UpsampleOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getScaleFactor(), op.getMode(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return upsampleConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<UpsampleOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getScaleFactor(), getMode(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> UpsampleOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return upsampleConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4588,17 +5933,31 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> embeddingConstraintsImpl(
+    EmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 2);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     weightShape, inputs[1],
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                               const OpConfig &opConfig) {
-  assert(inputs.size() == 2);
+  return embeddingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<EmbeddingOp>::getOpConstraints, *this, inputShape,
-      inputs[0], weightShape, inputs[1], opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> EmbeddingOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return embeddingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4618,19 +5977,35 @@ EmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingBackwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> embeddingBackwardConstraintsImpl(
+    EmbeddingBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 3);
+
+  const auto inputShape = op.getInput().getType().getShape();
+  const auto weightShape = op.getWeight().getType().getShape();
+  const auto inGradientShape = op.getInGradient().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     weightShape, inputs[1], inGradientShape,
+                                     inputs[2], opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                       const OpConfig &opConfig) {
-  assert(inputs.size() == 3);
+  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
+                                          /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-  const auto weightShape = getWeight().getType().getShape();
-  const auto inGradientShape = getInGradient().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<EmbeddingBackwardOp>::getOpConstraints, *this,
-      inputShape, inputs[0], weightShape, inputs[1], inGradientShape, inputs[2],
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+EmbeddingBackwardOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
+                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4769,16 +6144,33 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> meshPartitionConstraintsImpl(
+    MeshPartitionOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getDim(), op.getClusterAxis(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                   const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
+                                      /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<MeshPartitionOp>::getOpConstraints, *this, inputShape,
-      inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+MeshPartitionOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
+                                      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4797,14 +6189,27 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> constantConstraintsImpl(
+    ConstantOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 0);
+
+  return detail::constraintsDispatch(op, state, op.getValue(),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                              const OpConfig &opConfig) {
-  assert(inputs.size() == 0);
+  return constantConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<ConstantOp>::getOpConstraints, *this, getValue(),
-      opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints> ConstantOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return constantConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4874,16 +6279,33 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints> globalAvgPool2dConstraintsImpl(
+    GlobalAvgPool2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
+    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = op.getInput().getType().getShape();
+
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     dataTypeAttrToOptional(op.getDtypeAttr()),
+                                     opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                                     const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
+  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
+                                        /*state=*/nullptr);
+}
 
-  const auto inputShape = getInput().getType().getShape();
-
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<GlobalAvgPool2dOp>::getOpConstraints, *this, inputShape,
-      inputs[0], dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
+llvm::Expected<op_model::OpConstraints>
+GlobalAvgPool2dOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
+                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5114,15 +6536,29 @@ D2MSubgraphOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
+static llvm::Expected<op_model::OpConstraints>
+topKConstraintsImpl(TopKOp op, const std::vector<TTNNLayoutAttr> &inputs,
+                    const OpConfig &opConfig,
+                    const op_model::MockAllocatorState *state) {
+  assert(inputs.size() == 1);
+  const auto inputShape = op.getInputTensor().getType().getShape();
+  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+                                     op.getK(), op.getDim(), op.getLargest(),
+                                     op.getSorted(), opConfig.outputLayout);
+}
+
 llvm::Expected<op_model::OpConstraints>
 TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
                          const OpConfig &opConfig) {
-  assert(inputs.size() == 1);
-  const auto inputShape = getInputTensor().getType().getShape();
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<mlir::tt::ttnn::TopKOp>::getOpConstraints, *this,
-      inputShape, inputs[0], getK(), getDim(), getLargest(), getSorted(),
-      opConfig.outputLayout);
+  return topKConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints> TopKOp::getOpConstraintsWithState(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+  std::shared_ptr<op_model::MockAllocatorState> initialState =
+      op_model::buildInitialState(liveRecords);
+  return topKConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -59,9 +59,6 @@ namespace mlir::tt::ttnn {
 //     DeallocateOp, D2MSubgraphOp, DropoutOp, PrepareConv3dWeightsOp.
 //   * MoeGptOp -- getOpConstraints is not implemented at all (no tt-metal
 //     definition); there is no query to hand a state to.
-//   * IndexerScoreDsaOp -- its op-model entry predates this change and takes no
-//     `initialState`, so there is no state to hand down yet; threading
-//     liveRecords means adding the parameter at the op-model layer first.
 // Migrating an op that is only blocked here means threading `liveRecords`
 // through instead (see ReluOp / ChunkedScaledDotProductAttentionOp for the
 // pattern), which changes no existing behavior for stateless callers.
@@ -2677,18 +2674,17 @@ FlashMlaPrefillOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> IndexerScoreDsaOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
   auto queryShape = getQuery().getType().getShape();
   auto keyShape = getKey().getType().getShape();
   auto weightsShape = getWeights().getType().getShape();
 
-  return opConstraintsCache().getOrCompute(
-      op_model::OpModel<IndexerScoreDsaOp>::getOpConstraints, *this, queryShape,
-      inputs[0], keyShape, inputs[1], weightsShape, inputs[2],
-      getChunkStartIdx(), opConfig.outputLayout);
+  return detail::constraintsDispatch(
+      *this, liveRecords, queryShape, inputs[0], keyShape, inputs[1],
+      weightsShape, inputs[2], getChunkStartIdx(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -59,6 +59,9 @@ namespace mlir::tt::ttnn {
 //     DeallocateOp, D2MSubgraphOp, DropoutOp, PrepareConv3dWeightsOp.
 //   * MoeGptOp -- getOpConstraints is not implemented at all (no tt-metal
 //     definition); there is no query to hand a state to.
+//   * IndexerScoreDsaOp -- its op-model entry predates this change and takes no
+//     `initialState`, so there is no state to hand down yet; threading
+//     liveRecords means adding the parameter at the op-model layer first.
 // Migrating an op that is only blocked here means threading `liveRecords`
 // through instead (see ReluOp / ChunkedScaledDotProductAttentionOp for the
 // pattern), which changes no existing behavior for stateless callers.
@@ -2672,9 +2675,10 @@ FlashMlaPrefillOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // IndexerScoreDsaOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-IndexerScoreDsaOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> IndexerScoreDsaOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 3);
 
   auto queryShape = getQuery().getType().getShape();

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -45,21 +45,28 @@ namespace mlir::tt::ttnn {
 // fragmentation-aware if it ever appears in the spill window.
 //
 // Since the signature no longer distinguishes them, the ops below are the
-// INTENTIONALLY stateless ones as of this change (they are creation /
-// structural ops, or their stateful body has not been needed by the models this
-// pass targets); `grep -n 'liveRecords=\*/std::nullopt'` finds them in code.
-// This list exists so future readers can distinguish "intentionally stateless"
-// from "accidentally forgot" -- migrating any of them just means threading
-// `liveRecords` through instead (see ChunkedScaledDotProductAttentionOp for the
-// pattern) and changes no existing behavior:
-//   * Creation / no-activation-input ops: ArangeOp, EmptyOp, FullOp, OnesOp,
-//     ZerosOp, RandOp.
-//   * Structural / bookkeeping ops: AssignOp, DeallocateOp, D2MSubgraphOp,
-//     DropoutOp, PrepareConv3dWeightsOp.
-//   * Elementwise binary-composite / bitwise binaries: Atan2Op, MaximumOp,
-//     MinimumOp, PowTensorOp, RemainderOp, BitwiseAndOp, BitwiseOrOp,
-//     BitwiseXorOp.
-//   * QuantizeOp, DequantizeOp, Conv1dOp, MoeGptOp, TanhOp.
+// INTENTIONALLY stateless ones as of this change;
+// `grep -n 'liveRecords=\*/std::nullopt'` (plus the unnamed-parameter bodies)
+// finds them in code. This list exists so future readers can distinguish
+// "intentionally stateless" from "accidentally forgot". Each entry states the
+// reason it produces nothing worth tracking, or what blocks it:
+//   * Creation / no-activation-input ops -- const-evaluated or DRAM-resident in
+//     the graphs this pass sees, so they hold no L1 buffer across the spill
+//     window: ArangeOp, EmptyOp, FullOp, OnesOp, ZerosOp, RandOp.
+//   * Structural / bookkeeping ops -- no device compute and no L1 output buffer
+//     of their own (DeallocateOp is getOpRuntime-only by design; DropoutOp and
+//     PrepareConv3dWeightsOp do not appear in inference graphs): AssignOp,
+//     DeallocateOp, D2MSubgraphOp, DropoutOp, PrepareConv3dWeightsOp.
+//   * MoeGptOp -- getOpConstraints is not implemented at all (no tt-metal
+//     definition); there is no query to hand a state to.
+//   * QuantizeOp, DequantizeOp, Conv1dOp -- compute ops that *would* benefit,
+//     but blocked one level down: their op_model::OpModel<> entry points have
+//     no `initialState` parameter and their queries use QUERY_OP_CONSTRAINTS
+//     rather than QUERY_OP_CONSTRAINTS_WITH_STATE. Migrating them is a backend
+//     change in lib/OpModel/TTNN/TTNNOpModel.cpp, not a thread-through here.
+// Migrating an op that is only blocked here means threading `liveRecords`
+// through instead (see ReluOp / ChunkedScaledDotProductAttentionOp for the
+// pattern), which changes no existing behavior for stateless callers.
 //===----------------------------------------------------------------------===//
 
 namespace detail {
@@ -839,10 +846,9 @@ AcosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> TanhOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig,
-                                       /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1106,10 +1112,9 @@ SubtractOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> MaximumOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1124,10 +1129,9 @@ MaximumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> MinimumOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1142,10 +1146,9 @@ MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> BitwiseAndOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1160,10 +1163,9 @@ BitwiseAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> BitwiseOrOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1178,10 +1180,9 @@ BitwiseOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> BitwiseXorOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1277,10 +1278,9 @@ GatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> Atan2Op::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1330,10 +1330,9 @@ GeluBackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> RemainderOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1348,10 +1347,9 @@ RemainderOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints> PowTensorOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    std::optional<
-        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
-                                        /*liveRecords=*/std::nullopt);
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -34,25 +34,24 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 // Stateful op-model migration policy (L1 spill)
 //
-// Ops that participate in the stateful, allocator-backed L1 spill pass override
-// the OpModel interface's getOpConstraintsWithState -- directly, via a per-op
-// extraClassDeclaration + out-of-line body, via a per-family helper macro
-// (e.g. TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE), or via a templated
-// *OpModel body. Every op that does NOT override it inherits the interface
-// default, which delegates to the stateless getOpConstraints
-// (buildInitialState({}) yields a null state -> plain stateless query). That
-// default is SAFE, not buggy: an unmigrated op is modeled exactly as before
-// this feature (no live-record state), never silently wrong -- only less
+// There is exactly ONE constraint entry per op, getOpConstraints, whose
+// trailing `liveRecords` argument selects the query flavour (std::nullopt =
+// cached stateless; engaged, even if empty = allocator-backed stateful). Ops
+// that participate in the stateful, allocator-backed L1 spill pass thread their
+// caller's `liveRecords` straight through to the op-model query. Ops that do
+// not pass /*liveRecords=*/std::nullopt instead, and take the parameter unnamed
+// to say so. That is SAFE, not buggy: an unmigrated op is modeled exactly as
+// before this feature (no live-record state), never silently wrong -- only less
 // fragmentation-aware if it ever appears in the spill window.
 //
-// The ops below are INTENTIONALLY left on the stateless default as of this
-// change (they are creation / structural ops, or their stateful body has not
-// been needed by the models this pass targets). This list exists so future
-// readers can distinguish "intentionally stateless" from "accidentally
-// forgot" -- migrating any of them just means adding a
-// getOpConstraintsWithState override mirroring its stateless twin (see
-// ChunkedScaledDotProductAttentionOp for the pattern) and changes no existing
-// behavior:
+// Since the signature no longer distinguishes them, the ops below are the
+// INTENTIONALLY stateless ones as of this change (they are creation /
+// structural ops, or their stateful body has not been needed by the models this
+// pass targets); `grep -n 'liveRecords=\*/std::nullopt'` finds them in code.
+// This list exists so future readers can distinguish "intentionally stateless"
+// from "accidentally forgot" -- migrating any of them just means threading
+// `liveRecords` through instead (see ChunkedScaledDotProductAttentionOp for the
+// pattern) and changes no existing behavior:
 //   * Creation / no-activation-input ops: ArangeOp, EmptyOp, FullOp, OnesOp,
 //     ZerosOp, RandOp.
 //   * Structural / bookkeeping ops: AssignOp, DeallocateOp, D2MSubgraphOp,
@@ -159,51 +158,51 @@ convertOptionalArrayAttrToSmallVec(std::optional<mlir::ArrayAttr> arrayAttr) {
 // Centralizes the cache-vs-bypass decision for every constraints query.
 //
 // The opConstraintsCache key is the op plus its args; liveRecords are
-// deliberately NOT part of the key. A stateful query (state != nullptr)
+// deliberately NOT part of the key. A stateful query (liveRecords engaged)
 // therefore MUST bypass the cache -- otherwise it would return a fit decision
 // cached under a different (or empty) live set, i.e. a stale-fit result. A
-// stateless query (state == nullptr) goes through the cache exactly as before.
+// stateless query (std::nullopt) goes through the cache exactly as before.
 // Every op interface body routes through here so this invariant lives in one
 // place. Args are taken by value: they are cheap (ArrayRef views, attrs) and
 // each branch consumes them at most once.
+//
+// `liveRecords` is TRI-STATE: engaged-but-empty is a stateful query, NOT a
+// stateless one. buildInitialState({}) deliberately returns a non-null state so
+// the spill path can bootstrap its record set off the first op -- see its
+// definition in TTNNOpModel.cpp.
 template <typename OpT, typename... Args>
-llvm::Expected<op_model::OpConstraints>
-constraintsDispatch(OpT op, const op_model::MockAllocatorState *state,
-                    Args... args) {
-  if (state) {
-    return op_model::OpModel<OpT>::getOpConstraintsWithState(args..., state);
+llvm::Expected<op_model::OpConstraints> constraintsDispatch(
+    OpT op,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords,
+    Args... args) {
+  if (liveRecords) {
+    std::shared_ptr<op_model::MockAllocatorState> state =
+        op_model::buildInitialState(*liveRecords);
+    return op_model::OpModel<OpT>::getOpConstraints(args..., state.get());
   }
+  // The state parameter is defaulted, and a default argument does not survive
+  // the function-pointer conversion getOrCompute's is_invocable guard performs,
+  // so bind it here. The lambda also keeps the cache key at exactly |args|.
   return opConstraintsCache().getOrCompute(
-      op_model::OpModel<OpT>::getOpConstraints, op, args...);
+      [](auto &&...a) {
+        return op_model::OpModel<OpT>::getOpConstraints(
+            std::forward<decltype(a)>(a)..., /*initialState=*/nullptr);
+      },
+      op, args...);
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getUnaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig,
-                        const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> getUnaryOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
-  return constraintsDispatch(op, state, inputShape, inputs[0],
+  return constraintsDispatch(op, liveRecords, inputShape, inputs[0],
                              opConfig.outputLayout);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getUnaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig) {
-  return getUnaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getUnaryOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getUnaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -220,10 +219,10 @@ getUnaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getBinaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig,
-                         const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> getBinaryOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 2);
 
   const auto inputShapeA = op.getLhs().getType().getShape();
@@ -234,24 +233,9 @@ getBinaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
     opDtypeAttr = dtypeOp.getDtypeAttr();
   }
 
-  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
-                             inputs[1], opConfig.outputLayout, opDtypeAttr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getBinaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig) {
-  return getBinaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getBinaryOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getBinaryConstraintsImpl(op, inputs, opConfig, initialState.get());
+  return constraintsDispatch(op, liveRecords, inputShapeA, inputs[0],
+                             inputShapeB, inputs[1], opConfig.outputLayout,
+                             opDtypeAttr);
 }
 
 template <typename OpT>
@@ -269,35 +253,19 @@ getBinaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getTernaryConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig,
-                          const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> getTernaryOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
   const auto inputShapeA = op.getFirst().getType().getShape();
   const auto inputShapeB = op.getSecond().getType().getShape();
   const auto inputShapeC = op.getThird().getType().getShape();
 
-  return constraintsDispatch(op, state, inputShapeA, inputs[0], inputShapeB,
-                             inputs[1], inputShapeC, inputs[2],
+  return constraintsDispatch(op, liveRecords, inputShapeA, inputs[0],
+                             inputShapeB, inputs[1], inputShapeC, inputs[2],
                              opConfig.outputLayout);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getTernaryOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return getTernaryConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getTernaryOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getTernaryConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -316,32 +284,16 @@ getTernaryOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getReductionConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig,
-                            const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> getReductionOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
   const auto inputShape = op.getInput().getType().getShape();
   return constraintsDispatch(
-      op, state, inputShape, inputs[0],
+      op, liveRecords, inputShape, inputs[0],
       detail::convertOptionalArrayAttrToSmallVec(op.getDimArg()),
       op.getKeepDim(), opConfig.outputLayout);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getReductionOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return getReductionConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getReductionOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getReductionConstraintsImpl(op, inputs, opConfig, initialState.get());
 }
 
 template <typename OpT>
@@ -357,36 +309,20 @@ getReductionOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getPoolingConstraintsImpl(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig,
-                          const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> getPoolingOpConstraints(
+    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
   return constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
-      op.getPadding(), op.getDilation(), op.getCeilMode(),
-      op.getReallocateHaloOutput(), op.getConfigTensorsInDram(),
-      opConfig.outputLayout);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getPoolingOpConstraints(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return getPoolingConstraintsImpl(op, inputs, opConfig, /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getPoolingOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getPoolingConstraintsImpl(op, inputs, opConfig, initialState.get());
+      op, liveRecords, inputShape, inputs[0], op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getChannels(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getCeilMode(), op.getReallocateHaloOutput(),
+      op.getConfigTensorsInDram(), opConfig.outputLayout);
 }
 
 template <typename OpT>
@@ -406,40 +342,21 @@ getPoolingOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 template <typename OpT>
-llvm::Expected<op_model::OpConstraints> getMaxPool2dWithIndicesConstraintsImpl(
+llvm::Expected<op_model::OpConstraints> getMaxPool2dWithIndicesOpConstraints(
     OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const auto inputShape = op.getInput().getType().getShape();
 
   return constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getChannels(), op.getKernelSize(), op.getStride(),
-      op.getPadding(), op.getDilation(), op.getCeilMode(),
-      op.getReallocateHaloOutput(),
+      op, liveRecords, inputShape, inputs[0], op.getBatchSize(),
+      op.getInputHeight(), op.getInputWidth(), op.getChannels(),
+      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
+      op.getCeilMode(), op.getReallocateHaloOutput(),
       /*deallocate_input*/ false, /*return_indices*/ true,
       op.getConfigTensorsInDram(), opConfig.outputLayout);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getMaxPool2dWithIndicesOpConstraints(OpT op,
-                                     const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
-                                                /*state=*/nullptr);
-}
-
-template <typename OpT>
-llvm::Expected<op_model::OpConstraints>
-getMaxPool2dWithIndicesOpConstraintsWithState(
-    OpT op, const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return getMaxPool2dWithIndicesConstraintsImpl(op, inputs, opConfig,
-                                                initialState.get());
 }
 
 template <typename OpT>
@@ -512,10 +429,11 @@ getQuantizationOpRuntime(OpT op, const std::vector<TTNNLayoutAttr> &inputs,
 // ReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> ReluOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -525,94 +443,14 @@ ReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// Elementwise-unary family: stateful getOpConstraintsWithState overrides.
-// Uniform members route through the stateful helper (both UnaryEltwiseOpModel
-// and UnaryEltwiseWithFastApproxModeOpModel have migrated op-model bodies).
-// ErfOp and BitwiseNotOp provide their own per-op extraClassDeclaration in
-// tablegen (which declares getOpConstraintsWithState there), so they are
-// defined here via the same helper macro.
-//===----------------------------------------------------------------------===//
-
-#define TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(OP)                        \
-  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
-      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
-      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
-    return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,     \
-                                                  liveRecords);                \
-  }
-
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AbsOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(BitwiseNotOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CbrtOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CeilOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(CosOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ExpOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ErfcOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(NegOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReciprocalOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(ReluOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Relu6Op)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SinOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SqrtOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(RsqrtOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(HardsigmoidOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SiluOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(MishOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AcosOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AsinhOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(AtanOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Expm1Op)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(FloorOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(GeluOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(IsFiniteOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(Log1pOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(LogicalNotOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(SignOp)
-TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE(TanOp)
-
-#undef TTNN_DEFINE_UNARY_OP_CONSTRAINTS_WITH_STATE
-
-// SigmoidOp (bespoke op-model) has the standard unary
-// (inputShape, inputLayout, outputLayout) signature, so it routes through the
-// uniform stateful helper. LeakyReluOp carries an extra float parameter, so it
-// threads state through a bespoke query.
-llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getUnaryOpConstraintsWithState(*this, inputs, opConfig,
-                                                liveRecords);
-}
-
-static llvm::Expected<op_model::OpConstraints> leakyReluConstraintsImpl(
-    LeakyReluOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = op.getInput().getType().getShape();
-
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getParameter(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints> LeakyReluOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return leakyReluConstraintsImpl(*this, inputs, opConfig, initialState.get());
-}
-
-//===----------------------------------------------------------------------===//
 // Relu6Op - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-Relu6Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> Relu6Op::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -625,10 +463,11 @@ Relu6Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // HardsigmoidOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-HardsigmoidOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> HardsigmoidOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -641,10 +480,11 @@ HardsigmoidOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SqrtOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SqrtOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -657,10 +497,11 @@ SqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SinOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SinOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -673,10 +514,11 @@ SinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AsinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AsinOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AsinOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -689,10 +531,11 @@ AsinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AsinhOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AsinhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AsinhOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -705,10 +548,11 @@ AsinhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AbsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AbsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AbsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -721,10 +565,11 @@ AbsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CeilOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-CeilOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> CeilOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -737,10 +582,11 @@ CeilOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SignOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SignOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -753,10 +599,11 @@ SignOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ErfOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ErfOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> ErfOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -769,10 +616,11 @@ ErfOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ErfcOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ErfcOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> ErfcOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -785,10 +633,11 @@ ErfcOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FloorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-FloorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> FloorOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -801,10 +650,11 @@ FloorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GeluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-GeluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> GeluOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -817,10 +667,11 @@ GeluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // IsFiniteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-IsFiniteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> IsFiniteOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -833,10 +684,11 @@ IsFiniteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalNotOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalNotOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalNotOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -849,10 +701,11 @@ LogicalNotOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NegOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-NegOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> NegOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -865,10 +718,11 @@ NegOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-TanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> TanOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -881,10 +735,11 @@ TanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AtanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AtanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AtanOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -897,10 +752,11 @@ AtanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RsqrtOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-RsqrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> RsqrtOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -913,10 +769,11 @@ RsqrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Log1pOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-Log1pOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> Log1pOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -929,10 +786,11 @@ Log1pOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Expm1Op - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-Expm1Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> Expm1Op::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -945,10 +803,11 @@ Expm1Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-CosOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> CosOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -961,10 +820,11 @@ CosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AcosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AcosOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AcosOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -977,10 +837,12 @@ AcosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TanhOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-TanhOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> TanhOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig,
+                                       /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -993,10 +855,11 @@ TanhOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1009,10 +872,11 @@ LogOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ReciprocalOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ReciprocalOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> ReciprocalOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1025,10 +889,11 @@ ReciprocalOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CbrtOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-CbrtOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> CbrtOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1041,10 +906,11 @@ CbrtOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BitwiseNotOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BitwiseNotOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> BitwiseNotOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1057,10 +923,11 @@ BitwiseNotOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SigmoidOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SigmoidOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SigmoidOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1073,10 +940,11 @@ SigmoidOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SiluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SiluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SiluOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1089,10 +957,11 @@ SiluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MishOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MishOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MishOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1105,10 +974,11 @@ MishOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ExpOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ExpOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getUnaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> ExpOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getUnaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1121,10 +991,16 @@ ExpOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LeakyReluOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LeakyReluOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return leakyReluConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
+llvm::Expected<op_model::OpConstraints> LeakyReluOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getParameter(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1143,10 +1019,11 @@ LeakyReluOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AddOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AddOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AddOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1156,71 +1033,14 @@ AddOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
-// Elementwise-binary family: stateful getOpConstraintsWithState overrides.
-// Declared on the shared TTNN_ElementwiseBinaryOp base (extraClassDeclaration),
-// so every member defines it here. The uniform BinaryEltwiseOpModel members
-// route through the stateful helper; GeluBackwardOp (bespoke op-model, extra
-// approximate arg) is not yet state-aware and delegates to the stateless query.
-//===----------------------------------------------------------------------===//
-
-#define TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(OP)                       \
-  llvm::Expected<op_model::OpConstraints> OP::getOpConstraintsWithState(       \
-      const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,     \
-      llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {         \
-    return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,    \
-                                                   liveRecords);               \
-  }
-
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(AddOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(DivideOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(MultiplyOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(SubtractOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(EqualOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(NotEqualOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterEqualOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(GreaterThanOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessEqualOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LessThanOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalAndOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalOrOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalXorOp)
-TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE(LogicalRightShiftOp)
-
-#undef TTNN_DEFINE_BINARY_OP_CONSTRAINTS_WITH_STATE
-
-// GeluBackwardOp shares the binary tablegen base but has a bespoke op-model
-// (extra `approximate` arg), so it threads state through a bespoke query.
-static llvm::Expected<op_model::OpConstraints> geluBackwardConstraintsImpl(
-    GeluBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == 2);
-
-  const auto inputShapeA = op.getLhs().getType().getShape();
-  const auto inputShapeB = op.getRhs().getType().getShape();
-
-  return detail::constraintsDispatch(
-      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
-      op.getApproximate().str(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-GeluBackwardOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
-                                     initialState.get());
-}
-
-//===----------------------------------------------------------------------===//
 // MultiplyOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MultiplyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MultiplyOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1233,10 +1053,11 @@ MultiplyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalRightShiftOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalRightShiftOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalRightShiftOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1249,10 +1070,11 @@ LogicalRightShiftOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalLeftShiftOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalLeftShiftOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalLeftShiftOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1261,22 +1083,15 @@ LogicalLeftShiftOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getBinaryOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints>
-LogicalLeftShiftOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getBinaryOpConstraintsWithState(*this, inputs, opConfig,
-                                                 liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // SubtractOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SubtractOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SubtractOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1289,10 +1104,12 @@ SubtractOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MaximumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MaximumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MaximumOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1305,10 +1122,12 @@ MaximumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MinimumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MinimumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MinimumOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1321,10 +1140,12 @@ MinimumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BitwiseAndOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BitwiseAndOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> BitwiseAndOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1337,10 +1158,12 @@ BitwiseAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BitwiseOrOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BitwiseOrOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> BitwiseOrOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1353,10 +1176,12 @@ BitwiseOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BitwiseXorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-BitwiseXorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> BitwiseXorOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1369,40 +1194,26 @@ BitwiseXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ScatterOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-scatterConstraintsImpl(ScatterOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ScatterOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto indexShape = op.getIndex().getType().getShape();
-  const auto sourceShape = op.getSource().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto indexShape = getIndex().getType().getShape();
+  const auto sourceShape = getSource().getType().getShape();
 
   std::optional<ttcore::ReduceTypeAttr> reduceType =
-      ttcore::ReduceTypeAttr::get(op.getContext(), ttcore::ReduceType::Invalid);
-  if (op.getScatterReduceType() != ttcore::ReduceType::Invalid) {
+      ttcore::ReduceTypeAttr::get(getContext(), ttcore::ReduceType::Invalid);
+  if (getScatterReduceType() != ttcore::ReduceType::Invalid) {
     reduceType =
-        ttcore::ReduceTypeAttr::get(op.getContext(), op.getScatterReduceType());
+        ttcore::ReduceTypeAttr::get(getContext(), getScatterReduceType());
   }
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], indexShape, inputs[1], sourceShape,
-      inputs[2], op.getDim(), reduceType, opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ScatterOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return scatterConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ScatterOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return scatterConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShape, inputs[0], indexShape, inputs[1],
+      sourceShape, inputs[2], getDim(), reduceType, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1431,33 +1242,19 @@ ScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-gatherConstraintsImpl(GatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> GatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 2);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto indexShape = op.getIndex().getType().getShape();
-  int32_t dim = op.getDim();
+  const auto inputShape = getInput().getType().getShape();
+  const auto indexShape = getIndex().getType().getShape();
+  int32_t dim = getDim();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      indexShape, inputs[1], dim,
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-GatherOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return gatherConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> GatherOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return gatherConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1478,10 +1275,12 @@ GatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // Atan2Op - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-Atan2Op::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> Atan2Op::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1494,11 +1293,18 @@ Atan2Op::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GeluBackwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-GeluBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return geluBackwardConstraintsImpl(*this, inputs, opConfig,
-                                     /*state=*/nullptr);
+llvm::Expected<op_model::OpConstraints> GeluBackwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 2);
+
+  const auto inputShapeA = getLhs().getType().getShape();
+  const auto inputShapeB = getRhs().getType().getShape();
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      getApproximate().str(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1522,10 +1328,12 @@ GeluBackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RemainderOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-RemainderOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> RemainderOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1538,10 +1346,12 @@ RemainderOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PowTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-PowTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> PowTensorOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig,
+                                        /*liveRecords=*/std::nullopt);
 }
 
 llvm::Expected<size_t>
@@ -1554,29 +1364,16 @@ PowTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PowScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> powScalarConstraintsImpl(
-    PowScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PowScalarOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getLhs().getType().getShape();
+  const auto inputShape = getLhs().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getRhs(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PowScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return powScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> PowScalarOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return powScalarConstraintsImpl(*this, inputs, opConfig, initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getRhs(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -1595,10 +1392,11 @@ PowScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // DivideOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-DivideOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> DivideOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1611,10 +1409,11 @@ DivideOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-EqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> EqualOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1627,10 +1426,11 @@ EqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NotEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-NotEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> NotEqualOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1643,10 +1443,11 @@ NotEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GreaterEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-GreaterEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> GreaterEqualOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1659,10 +1460,11 @@ GreaterEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GreaterThanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-GreaterThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> GreaterThanOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1675,10 +1477,11 @@ GreaterThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LessEqualOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LessEqualOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LessEqualOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1691,10 +1494,11 @@ LessEqualOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LessThanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LessThanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LessThanOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1707,10 +1511,11 @@ LessThanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalAndOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalAndOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalAndOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1723,10 +1528,11 @@ LogicalAndOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalOrOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalOrOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalOrOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1739,10 +1545,11 @@ LogicalOrOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // LogicalXorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-LogicalXorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return detail::getBinaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> LogicalXorOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getBinaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1755,10 +1562,11 @@ LogicalXorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // WhereOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-WhereOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
-  return detail::getTernaryOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> WhereOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getTernaryOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1767,21 +1575,15 @@ WhereOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getTernaryOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> WhereOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getTernaryOpConstraintsWithState(*this, inputs, opConfig,
-                                                  liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // MeanOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MeanOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return getReductionOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MeanOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return getReductionOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1790,21 +1592,15 @@ MeanOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> MeanOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
-                                            liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // MaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return getReductionOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MaxOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return getReductionOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1813,21 +1609,15 @@ MaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> MaxOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
-                                            liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // MinOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MinOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return getReductionOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MinOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return getReductionOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1836,21 +1626,15 @@ MinOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> MinOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
-                                            liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // SumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-SumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return getReductionOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> SumOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return getReductionOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -1859,42 +1643,21 @@ SumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return getReductionOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> SumOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return getReductionOpConstraintsWithState(*this, inputs, opConfig,
-                                            liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // SoftmaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-softmaxConstraintsImpl(SoftmaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> SoftmaxOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDimension(), op.getNumericStable(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDimension(), getNumericStable(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SoftmaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return softmaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> SoftmaxOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return softmaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1913,32 +1676,18 @@ SoftmaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ReshapeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-reshapeConstraintsImpl(ReshapeOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ReshapeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  const auto outputShape = op.getResult().getType().getShape();
+  const auto outputShape = getResult().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      outputShape, opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ReshapeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return reshapeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ReshapeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return reshapeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -1958,34 +1707,19 @@ ReshapeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceStaticOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> sliceStaticConstraintsImpl(
-    SliceStaticOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> SliceStaticOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0],
-      detail::convertArrayAttrToSmallVec(op.getBegins()),
-      detail::convertArrayAttrToSmallVec(op.getEnds()),
-      detail::convertArrayAttrToSmallVec(op.getStep()), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SliceStaticOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return sliceStaticConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SliceStaticOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return sliceStaticConstraintsImpl(*this, inputs, opConfig,
-                                    initialState.get());
+      *this, liveRecords, inputShape, inputs[0],
+      detail::convertArrayAttrToSmallVec(getBegins()),
+      detail::convertArrayAttrToSmallVec(getEnds()),
+      detail::convertArrayAttrToSmallVec(getStep()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2006,36 +1740,21 @@ SliceStaticOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SliceDynamicOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> sliceDynamicConstraintsImpl(
-    SliceDynamicOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> SliceDynamicOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto beginsShape = op.getBegins().getType().getShape();
-  const auto endsShape = op.getEnds().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto beginsShape = getBegins().getType().getShape();
+  const auto endsShape = getEnds().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], beginsShape, inputs[1], endsShape,
-      inputs[2], detail::convertOptionalArrayAttrToSmallVec(op.getStep()),
+      *this, liveRecords, inputShape, inputs[0], beginsShape, inputs[1],
+      endsShape, inputs[2],
+      detail::convertOptionalArrayAttrToSmallVec(getStep()),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SliceDynamicOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
-  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
-                                     /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SliceDynamicOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return sliceDynamicConstraintsImpl(*this, inputs, opConfig,
-                                     initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2057,36 +1776,21 @@ SliceDynamicOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // BitcastConvertOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-static llvm::Expected<op_model::OpConstraints> bitcastConvertConstraintsImpl(
-    BitcastConvertOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+
+llvm::Expected<op_model::OpConstraints> BitcastConvertOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
+      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
   assert(dtype && "BitcastConvertOp requires output dtype");
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
-                                     opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-BitcastConvertOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
-                                       /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-BitcastConvertOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return bitcastConvertConstraintsImpl(*this, inputs, opConfig,
-                                       initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     dtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2109,38 +1813,25 @@ BitcastConvertOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TypecastOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> typecastConstraintsImpl(
-    TypecastOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> TypecastOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   if (inputs[0].getBufferType() == BufferType::SystemMemory) {
     return issueErrorForGetOpConstraints(
-        op.getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
+        getOperation(), detail::ReasonForLackOfSupport::NeedsMemoryIO);
   }
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   ttcore::DataTypeAttr dtype =
-      detail::resolveOutputDtype(op.getOperation(), opConfig.outputLayout);
+      detail::resolveOutputDtype(getOperation(), opConfig.outputLayout);
   assert(dtype && "TypecastOp requires output dtype");
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0], dtype,
-                                     opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-TypecastOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return typecastConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> TypecastOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return typecastConstraintsImpl(*this, inputs, opConfig, initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     dtype, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2168,42 +1859,29 @@ TypecastOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToLayoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> toLayoutConstraintsImpl(
-    ToLayoutOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ToLayoutOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
   assert(opConfig.outputLayout && "ToLayoutOp requires output layout");
-  assert(opConfig.outputLayout.getLayout() == op.getLayoutAttr().getValue());
+  assert(opConfig.outputLayout.getLayout() == getLayoutAttr().getValue());
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  // Only signal a dtype conversion to the op model when this to_layout is
+  // Only signal a dtype conversion to the *this model when this to_layout is
   // genuinely changing dtype. Use the resolved (candidate or intrinsic)
   // output dtype, and compare it against the input dtype.
   std::optional<ttcore::DataType> outputDtype = std::nullopt;
-  if (ttcore::DataTypeAttr dtype = detail::resolveOutputDtype(
-          op.getOperation(), opConfig.outputLayout)) {
+  if (ttcore::DataTypeAttr dtype =
+          detail::resolveOutputDtype(getOperation(), opConfig.outputLayout)) {
     if (dtype.getValue() != inputs[0].getDataType()) {
       outputDtype = dtype.getValue();
     }
   }
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      outputDtype, opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ToLayoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return toLayoutConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ToLayoutOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return toLayoutConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2232,37 +1910,21 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ToMemoryConfigOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> toMemoryConfigConstraintsImpl(
-    ToMemoryConfigOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ToMemoryConfigOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   TTNNLayoutAttr outputLayout =
       opConfig.outputLayout
           ? opConfig.outputLayout
-          : mlir::cast<TTNNLayoutAttr>(op.getResult().getType().getEncoding());
+          : mlir::cast<TTNNLayoutAttr>(getResult().getType().getEncoding());
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ToMemoryConfigOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
-                                       /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ToMemoryConfigOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return toMemoryConfigConstraintsImpl(*this, inputs, opConfig,
-                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2286,35 +1948,21 @@ ToMemoryConfigOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-concatConstraintsImpl(ConcatOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == op.getInputs().size());
+llvm::Expected<op_model::OpConstraints> ConcatOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == getInputs().size());
 
   std::vector<llvm::ArrayRef<int64_t>> inputShapes;
-  for (const Value &opInput : op.getInputs()) {
+  for (const Value &opInput : getInputs()) {
     mlir::RankedTensorType inputType =
         mlir::cast<mlir::RankedTensorType>(opInput.getType());
     inputShapes.push_back(inputType.getShape());
   }
 
-  return detail::constraintsDispatch(op, state, inputShapes, inputs,
-                                     op.getDim(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConcatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return concatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ConcatOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return concatConstraintsImpl(*this, inputs, opConfig, initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShapes, inputs,
+                                     getDim(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2338,30 +1986,17 @@ ConcatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TransposeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> transposeConstraintsImpl(
-    TransposeOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> TransposeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDim0(), op.getDim1(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDim0(), getDim1(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-TransposeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return transposeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> TransposeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return transposeConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2380,31 +2015,17 @@ TransposeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumSumOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-cumSumConstraintsImpl(CumSumOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> CumSumOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getDim(),
-      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-CumSumOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return cumSumConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> CumSumOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return cumSumConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShape, inputs[0], getDim(),
+      dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2423,31 +2044,17 @@ CumSumOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // CumProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-cumProdConstraintsImpl(CumProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> CumProdOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getDim(),
-      dataTypeAttrToOptional(op.getDtypeAttr()), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-CumProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return cumProdConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> CumProdOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return cumProdConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShape, inputs[0], getDim(),
+      dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -2466,32 +2073,16 @@ CumProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConcatenateHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> concatenateHeadsConstraintsImpl(
-    ConcatenateHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ConcatenateHeadsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConcatenateHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
-                                         /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConcatenateHeadsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return concatenateHeadsConstraintsImpl(*this, inputs, opConfig,
-                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -2580,11 +2171,11 @@ unpackScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-scaledDotProductAttentionDecodeConstraintsImpl(
-    ScaledDotProductAttentionDecodeOp op,
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   // Clang tidy falsley determines that the underling float data in the
   // llvm::APFloat is freed more than once as APFloat is passed by value and
   // then destroyed at the end of this function.
@@ -2599,35 +2190,18 @@ scaledDotProductAttentionDecodeConstraintsImpl(
          "4, 5, or 6 input tensors");
 
   ScaledDotProductAttentionDecodeArgs sdpaArgs =
-      unpackScaledDotProductAttentionDecodeArgs(inputs, op);
+      unpackScaledDotProductAttentionDecodeArgs(inputs, *this);
 
-  auto scale = op.getScale();
+  auto scale = getScale();
   return detail::constraintsDispatch(
-      op, state, sdpaArgs.queryShape, sdpaArgs.queryLayout, sdpaArgs.keyShape,
-      sdpaArgs.keyLayout, sdpaArgs.valueShape, sdpaArgs.valueLayout,
-      sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
+      *this, liveRecords, sdpaArgs.queryShape, sdpaArgs.queryLayout,
+      sdpaArgs.keyShape, sdpaArgs.keyLayout, sdpaArgs.valueShape,
+      sdpaArgs.valueLayout, sdpaArgs.isCausal, sdpaArgs.attentionMaskShape,
       sdpaArgs.attentionMaskLayout, sdpaArgs.curPosTensorShape,
       sdpaArgs.curPosTensorLayout, sdpaArgs.attentionSinkShape,
       sdpaArgs.attentionSinkLayout, sdpaArgs.scale, sdpaArgs.programConfig,
       opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
-}
-
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
-                                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return scaledDotProductAttentionDecodeConstraintsImpl(*this, inputs, opConfig,
-                                                        initialState.get());
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2733,11 +2307,11 @@ unpackPagedScaledDotProductAttentionDecodeArgs(
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-pagedScaledDotProductAttentionDecodeConstraintsImpl(
-    PagedScaledDotProductAttentionDecodeOp op,
+llvm::Expected<op_model::OpConstraints>
+PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   // See the comment in scaledDotProductAttentionDecodeOp::getOpConstraints for
   // an explanation of this lint suppression.
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
@@ -2746,10 +2320,10 @@ pagedScaledDotProductAttentionDecodeConstraintsImpl(
          "7 input tensors");
 
   PagedScaledDotProductAttentionDecodeArgs pagedSdpaArgs =
-      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, op);
+      unpackPagedScaledDotProductAttentionDecodeArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
+      *this, liveRecords, pagedSdpaArgs.queryShape, pagedSdpaArgs.queryLayout,
       pagedSdpaArgs.keyShape, pagedSdpaArgs.keyLayout, pagedSdpaArgs.valueShape,
       pagedSdpaArgs.valueLayout, pagedSdpaArgs.pageTableShape,
       pagedSdpaArgs.pageTableLayout, pagedSdpaArgs.isCausal,
@@ -2759,23 +2333,6 @@ pagedScaledDotProductAttentionDecodeConstraintsImpl(
       pagedSdpaArgs.scale, pagedSdpaArgs.slidingWindowSize,
       pagedSdpaArgs.programConfig, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedScaledDotProductAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
-      *this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedScaledDotProductAttentionDecodeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return pagedScaledDotProductAttentionDecodeConstraintsImpl(
-      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedScaledDotProductAttentionDecodeOp::getOpRuntime(
@@ -2882,41 +2439,24 @@ unpackPagedFlashMultiLatentAttentionDecodeArgs(
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
-    PagedFlashMultiLatentAttentionDecodeOp op,
+llvm::Expected<op_model::OpConstraints>
+PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDelete)
 
   PagedFlashMultiLatentAttentionDecodeArgs args =
-      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, op);
+      unpackPagedFlashMultiLatentAttentionDecodeArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      *this, liveRecords, args.queryShape, args.queryLayout, args.keyShape,
       args.keyLayout, args.valueShape, args.valueLayout, args.headDimV,
       args.pageTableShape, args.pageTableLayout, args.isCausal,
       args.attentionMaskShape, args.attentionMaskLayout, args.curPosTensorShape,
       args.curPosTensorLayout, args.attentionSinkShape,
       args.attentionSinkLayout, args.scale, opConfig.outputLayout);
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedFlashMultiLatentAttentionDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
-      *this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedFlashMultiLatentAttentionDecodeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return pagedFlashMultiLatentAttentionDecodeConstraintsImpl(
-      *this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
@@ -2940,42 +2480,25 @@ llvm::Expected<size_t> PagedFlashMultiLatentAttentionDecodeOp::getOpRuntime(
 // ChunkedScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-chunkedScaledDotProductAttentionConstraintsImpl(
-    ChunkedScaledDotProductAttentionOp op,
+llvm::Expected<op_model::OpConstraints>
+ChunkedScaledDotProductAttentionOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 5 &&
          "ttnn::chunked_scaled_dot_product_attention has 5 input tensors "
          "(q, k, v, page_table, chunk_start_idx)");
 
-  const auto queryShape = op.getQuery().getType().getShape();
-  const auto keyShape = op.getKey().getType().getShape();
-  const auto valueShape = op.getValue().getType().getShape();
-  const auto pageTableShape = op.getPageTable().getType().getShape();
-  const auto chunkStartIdxShape = op.getChunkStartIdx().getType().getShape();
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
+  const auto pageTableShape = getPageTable().getType().getShape();
+  const auto chunkStartIdxShape = getChunkStartIdx().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
-      inputs[2], pageTableShape, inputs[3], chunkStartIdxShape, inputs[4],
-      op.getScale(), op.getProgramConfig(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ChunkedScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return chunkedScaledDotProductAttentionConstraintsImpl(
-      *this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ChunkedScaledDotProductAttentionOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return chunkedScaledDotProductAttentionConstraintsImpl(
-      *this, inputs, opConfig, initialState.get());
+      *this, liveRecords, queryShape, inputs[0], keyShape, inputs[1],
+      valueShape, inputs[2], pageTableShape, inputs[3], chunkStartIdxShape,
+      inputs[4], getScale(), getProgramConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
@@ -3001,56 +2524,40 @@ llvm::Expected<size_t> ChunkedScaledDotProductAttentionOp::getOpRuntime(
 // ScaledDotProductAttentionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-scaledDotProductAttentionConstraintsImpl(
-    ScaledDotProductAttentionOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints>
+ScaledDotProductAttentionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() >= 3 && inputs.size() <= 5 &&
          "ttnn::scaled_dot_product_attention can have 3 to 5 operands input "
          "tensors (q, k, v, optional mask, optional attention_sink)");
 
-  const auto queryShape = op.getQuery().getType().getShape();
-  const auto keyShape = op.getKey().getType().getShape();
-  const auto valueShape = op.getValue().getType().getShape();
+  const auto queryShape = getQuery().getType().getShape();
+  const auto keyShape = getKey().getType().getShape();
+  const auto valueShape = getValue().getType().getShape();
 
   size_t idx = 3;
   const std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape =
-      op.getAttentionMask()
-          ? std::make_optional(op.getAttentionMask().getType().getShape())
+      getAttentionMask()
+          ? std::make_optional(getAttentionMask().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionMaskLayout =
-      op.getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      getAttentionMask() ? std::make_optional(inputs[idx++]) : std::nullopt;
   const std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape =
-      op.getAttentionSink()
-          ? std::make_optional(op.getAttentionSink().getType().getShape())
+      getAttentionSink()
+          ? std::make_optional(getAttentionSink().getType().getShape())
           : std::nullopt;
   const std::optional<TTNNLayoutAttr> attentionSinkLayout =
-      op.getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
+      getAttentionSink() ? std::make_optional(inputs[idx++]) : std::nullopt;
 
-  bool isCausal = op.getIsCausal();
+  bool isCausal = getIsCausal();
 
   return detail::constraintsDispatch(
-      op, state, queryShape, inputs[0], keyShape, inputs[1], valueShape,
-      inputs[2], attentionMaskShape, attentionMaskLayout, attentionSinkShape,
-      attentionSinkLayout, isCausal, op.getScale(), op.getSlidingWindowSize(),
-      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
-                                                  /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ScaledDotProductAttentionOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return scaledDotProductAttentionConstraintsImpl(*this, inputs, opConfig,
-                                                  initialState.get());
+      *this, liveRecords, queryShape, inputs[0], keyShape, inputs[1],
+      valueShape, inputs[2], attentionMaskShape, attentionMaskLayout,
+      attentionSinkShape, attentionSinkLayout, isCausal, getScale(),
+      getSlidingWindowSize(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> ScaledDotProductAttentionOp::getOpRuntime(
@@ -3135,37 +2642,21 @@ unpackFlashMlaPrefillArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints> flashMlaPrefillConstraintsImpl(
-    FlashMlaPrefillOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> FlashMlaPrefillOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() >= 2 && inputs.size() <= 4 &&
          "ttnn::flash_mla_prefill can have 2 to 4 input tensors "
          "(q, k, optional value, optional mask)");
 
-  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, op);
+  FlashMlaPrefillArgs args = unpackFlashMlaPrefillArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, args.queryShape, args.queryLayout, args.keyShape,
+      *this, liveRecords, args.queryShape, args.queryLayout, args.keyShape,
       args.keyLayout, args.valueShape, args.valueLayout,
       args.attentionMaskShape, args.attentionMaskLayout, args.headDimV,
-      args.isCausal, op.getScale(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-FlashMlaPrefillOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
-                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-FlashMlaPrefillOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return flashMlaPrefillConstraintsImpl(*this, inputs, opConfig,
-                                        initialState.get());
+      args.isCausal, getScale(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3222,39 +2713,22 @@ IndexerScoreDsaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingLlamaOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-rotaryEmbeddingLlamaConstraintsImpl(RotaryEmbeddingLlamaOp op,
-                                    const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig,
-                                    const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == 4);
-
-  auto inputShape = op.getInput().getType().getShape();
-  auto cosShape = op.getCosCache().getType().getShape();
-  auto sinShape = op.getSinCache().getType().getShape();
-  auto transMatShape = op.getTransMat().getType().getShape();
-  bool isDecodeMode = op.getIsDecodeMode();
-
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], cosShape, inputs[1], sinShape,
-      inputs[2], transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
-}
-
 llvm::Expected<op_model::OpConstraints>
 RotaryEmbeddingLlamaOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
-                                             /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RotaryEmbeddingLlamaOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return rotaryEmbeddingLlamaConstraintsImpl(*this, inputs, opConfig,
-                                             initialState.get());
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 4);
+
+  auto inputShape = getInput().getType().getShape();
+  auto cosShape = getCosCache().getType().getShape();
+  auto sinShape = getSinCache().getType().getShape();
+  auto transMatShape = getTransMat().getType().getShape();
+  bool isDecodeMode = getIsDecodeMode();
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], cosShape, inputs[1], sinShape,
+      inputs[2], transMatShape, inputs[3], isDecodeMode, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3278,36 +2752,20 @@ RotaryEmbeddingLlamaOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RotaryEmbeddingOp - TTNN Op Model Interface
 //===-----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> rotaryEmbeddingConstraintsImpl(
-    RotaryEmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> RotaryEmbeddingOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  auto inputShape = op.getInput().getType().getShape();
-  auto cosShape = op.getCosCache().getType().getShape();
-  auto sinShape = op.getSinCache().getType().getShape();
-  auto tokenIndex = op.getTokenIndex();
+  auto inputShape = getInput().getType().getShape();
+  auto cosShape = getCosCache().getType().getShape();
+  auto sinShape = getSinCache().getType().getShape();
+  auto tokenIndex = getTokenIndex();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0], cosShape,
-                                     inputs[1], sinShape, inputs[2], tokenIndex,
-                                     opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RotaryEmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
-                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RotaryEmbeddingOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return rotaryEmbeddingConstraintsImpl(*this, inputs, opConfig,
-                                        initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     cosShape, inputs[1], sinShape, inputs[2],
+                                     tokenIndex, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3330,42 +2788,26 @@ RotaryEmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // NLPCreateQKVHeadsDecodeOp - TTNN Op Model Interface
 // ===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-nLPCreateQKVHeadsDecodeConstraintsImpl(
-    NLPCreateQKVHeadsDecodeOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (1 + (op.getBatchOffset() == nullptr ? 0 : 1)));
+llvm::Expected<op_model::OpConstraints>
+NLPCreateQKVHeadsDecodeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (1 + (getBatchOffset() == nullptr ? 0 : 1)));
 
-  auto inputShape = op.getInput().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape;
   std::optional<TTNNLayoutAttr> batchOffsetEncoding;
   if (inputs.size() == 2) {
-    batchOffsetShape = op.getBatchOffset().getType().getShape();
+    batchOffsetShape = getBatchOffset().getType().getShape();
     batchOffsetEncoding = inputs[1];
   }
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], batchOffsetShape, batchOffsetEncoding,
-      op.getNumHeads(), op.getNumKvHeads(), op.getOverlapQkCoregrid(),
-      op.getSliceSize(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-NLPCreateQKVHeadsDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
-                                                /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-NLPCreateQKVHeadsDecodeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return nLPCreateQKVHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
-                                                initialState.get());
+      *this, liveRecords, inputShape, inputs[0], batchOffsetShape,
+      batchOffsetEncoding, getNumHeads(), getNumKvHeads(),
+      getOverlapQkCoregrid(), getSliceSize(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
@@ -3392,32 +2834,16 @@ llvm::Expected<size_t> NLPCreateQKVHeadsDecodeOp::getOpRuntime(
 // NLPConcatHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> nLPConcatHeadsConstraintsImpl(
-    NLPConcatHeadsOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> NLPConcatHeadsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  auto inputShape = op.getInput().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-NLPConcatHeadsOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
-                                       /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-NLPConcatHeadsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return nLPConcatHeadsConstraintsImpl(*this, inputs, opConfig,
-                                       initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3435,35 +2861,19 @@ NLPConcatHeadsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsDecodeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-static llvm::Expected<op_model::OpConstraints>
-nLPConcatHeadsDecodeConstraintsImpl(NLPConcatHeadsDecodeOp op,
-                                    const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig,
-                                    const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == 1);
-
-  const auto inputShape = op.getInput().getType().getShape();
-  uint32_t numHeads = op.getNumHeads();
-
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0], numHeads,
-                                     opConfig.outputLayout);
-}
 
 llvm::Expected<op_model::OpConstraints>
 NLPConcatHeadsDecodeOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
-                                             /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-NLPConcatHeadsDecodeOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return nLPConcatHeadsDecodeConstraintsImpl(*this, inputs, opConfig,
-                                             initialState.get());
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+  uint32_t numHeads = getNumHeads();
+
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     numHeads, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3481,45 +2891,28 @@ NLPConcatHeadsDecodeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 //===----------------------------------------------------------------------===//
 // SplitQueryKeyValueAndSplitHeadsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
-static llvm::Expected<op_model::OpConstraints>
-splitQueryKeyValueAndSplitHeadsConstraintsImpl(
-    SplitQueryKeyValueAndSplitHeadsOp op,
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (1 + (op.getKvInputTensor() ? 1 : 0)));
 
-  auto inputShape = op.getInputTensor().getType().getShape();
+llvm::Expected<op_model::OpConstraints>
+SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (1 + (getKvInputTensor() ? 1 : 0)));
+
+  auto inputShape = getInputTensor().getType().getShape();
 
   // Handle optional kv input tensor
   std::optional<llvm::ArrayRef<int64_t>> kvInputShape = std::nullopt;
   std::optional<TTNNLayoutAttr> kvInputLayout = std::nullopt;
 
-  if (op.getKvInputTensor()) {
-    kvInputShape = op.getKvInputTensor().getType().getShape();
+  if (getKvInputTensor()) {
+    kvInputShape = getKvInputTensor().getType().getShape();
     kvInputLayout = inputs[1];
   }
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], kvInputShape, kvInputLayout,
-      op.getNumHeads(), op.getNumKvHeads(), op.getTransposeKey(),
-      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SplitQueryKeyValueAndSplitHeadsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
-                                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SplitQueryKeyValueAndSplitHeadsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return splitQueryKeyValueAndSplitHeadsConstraintsImpl(*this, inputs, opConfig,
-                                                        initialState.get());
+      *this, liveRecords, inputShape, inputs[0], kvInputShape, kvInputLayout,
+      getNumHeads(), getNumKvHeads(), getTransposeKey(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
@@ -3543,33 +2936,17 @@ llvm::Expected<size_t> SplitQueryKeyValueAndSplitHeadsOp::getOpRuntime(
 // RepeatInterleaveOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> repeatInterleaveConstraintsImpl(
-    RepeatInterleaveOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> RepeatInterleaveOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getRepeats(), op.getDim(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getRepeats(), getDim(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RepeatInterleaveOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
-                                         /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RepeatInterleaveOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return repeatInterleaveConstraintsImpl(*this, inputs, opConfig,
-                                         initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3588,31 +2965,17 @@ RepeatInterleaveOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RepeatOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-repeatConstraintsImpl(RepeatOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> RepeatOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getRepeatDims().getShape(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getRepeatDims().getShape(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RepeatOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return repeatConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> RepeatOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return repeatConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3631,31 +2994,17 @@ RepeatOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PadOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-padConstraintsImpl(PadOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                   const OpConfig &opConfig,
-                   const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PadOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getPadding(), op.getValue(),
-      op.getUseMulticore(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PadOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                        const OpConfig &opConfig) {
-  return padConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> PadOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return padConstraintsImpl(*this, inputs, opConfig, initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getPadding(), getValue(),
+                                     getUseMulticore(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3674,31 +3023,17 @@ PadOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SortOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-sortConstraintsImpl(SortOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                    const OpConfig &opConfig,
-                    const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> SortOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDim(), op.getDescending(),
-                                     op.getStable(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SortOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return sortConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> SortOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return sortConstraintsImpl(*this, inputs, opConfig, initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDim(), getDescending(), getStable(),
+                                     opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3717,31 +3052,17 @@ SortOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ArgMaxOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-argMaxConstraintsImpl(ArgMaxOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ArgMaxOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDim(), op.getKeepDim(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDim(), getKeepDim(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ArgMaxOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return argMaxConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ArgMaxOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return argMaxConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3760,31 +3081,17 @@ ArgMaxOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ProdOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prodConstraintsImpl(ProdOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                    const OpConfig &opConfig,
-                    const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ProdOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDimArg(), op.getKeepDim(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDimArg(), getKeepDim(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ProdOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return prodConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ProdOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prodConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -3798,9 +3105,10 @@ ProdOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // QuantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-QuantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> QuantizeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return detail::getQuantizationOpConstraints(*this, inputs, opConfig);
 }
 
@@ -3814,9 +3122,10 @@ QuantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // DequantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-DequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> DequantizeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return detail::getQuantizationOpConstraints(*this, inputs, opConfig);
 }
 
@@ -3830,34 +3139,21 @@ DequantizeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RequantizeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> requantizeConstraintsImpl(
-    RequantizeOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 5);
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto inScaleShape = op.getInScale().getType().getShape();
-  const auto inZeroPointShape = op.getInZeroPoint().getType().getShape();
-  const auto outScaleShape = op.getOutScale().getType().getShape();
-  const auto outZeroPointShape = op.getOutZeroPoint().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto inScaleShape = getInScale().getType().getShape();
+  const auto inZeroPointShape = getInZeroPoint().getType().getShape();
+  const auto outScaleShape = getOutScale().getType().getShape();
+  const auto outZeroPointShape = getOutZeroPoint().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], inScaleShape, inputs[1],
+      *this, liveRecords, inputShape, inputs[0], inScaleShape, inputs[1],
       inZeroPointShape, inputs[2], outScaleShape, inputs[3], outZeroPointShape,
-      inputs[4], op.getAxis(), op.getOutputDtype(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RequantizeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
-  return requantizeConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> RequantizeOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return requantizeConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      inputs[4], getAxis(), getOutputDtype(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -3908,49 +3204,36 @@ static MatmulAttrs unpackMatmulAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-static llvm::Expected<op_model::OpConstraints>
-linearConstraintsImpl(LinearOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
+llvm::Expected<op_model::OpConstraints> LinearOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShapeA = op.getA().getType().getShape();
-  const auto inputShapeB = op.getB().getType().getShape();
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
 
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = op.getBias().getType().getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      op.getActivation() ? std::make_optional(op.getActivation().value())
-                         : std::nullopt;
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
 
-  // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
+  // Get matmul program config from opConfig if present, otherwise from
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1], biasShape,
-      biasLayout, opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(),
-      activation, attr.matmulProgramConfig, attr.computeKernelConfig);
-}
-
-llvm::Expected<op_model::OpConstraints>
-LinearOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return linearConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> LinearOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return linearConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      biasShape, biasLayout, opConfig.outputLayout, getTransposeA(),
+      getTransposeB(), activation, attr.matmulProgramConfig,
+      attr.computeKernelConfig);
 }
 
 llvm::Expected<size_t>
@@ -3979,41 +3262,27 @@ LinearOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MatmulOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-matmulConstraintsImpl(MatmulOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> MatmulOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 2);
 
-  const auto inputShapeA = op.getA().getType().getShape();
-  const auto inputShapeB = op.getB().getType().getShape();
+  const auto inputShapeA = getA().getType().getShape();
+  const auto inputShapeB = getB().getType().getShape();
 
   // Convert activation attribute to optional StringRef
   std::optional<llvm::StringRef> activation =
-      op.getActivation() ? std::make_optional(op.getActivation().value())
-                         : std::nullopt;
+      getActivation() ? std::make_optional(getActivation().value())
+                      : std::nullopt;
 
-  // Get matmul program config from opConfig if present, otherwise from op.
-  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, op);
+  // Get matmul program config from opConfig if present, otherwise from
+  MatmulAttrs attr = unpackMatmulAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShapeA, inputs[0], inputShapeB, inputs[1],
-      opConfig.outputLayout, op.getTransposeA(), op.getTransposeB(), activation,
+      *this, liveRecords, inputShapeA, inputs[0], inputShapeB, inputs[1],
+      opConfig.outputLayout, getTransposeA(), getTransposeB(), activation,
       attr.matmulProgramConfig, attr.computeKernelConfig);
-}
-
-llvm::Expected<op_model::OpConstraints>
-MatmulOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return matmulConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> MatmulOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return matmulConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4034,36 +3303,20 @@ MatmulOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKRouterGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> topKRouterGptConstraintsImpl(
-    TopKRouterGptOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> TopKRouterGptOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto weightShape = op.getWeight().getType().getShape();
-  const auto biasShape = op.getBias().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  const auto biasShape = getBias().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
-      inputs[2], static_cast<uint32_t>(op.getK()),
-      static_cast<uint32_t>(op.getNumExperts()), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-TopKRouterGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                  const OpConfig &opConfig) {
-  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
-                                      /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-TopKRouterGptOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return topKRouterGptConstraintsImpl(*this, inputs, opConfig,
-                                      initialState.get());
+      *this, liveRecords, inputShape, inputs[0], weightShape, inputs[1],
+      biasShape, inputs[2], static_cast<uint32_t>(getK()),
+      static_cast<uint32_t>(getNumExperts()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4086,9 +3339,10 @@ TopKRouterGptOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MoeGptOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MoeGptOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> MoeGptOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return issueErrorForGetOpConstraints(
       getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
 }
@@ -4104,44 +3358,27 @@ MoeGptOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareMoEComputeW0W1WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareMoEComputeW0W1WeightsConstraintsImpl(
-    PrepareMoEComputeW0W1WeightsOp op,
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
-  const bool hasBias = op.getBias_0() != nullptr;
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const bool hasBias = getBias_0() != nullptr;
   assert(inputs.size() == (hasBias ? 4u : 2u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias0Shape, bias1Shape;
   std::optional<TTNNLayoutAttr> bias0Layout, bias1Layout;
   if (hasBias) {
-    bias0Shape = op.getBias_0().getType().getShape();
-    bias1Shape = op.getBias_1().getType().getShape();
+    bias0Shape = getBias_0().getType().getShape();
+    bias1Shape = getBias_1().getType().getShape();
     bias0Layout = inputs[2];
     bias1Layout = inputs[3];
   }
 
   return detail::constraintsDispatch(
-      op, state, op.getW0().getType().getShape(), inputs[0],
-      op.getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
-      bias1Shape, bias1Layout, op.getHiddenSize(), op.getIntermediateSize());
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW0W1WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
-                                                     /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW0W1WeightsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareMoEComputeW0W1WeightsConstraintsImpl(*this, inputs, opConfig,
-                                                     initialState.get());
+      *this, liveRecords, getW0().getType().getShape(), inputs[0],
+      getW1().getType().getShape(), inputs[1], bias0Shape, bias0Layout,
+      bias1Shape, bias1Layout, getHiddenSize(), getIntermediateSize());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
@@ -4154,40 +3391,24 @@ llvm::Expected<size_t> PrepareMoEComputeW0W1WeightsOp::getOpRuntime(
 // PrepareMoEComputeW2WeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareMoEComputeW2WeightsConstraintsImpl(
-    PrepareMoEComputeW2WeightsOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  const bool hasBias = op.getBias_2() != nullptr;
+llvm::Expected<op_model::OpConstraints>
+PrepareMoEComputeW2WeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const bool hasBias = getBias_2() != nullptr;
   assert(inputs.size() == (hasBias ? 2u : 1u));
 
   std::optional<llvm::ArrayRef<int64_t>> bias2Shape;
   std::optional<TTNNLayoutAttr> bias2Layout;
   if (hasBias) {
-    bias2Shape = op.getBias_2().getType().getShape();
+    bias2Shape = getBias_2().getType().getShape();
     bias2Layout = inputs[1];
   }
 
   return detail::constraintsDispatch(
-      op, state, op.getW2().getType().getShape(), inputs[0], bias2Shape,
-      bias2Layout, op.getHiddenSize(), op.getIntermediateSize());
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW2WeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
-                                                   /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareMoEComputeW2WeightsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareMoEComputeW2WeightsConstraintsImpl(*this, inputs, opConfig,
-                                                   initialState.get());
+      *this, liveRecords, getW2().getType().getShape(), inputs[0], bias2Shape,
+      bias2Layout, getHiddenSize(), getIntermediateSize());
 }
 
 llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(
@@ -4200,9 +3421,10 @@ llvm::Expected<size_t> PrepareMoEComputeW2WeightsOp::getOpRuntime(
 // DeallocateOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-DeallocateOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                               const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> DeallocateOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return issueErrorForGetOpConstraints(
       getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
 }
@@ -4221,31 +3443,18 @@ DeallocateOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FillCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> fillCacheConstraintsImpl(
-    FillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> FillCacheOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 2);
 
-  auto cacheShape = op.getCache().getType().getShape();
-  auto inputShape = op.getInput().getType().getShape();
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
-                                     inputShape, inputs[1], op.getBatchOffset(),
+  return detail::constraintsDispatch(*this, liveRecords, cacheShape, inputs[0],
+                                     inputShape, inputs[1], getBatchOffset(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-FillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return fillCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> FillCacheOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return fillCacheConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4265,34 +3474,19 @@ FillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpdateCacheOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> updateCacheConstraintsImpl(
-    UpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> UpdateCacheOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  auto cacheShape = op.getCache().getType().getShape();
-  auto inputShape = op.getInput().getType().getShape();
-  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto updateIndexShape = getUpdateIndex().getType().getShape();
 
   return detail::constraintsDispatch(
-      op, state, cacheShape, inputs[0], inputShape, inputs[1], updateIndexShape,
-      inputs[2], op.getBatchOffset(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-UpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return updateCacheConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-UpdateCacheOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return updateCacheConstraintsImpl(*this, inputs, opConfig,
-                                    initialState.get());
+      *this, liveRecords, cacheShape, inputs[0], inputShape, inputs[1],
+      updateIndexShape, inputs[2], getBatchOffset(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4309,43 +3503,27 @@ UpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       getBatchOffset(), opConfig.outputLayout);
 }
 
-static llvm::Expected<op_model::OpConstraints> pagedUpdateCacheConstraintsImpl(
-    PagedUpdateCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PagedUpdateCacheOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedUpdateCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = op.getCache().getType().getShape();
-  auto inputShape = op.getInput().getType().getShape();
-  auto updateIndexShape = op.getUpdateIndex().getType().getShape();
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto updateIndexShape = getUpdateIndex().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> pageTableShape;
   std::optional<TTNNLayoutAttr> pageTableLayout;
-  if (op.getPageTable()) {
-    pageTableShape = op.getPageTable().getType().getShape();
+  if (getPageTable()) {
+    pageTableShape = getPageTable().getType().getShape();
     pageTableLayout = inputs[3];
   }
 
-  return detail::constraintsDispatch(op, state, cacheShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, cacheShape, inputs[0],
                                      inputShape, inputs[1], updateIndexShape,
                                      inputs[2], pageTableShape, pageTableLayout,
-                                     op.getShareCache(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedUpdateCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                     const OpConfig &opConfig) {
-  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
-                                         /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedUpdateCacheOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return pagedUpdateCacheConstraintsImpl(*this, inputs, opConfig,
-                                         initialState.get());
+                                     getShareCache(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4369,42 +3547,27 @@ PagedUpdateCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
       pageTableShape, pageTableLayout, getShareCache(), opConfig.outputLayout);
 }
 
-static llvm::Expected<op_model::OpConstraints> pagedFillCacheConstraintsImpl(
-    PagedFillCacheOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PagedFillCacheOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() >= 3 && inputs.size() <= 4 &&
          "PagedFillCacheOp must have 3 or 4 inputs");
 
-  auto cacheShape = op.getCache().getType().getShape();
-  auto inputShape = op.getInput().getType().getShape();
-  auto pageTableShape = op.getPageTable().getType().getShape();
+  auto cacheShape = getCache().getType().getShape();
+  auto inputShape = getInput().getType().getShape();
+  auto pageTableShape = getPageTable().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> batchIdxShape;
   std::optional<TTNNLayoutAttr> batchIdxLayout;
-  if (op.getBatchIdxTensor()) {
-    batchIdxShape = op.getBatchIdxTensor().getType().getShape();
+  if (getBatchIdxTensor()) {
+    batchIdxShape = getBatchIdxTensor().getType().getShape();
     batchIdxLayout = inputs[3];
   }
 
-  return detail::constraintsDispatch(
-      op, state, cacheShape, inputs[0], inputShape, inputs[1], pageTableShape,
-      inputs[2], batchIdxShape, batchIdxLayout, opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedFillCacheOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig) {
-  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
-                                       /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PagedFillCacheOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return pagedFillCacheConstraintsImpl(*this, inputs, opConfig,
-                                       initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, cacheShape, inputs[0],
+                                     inputShape, inputs[1], pageTableShape,
+                                     inputs[2], batchIdxShape, batchIdxLayout,
+                                     opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4432,30 +3595,17 @@ PagedFillCacheOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // SamplingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> samplingConstraintsImpl(
-    SamplingOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> SamplingOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 5);
   return detail::constraintsDispatch(
-      op, state, op.getInputValues().getType().getShape(), inputs[0],
-      op.getInputIndices().getType().getShape(), inputs[1],
-      op.getK().getType().getShape(), inputs[2], op.getP().getType().getShape(),
-      inputs[3], op.getTemp().getType().getShape(), inputs[4], op.getSeed(),
+      *this, liveRecords, getInputValues().getType().getShape(), inputs[0],
+      getInputIndices().getType().getShape(), inputs[1],
+      getK().getType().getShape(), inputs[2], getP().getType().getShape(),
+      inputs[3], getTemp().getType().getShape(), inputs[4], getSeed(),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-SamplingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return samplingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> SamplingOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return samplingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4497,9 +3647,10 @@ static Conv2dAttrs unpackConv1dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-llvm::Expected<op_model::OpConstraints>
-Conv1dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> Conv1dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
   const auto inputShape = getInput().getType().getShape();
@@ -4571,45 +3722,31 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-static llvm::Expected<op_model::OpConstraints>
-conv2dConstraintsImpl(Conv2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
+llvm::Expected<op_model::OpConstraints> Conv2dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto weightShape = op.getWeight().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = op.getBias().getType().getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+  Conv2dAttrs attr = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
-      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
-      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
-      op.getStride(), op.getPadding(), op.getDilation(), op.getGroups(),
-      attr.conv2dConfig, attr.deviceComputeKernelConfig,
-      op.getConv2dSliceConfigAttr(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-Conv2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return conv2dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> Conv2dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return conv2dConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShape, inputs[0], weightShape, inputs[1],
+      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getGroups(), attr.conv2dConfig,
+      attr.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4661,50 +3798,35 @@ static Conv3dAttrs unpackConv3dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                          : op.getComputeConfig()};
 }
 
-static llvm::Expected<op_model::OpConstraints>
-conv3dConstraintsImpl(Conv3dOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                      const OpConfig &opConfig,
-                      const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
+llvm::Expected<op_model::OpConstraints> Conv3dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
   // tt-metal's conv3d kernel consumes the prepared 2D weight; the in-IR
   // weight may still be raw 5D (before TTNNPrepareConv3dWeights runs), so
   // pass the prepared shape/layout regardless of what's currently in IR.
-  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(&op);
+  auto preparedWeight = op_model::getPreparedConv3dWeightsOutputTensor(this);
   const auto weightShape = preparedWeight.getShape();
   auto weightLayout = mlir::cast<TTNNLayoutAttr>(preparedWeight.getEncoding());
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = op.getBias().getType().getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, op);
+  Conv3dAttrs attr = unpackConv3dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], weightShape, weightLayout, biasShape,
-      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
-      op.getInputDepth(), op.getInputHeight(), op.getInputWidth(),
-      op.getKernelSize(), op.getStride(), op.getPadding(), op.getGroups(),
-      op.getPaddingMode(), op.getDtypeAttr(), attr.conv3dConfig,
-      attr.deviceComputeKernelConfig, opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-Conv3dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
-  return conv3dConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> Conv3dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return conv3dConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      *this, liveRecords, inputShape, inputs[0], weightShape, weightLayout,
+      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
+      getInputDepth(), getInputHeight(), getInputWidth(), getKernelSize(),
+      getStride(), getPadding(), getGroups(), getPaddingMode(), getDtypeAttr(),
+      attr.conv3dConfig, attr.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4760,48 +3882,32 @@ static Conv2dAttrs unpackConv2dAttrs(const OpConfig::OpSpecificAttrs &attrs,
                      std::nullopt};
 }
 
-static llvm::Expected<op_model::OpConstraints> convTranspose2dConstraintsImpl(
-    ConvTranspose2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == (2 + (op.getBias() == nullptr ? 0 : 1)));
+llvm::Expected<op_model::OpConstraints> ConvTranspose2dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == (2 + (getBias() == nullptr ? 0 : 1)));
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto weightShape = op.getWeight().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
   std::optional<llvm::ArrayRef<int64_t>> biasShape;
   std::optional<TTNNLayoutAttr> biasLayout;
 
   if (inputs.size() == 3) {
-    biasShape = op.getBias().getType().getShape();
+    biasShape = getBias().getType().getShape();
     biasLayout = inputs[2];
   }
 
-  // If a conv config has been specified, use that. If not, read the op property
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+  // If a conv config has been specified, use that. If not, read the *this
+  // property
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], weightShape, inputs[1], biasShape,
-      biasLayout, op.getInChannels(), op.getOutChannels(), op.getBatchSize(),
-      op.getInputHeight(), op.getInputWidth(), op.getKernelSize(),
-      op.getStride(), op.getPadding(), op.getOutputPadding(), op.getDilation(),
-      op.getGroups(), conv2dAttrs.conv2dConfig, op.getConv2dSliceConfig(),
-      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConvTranspose2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
-                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConvTranspose2dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return convTranspose2dConstraintsImpl(*this, inputs, opConfig,
-                                        initialState.get());
+      *this, liveRecords, inputShape, inputs[0], weightShape, inputs[1],
+      biasShape, biasLayout, getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getOutputPadding(), getDilation(), getGroups(),
+      conv2dAttrs.conv2dConfig, getConv2dSliceConfig(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4835,43 +3941,25 @@ ConvTranspose2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareConv2dWeightsConstraintsImpl(PrepareConv2dWeightsOp op,
-                                    const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig,
-                                    const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints>
+PrepareConv2dWeightsOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      op.getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+      getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
-      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
-      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getDilation(), op.getHasBias(), op.getGroups(), op.getInputDtype(),
-      op.getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfigAttr(),
+      *this, liveRecords, inputs[0], weightShape, getInputMemoryConfig(),
+      getInputTensorLayout(), getWeightsFormat(), getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getDilation(), getHasBias(),
+      getGroups(), getInputDtype(), getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfigAttr(),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
-                                             /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dWeightsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareConv2dWeightsConstraintsImpl(*this, inputs, opConfig,
-                                             initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -4885,40 +3973,23 @@ PrepareConv2dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConv2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> prepareConv2dBiasConstraintsImpl(
-    PrepareConv2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PrepareConv2dBiasOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      op.getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+      getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
-      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
-      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
-      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dBiasOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
-                                          /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConv2dBiasOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareConv2dBiasConstraintsImpl(*this, inputs, opConfig,
-                                          initialState.get());
+      *this, liveRecords, inputs[0], biasShape, getInputMemoryConfig(),
+      getInputTensorLayout(), getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getGroups(), getInputDtype(),
+      getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -4934,7 +4005,9 @@ PrepareConv2dBiasOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 
 llvm::Expected<op_model::OpConstraints>
 PrepareConv3dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 1);
   return issueErrorForGetOpConstraints(
       getOperation(), detail::ReasonForLackOfSupport::MissingMetalDefinition);
@@ -4951,43 +4024,26 @@ PrepareConv3dWeightsOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PrepareConvTranspose2dWeightsOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareConvTranspose2dWeightsConstraintsImpl(
-    PrepareConvTranspose2dWeightsOp op,
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dWeightsOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    const op_model::MockAllocatorState *state) {
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> weightShape =
-      op.getWeightTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+      getWeightTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputs[0], weightShape, op.getInputMemoryConfig(),
-      op.getInputTensorLayout(), op.getWeightsFormat(), op.getInChannels(),
-      op.getOutChannels(), op.getBatchSize(), op.getInputHeight(),
-      op.getInputWidth(), op.getKernelSize(), op.getStride(), op.getPadding(),
-      op.getOutputPadding(), op.getDilation(), op.getHasBias(), op.getGroups(),
-      op.getInputDtype(), op.getOutputDtype(), conv2dAttrs.conv2dConfig,
-      conv2dAttrs.deviceComputeKernelConfig, op.getConv2dSliceConfig(),
-      op.getMirrorKernel(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dWeightsOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
-                                                      /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dWeightsOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareConvTranspose2dWeightsConstraintsImpl(*this, inputs, opConfig,
-                                                      initialState.get());
+      *this, liveRecords, inputs[0], weightShape, getInputMemoryConfig(),
+      getInputTensorLayout(), getWeightsFormat(), getInChannels(),
+      getOutChannels(), getBatchSize(), getInputHeight(), getInputWidth(),
+      getKernelSize(), getStride(), getPadding(), getOutputPadding(),
+      getDilation(), getHasBias(), getGroups(), getInputDtype(),
+      getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
+      getMirrorKernel(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
@@ -5000,41 +4056,25 @@ llvm::Expected<size_t> PrepareConvTranspose2dWeightsOp::getOpRuntime(
 // PrepareConvTranspose2dBiasOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-prepareConvTranspose2dBiasConstraintsImpl(
-    PrepareConvTranspose2dBiasOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints>
+PrepareConvTranspose2dBiasOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
   const ::llvm::ArrayRef<int64_t> biasShape =
-      op.getBiasTensor().getType().getShape();
-  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, op);
+      getBiasTensor().getType().getShape();
+  Conv2dAttrs conv2dAttrs = unpackConv2dAttrs(opConfig.opSpecificAttrs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputs[0], biasShape, op.getInputMemoryConfig(),
-      op.getInputTensorLayout(), op.getInChannels(), op.getOutChannels(),
-      op.getBatchSize(), op.getInputHeight(), op.getInputWidth(),
-      op.getKernelSize(), op.getStride(), op.getPadding(), op.getDilation(),
-      op.getGroups(), op.getInputDtype(), op.getOutputDtype(),
-      conv2dAttrs.conv2dConfig, conv2dAttrs.deviceComputeKernelConfig,
-      op.getConv2dSliceConfig(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dBiasOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
-                                                   /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PrepareConvTranspose2dBiasOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return prepareConvTranspose2dBiasConstraintsImpl(*this, inputs, opConfig,
-                                                   initialState.get());
+      *this, liveRecords, inputs[0], biasShape, getInputMemoryConfig(),
+      getInputTensorLayout(), getInChannels(), getOutChannels(), getBatchSize(),
+      getInputHeight(), getInputWidth(), getKernelSize(), getStride(),
+      getPadding(), getDilation(), getGroups(), getInputDtype(),
+      getOutputDtype(), conv2dAttrs.conv2dConfig,
+      conv2dAttrs.deviceComputeKernelConfig, getConv2dSliceConfig(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(
@@ -5047,10 +4087,11 @@ llvm::Expected<size_t> PrepareConvTranspose2dBiasOp::getOpRuntime(
 // MaxPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-MaxPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getPoolingOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> MaxPool2dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getPoolingOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -5059,21 +4100,17 @@ MaxPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints> MaxPool2dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
-                                                  liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // MaxPool2dWithIndicesOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<op_model::OpConstraints>
 MaxPool2dWithIndicesOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return detail::getMaxPool2dWithIndicesOpConstraints(*this, inputs, opConfig);
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getMaxPool2dWithIndicesOpConstraints(*this, inputs, opConfig,
+                                                      liveRecords);
 }
 
 llvm::Expected<size_t>
@@ -5082,35 +4119,21 @@ MaxPool2dWithIndicesOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return detail::getMaxPool2dWithIndicesOpRuntime(*this, inputs, opConfig);
 }
 
-llvm::Expected<op_model::OpConstraints>
-MaxPool2dWithIndicesOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getMaxPool2dWithIndicesOpConstraintsWithState(
-      *this, inputs, opConfig, liveRecords);
-}
-
 //===----------------------------------------------------------------------===//
 // AvgPoo2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return detail::getPoolingOpConstraints(*this, inputs, opConfig);
+llvm::Expected<op_model::OpConstraints> AvgPool2dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  return detail::getPoolingOpConstraints(*this, inputs, opConfig, liveRecords);
 }
 
 llvm::Expected<size_t>
 AvgPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                           const OpConfig &opConfig) {
   return detail::getPoolingOpRuntime(*this, inputs, opConfig);
-}
-
-llvm::Expected<op_model::OpConstraints> AvgPool2dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  return detail::getPoolingOpConstraintsWithState(*this, inputs, opConfig,
-                                                  liveRecords);
 }
 
 //===----------------------------------------------------------------------===//
@@ -5146,41 +4169,25 @@ unpackBatchNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-batchNormInferenceConstraintsImpl(BatchNormInferenceOp op,
-                                  const std::vector<TTNNLayoutAttr> &inputs,
-                                  const OpConfig &opConfig,
-                                  const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 5 && "ttnn::batch_norm can only have 5 input tensors "
                                "(representing main input tensor, "
                                "running_mean, running_var, weight and bias).");
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
+  BatchNormOptionalArgs optionalArgs =
+      unpackBatchNormOptionalArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
+      *this, liveRecords, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints> BatchNormInferenceOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
-                                           /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-BatchNormInferenceOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return batchNormInferenceConstraintsImpl(*this, inputs, opConfig,
-                                           initialState.get());
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -5208,44 +4215,29 @@ BatchNormInferenceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // BatchNormTrainingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> batchNormTrainingConstraintsImpl(
-    BatchNormTrainingOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> BatchNormTrainingOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert((inputs.size() == 1 || inputs.size() == 5) &&
          "ttnn::batch_norm_training can either have 1 input tensor "
          "(representing the main input) or 5 input tensors (representing main "
          "input tensor, running_mean, running_var, weight and bias). The "
-         "usage of this op with 2-4 input tensors is discouraged as it's "
+         "usage of this *this with 2-4 input tensors is discouraged as it's "
          "ambiguous.");
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  BatchNormOptionalArgs optionalArgs = unpackBatchNormOptionalArgs(inputs, op);
+  BatchNormOptionalArgs optionalArgs =
+      unpackBatchNormOptionalArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.runningMeanShape,
+      *this, liveRecords, inputShape, inputs[0], optionalArgs.runningMeanShape,
       optionalArgs.runningMeanLayout, optionalArgs.runningVarShape,
       optionalArgs.runningVarLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, op.getEpsilon(), op.getMomentum(),
+      optionalArgs.biasLayout, getEpsilon(), getMomentum(),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-BatchNormTrainingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
-                                          /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-BatchNormTrainingOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return batchNormTrainingConstraintsImpl(*this, inputs, opConfig,
-                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5304,38 +4296,24 @@ unpackRMSNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-rMSNormConstraintsImpl(RMSNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
-  const auto inputShape = op.getInput().getType().getShape();
+llvm::Expected<op_model::OpConstraints> RMSNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
 
-  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, op);
+  RMSNormOptionalArgs optionalArgs = unpackRMSNormOptionalArgs(inputs, *this);
 
   std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig =
-      op.getComputeConfigAttr() ? std::optional<DeviceComputeKernelConfigAttr>(
-                                      op.getComputeConfigAttr())
-                                : std::nullopt;
+      getComputeConfigAttr()
+          ? std::optional<DeviceComputeKernelConfigAttr>(getComputeConfigAttr())
+          : std::nullopt;
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      *this, liveRecords, inputShape, inputs[0], optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout,
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout,
       computeKernelConfig);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RMSNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return rMSNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> RMSNormOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return rMSNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5382,37 +4360,20 @@ unpackRMSNormPreAllGatherOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-rMSNormPreAllGatherConstraintsImpl(RMSNormPreAllGatherOp op,
-                                   const std::vector<TTNNLayoutAttr> &inputs,
-                                   const OpConfig &opConfig,
-                                   const op_model::MockAllocatorState *state) {
-  const auto inputShape = op.getInput().getType().getShape();
+llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
 
   RMSNormPreAllGatherOptionalArgs optionalArgs =
-      unpackRMSNormPreAllGatherOptionalArgs(inputs, op);
+      unpackRMSNormPreAllGatherOptionalArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout,
-      dataTypeAttrToOptional(op.getDtypeAttr()), op.getUse_2dCoreGrid(),
+      *this, liveRecords, inputShape, inputs[0],
+      optionalArgs.residualInputShape, optionalArgs.residualInputLayout,
+      dataTypeAttrToOptional(getDtypeAttr()), getUse_2dCoreGrid(),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints> RMSNormPreAllGatherOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                            /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-RMSNormPreAllGatherOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return rMSNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                            initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5462,31 +4423,19 @@ unpackLayerNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints> layerNormConstraintsImpl(
-    LayerNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  const auto inputShape = op.getInput().getType().getShape();
+llvm::Expected<op_model::OpConstraints> LayerNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
 
-  LayerNormOptionalArgs optionalArgs = unpackLayerNormOptionalArgs(inputs, op);
+  LayerNormOptionalArgs optionalArgs =
+      unpackLayerNormOptionalArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.weightShape,
+      *this, liveRecords, inputShape, inputs[0], optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, op.getEpsilon(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-LayerNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return layerNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> LayerNormOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return layerNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
+      optionalArgs.biasLayout, getEpsilon(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -5536,37 +4485,21 @@ unpackLayerNormPreAllGatherOptionalArgs(
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-layerNormPreAllGatherConstraintsImpl(
-    LayerNormPreAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  const auto inputShape = op.getInput().getType().getShape();
-
-  LayerNormPreAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPreAllGatherOptionalArgs(inputs, op);
-
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.residualInputShape,
-      optionalArgs.residualInputLayout, optionalArgs.recipShape,
-      optionalArgs.recipLayout, dataTypeAttrToOptional(op.getDtypeAttr()),
-      opConfig.outputLayout);
-}
-
 llvm::Expected<op_model::OpConstraints>
 LayerNormPreAllGatherOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                              /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-LayerNormPreAllGatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return layerNormPreAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                              initialState.get());
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+
+  LayerNormPreAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPreAllGatherOptionalArgs(inputs, *this);
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0],
+      optionalArgs.residualInputShape, optionalArgs.residualInputLayout,
+      optionalArgs.recipShape, optionalArgs.recipLayout,
+      dataTypeAttrToOptional(getDtypeAttr()), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -5617,38 +4550,22 @@ unpackLayerNormPostAllGatherOptionalArgs(
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints>
-layerNormPostAllGatherConstraintsImpl(
-    LayerNormPostAllGatherOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto statsShape = op.getStats().getType().getShape();
-
-  LayerNormPostAllGatherOptionalArgs optionalArgs =
-      unpackLayerNormPostAllGatherOptionalArgs(inputs, op);
-
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], statsShape, inputs[1],
-      optionalArgs.weightShape, optionalArgs.weightLayout,
-      optionalArgs.biasShape, optionalArgs.biasLayout, op.getEpsilon(),
-      opConfig.outputLayout);
-}
-
 llvm::Expected<op_model::OpConstraints>
 LayerNormPostAllGatherOp::getOpConstraints(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig) {
-  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                               /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-LayerNormPostAllGatherOp::getOpConstraintsWithState(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return layerNormPostAllGatherConstraintsImpl(*this, inputs, opConfig,
-                                               initialState.get());
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  const auto inputShape = getInput().getType().getShape();
+  const auto statsShape = getStats().getType().getShape();
+
+  LayerNormPostAllGatherOptionalArgs optionalArgs =
+      unpackLayerNormPostAllGatherOptionalArgs(inputs, *this);
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], statsShape, inputs[1],
+      optionalArgs.weightShape, optionalArgs.weightLayout,
+      optionalArgs.biasShape, optionalArgs.biasLayout, getEpsilon(),
+      opConfig.outputLayout);
 }
 
 llvm::Expected<size_t> LayerNormPostAllGatherOp::getOpRuntime(
@@ -5706,35 +4623,23 @@ unpackGroupNormOptionalArgs(const std::vector<TTNNLayoutAttr> &inputs,
   return ret;
 }
 
-static llvm::Expected<op_model::OpConstraints> groupNormConstraintsImpl(
-    GroupNormOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> GroupNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(!inputs.empty() && "GroupNormOp requires at least input layout");
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  GroupNormOptionalArgs optionalArgs = unpackGroupNormOptionalArgs(inputs, op);
+  GroupNormOptionalArgs optionalArgs =
+      unpackGroupNormOptionalArgs(inputs, *this);
 
   return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], optionalArgs.inputMaskShape,
+      *this, liveRecords, inputShape, inputs[0], optionalArgs.inputMaskShape,
       optionalArgs.inputMaskLayout, optionalArgs.weightShape,
       optionalArgs.weightLayout, optionalArgs.biasShape,
-      optionalArgs.biasLayout, op.getNumGroups(), op.getEpsilon(),
+      optionalArgs.biasLayout, getNumGroups(), getEpsilon(),
       opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-GroupNormOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return groupNormConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> GroupNormOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return groupNormConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5758,32 +4663,17 @@ GroupNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampScalarOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> clampScalarConstraintsImpl(
-    ClampScalarOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ClampScalarOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getMinAttr(), op.getMaxAttr(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getMinAttr(), getMaxAttr(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ClampScalarOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return clampScalarConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ClampScalarOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return clampScalarConstraintsImpl(*this, inputs, opConfig,
-                                    initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5802,33 +4692,18 @@ ClampScalarOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ClampTensorOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> clampTensorConstraintsImpl(
-    ClampTensorOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ClampTensorOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(
-      op, state, inputShape, inputs[0], op.getMin().getType().getShape(),
-      inputs[1], op.getMax().getType().getShape(), inputs[2],
-      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ClampTensorOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
-  return clampTensorConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ClampTensorOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return clampTensorConstraintsImpl(*this, inputs, opConfig,
-                                    initialState.get());
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getMin().getType().getShape(), inputs[1],
+                                     getMax().getType().getShape(), inputs[2],
+                                     opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
@@ -5848,31 +4723,17 @@ ClampTensorOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // PermuteOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-permuteConstraintsImpl(PermuteOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                       const OpConfig &opConfig,
-                       const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> PermuteOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getPermutation(), op.getPadValue(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getPermutation(), getPadValue(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-PermuteOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
-  return permuteConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> PermuteOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return permuteConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5891,30 +4752,17 @@ PermuteOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // UpsampleOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> upsampleConstraintsImpl(
-    UpsampleOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> UpsampleOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getScaleFactor(), op.getMode(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getScaleFactor(), getMode(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-UpsampleOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return upsampleConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> UpsampleOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return upsampleConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5933,31 +4781,18 @@ UpsampleOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> embeddingConstraintsImpl(
-    EmbeddingOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> EmbeddingOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 2);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto weightShape = op.getWeight().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      weightShape, inputs[1],
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-EmbeddingOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                              const OpConfig &opConfig) {
-  return embeddingConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> EmbeddingOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return embeddingConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -5977,35 +4812,19 @@ EmbeddingOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmbeddingBackwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> embeddingBackwardConstraintsImpl(
-    EmbeddingBackwardOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> EmbeddingBackwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 3);
 
-  const auto inputShape = op.getInput().getType().getShape();
-  const auto weightShape = op.getWeight().getType().getShape();
-  const auto inGradientShape = op.getInGradient().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
+  const auto weightShape = getWeight().getType().getShape();
+  const auto inGradientShape = getInGradient().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
                                      weightShape, inputs[1], inGradientShape,
                                      inputs[2], opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-EmbeddingBackwardOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                      const OpConfig &opConfig) {
-  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
-                                          /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-EmbeddingBackwardOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return embeddingBackwardConstraintsImpl(*this, inputs, opConfig,
-                                          initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6027,9 +4846,10 @@ EmbeddingBackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // EmptyOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-EmptyOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> EmptyOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 0);
 
   const llvm::ArrayRef<int64_t> shape = getShape().getShape();
@@ -6054,9 +4874,10 @@ EmptyOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ArangeOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ArangeOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> ArangeOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 0);
 
   ::mlir::IntegerAttr startAttr = getStartAttr();
@@ -6081,9 +4902,10 @@ ArangeOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ZerosOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-ZerosOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                          const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> ZerosOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return detail::getNamedFullOpConstraints(*this, inputs, opConfig);
 }
 
@@ -6099,9 +4921,10 @@ ZerosOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // OnesOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-OnesOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> OnesOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   return detail::getNamedFullOpConstraints(*this, inputs, opConfig);
 }
 
@@ -6116,9 +4939,10 @@ OnesOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // FullOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-FullOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> FullOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 0);
 
   const mlir::tt::ttnn::ShapeAttr shape = getShape();
@@ -6144,33 +4968,17 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> meshPartitionConstraintsImpl(
-    MeshPartitionOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> MeshPartitionOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getDim(), op.getClusterAxis(),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getDim(), getClusterAxis(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-MeshPartitionOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                  const OpConfig &opConfig) {
-  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
-                                      /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-MeshPartitionOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return meshPartitionConstraintsImpl(*this, inputs, opConfig,
-                                      initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6189,27 +4997,14 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // ConstantOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> constantConstraintsImpl(
-    ConstantOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> ConstantOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 0);
 
-  return detail::constraintsDispatch(op, state, op.getValue(),
+  return detail::constraintsDispatch(*this, liveRecords, getValue(),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-ConstantOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                             const OpConfig &opConfig) {
-  return constantConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> ConstantOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return constantConstraintsImpl(*this, inputs, opConfig, initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6223,9 +5018,10 @@ ConstantOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // RandOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-RandOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> RandOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 0);
 
   ttcore::DataTypeAttr dtype =
@@ -6249,9 +5045,10 @@ RandOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // DropoutOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-DropoutOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                            const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> DropoutOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -6279,33 +5076,17 @@ DropoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // GlobalAvgPool2dOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints> globalAvgPool2dConstraintsImpl(
-    GlobalAvgPool2dOp op, const std::vector<TTNNLayoutAttr> &inputs,
-    const OpConfig &opConfig, const op_model::MockAllocatorState *state) {
+llvm::Expected<op_model::OpConstraints> GlobalAvgPool2dOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   assert(inputs.size() == 1);
 
-  const auto inputShape = op.getInput().getType().getShape();
+  const auto inputShape = getInput().getType().getShape();
 
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     dataTypeAttrToOptional(op.getDtypeAttr()),
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     dataTypeAttrToOptional(getDtypeAttr()),
                                      opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-GlobalAvgPool2dOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                    const OpConfig &opConfig) {
-  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
-                                        /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints>
-GlobalAvgPool2dOp::getOpConstraintsWithState(
-    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return globalAvgPool2dConstraintsImpl(*this, inputs, opConfig,
-                                        initialState.get());
 }
 
 llvm::Expected<size_t>
@@ -6324,9 +5105,10 @@ GlobalAvgPool2dOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // AssignOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-llvm::Expected<op_model::OpConstraints>
-AssignOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                           const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> AssignOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   assert(inputs.size() == 1);
 
   const auto inputShape = getInput().getType().getShape();
@@ -6412,9 +5194,10 @@ buildValueToLayoutMap(const std::vector<TTNNLayoutAttr> &inputs,
 // walk the function body, call getOpConstraints for each internal op with
 // the correct input layouts (from D2M inputs or from preceding op outputs),
 // and return the element-wise max of their constraints.
-llvm::Expected<op_model::OpConstraints>
-D2MSubgraphOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> D2MSubgraphOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<
+        llvm::ArrayRef<op_model::OpModelAllocationRecord>> /*liveRecords*/) {
   auto func = getD2MMainFunc();
   assert(func && "D2MSubgraphOp must have a D2M function");
   auto &body = func.getBody();
@@ -6536,29 +5319,15 @@ D2MSubgraphOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // TopKOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
-static llvm::Expected<op_model::OpConstraints>
-topKConstraintsImpl(TopKOp op, const std::vector<TTNNLayoutAttr> &inputs,
-                    const OpConfig &opConfig,
-                    const op_model::MockAllocatorState *state) {
-  assert(inputs.size() == 1);
-  const auto inputShape = op.getInputTensor().getType().getShape();
-  return detail::constraintsDispatch(op, state, inputShape, inputs[0],
-                                     op.getK(), op.getDim(), op.getLargest(),
-                                     op.getSorted(), opConfig.outputLayout);
-}
-
-llvm::Expected<op_model::OpConstraints>
-TopKOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                         const OpConfig &opConfig) {
-  return topKConstraintsImpl(*this, inputs, opConfig, /*state=*/nullptr);
-}
-
-llvm::Expected<op_model::OpConstraints> TopKOp::getOpConstraintsWithState(
+llvm::Expected<op_model::OpConstraints> TopKOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
-  std::shared_ptr<op_model::MockAllocatorState> initialState =
-      op_model::buildInitialState(liveRecords);
-  return topKConstraintsImpl(*this, inputs, opConfig, initialState.get());
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+  const auto inputShape = getInputTensor().getType().getShape();
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getK(), getDim(), getLargest(),
+                                     getSorted(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -132,6 +132,7 @@ void createTTNNPipelineAnalysisPasses(
     TTNNGreedyL1SpillManagementOptions spillOptions;
     spillOptions.enableDecisionTrace = options.enableDecisionTrace;
     spillOptions.decisionTraceDir = options.decisionTraceDir;
+    spillOptions.useMockAllocatorState = options.useMockAllocatorState;
 
     bool memLayoutEnabled = options.memoryLayoutAnalysisEnabled;
     pm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp
@@ -12,6 +12,7 @@
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpModel.h"
 #include "ttmlir/Support/Logger.h"
 #include "ttmlir/Utils.h"
 
@@ -19,6 +20,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::tt::ttnn {
@@ -66,43 +68,71 @@ public:
         observer = std::make_unique<DecisionTraceObserver>();
       }
 
-      L1SpillManagement<SumL1MemoryTracker> spill(
-          func, deviceGrid, l1BudgetPerCore, std::move(observer));
-      spill.run();
+      // Post-run finalize, shared by both tracker instantiations.
+      auto finalize = [&](auto &spill) -> WalkResult {
+        // run() emits a diagnostic but cannot fail the pass on its own; surface
+        // any unrecoverable condition (e.g. an op whose CBs overlap a required
+        // inserted-reshard input) as a pass failure. Interrupt the walk too:
+        // the pass is already doomed, so don't keep mutating later
+        // forward-device funcs.
+        if (spill.hasFailed()) {
+          signalPassFailure();
+          return WalkResult::interrupt();
+        }
 
-      // run() emits a diagnostic but cannot fail the pass on its own; surface
-      // any unrecoverable condition (e.g. an op whose CBs overlap a required
-      // inserted-reshard input) as a pass failure. Interrupt the walk too: the
-      // pass is already doomed, so don't keep mutating later forward-device
-      // funcs.
-      if (spill.hasFailed()) {
-        signalPassFailure();
-        return WalkResult::interrupt();
-      }
+        // Sync D2M subgraph function types to match dispatch op's current
+        // inputs (e.g. after spill, operand types may have changed to DRAM).
+        d2m_optimizer_utils::syncAllD2MFuncTypes(func);
 
-      // Sync D2M subgraph function types to match dispatch op's current inputs
-      // (e.g. after spill, operand types may have changed to DRAM).
-      d2m_optimizer_utils::syncAllD2MFuncTypes(func);
-
-      // Merge spill management data into the existing decision trace JSON.
-      if (enableDecisionTrace) {
-        if (const DecisionTrace *dt = spill.getObserver()->getDecisionTrace()) {
-          if (DecisionTrace::mergeSpillTrace(decisionTraceDir, func.getName(),
-                                             *dt)) {
-            TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                         "Merged spill management trace into {0}/{1}",
-                         decisionTraceDir, func.getName());
-          } else {
-            TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
-                         "Failed to merge spill management trace for func "
-                         "{0}; layout propagation may not have written a "
-                         "decision trace to {1}.",
-                         func.getName(), decisionTraceDir);
+        // Merge spill management data into the existing decision trace JSON.
+        if (enableDecisionTrace) {
+          if (const DecisionTrace *dt =
+                  spill.getObserver()->getDecisionTrace()) {
+            if (DecisionTrace::mergeSpillTrace(decisionTraceDir, func.getName(),
+                                               *dt)) {
+              TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                           "Merged spill management trace into {0}/{1}",
+                           decisionTraceDir, func.getName());
+            } else {
+              TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                           "Failed to merge spill management trace for func "
+                           "{0}; layout propagation may not have written a "
+                           "decision trace to {1}.",
+                           func.getName(), decisionTraceDir);
+            }
           }
         }
-      }
+        return WalkResult::advance();
+      };
 
-      return WalkResult::advance();
+      // Default: stateful, fragmentation-accurate L1 tracking backed by
+      // tt-metal's MockAllocatorState. Toggle off to fall back to the
+      // scalar-heuristic tracker.
+      if (useMockAllocatorState) {
+        StatefulL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                        std::move(observer));
+        {
+          // The stateful spill queries mutate the shared mock device's
+          // allocator. Snapshot it before and restore it after, so later
+          // stateless op-model queries (conv2d config search, pool/conv
+          // constraint checks in OperationValidationAndFallback) see the exact
+          // device state main sees. RAII: restore must run even if spill.run()
+          // throws or a future early-return is added between the snapshot and
+          // here -- otherwise a corrupted shared mock device leaks into every
+          // subsequent stateless query. The guard fires at this inner scope's
+          // exit, i.e. right after run() and before finalize(), matching the
+          // original explicit-restore ordering.
+          op_model::snapshotMockAllocatorState();
+          auto restoreGuard = llvm::make_scope_exit(
+              []() noexcept { op_model::restoreMockAllocatorState(); });
+          spill.run();
+        }
+        return finalize(spill);
+      }
+      SumL1SpillManagement spill(func, deviceGrid, l1BudgetPerCore,
+                                 std::move(observer));
+      spill.run();
+      return finalize(spill);
     });
 #endif
   }

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -25,9 +25,21 @@
 
 namespace mlir::tt::ttnn::utils {
 
+// Resolve the module carrying the optimizer's L1 policy attributes.
+// getParentOfType starts from getParentOp(), so it returns null when called on
+// the ModuleOp itself -- and callers legitimately pass the module (e.g. the L1
+// spill pass computing its per-core budget). Without this the lookup silently
+// falls back to the defaults, dropping both `ttnn.tensor_l1_usage_cap` and
+// `ttnn.l1_const_eval_usage`.
+static ModuleOp getPolicyModule(Operation *op) {
+  if (auto moduleOp = mlir::dyn_cast<ModuleOp>(op)) {
+    return moduleOp;
+  }
+  return op->getParentOfType<ModuleOp>();
+}
+
 float getTensorL1UsageCap(Operation *op, float defaultValue) {
-  // Walk up to find the module operation that has the attribute
-  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+  ModuleOp moduleOp = getPolicyModule(op);
 
   if (moduleOp) {
     if (auto attr =
@@ -40,7 +52,7 @@ float getTensorL1UsageCap(Operation *op, float defaultValue) {
 }
 
 uint64_t getReservedL1Usage(Operation *op) {
-  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+  ModuleOp moduleOp = getPolicyModule(op);
 
   if (moduleOp) {
     if (auto attr =

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -117,7 +117,7 @@ validateWithMultipleAttributes(Operation *op,
 ValidationResult
 checkConstraintsResult(Operation *contextOp,
                        llvm::Expected<op_model::OpConstraints> constraints,
-                       uint64_t additionalL1Usage) {
+                       uint64_t additionalL1Usage, bool statefulQuery) {
   if (!constraints) {
     ValidationResult result;
     llvm::handleAllErrors(
@@ -168,18 +168,24 @@ checkConstraintsResult(Operation *contextOp,
         outputTensorUsagePerCore, outputLayouts, outputAllocations] =
       constraints.get();
 
-  uint64_t effectiveL1Limit = utils::getUsableL1PerCore(contextOp);
-  uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
+  // Stateless-only L1 capacity model: both graph captures run NO_DISPATCH, so
+  // nothing is allocated and only this comparison keeps the beam search off
+  // illegal L1 layouts. The stateful path skips it -- tt-metal decides fit
+  // there, and MockAllocatorL1Tracker::validate's ceiling owns the byte budget.
+  if (!statefulQuery) {
+    uint64_t effectiveL1Limit = utils::getUsableL1PerCore(contextOp);
+    uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
 
-  if (totalL1Usage > effectiveL1Limit) {
-    TTMLIR_DEBUG(
-        ttmlir::LogComponent::OpValidation,
-        "Not enough L1 memory. "
-        "totalL1Usage: {} [overallPeakL1Usage={}, additionalL1Usage={}]"
-        " [cbPeakUsage={}, l1BuffersPeakUsage={}] limit: {}",
-        totalL1Usage, overallPeakL1Usage, additionalL1Usage, cbPeakUsage,
-        l1BuffersPeakUsage, effectiveL1Limit);
-    return ValidationResult::outOfMemoryError("Not enough L1 memory");
+    if (totalL1Usage > effectiveL1Limit) {
+      TTMLIR_DEBUG(
+          ttmlir::LogComponent::OpValidation,
+          "Not enough L1 memory. "
+          "totalL1Usage: {} [overallPeakL1Usage={}, additionalL1Usage={}]"
+          " [cbPeakUsage={}, l1BuffersPeakUsage={}] limit: {}",
+          totalL1Usage, overallPeakL1Usage, additionalL1Usage, cbPeakUsage,
+          l1BuffersPeakUsage, effectiveL1Limit);
+      return ValidationResult::outOfMemoryError("Not enough L1 memory");
+    }
   }
 
   TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
@@ -251,7 +257,8 @@ static ValidationResult validateConstraints(
           ? backend.getOpConstraintsWithState(inputLayouts, config, liveRecords)
           : backend.getOpConstraints(inputLayouts, config);
 
-  return checkConstraintsResult(op, std::move(l1UsageExp), additionalL1Usage);
+  return checkConstraintsResult(op, std::move(l1UsageExp), additionalL1Usage,
+                                useState);
 }
 
 } // namespace op_constraint_validation

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -41,8 +41,9 @@ llvm::StringRef validationStatusToString(ValidationStatus status) {
 
 static ValidationResult validateConstraints(
     Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-    const OpConfig &config, uint64_t additionalL1Usage, bool useState = false,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords = {});
+    const OpConfig &config, uint64_t additionalL1Usage,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords = std::nullopt);
 
 //----------- Public API implementations ----------
 
@@ -59,7 +60,7 @@ validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                   llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords,
                   uint64_t additionalL1Usage) {
   return validateConstraints(op, inputLayouts, config, additionalL1Usage,
-                             /*useState=*/true, liveRecords);
+                             liveRecords);
 }
 
 std::vector<ValidationResult>
@@ -206,8 +207,9 @@ checkConstraintsResult(Operation *contextOp,
 
 static ValidationResult validateConstraints(
     Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-    const OpConfig &config, uint64_t additionalL1Usage, bool useState,
-    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
+    const OpConfig &config, uint64_t additionalL1Usage,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
 
   // Check that operation supports OpModel interface.
   auto backend = mlir::dyn_cast<OpModel>(op);
@@ -249,16 +251,17 @@ static ValidationResult validateConstraints(
   }
   TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation, "Output config {}", config);
 
-  // Stateful path (L1 spill): route through the uncached
-  // getOpConstraintsWithState so the query is evaluated against the live
-  // allocation set. Stateless path (beam search): the cached getOpConstraints.
+  // One query, one selector: an engaged `liveRecords` (L1 spill) evaluates the
+  // op against the live allocation set through an uncached query; std::nullopt
+  // (beam search) takes the cached stateless query. `statefulQuery` is DERIVED
+  // from the same optional rather than passed alongside it, so the two can
+  // never disagree -- a stateful capacity model paired with a stateless query
+  // would leave the L1 byte budget unchecked on both sides.
   llvm::Expected<ttnn::op_model::OpConstraints> l1UsageExp =
-      useState
-          ? backend.getOpConstraintsWithState(inputLayouts, config, liveRecords)
-          : backend.getOpConstraints(inputLayouts, config);
+      backend.getOpConstraints(inputLayouts, config, liveRecords);
 
   return checkConstraintsResult(op, std::move(l1UsageExp), additionalL1Usage,
-                                useState);
+                                /*statefulQuery=*/liveRecords.has_value());
 }
 
 } // namespace op_constraint_validation

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -39,9 +39,10 @@ llvm::StringRef validationStatusToString(ValidationStatus status) {
   return "Unknown";
 }
 
-static ValidationResult
-validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config, uint64_t additionalL1Usage);
+static ValidationResult validateConstraints(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage, bool useState = false,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords = {});
 
 //----------- Public API implementations ----------
 
@@ -50,6 +51,15 @@ ValidationResult validateOperation(Operation *op,
                                    const OpConfig &config,
                                    uint64_t additionalL1Usage) {
   return validateConstraints(op, inputLayouts, config, additionalL1Usage);
+}
+
+ValidationResult
+validateOperation(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                  const OpConfig &config,
+                  llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords,
+                  uint64_t additionalL1Usage) {
+  return validateConstraints(op, inputLayouts, config, additionalL1Usage,
+                             /*useState=*/true, liveRecords);
 }
 
 std::vector<ValidationResult>
@@ -120,14 +130,43 @@ checkConstraintsResult(Operation *contextOp,
           TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation,
                        "OpModel constraints failed: {}",
                        ttmlir::utils::firstNLines(errorMsg, 8));
-          result = ValidationResult::metalBackendError(
-              ttmlir::utils::firstNLines(errorMsg, 8));
+          // The stateful (build-from-records) query places the currently-live
+          // tensors at real addresses, so an op that does not fit surfaces as a
+          // tt-metal exception from the backend rather than via the peak-usage
+          // budget check below. Two flavors are really L1-pressure conditions,
+          // both recoverable by the L1 spill pass's evict-and-refit path (the
+          // same path the scalar tracker's soft OOM takes):
+          //   1. Allocator exhaustion: "Out of Memory: Not enough space ...".
+          //   2. A CB-vs-L1 overlap: "Statically allocated circular buffers ...
+          //      clash with L1 buffers ..." -- the op's static circular-buffer
+          //      region collides with a still-live L1 input (e.g. a large
+          //      height-sharded conv activation). Evicting that L1 input to
+          //      DRAM and refitting resolves it.
+          // Classify both as OOM so run() calls handleOOM (which spills the
+          // offending L1 input) instead of the metalBackendError branch, which
+          // only demotes the op's *output* to DRAM -- useless here, since the
+          // clash is with the input -- leaving a layout that throws at runtime
+          // (https://github.com/tenstorrent/tt-mlir/issues/9064). Demoting
+          // straight to DRAM also skips config fallback and can leave a
+          // numerically-wrong op config
+          // (https://github.com/tenstorrent/tt-mlir/issues/9045). A genuine
+          // backend constraint (unsupported config, etc.) carries neither
+          // marker and still routes to metalBackendError.
+          if (errorMsg.find("Out of Memory") != std::string::npos ||
+              errorMsg.find("clash with L1 buffers") != std::string::npos) {
+            result = ValidationResult::outOfMemoryError(
+                ttmlir::utils::firstNLines(errorMsg, 8));
+          } else {
+            result = ValidationResult::metalBackendError(
+                ttmlir::utils::firstNLines(errorMsg, 8));
+          }
         });
     return result;
   }
 
   auto [cbPeakUsage, l1BuffersPeakUsage, overallPeakL1Usage,
-        outputTensorUsagePerCore, outputLayouts] = constraints.get();
+        outputTensorUsagePerCore, outputLayouts, outputAllocations] =
+      constraints.get();
 
   uint64_t effectiveL1Limit = utils::getUsableL1PerCore(contextOp);
   uint64_t totalL1Usage = overallPeakL1Usage + additionalL1Usage;
@@ -151,15 +190,18 @@ checkConstraintsResult(Operation *contextOp,
                overallPeakL1Usage, cbPeakUsage, l1BuffersPeakUsage,
                outputTensorUsagePerCore);
 
-  return ValidationResult::success(0, outputLayouts, outputTensorUsagePerCore,
-                                   cbPeakUsage);
+  ValidationResult result = ValidationResult::success(
+      0, outputLayouts, outputTensorUsagePerCore, cbPeakUsage);
+  result.outputAllocations = std::move(outputAllocations);
+  return result;
 }
 
 // ----------- Core constraint validation implementation ----------
 
-static ValidationResult
-validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
-                    const OpConfig &config, uint64_t additionalL1Usage) {
+static ValidationResult validateConstraints(
+    Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+    const OpConfig &config, uint64_t additionalL1Usage, bool useState,
+    llvm::ArrayRef<op_model::OpModelAllocationRecord> liveRecords) {
 
   // Check that operation supports OpModel interface.
   auto backend = mlir::dyn_cast<OpModel>(op);
@@ -201,8 +243,13 @@ validateConstraints(Operation *op, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
   }
   TTMLIR_DEBUG(ttmlir::LogComponent::OpValidation, "Output config {}", config);
 
+  // Stateful path (L1 spill): route through the uncached
+  // getOpConstraintsWithState so the query is evaluated against the live
+  // allocation set. Stateless path (beam search): the cached getOpConstraints.
   llvm::Expected<ttnn::op_model::OpConstraints> l1UsageExp =
-      backend.getOpConstraints(inputLayouts, config);
+      useState
+          ? backend.getOpConstraintsWithState(inputLayouts, config, liveRecords)
+          : backend.getOpConstraints(inputLayouts, config);
 
   return checkConstraintsResult(op, std::move(l1UsageExp), additionalL1Usage);
 }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -51,6 +51,10 @@ namespace mlir::tt::ttnn::op_model {
 #define QUERY_OP_CONSTRAINTS(op, device, ...)                                  \
   ::ttnn::graph::query_op_constraints(WRAP_OP(op), device, __VA_ARGS__)
 
+#define QUERY_OP_CONSTRAINTS_WITH_STATE(op, device, state, ...)                \
+  ::ttnn::graph::query_op_constraints_with_optional_state(WRAP_OP(op), device,  \
+                                                          state, __VA_ARGS__)
+
 #define QUERY_OP_RUNTIME(op, device, ...)                                      \
   ::ttnn::graph::query_op_runtime(WRAP_OP(op), device, __VA_ARGS__)
 // clang-format on
@@ -96,12 +100,20 @@ executeConstraintQuery(Callable &callable) {
     device->disable_and_clear_program_cache();
     query = callable();
   } catch (const std::exception &e) {
-    // We expect that query will handle exceptions and set error message. If
-    // not, we should not continue.
-    // TODO(rpavlovicTT): This should be a TT_FATAL.
+    // The query can throw from the backend allocator itself (e.g. the stateful
+    // override_mock_allocator_state failing to apply the accumulated live
+    // records to the target L1 layout) rather than returning a failed status.
+    // Surface the message and degrade to an error result so the spill manager's
+    // fallback (demote-to-DRAM / handleOOM) can recover, instead of aborting.
+    // The message is classified downstream in OpConstraintValidation
+    // (see https://github.com/tenstorrent/tt-mlir/issues/9045): an "Out of
+    // Memory" substring becomes an OOM result, anything else a backend error.
     llvm::errs() << "Exception thrown during op constraints query: " << e.what()
                  << "\n";
-    assert(false && "Exception thrown during op constraints query");
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        std::string("Exception thrown during op constraints query: ") +
+            e.what());
   }
 
   if (query.status != ::ttnn::graph::ExecutionStatus::Success) {
@@ -166,6 +178,124 @@ llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
                        response.resource_usage.peak_memory_usage_per_core,
                        response.resource_usage.l1_output_buffer_per_core,
                        layoutAttrs);
+}
+
+/**
+ * @brief Stateful variant of executeConstraintQuery.
+ *
+ * Mirrors executeConstraintQuery exactly (same ProgramCacheState +
+ * disable_and_clear_program_cache + LogLevelGuard + try/catch), but the
+ * callable yields a QueryOutput (response + new allocator state). Validation is
+ * performed against query.response, and the whole QueryOutput is returned on
+ * success.
+ *
+ * @param callable A callable object that performs the stateful query.
+ * @return A QueryOutput if successful, or an error.
+ */
+template <class Callable>
+llvm::Expected<::ttnn::graph::QueryOutput>
+executeConstraintQueryWithState(Callable &callable) {
+  ::ttnn::graph::QueryOutput query;
+  try {
+    auto *device = SingletonDeviceContext::getInstance().getDevice();
+    ::ttnn::graph::detail::LogLevelGuard log_guard(
+        spdlog::level::level_enum::off);
+    ProgramCacheState pcState(device);
+    device->disable_and_clear_program_cache();
+    query = callable();
+  } catch (const std::exception &e) {
+    // The query can throw from the backend allocator itself (e.g. the stateful
+    // override_mock_allocator_state failing to apply the accumulated live
+    // records to the target L1 layout) rather than returning a failed status.
+    // Surface the message and degrade to an error result so the spill manager's
+    // fallback (demote-to-DRAM / handleOOM) can recover, instead of aborting.
+    // The message is classified downstream in OpConstraintValidation
+    // (see https://github.com/tenstorrent/tt-mlir/issues/9045): an "Out of
+    // Memory" substring becomes an OOM result, anything else a backend error.
+    llvm::errs() << "Exception thrown during op constraints query: " << e.what()
+                 << "\n";
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        std::string("Exception thrown during op constraints query: ") +
+            e.what());
+  }
+
+  if (query.response.status != ::ttnn::graph::ExecutionStatus::Success) {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "Op constraint query failed with error: " +
+            query.response.error_message.value_or("<error message not set>"));
+  }
+
+  if (!query.response.output_tensor_specs.has_value() ||
+      query.response.output_tensor_specs->empty()) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Op constraint query missing output tensor");
+  }
+
+  return query;
+}
+
+/**
+ * @brief Stateful variant of getOpConstraints.
+ *
+ * Mirrors getOpConstraints but runs the stateful query path: it reads
+ * out.response for the resource usage + output tensor specs (identical logic to
+ * getOpConstraints). The build-from-records allocations
+ * (out.output_allocations) will be surfaced on OpConstraints in the
+ * validation-plumbing task; the optimizer consumes those per-output records,
+ * not new_state.
+ *
+ * @param context The MLIRContext to use for creating the TTNNLayoutAttr for the
+ * output tensor.
+ * @param callable A callable object that performs the stateful query.
+ * @return An OpConstraints or an error.
+ */
+template <class Callable>
+llvm::Expected<OpConstraints> getOpConstraintsWithState(MLIRContext *context,
+                                                        Callable &callable) {
+
+  llvm::Expected<::ttnn::graph::QueryOutput> query =
+      executeConstraintQueryWithState<Callable>(callable);
+  if (auto error = query.takeError()) {
+    return error;
+  }
+
+  ::ttnn::graph::QueryOutput out = query.get();
+
+  // The worker grid used to build interleaved output layouts is sourced from
+  // the open device rather than threaded in from the IR: the two are equivalent
+  // (the system desc that produced the IR's DeviceAttr is itself derived from
+  // this grid), and this is the only place the value is consumed. The context
+  // caches it across device open/reset, so this is a cheap lookup.
+  const llvm::ArrayRef<int64_t> deviceGrid =
+      SingletonDeviceContext::getInstance().getComputeGridShape();
+
+  llvm::SmallVector<TTNNLayoutAttr> layoutAttrs;
+  for (const auto &outputTensorSpec :
+       out.response.output_tensor_specs.value()) {
+    layoutAttrs.push_back(conversion::getLayoutAttrFromTensorSpec(
+        context, outputTensorSpec, deviceGrid));
+  }
+
+  // Build-from-records: surface each output buffer's placement as a tt-mlir
+  // mirror of tt-metal's AllocationRecord. The L1 spill path keeps these for
+  // still-live tensors and rebuilds allocator state from them (it does not
+  // thread new_state).
+  llvm::SmallVector<OpModelAllocationRecord> outputAllocations;
+  outputAllocations.reserve(out.output_allocations.size());
+  for (const auto &record : out.output_allocations) {
+    outputAllocations.push_back(
+        OpModelAllocationRecord{conversion::getBufferType(record.buffer_type),
+                                static_cast<uint64_t>(record.address),
+                                static_cast<uint64_t>(record.size_per_bank)});
+  }
+
+  return OpConstraints(out.response.resource_usage.cb_peak_size_per_core,
+                       out.response.resource_usage.l1_buffers_peak_per_core,
+                       out.response.resource_usage.peak_memory_usage_per_core,
+                       out.response.resource_usage.l1_output_buffer_per_core,
+                       layoutAttrs, std::move(outputAllocations));
 }
 
 template <class Callable>
@@ -550,6 +680,121 @@ inline bool programCarriesFusedActivation(
 
 } // namespace detail
 #endif // TTMLIR_ENABLE_OPMODEL
+
+std::shared_ptr<MockAllocatorState>
+buildInitialState(llvm::ArrayRef<OpModelAllocationRecord> liveRecords) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  // Build a mock allocator state even when there are no live allocations.
+  // An empty state gives the same fit decision as the stateless query, but it
+  // routes through the stateful (with_initial_state) query branch, which is the
+  // ONLY branch that reports output_allocations. The spill path bootstraps its
+  // record set from those per-op allocations; returning nullptr here would take
+  // the stateless branch (no allocations reported), so the record set could
+  // never seed off the first op and every subsequent query would also see an
+  // empty live set -- a permanent, silent degradation to stateless behavior.
+  std::vector<::tt::tt_metal::experimental::AllocationRecord> metalRecords;
+  metalRecords.reserve(liveRecords.size());
+  for (const OpModelAllocationRecord &record : liveRecords) {
+    metalRecords.push_back(::tt::tt_metal::experimental::AllocationRecord{
+        conversion::getBufferType(record.bufferType),
+        static_cast<::tt::tt_metal::DeviceAddr>(record.address),
+        static_cast<::tt::tt_metal::DeviceAddr>(record.sizePerBank)});
+  }
+
+  // RCA diagnostic (https://github.com/tenstorrent/tt-mlir/issues/9045
+  // follow-up): the Blackhole llama crash is override_mock_allocator_state
+  // failing to apply this record set to the target L1 layout. Set
+  // TTMLIR_SPILL_STATE_DEBUG=1 to dump the record set built for each stateful
+  // query; the last set printed before an "Exception thrown during op
+  // constraints query" line is the one that failed to apply.
+  if (::getenv("TTMLIR_SPILL_STATE_DEBUG")) {
+    uint64_t l1Total = 0;
+    for (const OpModelAllocationRecord &record : liveRecords) {
+      if (record.bufferType == BufferType::L1) {
+        l1Total += record.sizePerBank;
+      }
+    }
+    llvm::errs() << "[spill-state] applying " << liveRecords.size()
+                 << " live records (L1 total/bank=" << l1Total << "B):\n";
+    for (const OpModelAllocationRecord &record : liveRecords) {
+      llvm::errs() << "[spill-state]   bufferType="
+                   << static_cast<int>(record.bufferType)
+                   << " address=" << record.address
+                   << " sizePerBank=" << record.sizePerBank << "\n";
+    }
+  }
+
+  // The base state is a bank-config donor extracted from the open (mock)
+  // device; with_allocations replaces its regions with `metalRecords`,
+  // reproducing real placement/fragmentation at those addresses.
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  ::tt::tt_metal::experimental::MockAllocatorState base =
+      ::tt::tt_metal::experimental::extract_mock_allocator_state(*device);
+  return std::make_shared<MockAllocatorState>(
+      base.with_allocations(metalRecords));
+#else
+  return nullptr;
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+namespace {
+// Snapshot of the mock allocator state taken before a batch of stateful spill
+// queries, so it can be restored exactly afterward. Single mock device per
+// compile; snapshot is always paired with a restore by the spill pass.
+//
+// INVARIANT: this state relies on strictly sequential, non-reentrant use.
+// The op-model / SingletonDeviceContext layer is single-threaded per compile
+// (there is one shared mock device), and the only writer is the greedy L1 spill
+// pass, which brackets exactly one spill run with snapshot -> (queries) ->
+// restore via an RAII guard (see GreedyL1SpillManagement.cpp). There is no
+// nesting: a second snapshotMockAllocatorState() before the matching restore
+// would overwrite the pending snapshot and silently lose the original state.
+// Do not call these from a reentrant / concurrent context.
+//
+// Held in a function-local static rather than a namespace-scope global so the
+// mutable state stays encapsulated behind this accessor.
+std::optional<::tt::tt_metal::experimental::MockAllocatorState> &
+spillAllocatorSnapshot() {
+  static std::optional<::tt::tt_metal::experimental::MockAllocatorState>
+      snapshot;
+  return snapshot;
+}
+} // namespace
+#endif
+
+void snapshotMockAllocatorState() {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  auto *device = SingletonDeviceContext::getInstance().getDevice();
+  if (::tt::tt_metal::experimental::get_mock_allocator(*device) == nullptr) {
+    spillAllocatorSnapshot().reset();
+    return;
+  }
+  spillAllocatorSnapshot() =
+      ::tt::tt_metal::experimental::extract_mock_allocator_state(*device);
+#endif
+}
+
+void restoreMockAllocatorState() {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  if (!spillAllocatorSnapshot().has_value()) {
+    return;
+  }
+  // The stateful (build-from-records) query mutates the SHARED mock device's
+  // allocator (override_mock_allocator_state) and does not restore it. Restore
+  // the exact pre-spill snapshot so later stateless op-model queries (e.g. the
+  // conv2d config search in OperationValidationAndFallback, or pool/conv
+  // constraint queries) run against the same clean device main sees. A partial
+  // reset (clearing allocations only) is NOT enough: residual allocator state
+  // flips op-model validity (e.g. makes conv2d act_block_h_override=0
+  // spuriously legal), producing wrong configs and corrupt output.
+  auto *device = SingletonDeviceContext::getInstance().getDevice();
+  ::tt::tt_metal::experimental::override_mock_allocator_state(
+      *device, *spillAllocatorSnapshot());
+  spillAllocatorSnapshot().reset();
+#endif
+}
 
 bool isLayoutLegalForTensorShape(llvm::ArrayRef<int64_t> tensorShape,
                                  TTNNLayoutAttr layout,
@@ -997,11 +1242,44 @@ OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
     uint32_t intermediateSize) {
-#ifdef TTMLIR_ENABLE_OPMODEL
-  auto query = makePrepareMoEComputeW0W1WeightsQuery(
+  return getOpConstraintsWithState(
       w0Shape, w0Layout, w1Shape, w1Layout, bias0Shape, bias0Layout, bias1Shape,
-      bias1Layout, hiddenSize, intermediateSize);
-  return operation::getOpConstraints(w0Layout.getContext(), query);
+      bias1Layout, hiddenSize, intermediateSize, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
+    llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
+    std::optional<TTNNLayoutAttr> bias0Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
+    std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
+    uint32_t intermediateSize, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    ::ttnn::TensorSpec w0Spec = conversion::getTensorSpec(w0Shape, w0Layout);
+    ::ttnn::TensorSpec w1Spec = conversion::getTensorSpec(w1Shape, w1Layout);
+    std::optional<::ttnn::TensorSpec> b0Spec;
+    if (bias0Shape && bias0Layout) {
+      b0Spec = conversion::getTensorSpec(*bias0Shape, *bias0Layout);
+    }
+    std::optional<::ttnn::TensorSpec> b1Spec;
+    if (bias1Shape && bias1Layout) {
+      b1Spec = conversion::getTensorSpec(*bias1Shape, *bias1Layout);
+    }
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        moeComputePackW0W1, device, initialStateOpt, w0Spec, w1Spec, b0Spec,
+        b1Spec, hiddenSize, intermediateSize, device);
+  };
+  return operation::getOpConstraintsWithState(w0Layout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1013,10 +1291,36 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
     uint32_t intermediateSize) {
+  return getOpConstraintsWithState(w2Shape, w2Layout, bias2Shape, bias2Layout,
+                                   hiddenSize, intermediateSize,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
+    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
+    std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
+    uint32_t intermediateSize, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
-  auto query = makePrepareMoEComputeW2WeightsQuery(
-      w2Shape, w2Layout, bias2Shape, bias2Layout, hiddenSize, intermediateSize);
-  return operation::getOpConstraints(w2Layout.getContext(), query);
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    ::ttnn::TensorSpec w2Spec = conversion::getTensorSpec(w2Shape, w2Layout);
+    std::optional<::ttnn::TensorSpec> b2Spec;
+    if (bias2Shape && bias2Layout) {
+      b2Spec = conversion::getTensorSpec(*bias2Shape, *bias2Layout);
+    }
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        moeComputePackW2, device, initialStateOpt, w2Spec, b2Spec, hiddenSize,
+        intermediateSize, device);
+  };
+  return operation::getOpConstraintsWithState(w2Layout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1026,11 +1330,26 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
 
+// Cache-facing stateless entry. Its signature must stay exactly as the op-model
+// cache's getOrCompute invokes it (by function pointer), so it cannot grow
+// params; it forwards to the shared stateful body with a null state. The null
+// path runs query_op_constraints_with_optional_state(nullopt), which metal
+// dispatches straight to the stateless query.
 template <typename OpTy>
 llvm::Expected<OpConstraints>
 UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
 
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1040,14 +1359,18 @@ UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
         detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1084,6 +1407,15 @@ llvm::Expected<OpConstraints>
 UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1094,14 +1426,18 @@ UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
 
   bool fastApproxMode = true;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, fastApproxMode,
-        detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
+        fastApproxMode, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1176,6 +1512,13 @@ llvm::Expected<OpConstraints>
 OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                      TTNNLayoutAttr inputLayout,
                                      TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1189,14 +1532,18 @@ OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       static_cast<int32_t>(::ttnn::operations::unary::VecMode::RC);
   auto sigmoidMode = ::ttnn::operations::unary::SigmoidMode::ACCURATE;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sigmoid, device, inputSpec, vectorMode,
-                                sigmoidMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sigmoid, device, initialStateOpt, inputSpec, vectorMode,
+        sigmoidMode, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1238,6 +1585,14 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::APFloat slope, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, slope, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::APFloat slope, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1246,15 +1601,19 @@ llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto leakyReluOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::leaky_relu, device, inputSpec,
-                                slope.convertToFloat(),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::leaky_relu, device, initialStateOpt, inputSpec,
+        slope.convertToFloat(), detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     leakyReluOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              leakyReluOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1293,6 +1652,18 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, opDtypeAttr,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+BinaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1313,14 +1684,18 @@ llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputDType, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpecA,
+        inputSpecB, outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1365,7 +1740,19 @@ template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/) {
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, opDtypeAttr,
+                                   /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+BinaryCompositeOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1381,14 +1768,18 @@ llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(detail::getOpSymbol<OpTy>(), device,
+                                           initialStateOpt, inputSpecA,
+                                           inputSpecB, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1461,6 +1852,17 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::string approximate, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, approximate, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<GeluBackwardOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    std::string approximate, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1476,14 +1878,18 @@ llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::gelu_bw, device,
-                                inputSpecA, inputSpecB, approximate,
-                                outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::gelu_bw, device, initialStateOpt, inputSpecA,
+        inputSpecB, approximate, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1527,6 +1933,14 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute exponent, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, exponent,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1536,11 +1950,15 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Helper lambda to create the query with any exponent value type.
   auto powScalarQuery = [=](auto convertedExponent) {
     return [=]() {
-      return QUERY_OP_CONSTRAINTS(
-          ::ttnn::pow, device, inputSpec, convertedExponent,
+      return QUERY_OP_CONSTRAINTS_WITH_STATE(
+          ::ttnn::pow, device, initialStateOpt, inputSpec, convertedExponent,
           detail::getNullableMemoryConfig(outputLayout));
     };
   };
@@ -1550,12 +1968,14 @@ llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
   if (auto value = mlir::dyn_cast<mlir::IntegerAttr>(exponent)) {
     int32_t convertedExponent = static_cast<int32_t>(value.getInt());
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
+    return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                                query);
   }
   if (auto value = mlir::dyn_cast<mlir::FloatAttr>(exponent)) {
     float convertedExponent = value.getValue().convertToFloat();
     auto query = powScalarQuery(convertedExponent);
-    return operation::getOpConstraints(inputLayout.getContext(), query);
+    return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                                query);
   }
   return llvm::createStringError("Invalid exponent");
 #else
@@ -1612,6 +2032,18 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, inputShapeC, inputLayoutC,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints>
+TernaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1631,14 +2063,18 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(detail::getOpSymbol<OpTy>(),
-                                               device, inputSpecA, inputSpecB,
-                                               inputSpecC, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpecA,
+        inputSpecB, inputSpecC, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1694,6 +2130,15 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dimArg, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+template <typename OpTy>
+llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1710,17 +2155,21 @@ llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
     dimArgConverted = std::nullopt;
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, dimArgConverted,
-        keepDim, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
+        dimArgConverted, keepDim, detail::getNullableMemoryConfig(outputLayout),
         /*compute_kernel_config=*/std::nullopt,
         /*scalar=*/1.0f, /*correction=*/true,
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1820,6 +2269,15 @@ template struct NamedFullOpModel<OnesOp>;
 llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dimArg,
+                                   numericStable, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1828,15 +2286,21 @@ llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto softmaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::softmax, device, inputSpec, dimArg,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, // compute_kernel_config,
-                                numericStable);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::softmax, device, initialStateOpt, inputSpec, dimArg,
+        detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt, // compute_kernel_config,
+        numericStable);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), softmaxOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              softmaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1876,6 +2340,17 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
     int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, indexShape, indexLayout, sourceShape,
+      sourceLayout, dim, optReduction, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
+    llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
+    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1895,15 +2370,21 @@ llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
   // Convert optReduction to ScatterReductionType enum
   auto optReductionType = conversion::getScatterReductionType(optReduction);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   //  Create query closure
   auto scatterOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::scatter, device, inputSpec, dim, indexSpec, sourceSpec,
-        detail::getNullableMemoryConfig(outputLayout), optReductionType,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::scatter, device, initialStateOpt, inputSpec, dim, indexSpec,
+        sourceSpec, detail::getNullableMemoryConfig(outputLayout),
+        optReductionType,
         /* sub_core_grid */ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), scatterOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              scatterOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -1953,6 +2434,14 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputShape,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -1961,14 +2450,20 @@ llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto reshapeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::reshape, device, inputSpec,
-                                conversion::getShape(outputShape),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::reshape, device, initialStateOpt, inputSpec,
+        conversion::getShape(outputShape),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), reshapeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              reshapeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2005,6 +2500,15 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
     llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, begins, ends, step,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
+    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2025,15 +2529,20 @@ llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
   ttsl::Span<const int> endsSpan = ::ttsl::make_const_span(endsVec);
   ttsl::Span<const int> stepSpan = ::ttsl::make_const_span(stepVec);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::slice, device, inputSpec, beginsSpan,
-                                endsSpan, stepSpan,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::slice, device, initialStateOpt, inputSpec, beginsSpan, endsSpan,
+        stepSpan, detail::getNullableMemoryConfig(outputLayout), std::nullopt,
+        std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2087,6 +2596,18 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
     std::optional<llvm::SmallVector<int64_t>> step,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, beginsShape,
+                                   beginsLayout, endsShape, endsLayout, step,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<SliceDynamicOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
+    llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
+    std::optional<llvm::SmallVector<int64_t>> step, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2112,13 +2633,20 @@ llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
   // Default values in tt-metal:
   std::optional<::tt::tt_metal::TensorSpec> outputSpec = std::nullopt;
   std::optional<float> padValue = std::nullopt;
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure to make a call to the static version of the op:
   auto sliceOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::slice, device, inputSpec, beginsVec, endsVec, stepVec,
-        detail::getNullableMemoryConfig(outputLayout), outputSpec, padValue);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::slice, device, initialStateOpt, inputSpec, beginsVec, endsVec,
+        stepVec, detail::getNullableMemoryConfig(outputLayout), outputSpec,
+        padValue);
   };
-  return operation::getOpConstraints(inputLayout.getContext(), sliceOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sliceOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2176,6 +2704,15 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BitcastConvertOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2184,14 +2721,20 @@ llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto bitcastOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::bitcast, device, inputSpec,
-                                conversion::getDataType(dtype.getValue()),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::bitcast, device, initialStateOpt, inputSpec,
+        conversion::getDataType(dtype.getValue()),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), bitcastOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              bitcastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2227,6 +2770,14 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2235,14 +2786,20 @@ llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto typecastOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::typecast, device, inputSpec,
-                                conversion::getDataType(dtype.getValue()),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::typecast, device, initialStateOpt, inputSpec,
+        conversion::getDataType(dtype.getValue()),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), typecastOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              typecastOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2278,6 +2835,14 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputDtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2293,14 +2858,19 @@ llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
     dtype = std::nullopt;
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto toLayoutOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::to_layout, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::to_layout, device, initialStateOpt, inputSpec,
         conversion::getPageLayout(outputLayout.getLayout()), dtype,
         detail::getNullableMemoryConfig(outputLayout));
   };
-  return operation::getOpConstraints(inputLayout.getContext(), toLayoutOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              toLayoutOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2345,6 +2915,14 @@ llvm::Expected<OpConstraints>
 OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ToMemoryConfigOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2353,15 +2931,19 @@ OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto toMemoryConfigOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::to_memory_config, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::to_memory_config, device, initialStateOpt, inputSpec,
         conversion::getMemoryConfig(MemoryConfigAttr::get(outputLayout)));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     toMemoryConfigOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              toMemoryConfigOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2398,6 +2980,14 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShapes, inputLayouts, dim, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraintsWithState(
+    std::vector<llvm::ArrayRef<int64_t>> inputShapes,
+    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2413,14 +3003,19 @@ llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     inputSpecs.push_back(std::move(_push_tmp));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto concatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::concat, device, inputSpecs, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::concat, device, initialStateOpt, inputSpecs, dim,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayouts[0].getContext(),
-                                     concatOpQuery);
+  return operation::getOpConstraintsWithState(inputLayouts[0].getContext(),
+                                              concatOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2463,6 +3058,14 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim0, dim1,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int dim0, const int dim1, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2471,16 +3074,20 @@ llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto transposeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transpose, device, inputSpec,
-                                static_cast<int64_t>(dim0),
-                                static_cast<int64_t>(dim1),
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transpose, device, initialStateOpt, inputSpec,
+        static_cast<int64_t>(dim0), static_cast<int64_t>(dim1),
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     transposeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              transposeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2518,6 +3125,14 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int32_t dim, std::optional<ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2531,14 +3146,19 @@ llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     ttnnDtype = conversion::getDataType(*dtype);
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto cumSumOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::cumsum, device, inputSpec, dim,
-                                ttnnDtype, false, std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::cumsum, device, initialStateOpt, inputSpec, dim, ttnnDtype,
+        false, std::nullopt, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), cumSumOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              cumSumOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2582,6 +3202,14 @@ llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const int32_t dim, std::optional<ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2595,14 +3223,20 @@ llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
     ttnnDtype = conversion::getDataType(*dtype);
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto cumProdOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::cumprod, device, inputSpec, dim,
-                                ttnnDtype, /*reverse_order=*/false,
-                                /*optional_out=*/std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::cumprod, device, initialStateOpt, inputSpec, dim, ttnnDtype,
+        /*reverse_order=*/false,
+        /*optional_out=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), cumProdOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              cumProdOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2646,6 +3280,14 @@ OpModel<CumProdOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ConcatenateHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -2654,15 +3296,19 @@ llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto concatenateHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transformer::concatenate_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::concatenate_heads, device, initialStateOpt,
+        inputSpec, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     concatenateHeadsOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              concatenateHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2710,6 +3356,27 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::APFloat> scale,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      isCausal, attentionMaskShape, attentionMaskLayout, curPosTensorShape,
+      curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
+      programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2746,18 +3413,23 @@ OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
   auto sdpaProgramConfigConverted =
       conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto scaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, isCausal, attentionMaskSpec, curPosEmpty,
-        curPosTensorSpec, attentionSinkSpec, scaleFloat, slidingWindowSize,
+        initialStateOpt, querySpec, keySpec, valueSpec, isCausal,
+        attentionMaskSpec, curPosEmpty, curPosTensorSpec, attentionSinkSpec,
+        scaleFloat, slidingWindowSize,
         detail::getNullableMemoryConfig(outputLayout),
         sdpaProgramConfigConverted,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     scaledDotProductAttentionDecodeOpQuery);
+  return operation::getOpConstraintsWithState(
+      queryLayout.getContext(), scaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -2843,6 +3515,30 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
     std::optional<uint32_t> slidingWindowSize,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
+      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
+      attentionSinkShape, attentionSinkLayout, scale, slidingWindowSize,
+      programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2875,17 +3571,21 @@ OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedScaledDotProductAttentionDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::paged_scaled_dot_product_attention_decode, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
+        initialStateOpt, querySpec, keySpec, valueSpec, pageTableSpec, isCausal,
         attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
         slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
         sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(
+  return operation::getOpConstraintsWithState(
       queryLayout.getContext(), pagedScaledDotProductAttentionDecodeOpQuery);
 #else
   return OpConstraints{};
@@ -2988,6 +3688,29 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      headDimV, pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
+      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
+      attentionSinkShape, attentionSinkLayout, scale, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    std::optional<llvm::ArrayRef<int64_t>> valueShape,
+    std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
+    std::optional<TTNNLayoutAttr> curPosTensorLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout,
+    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3019,18 +3742,23 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       programConfig = getPagedFlashMlaDecodeProgramConfig(device);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedFlashMlaDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::paged_flash_multi_latent_attention_decode, device,
-        querySpec, keySpec, valueSpec, headDimV, pageTableSpec, isCausal,
-        attentionMaskSpec, curPosTensorSpec, attentionSinkSpec, scaleFloat,
+        initialStateOpt, querySpec, keySpec, valueSpec, headDimV, pageTableSpec,
+        isCausal, attentionMaskSpec, curPosTensorSpec, attentionSinkSpec,
+        scaleFloat,
         /*slidingWindowSize=*/std::nullopt,
         detail::getNullableMemoryConfig(outputLayout), programConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     pagedFlashMlaDecodeOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              pagedFlashMlaDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3111,6 +3839,22 @@ OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
     TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
     std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      pageTableShape, pageTableLayout, chunkStartIdxShape, chunkStartIdxLayout,
+      scale, programConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    llvm::ArrayRef<int64_t> chunkStartIdxShape,
+    TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
+    std::optional<SDPAProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3135,17 +3879,21 @@ OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
   std::optional<::ttnn::operations::transformer::SDPAProgramConfig>
       sdpaProgramConfig = conversion::getSDPAProgramConfig(programConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto chunkedScaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::chunked_scaled_dot_product_attention, device,
-        querySpec, keySpec, valueSpec, pageTableSpec, chunkStartIdxSpec,
-        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
-        sdpaProgramConfig,
+        initialStateOpt, querySpec, keySpec, valueSpec, pageTableSpec,
+        chunkStartIdxSpec, scaleFloat,
+        detail::getNullableMemoryConfig(outputLayout), sdpaProgramConfig,
         /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     chunkedScaledDotProductAttentionOpQuery);
+  return operation::getOpConstraintsWithState(
+      queryLayout.getContext(), chunkedScaledDotProductAttentionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3215,6 +3963,25 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
     std::optional<llvm::APFloat> scale,
     std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
+      attentionSinkLayout, isCausal, scale, slidingWindowSize, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ScaledDotProductAttentionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
+    std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
+    std::optional<llvm::APFloat> scale,
+    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3238,17 +4005,22 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto scaledDotProductAttentionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::transformer::scaled_dot_product_attention, device, querySpec,
-        keySpec, valueSpec, attentionMaskSpec, isCausal, scaleFloat,
-        slidingWindowSize, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::scaled_dot_product_attention, device,
+        initialStateOpt, querySpec, keySpec, valueSpec, attentionMaskSpec,
+        isCausal, scaleFloat, slidingWindowSize,
+        detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt, attentionSinkSpec);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     scaledDotProductAttentionOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              scaledDotProductAttentionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3316,6 +4088,22 @@ llvm::Expected<OpConstraints> OpModel<FlashMlaPrefillOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
     bool isCausal, std::optional<llvm::APFloat> scale,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
+      attentionMaskShape, attentionMaskLayout, headDimV, isCausal, scale,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<FlashMlaPrefillOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    std::optional<llvm::ArrayRef<int64_t>> valueShape,
+    std::optional<TTNNLayoutAttr> valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
+    bool isCausal, std::optional<llvm::APFloat> scale,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3335,17 +4123,21 @@ llvm::Expected<OpConstraints> OpModel<FlashMlaPrefillOp>::getOpConstraints(
   std::optional<float> scaleFloat =
       scale ? std::make_optional(scale.value().convertToFloat()) : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto flashMlaPrefillOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::transformer::flash_mla_prefill, device,
-                                querySpec, keySpec, headDimV, valueSpec,
-                                attentionMaskSpec, isCausal, scaleFloat,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*program_config=*/std::nullopt,
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::transformer::flash_mla_prefill, device, initialStateOpt,
+        querySpec, keySpec, headDimV, valueSpec, attentionMaskSpec, isCausal,
+        scaleFloat, detail::getNullableMemoryConfig(outputLayout),
+        /*program_config=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     flashMlaPrefillOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              flashMlaPrefillOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3470,6 +4262,20 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
     bool isDecodeMode, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
+                                   sinShape, sinLayout, transMatShape,
+                                   transMatLayout, isDecodeMode, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RotaryEmbeddingLlamaOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
+    bool isDecodeMode, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3485,15 +4291,19 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec transMatSpec,
       detail::convertToTensorSpec(device, transMatShape, transMatLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto rotaryEmbeddingLlamaOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding_llama,
-                                device, inputSpec, cosSpec, sinSpec,
-                                transMatSpec, isDecodeMode,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::rotary_embedding_llama, device, initialStateOpt,
+        inputSpec, cosSpec, sinSpec, transMatSpec, isDecodeMode,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     rotaryEmbeddingLlamaOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rotaryEmbeddingLlamaOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3543,6 +4353,18 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
+                                   sinShape, sinLayout, tokenIndex,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RotaryEmbeddingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
+    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
+    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3555,14 +4377,19 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec sinSpec,
                    detail::convertToTensorSpec(device, sinShape, sinLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto rotaryEmbeddingOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::rotary_embedding, device,
-                                inputSpec, cosSpec, sinSpec, tokenIndex,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::rotary_embedding, device, initialStateOpt,
+        inputSpec, cosSpec, sinSpec, tokenIndex,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     rotaryEmbeddingOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rotaryEmbeddingOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3608,6 +4435,20 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
     std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, batchOffsetShape,
+                                   batchOffsetLayout, numHeads, numKVHeads,
+                                   overlapQKCoregrid, sliceSize, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<op_model::OpConstraints>
+OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
+    std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
+    std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
+    std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3622,19 +4463,23 @@ OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   std::optional<std::array<::ttnn::Tensor, 3>> optionalOutputTensors =
       std::nullopt;
   auto nlpCreateQKVHeadsDecode = [&]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_create_qkv_heads_decode, device, inputSpec,
-        numHeads, numKVHeads, optionalOutputTensors,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_create_qkv_heads_decode, device,
+        initialStateOpt, inputSpec, numHeads, numKVHeads, optionalOutputTensors,
         std::optional<const bool>(overlapQKCoregrid), batchOffsetSpec,
         sliceSize, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpCreateQKVHeadsDecode);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpCreateQKVHeadsDecode);
 
 #else
   return OpConstraints{};
@@ -3688,6 +4533,18 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
     std::optional<uint32_t> numKVHeads, bool transposeKey,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, inputKVShape, inputKVLayout, numHeads,
+      numKVHeads, transposeKey, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
+    std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
+    std::optional<uint32_t> numKVHeads, bool transposeKey,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3703,16 +4560,20 @@ OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
                                                  inputKVLayout.value()));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto splitQueryKeyValueAndSplitHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttnn::transformer::split_query_key_value_and_split_heads, device,
-        inputSpec, inputKVSpec, numHeads, numKVHeads, transposeKey,
-        detail::getNullableMemoryConfig(outputLayout));
+        initialStateOpt, inputSpec, inputKVSpec, numHeads, numKVHeads,
+        transposeKey, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     splitQueryKeyValueAndSplitHeadsOpQuery);
+  return operation::getOpConstraintsWithState(
+      inputLayout.getContext(), splitQueryKeyValueAndSplitHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3760,6 +4621,14 @@ llvm::Expected<OpConstraints>
 OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
                                             TTNNLayoutAttr inputLayout,
                                             TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<NLPConcatHeadsOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3768,15 +4637,19 @@ OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto nlpConcatHeadsOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::nlp_concat_heads, device,
-                                inputSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_concat_heads, device, initialStateOpt,
+        inputSpec, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpConcatHeadsOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpConcatHeadsOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3813,6 +4686,15 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t numHeads, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, numHeads,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<NLPConcatHeadsDecodeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t numHeads, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3837,16 +4719,20 @@ llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     }
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto nlpConcatHeadsDecodeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::nlp_concat_heads_decode, device, inputSpec,
-        numHeads, detail::getNullableMemoryConfig(outputLayout),
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::nlp_concat_heads_decode, device, initialStateOpt,
+        inputSpec, numHeads, detail::getNullableMemoryConfig(outputLayout),
         std::optional<::ttnn::Tensor>(std::nullopt), subCoreGrids);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     nlpConcatHeadsDecodeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              nlpConcatHeadsDecodeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3896,6 +4782,15 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, repeats, dim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RepeatInterleaveOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3904,15 +4799,19 @@ llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto repeatInterleaveOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat_interleave, device, inputSpec,
-                                repeats, dim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::repeat_interleave, device, initialStateOpt, inputSpec, repeats,
+        dim, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     repeatInterleaveOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              repeatInterleaveOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -3948,6 +4847,14 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, repeats,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -3967,13 +4874,19 @@ llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
   ::ttsl::SmallVector<uint32_t> repeatVec(repeatShape.cbegin(),
                                           repeatShape.cend());
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto repeatOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::repeat, device, inputSpec, repeatVec,
-                                outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::repeat, device,
+                                           initialStateOpt, inputSpec,
+                                           repeatVec, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), repeatOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              repeatOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4049,6 +4962,15 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, padding, padValue,
+                                   multicore, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4060,14 +4982,20 @@ llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
   // Convert padding to PadSpecDim format
   auto paddingSpec = convertPadding(padding);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto padOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::pad, device, inputSpec, paddingSpec,
-                                padValue.convertToFloat(), multicore,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::pad, device, initialStateOpt, inputSpec, paddingSpec,
+        padValue.convertToFloat(), multicore,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), padOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              padOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4107,6 +5035,15 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
     bool descending, bool stable, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, descending,
+                                   stable, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
+    bool descending, bool stable, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4115,14 +5052,19 @@ llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto sortOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sort, device, inputSpec, dim,
-                                descending, stable,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sort, device, initialStateOpt, inputSpec, dim, descending,
+        stable, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), sortOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              sortOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4161,6 +5103,19 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
     uint32_t numExperts, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, k,
+                                   numExperts, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<TopKRouterGptOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
+    uint32_t numExperts, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4176,13 +5131,18 @@ llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec biasSpec,
                    detail::convertToTensorSpec(device, biasShape, biasLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto topKRouterGptQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::topk_router_gpt, device,
-                                inputSpec, weightSpec, biasSpec, k, numExperts);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::topk_router_gpt, device, initialStateOpt,
+        inputSpec, weightSpec, biasSpec, k, numExperts);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     topKRouterGptQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              topKRouterGptQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4225,6 +5185,14 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4233,14 +5201,20 @@ llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto argMaxOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::argmax, device, inputSpec, dim, keepDim, std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout), std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::argmax, device, initialStateOpt, inputSpec, dim, keepDim,
+        std::nullopt, detail::getNullableMemoryConfig(outputLayout),
+        std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), argMaxOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              argMaxOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4276,6 +5250,14 @@ llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4284,13 +5266,19 @@ llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto prodOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::prod, device, inputSpec, dim, keepDim,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::prod, device, initialStateOpt, inputSpec, dim, keepDim,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), prodOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              prodOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4412,6 +5400,22 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> outZeroPointShape,
     TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, inScaleShape, inScaleLayout, inZeroPointShape,
+      inZeroPointLayout, outScaleShape, outScaleLayout, outZeroPointShape,
+      outZeroPointLayout, axis, outputDtype, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
+    llvm::ArrayRef<int64_t> inZeroPointShape, TTNNLayoutAttr inZeroPointLayout,
+    llvm::ArrayRef<int64_t> outScaleShape, TTNNLayoutAttr outScaleLayout,
+    llvm::ArrayRef<int64_t> outZeroPointShape,
+    TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
+    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4447,16 +5451,21 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
 
   auto requantizeOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::requantize, device, inputSpec, inScaleSpec, inZeroPointSpec,
-        outScaleSpec, outZeroPointSpec, axis, outputDType, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::requantize, device, initialStateOpt, inputSpec, inScaleSpec,
+        inZeroPointSpec, outScaleSpec, outZeroPointSpec, axis, outputDType,
+        outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     requantizeOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              requantizeOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4530,6 +5539,21 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
     std::optional<mlir::Attribute> programConfigAttr,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(
+      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
+      biasLayout, outputLayout, transposeA, transposeB, activation,
+      programConfigAttr, computeKernelConfig, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
+    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4568,18 +5592,23 @@ llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto linearOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::linear, device, inputSpecA, inputSpecB, biasTensor, transposeA,
-        transposeB, outputMemoryConfig, outputDType, programConfig,
-        activationStr, computeKernelConfigConverted,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::linear, device, initialStateOpt, inputSpecA, inputSpecB,
+        biasTensor, transposeA, transposeB, outputMemoryConfig, outputDType,
+        programConfig, activationStr, computeKernelConfigConverted,
         /*core_grid=*/std::nullopt, /*output_tile=*/std::nullopt,
         /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), linearOpQuery);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(),
+                                              linearOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4636,6 +5665,9 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
+// Cache-facing stateless entry; signature fixed for getOrCompute. Forwards to
+// the shared stateful body with a null state (metal dispatches nullopt to the
+// stateless query).
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
@@ -4643,6 +5675,22 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
     std::optional<llvm::StringRef> activation,
     std::optional<mlir::Attribute> programConfigAttr,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
+                                   inputLayoutB, outputLayout, transposeA,
+                                   transposeB, activation, programConfigAttr,
+                                   computeKernelConfig,
+                                   /*initialState=*/nullptr);
+}
+
+// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
+llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
+    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
+    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
+    std::optional<llvm::StringRef> activation,
+    std::optional<mlir::Attribute> programConfigAttr,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4674,17 +5722,22 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto matmulOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::matmul, device, inputSpecA, inputSpecB, transposeA, transposeB,
-        outputMemoryConfig, outputDType, programConfig, activationStr,
-        computeKernelConfigConverted, /*core_grid=*/std::nullopt,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::matmul, device, initialStateOpt, inputSpecA, inputSpecB,
+        transposeA, transposeB, outputMemoryConfig, outputDType, programConfig,
+        activationStr, computeKernelConfigConverted, /*core_grid=*/std::nullopt,
         /*output_tile=*/std::nullopt, /*optional_output_tensor=*/std::nullopt,
         /*global_cb=*/std::nullopt, /*sub_device_id=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayoutA.getContext(), matmulOpQuery);
+  return operation::getOpConstraintsWithState(inputLayoutA.getContext(),
+                                              matmulOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -4765,6 +5818,16 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
+                                   inputLayout, batchOffset, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4776,13 +5839,18 @@ llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto fillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::fill_cache, device, cacheSpec,
-                                inputSpec, batchOffset);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::fill_cache, device,
+                                           initialStateOpt, cacheSpec,
+                                           inputSpec, batchOffset);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     fillCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              fillCacheOpQuery);
 
 #else
   return llvm::createStringError("Not Implemented");
@@ -4824,6 +5892,17 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
     uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, batchOffset, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
+    uint32_t batchOffset, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4850,14 +5929,19 @@ llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
   (void)updateIndexShape;
   (void)updateIndexLayout;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto updateCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::update_cache, device, cacheSpec,
-                                inputSpec, updateIdx, batchOffset,
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::update_cache, device, initialStateOpt, cacheSpec, inputSpec,
+        updateIdx, batchOffset,
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     updateCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              updateCacheOpQuery);
 
 #else
   return llvm::createStringError("Not Implemented");
@@ -4908,6 +5992,20 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
     std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
+      updateIndexLayout, pageTableShape, pageTableLayout, shareCache,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedUpdateCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
+    std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
+    std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -4931,17 +6029,22 @@ llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *pageTableShape, *pageTableLayout));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   std::vector<uint32_t> emptyUpdateIndex = {};
   auto pagedUpdateCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_update_cache, device, cacheSpec, inputSpec,
-        emptyUpdateIndex, updateIndexSpec, shareCache, pageTableSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::paged_update_cache, device, initialStateOpt,
+        cacheSpec, inputSpec, emptyUpdateIndex, updateIndexSpec, shareCache,
+        pageTableSpec,
         /*batch_offset=*/0,
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     pagedUpdateCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              pagedUpdateCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5001,6 +6104,20 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
     std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
+                                   inputLayout, pageTableShape, pageTableLayout,
+                                   batchIdxShape, batchIdxLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PagedFillCacheOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
+    std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
+    std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5023,16 +6140,20 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
         detail::convertToTensorSpec(device, *batchIdxShape, *batchIdxLayout));
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto pagedFillCacheOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::paged_fill_cache, device, cacheSpec, inputSpec,
-        pageTableSpec, batchIdxSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::paged_fill_cache, device, initialStateOpt,
+        cacheSpec, inputSpec, pageTableSpec, batchIdxSpec,
         /*batch_offset=*/0,
         /*compute_kernel_config=*/std::nullopt, /*mesh_coords=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(cacheLayout.getContext(),
-                                     pagedFillCacheOpQuery);
+  return operation::getOpConstraintsWithState(cacheLayout.getContext(),
+                                              pagedFillCacheOpQuery);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5096,6 +6217,27 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, dilation, groups, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::tt::tt_metal::TensorSpec> preparedWeightExp =
@@ -5144,11 +6286,15 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto conv2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv2d, device, inputSpec, weightSpec, device, in_channels,
-        out_channels, batch_size, input_height, input_width,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::conv2d, device, initialStateOpt, inputSpec, weightSpec, device,
+        in_channels, out_channels, batch_size, input_height, input_width,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -5160,7 +6306,8 @@ llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), conv2dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              conv2dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5588,6 +6735,28 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
     std::optional<Conv3dConfigAttr> conv3dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_depth, input_height,
+      input_width, kernel_size, stride, padding, groups, padding_mode,
+      outputDtype, conv3dConfig, deviceComputeKernelConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
+    uint32_t input_height, uint32_t input_width,
+    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, uint32_t groups,
+    llvm::StringRef padding_mode,
+    std::optional<ttcore::DataTypeAttr> outputDtype,
+    std::optional<Conv3dConfigAttr> conv3dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5602,9 +6771,14 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
   }
   auto specs = specsExp.get();
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto conv3dOpQuery = [=, &specs]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::experimental::conv3d, device, specs.inputSpec, specs.weightSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::conv3d, device, initialStateOpt, specs.inputSpec,
+        specs.weightSpec,
         std::optional<::tt::tt_metal::distributed::MeshDevice *>(device),
         specs.biasSpec, specs.config, specs.dtype, specs.outputChannels,
         specs.kernelSize, specs.stride, specs.padding,
@@ -5613,7 +6787,8 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
         specs.deviceComputeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), conv3dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              conv3dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5679,6 +6854,26 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
+      in_channels, out_channels, batch_size, input_height, input_width,
+      kernel_size, stride, padding, output_padding, dilation, groups,
+      conv2dConfig, conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<ConvTranspose2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
+    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
+    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
+    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   // Prepare weight tensor first.
   llvm::Expected<::tt::tt_metal::TensorSpec> preparedWeightExp =
@@ -5722,11 +6917,16 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> conv2dSliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto convTranspose2dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv_transpose2d, device, inputSpec, weightSpec, device,
-        in_channels, out_channels, batch_size, input_height, input_width,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::conv_transpose2d, device, initialStateOpt, inputSpec,
+        weightSpec, device, in_channels, out_channels, batch_size, input_height,
+        input_width,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernel_size),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding),
@@ -5741,8 +6941,8 @@ llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     convTranspose2dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              convTranspose2dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5846,6 +7046,28 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, dilation, hasBias, groups,
+      inputDtype, outputDtype, conv2dConfig, deviceComputeKernelConfig,
+      conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConv2dWeightsOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
+    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
+    std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5866,10 +7088,15 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfigConverted =
       conversion::getConv2dSliceConfig(conv2dSliceConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv2d::prepare_conv_weights, device,
-        weightTensor, conversion::getMemoryConfig(inputMemConfig),
+        initialStateOpt, weightTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
         inChannels, outChannels, batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5882,8 +7109,8 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
         sliceConfigConverted);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(),
-                                     prepareConv2dWeightsQuery);
+  return operation::getOpConstraintsWithState(weightLayout.getContext(),
+                                              prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5904,6 +7131,25 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5923,10 +7169,15 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
 
   std::optional<::ttnn::Conv2dSliceConfig> sliceConfig = std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConv2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv2d::prepare_conv_bias, device,
-        biasTensor, conversion::getMemoryConfig(inputMemConfig),
+        initialStateOpt, biasTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
         batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5939,8 +7190,8 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
         sliceConfig);
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(),
-                                     prepareConv2dWeightsQuery);
+  return operation::getOpConstraintsWithState(biasLayout.getContext(),
+                                              prepareConv2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5964,6 +7215,29 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
+      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
+      inputWidth, kernelSize, stride, padding, output_padding, dilation,
+      hasBias, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, mirrorKernel, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
+    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
+    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -5981,11 +7255,16 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
     convertedOutputDtype = conversion::getDataType(outputDtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConvTranspose2dWeightsQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv_transpose2d::
             prepare_conv_transpose2d_weights,
-        device, weightTensor, conversion::getMemoryConfig(inputMemConfig),
+        device, initialStateOpt, weightTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), weightsFormat.str(),
         inChannels, outChannels, batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -5999,8 +7278,8 @@ OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig), mirrorKernel);
   };
 
-  return operation::getOpConstraints(weightLayout.getContext(),
-                                     prepareConvTranspose2dWeightsQuery);
+  return operation::getOpConstraintsWithState(
+      weightLayout.getContext(), prepareConvTranspose2dWeightsQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6023,6 +7302,27 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
+      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
+      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
+      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraintsWithState(
+    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
+    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
+    int32_t inChannels, int32_t outChannels, int32_t batchSize,
+    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, int32_t groups,
+    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
+    std::optional<Conv2dConfigAttr> conv2dConfig,
+    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
+    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6040,11 +7340,16 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
     convertedOutputDtype = conversion::getDataType(outputDtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto prepareConvTranspose2dBiasQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
         &::ttnn::operations::conv::conv_transpose2d::
             prepare_conv_transpose2d_bias,
-        device, biasTensor, conversion::getMemoryConfig(inputMemConfig),
+        device, initialStateOpt, biasTensor,
+        conversion::getMemoryConfig(inputMemConfig),
         conversion::getPageLayout(inputTensorLayout), inChannels, outChannels,
         batchSize, inputHeight, inputWidth,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
@@ -6057,8 +7362,8 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
         conversion::getConv2dSliceConfig(conv2dSliceConfig));
   };
 
-  return operation::getOpConstraints(biasLayout.getContext(),
-                                     prepareConvTranspose2dBiasQuery);
+  return operation::getOpConstraintsWithState(biasLayout.getContext(),
+                                              prepareConvTranspose2dBiasQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6074,6 +7379,21 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, configTensorsInDram, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6091,11 +7411,15 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto maxPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::max_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -6108,7 +7432,8 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), maxPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              maxPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6171,6 +7496,23 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     bool deallocateInput, bool returnIndices,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, deallocateInput, returnIndices, configTensorsInDram,
+      outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<MaxPool2dWithIndicesOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    bool deallocateInput, bool returnIndices,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6188,12 +7530,16 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   // When return_indices=true, tt-metal requires ROW_MAJOR layout and BFLOAT16
   auto maxPool2DWithIndicesQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::max_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::max_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding),
@@ -6205,8 +7551,8 @@ llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
         ::ttnn::Layout::ROW_MAJOR, configTensorsInDram.value_or(false));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     maxPool2DWithIndicesQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              maxPool2DWithIndicesQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6269,6 +7615,21 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
     llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
     std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
+      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
+      reallocateHaloOutput, configTensorsInDram, outputLayout,
+      /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
+    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
+    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
+    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
+    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6293,11 +7654,15 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
   std::optional<::ttnn::DeviceComputeKernelConfig> computeKernelConfig =
       std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto avgPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::avg_pool2d, device, inputSpec, batchSizeU, inputHeightU,
-        inputWidthU, inputChannelsU,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::avg_pool2d, device, initialStateOpt, inputSpec, batchSizeU,
+        inputHeightU, inputWidthU, inputChannelsU,
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(kernelSize),
         conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(stride),
         detail::reorderPool2dPadding(padding), ceilMode, countIncludePad,
@@ -6309,7 +7674,8 @@ llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
         configTensorsInDram.value_or(false) /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), avgPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              avgPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6374,6 +7740,15 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<GlobalAvgPool2dOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<mlir::tt::ttcore::DataType> dtype,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6401,11 +7776,15 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
       outputLayout ? conversion::getPageLayout(outputLayout)
                    : ::ttnn::Layout::TILE;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto globalAvgPool2DQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::avg_pool2d, device, inputSpec, batchSize, inputHeight,
-        inputWidth, inputChannels,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::avg_pool2d, device, initialStateOpt, inputSpec, batchSize,
+        inputHeight, inputWidth, inputChannels,
         /*kernel_size=*/std::array<uint32_t, 2>{inputHeight, inputWidth},
         /*stride=*/std::array<uint32_t, 2>{1, 1},
         /*padding=*/std::array<uint32_t, 2>{0, 0},
@@ -6418,8 +7797,8 @@ llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
         outputDType, outputPageLayout, false /* config_tensors_in_dram */);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     globalAvgPool2DQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              globalAvgPool2DQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6493,6 +7872,24 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
+      biasLayout, epsilon, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BatchNormInferenceOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+    std::optional<TTNNLayoutAttr> runningMeanLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+    std::optional<TTNNLayoutAttr> runningVarLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6521,15 +7918,20 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
   bool training = false;
   float momentum = 0.1f;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum, weightSpec, biasSpec,
-        outputSpec, detail::getNullableMemoryConfig(outputLayout),
-        computeKernelConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::batch_norm, device, initialStateOpt, inputSpec, runningMeanSpec,
+        runningVarSpec, training, epsilon.convertToFloat(), momentum,
+        weightSpec, biasSpec, outputSpec,
+        detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6604,6 +8006,25 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     llvm::APFloat momentum, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
+      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
+      biasLayout, epsilon, momentum, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<BatchNormTrainingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
+    std::optional<TTNNLayoutAttr> runningMeanLayout,
+    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
+    std::optional<TTNNLayoutAttr> runningVarLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    llvm::APFloat momentum, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6631,15 +8052,20 @@ llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
   // For training mode
   bool training = true;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto batchNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::batch_norm, device, inputSpec, runningMeanSpec, runningVarSpec,
-        training, epsilon.convertToFloat(), momentum.convertToFloat(),
-        weightSpec, biasSpec, outputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::batch_norm, device, initialStateOpt, inputSpec, runningMeanSpec,
+        runningVarSpec, training, epsilon.convertToFloat(),
+        momentum.convertToFloat(), weightSpec, biasSpec, outputSpec,
         detail::getNullableMemoryConfig(outputLayout), computeKernelConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), batchNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              batchNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6710,6 +8136,21 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, epsilon,
+                                   outputLayout, computeKernelConfig,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout,
+    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6730,16 +8171,21 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
       computeKernelConfigConverted =
           conversion::getDeviceComputeKernelConfig(computeKernelConfig);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto rmsNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::rms_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::rms_norm, device, initialStateOpt, inputSpec,
+        epsilon.convertToFloat(), weightSpec, biasSpec, residualInputSpec,
         detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt, computeKernelConfigConverted);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), rmsNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rmsNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6798,6 +8244,18 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
+                                   residualInputLayout, dtype, use2DCoreGrid,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<RMSNormPreAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6815,9 +8273,13 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     metalDtype = conversion::getDataType(dtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::rms_norm_pre_all_gather, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::rms_norm_pre_all_gather, device, initialStateOpt, inputSpec,
         /*dtype=*/metalDtype,
         /*residual_input_tensor=*/residualInputSpec,
         /*compute_kernel_config=*/std::nullopt,
@@ -6826,7 +8288,7 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
         /*use_2d_core_grid=*/use2DCoreGrid);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 
 #else
   return OpConstraints{};
@@ -6883,6 +8345,19 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, biasShape, biasLayout, epsilon,
+                                   outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6898,16 +8373,21 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
 
   std::optional<::tt::tt_metal::TensorSpec> residualInputSpec = std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto layerNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::layer_norm, device, inputSpec, epsilon.convertToFloat(),
-        weightSpec, biasSpec, residualInputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm, device, initialStateOpt, inputSpec,
+        epsilon.convertToFloat(), weightSpec, biasSpec, residualInputSpec,
         detail::getNullableMemoryConfig(outputLayout),
         /*program_config=*/std::nullopt,
         /*compute_kernel_config=*/std::nullopt, /*recip_tensor=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), layerNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              layerNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -6963,6 +8443,21 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> recipShape,
     std::optional<TTNNLayoutAttr> recipLayout,
     std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
+                                   residualInputLayout, recipShape, recipLayout,
+                                   dtype, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPreAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
+    std::optional<TTNNLayoutAttr> residualInputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> recipShape,
+    std::optional<TTNNLayoutAttr> recipLayout,
+    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -6982,9 +8477,13 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
     metalDtype = conversion::getDataType(dtype.value());
   }
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm_pre_all_gather, device, initialStateOpt, inputSpec,
         /*dtype=*/metalDtype,
         /*residual_input_tensor=*/residualInputSpec,
         /*compute_kernel_config=*/std::nullopt,
@@ -6993,7 +8492,7 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
         /*recip_tensor=*/recipSpec);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7055,6 +8554,21 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, statsShape,
+                                   statsLayout, weightShape, weightLayout,
+                                   biasShape, biasLayout, epsilon, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<LayerNormPostAllGatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7072,17 +8586,21 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
   std::optional<::tt::tt_metal::TensorSpec> biasSpec =
       detail::convertToOptionalTensorSpec(device, biasShape, biasLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto query = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::layer_norm_post_all_gather, device,
-                                inputSpec, statsSpec, epsilon.convertToFloat(),
-                                weightSpec, biasSpec,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*program_config=*/std::nullopt,
-                                /*dtype=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::layer_norm_post_all_gather, device, initialStateOpt, inputSpec,
+        statsSpec, epsilon.convertToFloat(), weightSpec, biasSpec,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*compute_kernel_config=*/std::nullopt,
+        /*program_config=*/std::nullopt,
+        /*dtype=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), query);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7142,6 +8660,22 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
     llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, inputMaskShape,
+                                   inputMaskLayout, weightShape, weightLayout,
+                                   biasShape, biasLayout, numGroups, epsilon,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
+    std::optional<TTNNLayoutAttr> inputMaskLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> biasShape,
+    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
+    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7161,23 +8695,28 @@ llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
   int numGroupsInt = static_cast<int>(numGroups);
   float epsilonFloat = epsilon.convertToFloat();
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto groupNormQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::group_norm, device, inputSpec,
-                                numGroupsInt, epsilonFloat, inputMaskSpec,
-                                weightSpec, biasSpec,
-                                /*reciprocals=*/std::nullopt,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*dtype=*/std::nullopt,
-                                /*core_grid=*/std::nullopt,
-                                /*inplace=*/std::nullopt,
-                                /*output_layout=*/std::nullopt,
-                                /*num_out_blocks=*/std::nullopt,
-                                /*compute_kernel_config=*/std::nullopt,
-                                /*negative_mask=*/std::nullopt,
-                                /*use_welford=*/false);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::group_norm, device, initialStateOpt, inputSpec, numGroupsInt,
+        epsilonFloat, inputMaskSpec, weightSpec, biasSpec,
+        /*reciprocals=*/std::nullopt,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*dtype=*/std::nullopt,
+        /*core_grid=*/std::nullopt,
+        /*inplace=*/std::nullopt,
+        /*output_layout=*/std::nullopt,
+        /*num_out_blocks=*/std::nullopt,
+        /*compute_kernel_config=*/std::nullopt,
+        /*negative_mask=*/std::nullopt,
+        /*use_welford=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), groupNormQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              groupNormQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7253,6 +8792,14 @@ clampAttrToVariant(mlir::Attribute attr) {
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, min, max,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7266,13 +8813,18 @@ llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
   auto minVariant = clampAttrToVariant(min);
   auto maxVariant = clampAttrToVariant(max);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto clampScalarQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minVariant,
-                                maxVariant, memConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(::ttnn::clamp, device,
+                                           initialStateOpt, inputSpec,
+                                           minVariant, maxVariant, memConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampScalarQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              clampScalarQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7313,6 +8865,16 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
     llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, minShape, minLayout,
+                                   maxShape, maxLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
+    llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7328,15 +8890,19 @@ llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec maxSpec,
                    detail::convertToTensorSpec(device, maxShape, maxLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto clampTensorQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::clamp, device, inputSpec, minSpec,
-                                maxSpec,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::clamp, device, initialStateOpt, inputSpec, minSpec, maxSpec,
+        detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     clampTensorQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              clampTensorQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7381,6 +8947,15 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, permutation,
+                                   padValue, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7395,14 +8970,19 @@ llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto permuteQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::permute, device, inputSpec, dims,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                defaultedPadValue);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::permute, device, initialStateOpt, inputSpec, dims,
+        detail::getNullableMemoryConfig(outputLayout), defaultedPadValue);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), permuteQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              permuteQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7447,6 +9027,14 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute scaleFactor, llvm::StringRef mode,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, scaleFactor, mode,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    mlir::Attribute scaleFactor, llvm::StringRef mode,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7473,15 +9061,21 @@ llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto upsampleQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::upsample, device, inputSpec,
-                                convertedScaleFactor, std::string(mode),
-                                detail::getNullableMemoryConfig(outputLayout),
-                                /*compute_kernel_config=*/std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::upsample, device, initialStateOpt, inputSpec,
+        convertedScaleFactor, std::string(mode),
+        detail::getNullableMemoryConfig(outputLayout),
+        /*compute_kernel_config=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), upsampleQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              upsampleQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7561,6 +9155,15 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7586,15 +9189,19 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
                          conversion::getDataType(outputLayout.getDataType()))
                    : std::nullopt;
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto embeddingOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::embedding, device, embeddingOpArgs.inputSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::embedding, device, initialStateOpt, embeddingOpArgs.inputSpec,
         embeddingOpArgs.weightSpec, padToken, layout, embeddingsType, dtype,
         detail::getNullableMemoryConfig(outputLayout), std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     embeddingOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              embeddingOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7651,6 +9258,18 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
+                                   weightLayout, inGradientShape,
+                                   inGradientLayout, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<EmbeddingBackwardOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
+    llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7667,15 +9286,20 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inGradientSpec,
       detail::convertToTensorSpec(device, inGradientShape, inGradientLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto embeddingBackwardOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::embedding_bw, device, inputSpec, weightSpec, inGradientSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::embedding_bw, device, initialStateOpt, inputSpec, weightSpec,
+        inGradientSpec,
         /*dtype*/ std::nullopt, detail::getNullableMemoryConfig(outputLayout),
         /*optional_output_tensor*/ std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     embeddingBackwardOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              embeddingBackwardOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -7724,6 +9348,15 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, indexShape,
+                                   indexLayout, dim, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -7735,15 +9368,21 @@ llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec indexSpec,
       detail::convertToTensorSpec(device, indexShape, indexLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto gatherOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::gather, device, inputSpec, static_cast<int8_t>(dim), indexSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::gather, device, initialStateOpt, inputSpec,
+        static_cast<int8_t>(dim), indexSpec,
         /*sparse_grad=*/false, detail::getNullableMemoryConfig(outputLayout),
         /*optional_output_tensor=*/std::nullopt,
         /*sub_core_grids=*/std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), gatherOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              gatherOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8102,6 +9741,13 @@ auto dispatchGetRawData(mlir::ElementsAttr value, Func &&func)
 llvm::Expected<OpConstraints>
 OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
                                       TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(value, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<ConstantOp>::getOpConstraintsWithState(
+    mlir::ElementsAttr value, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8110,14 +9756,18 @@ OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
   if (outputLayout) {
     metalLayout = conversion::getPageLayout(outputLayout);
   }
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
   auto func = [&](auto rawData) {
     auto constantOpQuery = [=]() {
-      return QUERY_OP_CONSTRAINTS(
-          ::ttnn::from_buffer, device, rawData, getShape(value),
-          getDataType(value), device, metalLayout,
+      return QUERY_OP_CONSTRAINTS_WITH_STATE(
+          ::ttnn::from_buffer, device, initialStateOpt, rawData,
+          getShape(value), getDataType(value), device, metalLayout,
           detail::getNullableMemoryConfig(outputLayout));
     };
-    return operation::getOpConstraints(value.getContext(), constantOpQuery);
+    return operation::getOpConstraintsWithState(value.getContext(),
+                                                constantOpQuery);
   };
   return dispatchGetRawData(value, func);
 #else
@@ -8204,6 +9854,15 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
     int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, k, dim, largest,
+                                   sorted, outputLayout,
+                                   /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
+    int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8213,16 +9872,21 @@ llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto topKQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::topk, device, inputSpec,
-                                static_cast<uint32_t>(k),
-                                static_cast<int8_t>(dim), largest, sorted,
-                                detail::getNullableMemoryConfig(outputLayout),
-                                std::nullopt, std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::topk, device, initialStateOpt, inputSpec,
+        static_cast<uint32_t>(k), static_cast<int8_t>(dim), largest, sorted,
+        detail::getNullableMemoryConfig(outputLayout), std::nullopt,
+        std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), topKQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              topKQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8267,6 +9931,20 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
     TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
     TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
     TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(
+      inputValuesShape, inputValuesLayout, inputIndicesShape,
+      inputIndicesLayout, kShape, kLayout, pShape, pLayout, tempShape,
+      tempLayout, seed, outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
+    llvm::ArrayRef<int64_t> inputIndicesShape,
+    TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
+    TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
+    TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
+    TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8300,14 +9978,18 @@ llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
   ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec tempSpec,
                    detail::convertToTensorSpec(device, tempShape, tempLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto samplingQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::sampling, device, valuesSpec,
-                                indicesSpec, kSpec, pSpec, tempSpec, seed,
-                                std::nullopt, std::nullopt);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::sampling, device, initialStateOpt, valuesSpec, indicesSpec,
+        kSpec, pSpec, tempSpec, seed, std::nullopt, std::nullopt);
   };
 
-  return operation::getOpConstraints(inputValuesLayout.getContext(),
-                                     samplingQuery);
+  return operation::getOpConstraintsWithState(inputValuesLayout.getContext(),
+                                              samplingQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -8371,6 +10053,15 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
 llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
     std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout) {
+  return getOpConstraintsWithState(inputShape, inputLayout, dim, clusterAxis,
+                                   outputLayout, /*initialState=*/nullptr);
+}
+
+llvm::Expected<OpConstraints>
+OpModel<MeshPartitionOp>::getOpConstraintsWithState(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
+    std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -8380,15 +10071,19 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
       ::tt::tt_metal::TensorSpec inputSpec,
       detail::convertToTensorSpec(device, inputShape, inputLayout));
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto meshPartitionOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::mesh_partition, device, inputSpec, dim,
-                                clusterAxis,
-                                detail::getNullableMemoryConfig(outputLayout));
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::mesh_partition, device, initialStateOpt, inputSpec, dim,
+        clusterAxis, detail::getNullableMemoryConfig(outputLayout));
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     meshPartitionOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              meshPartitionOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1241,20 +1241,6 @@ OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> bias0Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
     std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize) {
-  return getOpConstraintsWithState(
-      w0Shape, w0Layout, w1Shape, w1Layout, bias0Shape, bias0Layout, bias1Shape,
-      bias1Layout, hiddenSize, intermediateSize, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> w0Shape, TTNNLayoutAttr w0Layout,
-    llvm::ArrayRef<int64_t> w1Shape, TTNNLayoutAttr w1Layout,
-    std::optional<llvm::ArrayRef<int64_t>> bias0Shape,
-    std::optional<TTNNLayoutAttr> bias0Layout,
-    std::optional<llvm::ArrayRef<int64_t>> bias1Shape,
-    std::optional<TTNNLayoutAttr> bias1Layout, uint32_t hiddenSize,
     uint32_t intermediateSize, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1290,17 +1276,6 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
     std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
     std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
-    uint32_t intermediateSize) {
-  return getOpConstraintsWithState(w2Shape, w2Layout, bias2Shape, bias2Layout,
-                                   hiddenSize, intermediateSize,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> w2Shape, TTNNLayoutAttr w2Layout,
-    std::optional<llvm::ArrayRef<int64_t>> bias2Shape,
-    std::optional<TTNNLayoutAttr> bias2Layout, uint32_t hiddenSize,
     uint32_t intermediateSize, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -1330,24 +1305,12 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraintsWithState(
 // Unary Eltwise Ops
 //===----------------------------------------------------------------------===//
 
-// Cache-facing stateless entry. Its signature must stay exactly as the op-model
-// cache's getOrCompute invokes it (by function pointer), so it cannot grow
-// params; it forwards to the shared stateful body with a null state. The null
-// path runs query_op_constraints_with_optional_state(nullopt), which metal
-// dispatches straight to the stateless query.
+// Single constraint entry; `initialState` selects the query flavour. Both
+// flavours go through query_op_constraints_with_optional_state, which metal
+// dispatches on the optional: nullopt -> the stateless query, a value -> the
+// build-from-records query. See the convention comment in TTNNOpModel.h.
 template <typename OpTy>
-llvm::Expected<OpConstraints>
-UnaryEltwiseOpModel<OpTy>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                                            TTNNLayoutAttr inputLayout,
-                                            TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
-template <typename OpTy>
-llvm::Expected<OpConstraints>
-UnaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> UnaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1405,15 +1368,6 @@ UnaryEltwiseOpModel<OpTy>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 template <typename OpTy>
 llvm::Expected<OpConstraints>
 UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-template <typename OpTy>
-llvm::Expected<OpConstraints>
-UnaryEltwiseWithFastApproxModeOpModel<OpTy>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1508,15 +1462,8 @@ template struct UnaryEltwiseWithFastApproxModeOpModel<GeluOp>;
 //===----------------------------------------------------------------------===//
 // SigmoidOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<SigmoidOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                                     TTNNLayoutAttr inputLayout,
-                                     TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<SigmoidOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1582,14 +1529,8 @@ OpModel<SigmoidOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // LeakyReluOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::APFloat slope, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, slope, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<LeakyReluOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::APFloat slope, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -1649,17 +1590,6 @@ llvm::Expected<size_t> OpModel<LeakyReluOp>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryEltwiseOpModel<OpTy>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
-  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, outputLayout, opDtypeAttr,
-                                   /*initialState=*/nullptr);
-}
-
-template <typename OpTy>
-llvm::Expected<OpConstraints>
-BinaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr,
@@ -1738,17 +1668,6 @@ llvm::Expected<size_t> BinaryEltwiseOpModel<OpTy>::getOpRuntime(
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> BinaryCompositeOpModel<OpTy>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr opDtypeAttr) {
-  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, outputLayout, opDtypeAttr,
-                                   /*initialState=*/nullptr);
-}
-
-template <typename OpTy>
-llvm::Expected<OpConstraints>
-BinaryCompositeOpModel<OpTy>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout, ttcore::DataTypeAttr /*opDtypeAttr*/,
@@ -1851,16 +1770,6 @@ template struct BinaryCompositeOpModel<Atan2Op>;
 llvm::Expected<OpConstraints> OpModel<GeluBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    std::string approximate, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, approximate, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<GeluBackwardOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::string approximate, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -1930,14 +1839,8 @@ llvm::Expected<size_t> OpModel<GeluBackwardOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PowScalar
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    mlir::Attribute exponent, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, exponent,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<PowScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute exponent, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2031,18 +1934,6 @@ llvm::Expected<OpConstraints> TernaryEltwiseOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, inputShapeC, inputLayoutC,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-template <typename OpTy>
-llvm::Expected<OpConstraints>
-TernaryEltwiseOpModel<OpTy>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    llvm::ArrayRef<int64_t> inputShapeC, TTNNLayoutAttr inputLayoutC,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -2127,15 +2018,6 @@ template struct TernaryEltwiseOpModel<WhereOp>;
 
 template <typename OpTy>
 llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dimArg, keepDim,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-template <typename OpTy>
-llvm::Expected<OpConstraints> ReductionOpModel<OpTy>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> dimArg, bool keepDim,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -2266,15 +2148,8 @@ template struct NamedFullOpModel<OnesOp>;
 //===----------------------------------------------------------------------===//
 // SoftmaxOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dimArg,
-                                   numericStable, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<SoftmaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dimArg, bool numericStable, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2334,18 +2209,8 @@ llvm::Expected<size_t> OpModel<SoftmaxOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ScatterOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
-    llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
-    int32_t dim, std::optional<ttcore::ReduceTypeAttr> optReduction,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, indexShape, indexLayout, sourceShape,
-      sourceLayout, dim, optReduction, outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ScatterOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout,
     llvm::ArrayRef<int64_t> sourceShape, TTNNLayoutAttr sourceLayout,
@@ -2431,14 +2296,8 @@ llvm::Expected<size_t> OpModel<ScatterOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ReshapeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputShape,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ReshapeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> outputShape, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2496,15 +2355,8 @@ llvm::Expected<size_t> OpModel<ReshapeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SliceStaticOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
-    llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, begins, ends, step,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<SliceStaticOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> begins, llvm::ArrayRef<int64_t> ends,
     llvm::ArrayRef<int64_t> step, TTNNLayoutAttr outputLayout,
@@ -2591,18 +2443,6 @@ llvm::Expected<size_t> OpModel<SliceStaticOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<SliceDynamicOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
-    llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
-    std::optional<llvm::SmallVector<int64_t>> step,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, beginsShape,
-                                   beginsLayout, endsShape, endsLayout, step,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<SliceDynamicOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> beginsShape, TTNNLayoutAttr beginsLayout,
     llvm::ArrayRef<int64_t> endsShape, TTNNLayoutAttr endsLayout,
@@ -2701,15 +2541,8 @@ llvm::Expected<size_t> OpModel<SliceDynamicOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // BitcastConvertOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<BitcastConvertOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<BitcastConvertOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2767,14 +2600,8 @@ llvm::Expected<size_t> OpModel<BitcastConvertOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // TypecastOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<TypecastOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     ttcore::DataTypeAttr dtype, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2832,14 +2659,8 @@ llvm::Expected<size_t> OpModel<TypecastOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ToLayoutOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputDtype,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ToLayoutOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -2911,16 +2732,8 @@ llvm::Expected<size_t> OpModel<ToLayoutOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ToMemoryConfigOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<ToMemoryConfigOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                                            TTNNLayoutAttr inputLayout,
-                                            TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<ToMemoryConfigOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ToMemoryConfigOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -2976,15 +2789,8 @@ OpModel<ToMemoryConfigOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // ConcatOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
-    std::vector<llvm::ArrayRef<int64_t>> inputShapes,
-    std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShapes, inputLayouts, dim, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ConcatOp>::getOpConstraints(
     std::vector<llvm::ArrayRef<int64_t>> inputShapes,
     std::vector<TTNNLayoutAttr> inputLayouts, const int dim,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -3055,14 +2861,8 @@ llvm::Expected<size_t> OpModel<ConcatOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int dim0, const int dim1, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim0, dim1,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<TransposeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int dim0, const int dim1, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -3121,15 +2921,8 @@ llvm::Expected<size_t> OpModel<TransposeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // CumSumOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int32_t dim, std::optional<ttcore::DataType> dtype,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<CumSumOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -3198,15 +2991,8 @@ OpModel<CumSumOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // CumProdOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const int32_t dim, std::optional<ttcore::DataType> dtype,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, dtype,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<CumProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const int32_t dim, std::optional<ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -3279,14 +3065,6 @@ OpModel<CumProdOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 
 llvm::Expected<OpConstraints> OpModel<ConcatenateHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<ConcatenateHeadsOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -3342,29 +3120,9 @@ OpModel<ConcatenateHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // ScaledDotProductAttentionDecodeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-    std::optional<TTNNLayoutAttr> attentionMaskLayout,
-    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-    std::optional<TTNNLayoutAttr> curPosTensorLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-    std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale,
-    std::optional<SDPAProgramConfigAttr> programConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      isCausal, attentionMaskShape, attentionMaskLayout, curPosTensorShape,
-      curPosTensorLayout, attentionSinkShape, attentionSinkLayout, scale,
-      programConfig, outputLayout, /*initialState=*/nullptr);
-}
 
 llvm::Expected<OpConstraints>
-OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
+OpModel<ScaledDotProductAttentionDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
     llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
     llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
@@ -3501,30 +3259,6 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionDecodeOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-    std::optional<TTNNLayoutAttr> attentionMaskLayout,
-    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-    std::optional<TTNNLayoutAttr> curPosTensorLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-    std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize,
-    std::optional<SDPAProgramConfigAttr> programConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
-      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
-      attentionSinkShape, attentionSinkLayout, scale, slidingWindowSize,
-      programConfig, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PagedScaledDotProductAttentionDecodeOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
     llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
     llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
@@ -3687,28 +3421,6 @@ OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> curPosTensorLayout,
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout,
-    std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      headDimV, pageTableShape, pageTableLayout, isCausal, attentionMaskShape,
-      attentionMaskLayout, curPosTensorShape, curPosTensorLayout,
-      attentionSinkShape, attentionSinkLayout, scale, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PagedFlashMultiLatentAttentionDecodeOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    std::optional<llvm::ArrayRef<int64_t>> valueShape,
-    std::optional<TTNNLayoutAttr> valueLayout, uint32_t headDimV,
-    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-    bool isCausal, std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-    std::optional<TTNNLayoutAttr> attentionMaskLayout,
-    std::optional<llvm::ArrayRef<int64_t>> curPosTensorShape,
-    std::optional<TTNNLayoutAttr> curPosTensorLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-    std::optional<TTNNLayoutAttr> attentionSinkLayout,
     std::optional<llvm::APFloat> scale, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -3838,22 +3550,6 @@ OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> chunkStartIdxShape,
     TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
     std::optional<SDPAProgramConfigAttr> programConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      pageTableShape, pageTableLayout, chunkStartIdxShape, chunkStartIdxLayout,
-      scale, programConfig, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<ChunkedScaledDotProductAttentionOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-    llvm::ArrayRef<int64_t> chunkStartIdxShape,
-    TTNNLayoutAttr chunkStartIdxLayout, std::optional<llvm::APFloat> scale,
-    std::optional<SDPAProgramConfigAttr> programConfig,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -3962,24 +3658,6 @@ OpModel<ScaledDotProductAttentionOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
     std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
     std::optional<llvm::APFloat> scale,
-    std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      attentionMaskShape, attentionMaskLayout, attentionSinkShape,
-      attentionSinkLayout, isCausal, scale, slidingWindowSize, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<ScaledDotProductAttentionOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-    std::optional<TTNNLayoutAttr> attentionMaskLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionSinkShape,
-    std::optional<TTNNLayoutAttr> attentionSinkLayout, bool isCausal,
-    std::optional<llvm::APFloat> scale,
     std::optional<uint32_t> slidingWindowSize, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -4080,22 +3758,6 @@ llvm::Expected<size_t> OpModel<ScaledDotProductAttentionOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<FlashMlaPrefillOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
-    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
-    std::optional<llvm::ArrayRef<int64_t>> valueShape,
-    std::optional<TTNNLayoutAttr> valueLayout,
-    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
-    std::optional<TTNNLayoutAttr> attentionMaskLayout, uint32_t headDimV,
-    bool isCausal, std::optional<llvm::APFloat> scale,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      queryShape, queryLayout, keyShape, keyLayout, valueShape, valueLayout,
-      attentionMaskShape, attentionMaskLayout, headDimV, isCausal, scale,
-      outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<FlashMlaPrefillOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
     llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
     std::optional<llvm::ArrayRef<int64_t>> valueShape,
@@ -4256,20 +3918,8 @@ llvm::Expected<size_t> OpModel<IndexerScoreDsaOp>::getOpRuntime(
 //===-----------------------------------------------------------------------===//
 // RotaryEmbeddingLlamaOp
 // ===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
-    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-    llvm::ArrayRef<int64_t> transMatShape, TTNNLayoutAttr transMatLayout,
-    bool isDecodeMode, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
-                                   sinShape, sinLayout, transMatShape,
-                                   transMatLayout, isDecodeMode, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<RotaryEmbeddingLlamaOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingLlamaOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
@@ -4352,17 +4002,6 @@ llvm::Expected<OpConstraints> OpModel<RotaryEmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
     llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
-    std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, cosShape, cosLayout,
-                                   sinShape, sinLayout, tokenIndex,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<RotaryEmbeddingOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> cosShape, TTNNLayoutAttr cosLayout,
-    llvm::ArrayRef<int64_t> sinShape, TTNNLayoutAttr sinLayout,
     std::optional<uint32_t> tokenIndex, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -4428,21 +4067,9 @@ llvm::Expected<size_t> OpModel<RotaryEmbeddingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // NLPCreateQKVHeadsDecodeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<op_model::OpConstraints>
-OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
-    std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
-    std::optional<uint32_t> numKVHeads, std::optional<bool> overlapQKCoregrid,
-    std::optional<uint32_t> sliceSize, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, batchOffsetShape,
-                                   batchOffsetLayout, numHeads, numKVHeads,
-                                   overlapQKCoregrid, sliceSize, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
 llvm::Expected<op_model::OpConstraints>
-OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraintsWithState(
+OpModel<NLPCreateQKVHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchOffsetShape,
     std::optional<TTNNLayoutAttr> batchOffsetLayout, uint32_t numHeads,
@@ -4526,20 +4153,9 @@ llvm::Expected<size_t> OpModel<NLPCreateQKVHeadsDecodeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SplitQueryKeyValueAndSplitHeadsOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
-    std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
-    std::optional<uint32_t> numKVHeads, bool transposeKey,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, inputKVShape, inputKVLayout, numHeads,
-      numKVHeads, transposeKey, outputLayout, /*initialState=*/nullptr);
-}
 
 llvm::Expected<OpConstraints>
-OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraintsWithState(
+OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> inputKVShape,
     std::optional<TTNNLayoutAttr> inputKVLayout, uint32_t numHeads,
@@ -4617,16 +4233,8 @@ llvm::Expected<size_t> OpModel<SplitQueryKeyValueAndSplitHeadsOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints>
-OpModel<NLPConcatHeadsOp>::getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                                            TTNNLayoutAttr inputLayout,
-                                            TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<NLPConcatHeadsOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -4683,15 +4291,8 @@ OpModel<NLPConcatHeadsOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 //===----------------------------------------------------------------------===//
 // NLPConcatHeadsDecodeOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    uint32_t numHeads, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, numHeads,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<NLPConcatHeadsDecodeOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<NLPConcatHeadsDecodeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t numHeads, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -4779,15 +4380,8 @@ llvm::Expected<size_t> OpModel<NLPConcatHeadsDecodeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // RepeatInterleaveOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, repeats, dim,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<RepeatInterleaveOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<RepeatInterleaveOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     const unsigned int repeats, const int dim, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -4844,14 +4438,8 @@ llvm::Expected<size_t> OpModel<RepeatInterleaveOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // RepeatOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, repeats,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<RepeatOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> repeats, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -4961,15 +4549,6 @@ convertPadding(llvm::ArrayRef<int32_t> padding) {
 llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, padding, padValue,
-                                   multicore, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<PadOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int32_t> padding, llvm::APFloat padValue, bool multicore,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -5032,15 +4611,8 @@ llvm::Expected<size_t> OpModel<PadOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // SortOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
-    bool descending, bool stable, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, descending,
-                                   stable, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<SortOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int dim,
     bool descending, bool stable, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -5099,18 +4671,6 @@ llvm::Expected<size_t> OpModel<SortOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<TopKRouterGptOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
-    uint32_t numExperts, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
-                                   weightLayout, biasShape, biasLayout, k,
-                                   numExperts, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<TopKRouterGptOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> biasShape, TTNNLayoutAttr biasLayout, uint32_t k,
@@ -5182,14 +4742,8 @@ llvm::Expected<size_t> OpModel<TopKRouterGptOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ArgMaxOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ArgMaxOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int32_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -5247,14 +4801,8 @@ llvm::Expected<size_t> OpModel<ArgMaxOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ProdOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, keepDim,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ProdOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<int64_t> dim, bool keepDim, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
@@ -5399,21 +4947,6 @@ llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> outScaleShape, TTNNLayoutAttr outScaleLayout,
     llvm::ArrayRef<int64_t> outZeroPointShape,
     TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
-    std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, inScaleShape, inScaleLayout, inZeroPointShape,
-      inZeroPointLayout, outScaleShape, outScaleLayout, outZeroPointShape,
-      outZeroPointLayout, axis, outputDtype, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<RequantizeOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> inScaleShape, TTNNLayoutAttr inScaleLayout,
-    llvm::ArrayRef<int64_t> inZeroPointShape, TTNNLayoutAttr inZeroPointLayout,
-    llvm::ArrayRef<int64_t> outScaleShape, TTNNLayoutAttr outScaleLayout,
-    llvm::ArrayRef<int64_t> outZeroPointShape,
-    TTNNLayoutAttr outZeroPointLayout, std::optional<int32_t> axis,
     std::optional<ttcore::DataType> outputDtype, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -5531,21 +5064,8 @@ llvm::Expected<size_t> OpModel<RequantizeOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // LinearOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, TTNNLayoutAttr outputLayout,
-    bool transposeA, bool transposeB, std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr,
-    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
-  return getOpConstraintsWithState(
-      inputShapeA, inputLayoutA, inputShapeB, inputLayoutB, biasShape,
-      biasLayout, outputLayout, transposeA, transposeB, activation,
-      programConfigAttr, computeKernelConfig, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<LinearOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -5665,25 +5185,7 @@ llvm::Expected<size_t> OpModel<LinearOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MatmulOp
 //===----------------------------------------------------------------------===//
-// Cache-facing stateless entry; signature fixed for getOrCompute. Forwards to
-// the shared stateful body with a null state (metal dispatches nullopt to the
-// stateless query).
 llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
-    llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
-    TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
-    std::optional<llvm::StringRef> activation,
-    std::optional<mlir::Attribute> programConfigAttr,
-    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
-  return getOpConstraintsWithState(inputShapeA, inputLayoutA, inputShapeB,
-                                   inputLayoutB, outputLayout, transposeA,
-                                   transposeB, activation, programConfigAttr,
-                                   computeKernelConfig,
-                                   /*initialState=*/nullptr);
-}
-
-// Shared body. Stateful entry (L1 spill path); bypasses the op-model cache.
-llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShapeA, TTNNLayoutAttr inputLayoutA,
     llvm::ArrayRef<int64_t> inputShapeB, TTNNLayoutAttr inputLayoutB,
     TTNNLayoutAttr outputLayout, bool transposeA, bool transposeB,
@@ -5817,15 +5319,6 @@ OpModel<DeallocateOp>::getOpRuntime(llvm::ArrayRef<int64_t> inputShape,
 llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
-                                   inputLayout, batchOffset, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<FillCacheOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     uint32_t batchOffset, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -5888,16 +5381,6 @@ llvm::Expected<size_t> OpModel<FillCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
-    uint32_t batchOffset, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
-      updateIndexLayout, batchOffset, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<UpdateCacheOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
@@ -5985,21 +5468,8 @@ llvm::Expected<size_t> OpModel<UpdateCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // PagedUpdateCacheOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
-    std::optional<llvm::ArrayRef<int64_t>> pageTableShape,
-    std::optional<TTNNLayoutAttr> pageTableLayout, bool shareCache,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      cacheShape, cacheLayout, inputShape, inputLayout, updateIndexShape,
-      updateIndexLayout, pageTableShape, pageTableLayout, shareCache,
-      outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<PagedUpdateCacheOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<PagedUpdateCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> updateIndexShape, TTNNLayoutAttr updateIndexLayout,
@@ -6103,19 +5573,6 @@ llvm::Expected<OpConstraints> OpModel<PagedFillCacheOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
     std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
-    std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(cacheShape, cacheLayout, inputShape,
-                                   inputLayout, pageTableShape, pageTableLayout,
-                                   batchIdxShape, batchIdxLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PagedFillCacheOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> cacheShape, TTNNLayoutAttr cacheLayout,
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> pageTableShape, TTNNLayoutAttr pageTableLayout,
-    std::optional<llvm::ArrayRef<int64_t>> batchIdxShape,
     std::optional<TTNNLayoutAttr> batchIdxLayout, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -6204,28 +5661,8 @@ llvm::Expected<size_t> OpModel<PagedFillCacheOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Conv2dOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
-    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, uint32_t groups,
-    std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
-      in_channels, out_channels, batch_size, input_height, input_width,
-      kernel_size, stride, padding, dilation, groups, conv2dConfig,
-      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
-      /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<Conv2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -6734,28 +6171,6 @@ llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraints(
     std::optional<ttcore::DataTypeAttr> outputDtype,
     std::optional<Conv3dConfigAttr> conv3dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
-      in_channels, out_channels, batch_size, input_depth, input_height,
-      input_width, kernel_size, stride, padding, groups, padding_mode,
-      outputDtype, conv3dConfig, deviceComputeKernelConfig, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<Conv3dOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-    uint32_t out_channels, uint32_t batch_size, uint32_t input_depth,
-    uint32_t input_height, uint32_t input_width,
-    llvm::ArrayRef<int32_t> kernel_size, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, uint32_t groups,
-    llvm::StringRef padding_mode,
-    std::optional<ttcore::DataTypeAttr> outputDtype,
-    std::optional<Conv3dConfigAttr> conv3dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -6842,27 +6257,8 @@ llvm::Expected<size_t> OpModel<Conv3dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ConvTranspose2dOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, uint32_t in_channels,
-    uint32_t out_channels, uint32_t batch_size, uint32_t input_height,
-    uint32_t input_width, llvm::ArrayRef<int32_t> kernel_size,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> output_padding, llvm::ArrayRef<int32_t> dilation,
-    uint32_t groups, std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, weightShape, weightLayout, biasShape, biasLayout,
-      in_channels, out_channels, batch_size, input_height, input_width,
-      kernel_size, stride, padding, output_padding, dilation, groups,
-      conv2dConfig, conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<ConvTranspose2dOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ConvTranspose2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
@@ -7045,28 +6441,6 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dWeightsOp>::getOpConstraints(
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
-      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
-      inputWidth, kernelSize, stride, padding, dilation, hasBias, groups,
-      inputDtype, outputDtype, conv2dConfig, deviceComputeKernelConfig,
-      conv2dSliceConfig, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareConv2dWeightsOp>::getOpConstraintsWithState(
-    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
-    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
-    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
-    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> dilation,
-    bool hasBias, int32_t groups, ttcore::DataType inputDtype,
-    std::optional<ttcore::DataType> outputDtype,
-    std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7130,25 +6504,6 @@ llvm::Expected<OpConstraints> OpModel<PrepareConv2dBiasOp>::getOpConstraints(
     ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
-      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
-      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
-      deviceComputeKernelConfig, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
-    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
-    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
-    int32_t inChannels, int32_t outChannels, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, int32_t groups,
-    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-    std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7203,29 +6558,6 @@ OpModel<PrepareConv2dBiasOp>::getOpConstraintsWithState(
 
 llvm::Expected<OpConstraints>
 OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraints(
-    TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
-    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
-    llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
-    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-    llvm::ArrayRef<int32_t> kernelSize, llvm::ArrayRef<int32_t> stride,
-    llvm::ArrayRef<int32_t> padding, llvm::ArrayRef<int32_t> output_padding,
-    llvm::ArrayRef<int32_t> dilation, bool hasBias, int32_t groups,
-    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-    std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig, bool mirrorKernel,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      weightLayout, weightShape, inputMemConfig, inputTensorLayout,
-      weightsFormat, inChannels, outChannels, batchSize, inputHeight,
-      inputWidth, kernelSize, stride, padding, output_padding, dilation,
-      hasBias, groups, inputDtype, outputDtype, conv2dConfig,
-      deviceComputeKernelConfig, conv2dSliceConfig, mirrorKernel, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareConvTranspose2dWeightsOp>::getOpConstraintsWithState(
     TTNNLayoutAttr weightLayout, llvm::ArrayRef<int64_t> weightShape,
     MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
     llvm::StringRef weightsFormat, int32_t inChannels, int32_t outChannels,
@@ -7301,27 +6633,6 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraints(
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      biasLayout, biasShape, inputMemConfig, inputTensorLayout, inChannels,
-      outChannels, batchSize, inputHeight, inputWidth, kernelSize, stride,
-      padding, dilation, groups, inputDtype, outputDtype, conv2dConfig,
-      deviceComputeKernelConfig, conv2dSliceConfig, outputLayout,
-      /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraintsWithState(
-    TTNNLayoutAttr biasLayout, llvm::ArrayRef<int64_t> biasShape,
-    MemoryConfigAttr inputMemConfig, ::mlir::tt::ttnn::Layout inputTensorLayout,
-    int32_t inChannels, int32_t outChannels, int32_t batchSize,
-    int32_t inputHeight, int32_t inputWidth, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, int32_t groups,
-    ttcore::DataType inputDtype, std::optional<ttcore::DataType> outputDtype,
-    std::optional<Conv2dConfigAttr> conv2dConfig,
-    std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
-    std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7372,21 +6683,8 @@ OpModel<PrepareConvTranspose2dBiasOp>::getOpConstraintsWithState(
 //===----------------------------------------------------------------------===//
 // MaxPool2D
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
-    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
-      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
-      reallocateHaloOutput, configTensorsInDram, outputLayout,
-      /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<MaxPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
     int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
@@ -7488,23 +6786,8 @@ llvm::Expected<size_t> OpModel<MaxPool2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // MaxPool2DWithIndices
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
-    bool deallocateInput, bool returnIndices,
-    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
-      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
-      reallocateHaloOutput, deallocateInput, returnIndices, configTensorsInDram,
-      outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<MaxPool2dWithIndicesOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<MaxPool2dWithIndicesOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
     int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
@@ -7608,21 +6891,8 @@ llvm::Expected<size_t> OpModel<MaxPool2dWithIndicesOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // AvgPool2D
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
-    int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
-    llvm::ArrayRef<int32_t> stride, llvm::ArrayRef<int32_t> padding,
-    llvm::ArrayRef<int32_t> dilation, bool ceilMode, bool reallocateHaloOutput,
-    std::optional<bool> configTensorsInDram, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, batchSize, inputHeight, inputWidth,
-      inputChannels, kernelSize, stride, padding, dilation, ceilMode,
-      reallocateHaloOutput, configTensorsInDram, outputLayout,
-      /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<AvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     int32_t batchSize, int32_t inputHeight, int32_t inputWidth,
     int32_t inputChannels, llvm::ArrayRef<int32_t> kernelSize,
@@ -7736,16 +7006,8 @@ llvm::Expected<size_t> OpModel<AvgPool2dOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // GlobalAvgPool2dOp
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<mlir::tt::ttcore::DataType> dtype,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dtype, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints>
-OpModel<GlobalAvgPool2dOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<GlobalAvgPool2dOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<mlir::tt::ttcore::DataType> dtype,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -7871,24 +7133,6 @@ llvm::Expected<OpConstraints> OpModel<BatchNormInferenceOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
-      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
-      biasLayout, epsilon, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<BatchNormInferenceOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
-    std::optional<TTNNLayoutAttr> runningMeanLayout,
-    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
-    std::optional<TTNNLayoutAttr> runningVarLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -7996,24 +7240,6 @@ llvm::Expected<size_t> OpModel<BatchNormInferenceOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<BatchNormTrainingOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
-    std::optional<TTNNLayoutAttr> runningMeanLayout,
-    std::optional<llvm::ArrayRef<int64_t>> runningVarShape,
-    std::optional<TTNNLayoutAttr> runningVarLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    llvm::APFloat momentum, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputShape, inputLayout, runningMeanShape, runningMeanLayout,
-      runningVarShape, runningVarLayout, weightShape, weightLayout, biasShape,
-      biasLayout, epsilon, momentum, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<BatchNormTrainingOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> runningMeanShape,
     std::optional<TTNNLayoutAttr> runningMeanLayout,
@@ -8135,20 +7361,6 @@ llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout,
-    std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig) {
-  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
-                                   weightLayout, biasShape, biasLayout, epsilon,
-                                   outputLayout, computeKernelConfig,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<RMSNormOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    TTNNLayoutAttr outputLayout,
     std::optional<DeviceComputeKernelConfigAttr> computeKernelConfig,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -8243,18 +7455,6 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
     std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
-                                   residualInputLayout, dtype, use2DCoreGrid,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<RMSNormPreAllGatherOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-    std::optional<TTNNLayoutAttr> residualInputLayout,
-    std::optional<ttcore::DataType> dtype, std::optional<bool> use2DCoreGrid,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -8344,19 +7544,6 @@ llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
-                                   weightLayout, biasShape, biasLayout, epsilon,
-                                   outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<LayerNormOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -8437,20 +7624,6 @@ llvm::Expected<size_t> OpModel<LayerNormOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints>
 OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
-    std::optional<TTNNLayoutAttr> residualInputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> recipShape,
-    std::optional<TTNNLayoutAttr> recipLayout,
-    std::optional<ttcore::DataType> dtype, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, residualInputShape,
-                                   residualInputLayout, recipShape, recipLayout,
-                                   dtype, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<LayerNormPreAllGatherOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> residualInputShape,
     std::optional<TTNNLayoutAttr> residualInputLayout,
@@ -8553,21 +7726,6 @@ OpModel<LayerNormPostAllGatherOp>::getOpConstraints(
     std::optional<TTNNLayoutAttr> weightLayout,
     std::optional<llvm::ArrayRef<int64_t>> biasShape,
     std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, statsShape,
-                                   statsLayout, weightShape, weightLayout,
-                                   biasShape, biasLayout, epsilon, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<LayerNormPostAllGatherOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> statsShape, TTNNLayoutAttr statsLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, llvm::APFloat epsilon,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -8652,21 +7810,6 @@ llvm::Expected<size_t> OpModel<LayerNormPostAllGatherOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
-    std::optional<TTNNLayoutAttr> inputMaskLayout,
-    std::optional<llvm::ArrayRef<int64_t>> weightShape,
-    std::optional<TTNNLayoutAttr> weightLayout,
-    std::optional<llvm::ArrayRef<int64_t>> biasShape,
-    std::optional<TTNNLayoutAttr> biasLayout, int64_t numGroups,
-    llvm::APFloat epsilon, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, inputMaskShape,
-                                   inputMaskLayout, weightShape, weightLayout,
-                                   biasShape, biasLayout, numGroups, epsilon,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<GroupNormOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     std::optional<llvm::ArrayRef<int64_t>> inputMaskShape,
     std::optional<TTNNLayoutAttr> inputMaskLayout,
@@ -8791,13 +7934,6 @@ clampAttrToVariant(mlir::Attribute attr) {
 
 llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, min, max,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<ClampScalarOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute min, mlir::Attribute max, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 
@@ -8860,17 +7996,8 @@ llvm::Expected<size_t> OpModel<ClampScalarOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // ClampTensor
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
-    llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, minShape, minLayout,
-                                   maxShape, maxLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<ClampTensorOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> minShape, TTNNLayoutAttr minLayout,
     llvm::ArrayRef<int64_t> maxShape, TTNNLayoutAttr maxLayout,
@@ -8943,16 +8070,8 @@ llvm::Expected<size_t> OpModel<ClampTensorOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Permute
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, permutation,
-                                   padValue, outputLayout,
-                                   /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<PermuteOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> permutation, llvm::APFloat padValue,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -9023,15 +8142,8 @@ llvm::Expected<size_t> OpModel<PermuteOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 // Upsample
 //===----------------------------------------------------------------------===//
-llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    mlir::Attribute scaleFactor, llvm::StringRef mode,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, scaleFactor, mode,
-                                   outputLayout, /*initialState=*/nullptr);
-}
 
-llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraintsWithState(
+llvm::Expected<OpConstraints> OpModel<UpsampleOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     mlir::Attribute scaleFactor, llvm::StringRef mode,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -9154,15 +8266,6 @@ llvm::Expected<EmbeddingOpArgs> getEmbeddingOpArgs(
 llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
-                                   weightLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<EmbeddingOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -9257,18 +8360,6 @@ llvm::Expected<OpConstraints> OpModel<EmbeddingBackwardOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
     llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, weightShape,
-                                   weightLayout, inGradientShape,
-                                   inGradientLayout, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<EmbeddingBackwardOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> weightShape, TTNNLayoutAttr weightLayout,
-    llvm::ArrayRef<int64_t> inGradientShape, TTNNLayoutAttr inGradientLayout,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
@@ -9345,15 +8436,6 @@ OpModel<mlir::tt::ttnn::EmbeddingBackwardOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-    llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, indexShape,
-                                   indexLayout, dim, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<GatherOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
     llvm::ArrayRef<int64_t> indexShape, TTNNLayoutAttr indexLayout, int32_t dim,
     TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
@@ -9740,14 +8822,8 @@ auto dispatchGetRawData(mlir::ElementsAttr value, Func &&func)
 
 llvm::Expected<OpConstraints>
 OpModel<ConstantOp>::getOpConstraints(mlir::ElementsAttr value,
-                                      TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(value, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<ConstantOp>::getOpConstraintsWithState(
-    mlir::ElementsAttr value, TTNNLayoutAttr outputLayout,
-    const MockAllocatorState *initialState) {
+                                      TTNNLayoutAttr outputLayout,
+                                      const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -9853,14 +8929,6 @@ llvm::Expected<size_t> OpModel<mlir::tt::ttnn::AssignOp>::getOpRuntime(
 
 llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
-    int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, k, dim, largest,
-                                   sorted, outputLayout,
-                                   /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<TopKOp>::getOpConstraintsWithState(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t k,
     int32_t dim, bool largest, bool sorted, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -9924,20 +8992,6 @@ llvm::Expected<size_t> OpModel<TopKOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
-    llvm::ArrayRef<int64_t> inputIndicesShape,
-    TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
-    TTNNLayoutAttr kLayout, llvm::ArrayRef<int64_t> pShape,
-    TTNNLayoutAttr pLayout, llvm::ArrayRef<int64_t> tempShape,
-    TTNNLayoutAttr tempLayout, std::optional<uint32_t> seed,
-    TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(
-      inputValuesShape, inputValuesLayout, inputIndicesShape,
-      inputIndicesLayout, kShape, kLayout, pShape, pLayout, tempShape,
-      tempLayout, seed, outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints> OpModel<SamplingOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputValuesShape, TTNNLayoutAttr inputValuesLayout,
     llvm::ArrayRef<int64_t> inputIndicesShape,
     TTNNLayoutAttr inputIndicesLayout, llvm::ArrayRef<int64_t> kShape,
@@ -10051,14 +9105,6 @@ llvm::Expected<size_t> OpModel<SamplingOp>::getOpRuntime(
 //===----------------------------------------------------------------------===//
 
 llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
-    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
-    std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout) {
-  return getOpConstraintsWithState(inputShape, inputLayout, dim, clusterAxis,
-                                   outputLayout, /*initialState=*/nullptr);
-}
-
-llvm::Expected<OpConstraints>
-OpModel<MeshPartitionOp>::getOpConstraintsWithState(
     llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout, int32_t dim,
     std::optional<uint32_t> clusterAxis, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -1251,13 +1251,15 @@ OpModel<PrepareMoEComputeW0W1WeightsOp>::getOpConstraints(
                    : std::nullopt;
 
   auto query = [=]() {
-    ::ttnn::TensorSpec w0Spec = conversion::getTensorSpec(w0Shape, w0Layout);
-    ::ttnn::TensorSpec w1Spec = conversion::getTensorSpec(w1Shape, w1Layout);
-    std::optional<::ttnn::TensorSpec> b0Spec;
+    ::tt::tt_metal::TensorSpec w0Spec =
+        conversion::getTensorSpec(w0Shape, w0Layout);
+    ::tt::tt_metal::TensorSpec w1Spec =
+        conversion::getTensorSpec(w1Shape, w1Layout);
+    std::optional<::tt::tt_metal::TensorSpec> b0Spec;
     if (bias0Shape && bias0Layout) {
       b0Spec = conversion::getTensorSpec(*bias0Shape, *bias0Layout);
     }
-    std::optional<::ttnn::TensorSpec> b1Spec;
+    std::optional<::tt::tt_metal::TensorSpec> b1Spec;
     if (bias1Shape && bias1Layout) {
       b1Spec = conversion::getTensorSpec(*bias1Shape, *bias1Layout);
     }
@@ -1286,8 +1288,9 @@ OpModel<PrepareMoEComputeW2WeightsOp>::getOpConstraints(
                    : std::nullopt;
 
   auto query = [=]() {
-    ::ttnn::TensorSpec w2Spec = conversion::getTensorSpec(w2Shape, w2Layout);
-    std::optional<::ttnn::TensorSpec> b2Spec;
+    ::tt::tt_metal::TensorSpec w2Spec =
+        conversion::getTensorSpec(w2Shape, w2Layout);
+    std::optional<::tt::tt_metal::TensorSpec> b2Spec;
     if (bias2Shape && bias2Layout) {
       b2Spec = conversion::getTensorSpec(*bias2Shape, *bias2Layout);
     }

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4842,7 +4842,7 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
     llvm::ArrayRef<int64_t> scaleShape, TTNNLayoutAttr scaleLayout,
     llvm::ArrayRef<int64_t> zeroPointShape, TTNNLayoutAttr zeroPointLayout,
     std::optional<int32_t> axis, std::optional<ttcore::DataType> outputDtype,
-    TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
@@ -4870,15 +4870,19 @@ llvm::Expected<OpConstraints> QuantizationOpModel<OpTy>::getOpConstraints(
   std::optional<::tt::tt_metal::MemoryConfig> outputMemoryConfig =
       detail::getNullableMemoryConfig(outputLayout);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   // Create query closure
   auto quantizationOpQuery = [=]() {
-    return ::ttnn::graph::query_op_constraints(
-        detail::getOpSymbol<OpTy>(), device, inputSpec, scaleSpec,
-        zeroPointSpec, axis, outputDType, outputMemoryConfig);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        detail::getOpSymbol<OpTy>(), device, initialStateOpt, inputSpec,
+        scaleSpec, zeroPointSpec, axis, outputDType, outputMemoryConfig);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(),
-                                     quantizationOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              quantizationOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL
@@ -5890,7 +5894,7 @@ llvm::Expected<OpConstraints> OpModel<Conv1dOp>::getOpConstraints(
     std::optional<Conv2dConfigAttr> conv2dConfig,
     std::optional<DeviceComputeKernelConfigAttr> deviceComputeKernelConfig,
     std::optional<Conv2dSliceConfigAttr> conv2dSliceConfig,
-    TTNNLayoutAttr outputLayout) {
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   Conv1dConv2dPrepParams prep = getConv1dConv2dPrepParams(
       inputShape, weightShape, kernel_size, stride, padding, dilation);
@@ -5948,18 +5952,23 @@ llvm::Expected<OpConstraints> OpModel<Conv1dOp>::getOpConstraints(
   std::variant<std::array<uint32_t, 2>, uint32_t> conv1dPadding =
       conversion::convertLLVMArrayRefToStdArray<uint32_t, 2>(padding);
 
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
   auto conv1dOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(
-        ::ttnn::conv1d, device, inputSpec, weightSpec, device, in_channels,
-        out_channels, batch_size, input_length, kernel_size, stride,
-        conv1dPadding, dilation, groups, outputDtype, biasSpec,
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::conv1d, device, initialStateOpt, inputSpec, weightSpec, device,
+        in_channels, out_channels, batch_size, input_length, kernel_size,
+        stride, conv1dPadding, dilation, groups, outputDtype, biasSpec,
         conv2dConfigConverted, deviceComputeKernelConfigConverted,
         detail::getNullableMemoryConfig(outputLayout), sliceConfigConverted,
         /*return_output_dim=*/false,
         /*return_weights_and_bias=*/false);
   };
 
-  return operation::getOpConstraints(inputLayout.getContext(), conv1dOpQuery);
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              conv1dOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -3859,10 +3859,15 @@ llvm::Expected<OpConstraints> OpModel<IndexerScoreDsaOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
     llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
     llvm::ArrayRef<int64_t> weightsShape, TTNNLayoutAttr weightsLayout,
-    uint32_t chunkStartIdx, TTNNLayoutAttr outputLayout) {
+    uint32_t chunkStartIdx, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
 
   ASSIGN_OR_RETURN(
       ::tt::tt_metal::TensorSpec querySpec,
@@ -3878,12 +3883,13 @@ llvm::Expected<OpConstraints> OpModel<IndexerScoreDsaOp>::getOpConstraints(
   // forwarded and program_config / compute_kernel_config fall back to the
   // ttnn defaults.
   auto indexerScoreDsaOpQuery = [=]() {
-    return QUERY_OP_CONSTRAINTS(::ttnn::experimental::indexer_score_dsa, device,
-                                querySpec, keySpec, weightsSpec, chunkStartIdx);
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::experimental::indexer_score_dsa, device, initialStateOpt,
+        querySpec, keySpec, weightsSpec, chunkStartIdx);
   };
 
-  return operation::getOpConstraints(queryLayout.getContext(),
-                                     indexerScoreDsaOpQuery);
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              indexerScoreDsaOpQuery);
 #else
   return OpConstraints{};
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -89,7 +89,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -131,7 +132,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -390,7 +392,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -548,8 +551,8 @@ TEST_F(OpModelTest, SoftmaxInterleaved) {
   auto constraintsExp = OpModel<SoftmaxOp>::getOpConstraints(
       tensorShape, inputLayout_dram, -1, false, inputLayout_dram);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_EQ(outputSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
@@ -1029,8 +1032,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
 
     if (expectedLegal) {
-      auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutResults] = constraintsExp.get();
+      auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutResults,
+            outputAllocationsResults] = constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -1168,8 +1171,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
 
     if (expectedLegal) {
-      auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutResults] = constraintsExp.get();
+      auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutResults,
+            outputAllocationsResults] = constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -1779,7 +1782,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -1824,7 +1828,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
 
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
@@ -1882,7 +1887,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -2222,7 +2228,8 @@ TEST_P(OpModelPowScalarParam, PowScalarParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
 
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -2305,7 +2312,8 @@ TEST_P(OpModelLinearParam, LinearParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (expectedLegal) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -2526,7 +2534,8 @@ TEST_P(OpModelMatmulParam, MatmulParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (expectedLegal) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -2759,7 +2768,8 @@ TEST_P(OpModelConv2dParam, Conv2d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2875,7 +2885,8 @@ TEST_P(OpModelConv1dParam, Conv1d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2988,7 +2999,8 @@ TEST_P(OpModelConvTranspose2dParam, ConvTranspose2d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -3097,7 +3109,8 @@ TEST_P(OpModelConv3dParam, Conv3d) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     // Conv3d (experimental) ignores the requested L1 output memory config and
     // forces output to DRAM (copies input's memory config). Therefore:
     // - outputSize (l1_output_buffer_per_core) = 0 (output is in DRAM, not L1)
@@ -3201,7 +3214,8 @@ protected:
 
     if (constraintsExp) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GT(cbSize, 0);
       EXPECT_GT(l1PeakSize, 0);
       EXPECT_EQ(outputSize, 0);
@@ -3305,7 +3319,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3420,7 +3435,8 @@ TEST_P(OpModelLeakyReluParam, LeakyReluParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3487,7 +3503,8 @@ TEST_P(OpModelClampScalarParam, ClampScalarParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3534,7 +3551,8 @@ TEST_F(OpModelTest, ClampScalarInt32DtypePreserved) {
       << "Constraints failed: " << llvm::toString(constraintsExp.takeError());
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   ASSERT_FALSE(outputLayoutReadBacks.empty());
   ExpectLayoutsEQ(outputLayout, outputLayoutReadBacks[0]);
 }
@@ -3580,7 +3598,8 @@ TEST_P(OpModelClampTensorParam, ClampTensorParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3651,7 +3670,8 @@ TEST_P(OpModelPermuteParam, PermuteParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3732,7 +3752,8 @@ TEST_P(OpModelUpsampleParam, UpsampleParam) {
 
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -3790,7 +3811,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3855,8 +3877,8 @@ TEST_F(OpModelTest, EmbeddingBackwardOp) {
       inputShape, inputLayout, weightShape, weightLayout, inGradientShape,
       inGradientLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(totalPeakSize, 0);
@@ -3880,8 +3902,8 @@ TEST_F(OpModelTest, Where) {
       inputTensorShape, inputLayout, inputTensorShape, inputLayout,
       inputTensorShape, inputLayout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3905,8 +3927,8 @@ TEST_F(OpModelTest, EmptyOp) {
       ttnn::op_model::OpModel<mlir::tt::ttnn::EmptyOp>::getOpConstraints(
           inputTensorShape, dtype, layout, outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3931,8 +3953,8 @@ TEST_F(OpModelTest, ArangeOp) {
       ttnn::op_model::OpModel<mlir::tt::ttnn::ArangeOp>::getOpConstraints(
           startAttr, endAttr, stepAttr, dtype, inputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   // Basic assertions to verify the op constraints are computed
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
@@ -3963,7 +3985,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutReadBacks] = constraintsExp.get();
+            outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -3997,8 +4020,8 @@ TEST_F(OpModelTest, FullOp) {
           shapeAttr, builder.getI32IntegerAttr(0), std::nullopt, std::nullopt,
           outputLayout);
   EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks] =
-      constraintsExp.get();
+  auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayoutReadBacks,
+        outputAllocationsReadBacks] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4068,7 +4091,8 @@ TEST_P(OpModelPrepareConv2dWeightsParam, PrepareConv2dWeights) {
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4159,7 +4183,8 @@ TEST_P(OpModelPrepareConv2dBiasParam, PrepareConv2dBias) {
 
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBacks] = constraintsExp.get();
+              outputLayoutReadBacks, outputAllocationsReadBacks] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(totalPeakSize, 0);
@@ -4302,7 +4327,8 @@ TEST_P(OpModelBatchNormParam, BatchNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4472,7 +4498,8 @@ TEST_P(OpModelRMSNormParam, RMSNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4603,7 +4630,8 @@ TEST_P(OpModelRMSNormPreAllGatherParam, RMSNormPreAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4725,7 +4753,8 @@ TEST_P(OpModelLayerNormParam, LayerNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4863,7 +4892,8 @@ TEST_P(OpModelLayerNormPreAllGatherParam, LayerNormPreAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -4990,7 +5020,8 @@ TEST_P(OpModelLayerNormPostAllGatherParam, LayerNormPostAllGatherParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBacks] = constraintsExp.get();
+                outputLayoutReadBacks, outputAllocationsReadBacks] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5125,7 +5156,8 @@ TEST_P(OpModelGroupNormParam, GroupNormParam) {
   EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
   if (constraintsExp) {
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5219,7 +5251,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-            outputLayoutReadBacks] = constraintsExp.get();
+            outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -5702,7 +5735,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -5856,7 +5890,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6012,7 +6047,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6237,7 +6273,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6557,7 +6594,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6680,7 +6718,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -6827,7 +6866,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocations] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7034,7 +7074,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7164,7 +7205,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);
@@ -7284,7 +7326,8 @@ protected:
     EXPECT_EQ(static_cast<bool>(constraintsExp), expectedLegal);
     if (expectedLegal) {
       const auto [cbSize, l1PeakSize, totalPeakSize, outputSizeResult,
-                  outputLayoutReadBacks] = constraintsExp.get();
+                  outputLayoutReadBacks, outputAllocationsReadBacks] =
+          constraintsExp.get();
       EXPECT_GE(cbSize, 0);
       EXPECT_GE(l1PeakSize, 0);
       EXPECT_GE(totalPeakSize, 0);

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
@@ -161,6 +161,138 @@ INSTANTIATE_TEST_SUITE_P(
         MeshPartitionParam{4, 1, 1, 0}  // split dim 1 on axis 0
         ));
 
+// --- IndexerScoreDsaOp stateful-constraint test ---
+
+// ttnn.experimental.indexer_score_dsa is Blackhole-only (its device op asserts
+// arch == BLACKHOLE), so this fixture reopens the per-binary singleton on a
+// Blackhole mock and restores the Wormhole 1x8 device afterwards -- leaving the
+// singleton on Blackhole would poison every later test in this binary.
+class IndexerScoreDsaLibMockDeviceTest : public OpModelLibMockDeviceBase {
+public:
+  void SetUp() override {
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
+    module = mlir::ModuleOp::create(builder.getUnknownLoc());
+    builder.setInsertionPointToStart(&module->getBodyRegion().front());
+
+    reopenMockDevice(ttcore::Arch::Blackhole, {1, 1});
+    mlir::tt::ttcore::registerDevice(module.get());
+  }
+
+  void TearDown() override {
+    // Restore the topology MockDeviceEnvironment established for this binary.
+    reopenMockDevice(ttcore::Arch::WormholeB0, {1, maxMockChips});
+  }
+
+private:
+  // SystemDescAttr::getDefault's Blackhole worker grid (TTCoreOpsTypes.cpp) is
+  // 13 wide, but tt-metal's mock blackhole_P150.yaml is 2-column harvested and
+  // its device reports 11. SingletonDeviceContext::openDevice validates the two
+  // against each other and hard-errors on a mismatch, so give this test a desc
+  // whose grid matches the mock device it opens. Only the grid differs from the
+  // default; the shared default is deliberately left alone, since it is the
+  // fallback for every Blackhole compile and correcting it is a separate change
+  // with its own golden churn.
+  static constexpr int64_t mockBlackholeGridX = 11;
+
+  static ttcore::SystemDescAttr
+  withGridMatchingMockDevice(mlir::MLIRContext *ctx,
+                             ttcore::SystemDescAttr desc) {
+    llvm::SmallVector<ttcore::ChipDescAttr> chipDescs;
+    for (ttcore::ChipDescAttr chip : desc.getChipDescs()) {
+      llvm::SmallVector<int64_t> grid(chip.getGrid());
+      assert(grid.size() == 2 && "expected a 2D worker grid");
+      grid[1] = mockBlackholeGridX;
+      chipDescs.push_back(ttcore::ChipDescAttr::get(
+          ctx, chip.getArch(), grid, chip.getCoordTranslationOffsets(),
+          chip.getL1Size(), chip.getNumDramChannels(),
+          chip.getDramChannelSize(), chip.getNocL1AddressAlignBytes(),
+          chip.getPcieAddressAlignBytes(), chip.getNocDRAMAddressAlignBytes(),
+          chip.getL1UnreservedBase(), chip.getEriscL1UnreservedBase(),
+          chip.getDramUnreservedBase(), chip.getDramUnreservedEnd(),
+          chip.getSupportedDataTypes(), chip.getSupportedTileSizes(),
+          chip.getDstPhysicalSizeTiles(), chip.getNumCBs(),
+          chip.getNumComputeThreads(), chip.getNumDatamovementThreads(),
+          chip.getDramGrid(), chip.getDramBankToLogicalWorkerNoc0(),
+          chip.getDramBankToLogicalWorkerNoc1()));
+    }
+    return ttcore::SystemDescAttr::get(
+        ctx, desc.getCpuDescs(), chipDescs, desc.getChipDescIndices(),
+        desc.getChipCapabilities(), desc.getChipCoords(),
+        desc.getChipChannels());
+  }
+
+  void reopenMockDevice(ttcore::Arch arch,
+                        const std::pair<size_t, size_t> &meshShape) {
+    mlir::MLIRContext tmpCtx;
+    tmpCtx.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    ttcore::SystemDescAttr desc = ttcore::SystemDescAttr::getDefault(
+        &tmpCtx, arch,
+        {static_cast<int>(meshShape.first),
+         static_cast<int>(meshShape.second)});
+    if (arch == ttcore::Arch::Blackhole) {
+      desc = withGridMatchingMockDevice(&tmpCtx, desc);
+    }
+    SingletonDeviceContext::closeInstance();
+    SingletonDeviceContext::setSystemDesc(desc);
+    SingletonDeviceContext::getInstance().openMockDevice(
+        /*traceRegionSize=*/0, meshShape);
+  }
+};
+
+// Pins the branch that the stateful migration introduced: a null initialState
+// takes the stateless query, which reports no output allocations; a non-null
+// one takes the with-state query, which really allocates and reports the
+// output's record. The indexer's output inherits q's memory config, so an
+// L1-resident q yields an L1 record -- the untracked-L1-output gap this
+// migration closes.
+TEST_F(IndexerScoreDsaLibMockDeviceTest, StatefulReportsOutputAllocation) {
+  // Shapes mirror the transformer lit tests: query [B, Hi, Sq, D],
+  // key [B, 1, T, D], weights [B, Hi, Sq, 1] -> score [B, 1, Sq, T].
+  const llvm::SmallVector<int64_t> queryShape = {1, 8, 32, 128};
+  const llvm::SmallVector<int64_t> keyShape = {1, 1, 32, 128};
+  const llvm::SmallVector<int64_t> weightsShape = {1, 8, 32, 1};
+  const llvm::SmallVector<int64_t> outputShape = {1, 1, 32, 32};
+
+  const llvm::SmallVector<int64_t> physicalGrid = {1, 1};
+
+  // q in L1 so the output inherits an L1 memory config.
+  const TTNNLayoutAttr queryLayout = CreateTiledLayout(
+      queryShape, BufferType::L1, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, physicalGrid);
+  const TTNNLayoutAttr keyLayout = CreateTiledLayout(
+      keyShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, physicalGrid);
+  const TTNNLayoutAttr weightsLayout = CreateTiledLayout(
+      weightsShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, physicalGrid);
+  const TTNNLayoutAttr outputLayout = CreateTiledLayout(
+      outputShape, BufferType::L1, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, physicalGrid);
+
+  // Stateless: no state to apply, so tt-metal runs the NO_DISPATCH capture and
+  // reports no output allocations.
+  auto statelessExp = OpModel<IndexerScoreDsaOp>::getOpConstraints(
+      queryShape, queryLayout, keyShape, keyLayout, weightsShape, weightsLayout,
+      /*chunkStartIdx=*/0, outputLayout, /*initialState=*/nullptr);
+  ASSERT_TRUE(static_cast<bool>(statelessExp))
+      << llvm::toString(statelessExp.takeError());
+  EXPECT_TRUE(statelessExp->outputAllocations.empty());
+
+  // Stateful: an empty live set still yields a non-null state, which selects
+  // the with-initial-state query and its NORMAL-mode allocating capture.
+  std::shared_ptr<MockAllocatorState> state = buildInitialState({});
+  ASSERT_NE(state, nullptr);
+
+  auto statefulExp = OpModel<IndexerScoreDsaOp>::getOpConstraints(
+      queryShape, queryLayout, keyShape, keyLayout, weightsShape, weightsLayout,
+      /*chunkStartIdx=*/0, outputLayout, state.get());
+  ASSERT_TRUE(static_cast<bool>(statefulExp))
+      << llvm::toString(statefulExp.takeError());
+  ASSERT_EQ(statefulExp->outputAllocations.size(), 1u);
+  EXPECT_EQ(statefulExp->outputAllocations[0].bufferType, BufferType::L1);
+}
+
 } // namespace mlir::tt::ttnn::op_model
 
 int main(int argc, char **argv) {

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -134,8 +134,8 @@ TEST_P(UnaryOpModelTest, TestOpInterface) {
   auto constraintsExp = getOpConstraints(op);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -170,8 +170,8 @@ TEST_P(UnaryOpModelTest, TestOpInterfaceNullOutput) {
   ASSERT_EQ(static_cast<bool>(constraintsExp),
             params.expectedResult.expectedLegal);
 
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -374,8 +374,8 @@ TEST_P(BinaryOpModelTest, TestOpInterface) {
   auto constraintsExp = getOpConstraints(op);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -411,8 +411,8 @@ TEST_P(BinaryOpModelTest, TestOpInterfaceNullOutput) {
   ASSERT_EQ(static_cast<bool>(constraintsExp),
             params.expectedResult.expectedLegal);
 
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -463,7 +463,8 @@ TEST_P(BinaryBitwiseOpModelTest, TestOpInterface) {
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
   const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize,
-               outputLayoutReadBack] = constraintsExp.get();
+               outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);
@@ -618,8 +619,8 @@ TEST_F(OpModelBase, PowScalarOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
@@ -670,8 +671,8 @@ TEST_F(OpModelBase, BitwiseNotOpInterface) {
   auto constraintsExp = getOpConstraints(bitwiseNot.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -729,8 +730,8 @@ TEST_F(OpModelBase, LogicalRightShiftOpInterface) {
   auto constraintsExp = getOpConstraints(logicalRightShift.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -787,8 +788,8 @@ TEST_F(OpModelBase, LogicalLeftShiftOpInterface) {
   auto constraintsExp = getOpConstraints(logicalLeftShift.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -820,8 +821,8 @@ TEST_F(OpModelBase, SqrtOpInterface) {
   auto constraintsExp = getOpConstraints(sqrt.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -852,8 +853,8 @@ TEST_F(OpModelBase, SigmoidOpInterface) {
   auto constraintsExp = getOpConstraints(sigmoid.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -884,8 +885,8 @@ TEST_F(OpModelBase, SoftmaxOpInterface) {
   auto constraintsExp = getOpConstraints(softmax.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -922,8 +923,8 @@ TEST_F(OpModelBase, LinearOpInterface) {
   auto constraintsExp = getOpConstraints(linear.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -962,8 +963,8 @@ TEST_F(OpModelBase, LinearOpInterfaceNullOutput) {
       getInputLayouts(linear), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -1026,8 +1027,8 @@ TEST_F(OpModelBase, MatmulOpInterface) {
   auto constraintsExp = getOpConstraints(matmul.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1063,8 +1064,8 @@ TEST_F(OpModelBase, MatmulOpInterfaceNullOutput) {
       getInputLayouts(matmul), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -1129,8 +1130,8 @@ void testReductionOp(OpModelBase *testFixture, mlir::OpBuilder &builder,
   auto constraintsExp = (testFixture->*getOpConstraintsFn)(op.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -1219,7 +1220,7 @@ TEST_F(OpModelBase, ArgMaxOpInterface) {
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
     const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize,
-                 outputLayoutReadBack] = l1;
+                 outputLayoutReadBack, outputAllocationsReadBack] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1252,8 +1253,8 @@ TEST_F(OpModelBase, ProdOpInterface) {
   auto constraintsExp = getOpConstraints(prod.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -1288,8 +1289,8 @@ TEST_F(OpModelBase, ScatterOpInterface) {
   auto constraintsExp = getOpConstraints(scatter.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1329,8 +1330,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   auto constraintsExp = getOpConstraints(reshape.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1349,8 +1350,8 @@ TEST_F(OpModelBase, ReshapeOpInterface) {
   auto cachedConstraintsExp = getOpConstraints(reshape.getOperation());
   if (cachedConstraintsExp) {
     auto l1 = cachedConstraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1396,8 +1397,8 @@ TEST_F(OpModelBase, SliceStaticOpInterface) {
   auto constraintsExp = getOpConstraints(sliceStaticOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1442,8 +1443,8 @@ TEST_F(OpModelBase, SliceDynamicOpInterface) {
   auto constraintsExp = getOpConstraints(sliceDynamicOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -1489,8 +1490,8 @@ TEST_F(OpModelBase, toLayoutOp) {
       std::vector{layoutDRAMRowMajor}, layoutDRAMTiled);
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -1531,8 +1532,8 @@ TEST_F(OpModelBase, toMemoryConfigOp) {
       backend.getOpConstraints(std::vector{inputLayout_L1Tiled}, OpConfig());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -1570,8 +1571,8 @@ TEST_F(OpModelBase, concatOp) {
   auto constraintsExp = getOpConstraints(concatOp.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1603,8 +1604,8 @@ TEST_F(OpModelBase, transposeOp) {
   auto constraintsExp = getOpConstraints(transpose.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1637,8 +1638,8 @@ TEST_F(OpModelBase, cumSumOp) {
   auto constraintsExp = getOpConstraints(cumSum.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1671,8 +1672,8 @@ TEST_F(OpModelBase, cumProdOp) {
   auto constraintsExp = getOpConstraints(cumProd.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1709,8 +1710,8 @@ TEST_F(OpModelBase, TopKOp) {
   auto constraintsExp = getOpConstraints(topK.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayout,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1753,8 +1754,8 @@ TEST_F(OpModelBase, ConcatenateHeadsOpInterface) {
   auto constraintsExp = getOpConstraints(concatenateHeads.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1798,8 +1799,8 @@ TEST_F(OpModelBase, RotaryEmbeddingLlamaOpInterface) {
   auto constraintsExp = getOpConstraints(rotaryEmbeddingLlama.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1839,8 +1840,8 @@ TEST_F(OpModelBase, RotaryEmbeddingOpInterface) {
   auto constraintsExp = getOpConstraints(rotaryEmbedding.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -1896,8 +1897,8 @@ TEST_F(OpModelBase, NLPCreateQKVHeadsDecodeOpInterface) {
       getOpConstraints(nlpCreateQKVHeadsDecode.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -1947,8 +1948,8 @@ TEST_F(OpModelBase, SplitQueryKeyValueAndSplitHeadsOpInterface) {
 
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2028,8 +2029,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2112,8 +2113,8 @@ TEST_F(OpModelBase,
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2204,8 +2205,8 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(sdpAttentionDecode), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2295,8 +2296,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
                                                  OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2375,8 +2376,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterfaceWithAttentionSink) {
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
                                                  OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2461,8 +2462,8 @@ TEST_F(OpModelBase, ChunkedScaledDotProductAttentionOpInterface) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(chunkedSdpAttention), OpConfig(queryLayout));
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
 
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(totalPeakSize, 0);
@@ -2513,8 +2514,8 @@ TEST_F(OpModelBase, NLPConcatHeadsOpInterface) {
   auto constraintsExp = getOpConstraints(nlpConcatHeads.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2548,8 +2549,8 @@ TEST_F(OpModelBase, repeatInterleaveOp) {
   auto constraintsExp = getOpConstraints(repeatInterleave.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2585,8 +2586,8 @@ TEST_F(OpModelBase, repeatOp) {
   auto constraintsExp = getOpConstraints(repeat.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2621,8 +2622,8 @@ TEST_F(OpModelBase, padOp) {
   auto constraintsExp = getOpConstraints(pad.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2658,8 +2659,8 @@ TEST_F(OpModelBase, sortOp) {
   auto constraintsExp = getOpConstraints(sort.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2730,8 +2731,8 @@ TEST_F(OpModelBase, maxPool2dWithIndicesOp) {
   auto constraintsExp = getOpConstraints(maxPool2dWithIndices.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2761,8 +2762,8 @@ TEST_F(OpModelBase, typecastOp) {
   auto constraintsExp = getOpConstraints(typecast.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2798,8 +2799,8 @@ TEST_F(OpModelBase, bitcastConvertOp) {
   auto constraintsExp = getOpConstraints(bitcastConvert.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -2862,8 +2863,8 @@ TEST_F(OpModelBase, Conv2dInterface) {
   // test Conv2dOp interface
   auto constraintsExp = getOpConstraints(conv2d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -2925,8 +2926,8 @@ TEST_F(OpModelBase, Conv1dInterface) {
   // test Conv1dOp interface
   auto constraintsExp = getOpConstraints(conv1d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3117,8 +3118,8 @@ TEST_F(OpModelBase, Conv2dInterfaceNullOutput) {
   auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(conv2d), OpConfig(/*outputLayout=*/nullptr));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -3278,8 +3279,8 @@ TEST_F(OpModelBase, Conv2dInterfaceConfigs) {
       OpConfig(getOutputLayout(conv2d),
                Conv2dAttrs{goodConvConfig, std::nullopt}));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -3343,8 +3344,8 @@ TEST_F(OpModelBase, conv2dInterfaceComputeKernelConfig) {
       OpConfig(getOutputLayout(conv2d), opConfigAttrs));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -3408,8 +3409,8 @@ TEST_F(OpModelBase, Conv3dInterface) {
   // test Conv3dOp interface
   auto constraintsExp = getOpConstraints(conv3d.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   // Conv3d (experimental) ignores the requested L1 output memory config and
   // forces output to DRAM (copies input's memory config). Therefore:
   // - outputSize (l1_output_buffer_per_core) = 0 (output is in DRAM, not L1)
@@ -3520,8 +3521,8 @@ TEST_F(OpModelBase, Conv3dInterfaceConfigs) {
   ASSERT_TRUE(static_cast<bool>(goodConstraintsExp))
       << llvm::toString(goodConstraintsExp.takeError());
   {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        goodConstraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = goodConstraintsExp.get();
     EXPECT_GT(cbSize, 0);
   }
 
@@ -3539,8 +3540,8 @@ TEST_F(OpModelBase, Conv3dInterfaceConfigs) {
   ASSERT_TRUE(static_cast<bool>(fallbackConstraintsExp))
       << llvm::toString(fallbackConstraintsExp.takeError());
   {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        fallbackConstraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = fallbackConstraintsExp.get();
     EXPECT_GT(cbSize, 0);
   }
 }
@@ -3604,8 +3605,8 @@ TEST_F(OpModelBase, ConvTranspose2dInterfaceConfigs) {
       OpConfig(getOutputLayout(convTranspose2d),
                Conv2dAttrs{goodConvConfig, std::nullopt}));
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3710,8 +3711,8 @@ TEST_F(OpModelBase, PrepareConv2dWeightsTest) {
 
   auto constraintsExp = getOpConstraints(prepareConv2dWeights.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3830,8 +3831,8 @@ TEST_F(OpModelBase, PrepareConv2dBiasTest) {
 
   auto constraintsExp = getOpConstraints(prepareConv2dBias.getOperation());
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_EQ(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -3904,8 +3905,8 @@ TEST_F(OpModelBase, maxPool2DOp) {
              << llvm::toString(constraintsExp.takeError()) << std::endl;
     }
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -3972,8 +3973,8 @@ TEST_F(OpModelBase, avgPool2DOp) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
   auto l1 = constraintsExp.get();
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      l1;
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = l1;
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4014,7 +4015,7 @@ TEST_F(OpModelBase, globalAvgPool2dOp) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
   auto l1 = constraintsExp.get();
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts, outputAllocations] =
       l1;
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -4052,8 +4053,8 @@ TEST_F(OpModelBase, LeakyReluOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4085,7 +4086,8 @@ TEST_F(OpModelBase, GeluBackwardOp) {
            << llvm::toString(constraintsExpNone.takeError()) << std::endl;
   }
   const auto &[cbSizeNone, l1PeakSizeNone, totalPeakSizeNone, outputSizeNone,
-               outputLayoutNone] = constraintsExpNone.get();
+               outputLayoutNone, outputAllocationsNone] =
+      constraintsExpNone.get();
   EXPECT_EQ(cbSizeNone, 12288);
   EXPECT_EQ(l1PeakSizeNone, 6144);
   EXPECT_EQ(outputSizeNone, 2048);
@@ -4112,7 +4114,8 @@ TEST_F(OpModelBase, GeluBackwardOp) {
            << llvm::toString(constraintsExpTanh.takeError()) << std::endl;
   }
   const auto &[cbSizeTanh, l1PeakSizeTanh, totalPeakSizeTanh, outputSizeTanh,
-               outputLayoutTanh] = constraintsExpTanh.get();
+               outputLayoutTanh, outputAllocationsTanh] =
+      constraintsExpTanh.get();
   EXPECT_EQ(cbSizeTanh, 12288);
   EXPECT_EQ(l1PeakSizeTanh, 6144);
   EXPECT_EQ(outputSizeTanh, 2048);
@@ -4151,8 +4154,8 @@ TEST_F(OpModelBase, clampScalarOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4183,8 +4186,8 @@ TEST_F(OpModelBase, clampTensorOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4214,8 +4217,8 @@ TEST_F(OpModelBase, permuteOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4263,8 +4266,8 @@ TEST_F(OpModelBase, upsampleOp) {
     FAIL() << "Missing L1 constraints; Error="
            << llvm::toString(constraintsExp.takeError()) << std::endl;
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_EQ(l1PeakSize, 0);
   EXPECT_EQ(outputSize, 0);
@@ -4298,8 +4301,8 @@ TEST_F(OpModelBase, EmbeddingOpInterface) {
   auto constraintsExp = getOpConstraints(embedding.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4339,8 +4342,8 @@ TEST_F(OpModelBase, EmbeddingOpNullOutputLayout) {
       getInputLayouts(embedding), OpConfig(/*outputLayout=*/nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4385,8 +4388,8 @@ TEST_F(OpModelBase, EmbeddingBackwardOp) {
   auto constraintsExp = getOpConstraints(embeddingBackward.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4512,8 +4515,8 @@ TEST_F(OpModelBase, WhereOpInterface) {
   auto constraintsExp = getOpConstraints(where.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4560,7 +4563,8 @@ TEST_F(OpModelBase, batchNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4614,7 +4618,8 @@ TEST_F(OpModelBase, batchNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4657,7 +4662,8 @@ TEST_F(OpModelBase, batchNormOpTraining) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4692,7 +4698,8 @@ TEST_F(OpModelBase, batchNormOpTrainingMinimal) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4747,7 +4754,8 @@ TEST_F(OpModelBase, batchNormOpTrainingL1Memory) {
            << llvm::toString(constraintsExp.takeError()) << std::endl;
 
     const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-                outputLayoutReadBack] = constraintsExp.get();
+                outputLayoutReadBack, outputAllocationsReadBack] =
+        constraintsExp.get();
     EXPECT_GT(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -4788,7 +4796,8 @@ TEST_F(OpModelBase, rmsNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4822,7 +4831,8 @@ TEST_F(OpModelBase, rmsNormOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4871,7 +4881,8 @@ TEST_F(OpModelBase, rmsNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4907,7 +4918,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4944,7 +4956,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOpWithResidual) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -4984,7 +4997,8 @@ TEST_F(OpModelBase, rmsNormPreAllGatherOpWithL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5024,7 +5038,8 @@ TEST_F(OpModelBase, layerNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5058,7 +5073,8 @@ TEST_F(OpModelBase, layerNormOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5107,7 +5123,8 @@ TEST_F(OpModelBase, layerNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5141,7 +5158,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5176,7 +5194,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOpWithResidual) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5214,7 +5233,8 @@ TEST_F(OpModelBase, layerNormPreAllGatherOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5254,7 +5274,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5290,7 +5311,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOpMinimal) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5341,7 +5363,8 @@ TEST_F(OpModelBase, layerNormPostAllGatherOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5386,7 +5409,8 @@ TEST_F(OpModelBase, groupNormOp) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5438,7 +5462,8 @@ TEST_F(OpModelBase, groupNormOpL1Memory) {
   }
 
   const auto [cbSize, l1PeakSize, totalPeakSize, outputSize,
-              outputLayoutReadBack] = constraintsExp.get();
+              outputLayoutReadBack, outputAllocationsReadBack] =
+      constraintsExp.get();
   EXPECT_GT(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GT(outputSize, 0);
@@ -5479,8 +5504,8 @@ TEST_F(OpModelBase, EmptyOpInterface) {
   auto constraintsExp = getOpConstraints(empty.getOperation());
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -5513,8 +5538,8 @@ TEST_F(OpModelBase, ArangeOpInterface) {
       backend.getOpConstraints(getInputLayouts(arange), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5557,8 +5582,8 @@ TEST_P(NamedFullOpModelTest, TestOpInterface) {
       backend.getOpConstraints(getInputLayouts(op), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -5608,8 +5633,8 @@ TEST_F(OpModelBase, FullOpInterface) {
       backendI.getOpConstraints(getInputLayouts(fullInt), OpConfig(nullptr));
   if (constraintsExpI) {
     auto l1 = constraintsExpI.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5628,8 +5653,8 @@ TEST_F(OpModelBase, FullOpInterface) {
       backendF.getOpConstraints(getInputLayouts(fullF), OpConfig(nullptr));
   if (constraintsExpF) {
     auto l1 = constraintsExpF.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5663,8 +5688,8 @@ TEST_F(OpModelBase, ConstantOpInterface) {
                                                  OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GT(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -5702,8 +5727,8 @@ TEST_F(OpModelBase, ConstantOpInterfaceBF16) {
                                                  OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -5738,8 +5763,8 @@ TEST_F(OpModelBase, ConstantOpInterfaceNullOutputLayout) {
       backend.getOpConstraints(getInputLayouts(constant), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_EQ(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5775,8 +5800,8 @@ TEST_F(OpModelBase, RandOpInterface) {
       backend.getOpConstraints(getInputLayouts(randOp), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5799,8 +5824,8 @@ TEST_F(OpModelBase, RandOpInterface) {
       getInputLayouts(randOpCustom), OpConfig(nullptr));
   if (constraintsExpCustom) {
     auto l1 = constraintsExpCustom.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -5858,8 +5883,8 @@ TEST_F(OpModelBase, FillCacheOpInterface) {
       getInputLayouts(fillCache.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     // Basic validation that constraints are reasonable
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -5908,8 +5933,8 @@ TEST_F(OpModelBase, UpdateCacheOpInterface) {
       getInputLayouts(updateCache.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     // Basic validation that constraints are reasonable
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
@@ -5968,8 +5993,8 @@ TEST_F(OpModelBase, PagedUpdateCacheOpInterface) {
       getInputLayouts(pagedUpdateCacheOp.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6027,8 +6052,8 @@ TEST_F(OpModelBase, PagedFillCacheOpInterface) {
       getInputLayouts(pagedFillCacheOp.getOperation()), OpConfig());
   if (constraintsExp) {
     auto constraints = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraints;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6083,8 +6108,8 @@ TEST_F(OpModelBase, QuantizeOpInterface) {
       getInputLayouts(quantizeOp), OpConfig(getOutputLayout(quantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6139,8 +6164,8 @@ TEST_F(OpModelBase, QuantizeOpInterfaceNullOutput) {
       getInputLayouts(quantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6208,8 +6233,8 @@ TEST_F(OpModelBase, RequantizeOpInterface) {
       getInputLayouts(requantizeOp), OpConfig(getOutputLayout(requantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6278,8 +6303,8 @@ TEST_F(OpModelBase, RequantizeOpInterfaceNullOutput) {
       getInputLayouts(requantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6334,8 +6359,8 @@ TEST_F(OpModelBase, DequantizeOpInterface) {
       getInputLayouts(dequantizeOp), OpConfig(getOutputLayout(dequantizeOp)));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6391,8 +6416,8 @@ TEST_F(OpModelBase, DequantizeOpInterfaceNullOutput) {
       getInputLayouts(dequantizeOp), OpConfig(/*outputLayout=*/nullptr));
 
   ASSERT_TRUE(static_cast<bool>(constraintsExp));
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
 
   EXPECT_GT(cbSize, 0);
   EXPECT_GT(l1PeakSize, 0);
@@ -6436,8 +6461,8 @@ TEST_F(OpModelBase, AssignOpInterface) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_EQ(l1PeakSize, 0);
     EXPECT_EQ(outputSize, 0);
@@ -6476,8 +6501,8 @@ TEST_F(OpModelBase, AssignOpInterfaceL1Output) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6519,8 +6544,8 @@ TEST_F(OpModelBase, AssignOpInterfaceWithOutputDtype) {
       backend.getOpConstraints({inputLayout}, OpConfig(outputLayout));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = l1;
     EXPECT_GT(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GT(outputSize, 0);
@@ -6552,8 +6577,8 @@ TEST_F(OpModelBase, DropoutOpInterface) {
       backend.getOpConstraints(getInputLayouts(dropoutOp), OpConfig(nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6574,8 +6599,8 @@ TEST_F(OpModelBase, DropoutOpInterface) {
       getInputLayouts(dropoutOpCustom), OpConfig(nullptr));
   if (constraintsExpCustom) {
     auto l1 = constraintsExpCustom.get();
-    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        l1;
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = l1;
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6711,8 +6736,8 @@ TEST_F(OpModelBase, GatherOpInterface) {
 
   auto constraintsExp = getOpConstraints(gatherOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(outputSize, 0);
@@ -6794,8 +6819,8 @@ TEST_F(OpModelBase, PagedFlashMultiLatentAttentionDecodeOpInterface) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -6891,8 +6916,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterface) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -6951,8 +6976,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithValue) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -7012,8 +7037,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithMask) {
 
   auto constraintsExp = getOpConstraints(mlaOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     EXPECT_GE(totalPeakSize, 0);
@@ -7159,8 +7184,8 @@ TEST_F(OpModelBase, SamplingOp) {
 
   auto constraintsExp = getOpConstraints(samplingOp.getOperation());
   if (constraintsExp) {
-    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-        constraintsExp.get();
+    const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                 outputAllocations] = constraintsExp.get();
     EXPECT_GE(cbSize, 0);
     EXPECT_GE(l1PeakSize, 0);
     // outputSize is l1_output_buffer_per_core; ttnn::sampling's signature

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -7115,8 +7115,8 @@ TEST_F(OpModelBase, IndexerScoreDsaOpInterface) {
                     "(Blackhole-only): "
                  << llvm::toString(constraintsExp.takeError());
   }
-  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts] =
-      constraintsExp.get();
+  const auto &[cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+               outputAllocations] = constraintsExp.get();
   EXPECT_GE(cbSize, 0);
   EXPECT_GE(l1PeakSize, 0);
   EXPECT_GE(totalPeakSize, 0);

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4337,8 +4337,12 @@ TEST_F(OpModelBase, EmbeddingOpNullOutputLayout) {
   auto embedding = builder.create<EmbeddingOp>(
       builder.getUnknownLoc(), outputType, ::mlir::ValueRange{input, weight});
 
-  // Test EmbeddingOp interface constraints
-  auto constraintsExp = embedding.getOpConstraints(
+  // Test EmbeddingOp interface constraints. The stateless 2-argument
+  // convenience overload lives on the interface class, so go through the
+  // interface handle rather than the concrete op (which only declares the
+  // 3-argument form).
+  OpModel backend = dyn_cast<OpModel>(embedding.getOperation());
+  auto constraintsExp = backend.getOpConstraints(
       getInputLayouts(embedding), OpConfig(/*outputLayout=*/nullptr));
   if (constraintsExp) {
     auto l1 = constraintsExp.get();

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -44,3 +44,38 @@ target_link_libraries(L1SpillManagementTests
     MLIRTTNNAnalysis
     MLIRTTNNValidation
 )
+
+if (TTMLIR_ENABLE_OPMODEL)
+    # Allocator-backed stateful spill tests. Standalone binary (custom main()
+    # registering MockDeviceEnvironment) rather than add_mlir_unittest, so it is
+    # NOT wired into MLIRUnitTests/check-ttmlir -- it needs the op-model lib and
+    # a mock device, matching the TestOpModelLibMockDevice convention. Runs
+    # HW-free (mock device) on any box with the op-model build. Invoked in CI by
+    # .github/test_scripts/op_model.sh (alongside the other mock-device gtest
+    # binaries), since check-ttmlir does not run it.
+    add_executable(L1SpillManagementMockAllocatorTests
+        TestL1SpillManagementMockAllocator.cpp
+    )
+
+    target_compile_options(L1SpillManagementMockAllocatorTests
+        PRIVATE
+        -fno-rtti
+    )
+
+    target_include_directories(L1SpillManagementMockAllocatorTests
+        PUBLIC
+        ${PROJECT_SOURCE_DIR}/test/unittests/OpModel/TTNN/
+    )
+
+    target_link_libraries(L1SpillManagementMockAllocatorTests
+        PRIVATE
+        gtest
+        TTNNOpModelLib
+        MLIRTTCoreDialect
+        MLIRTTNNDialect
+        MLIRTTTransforms
+        MLIRTTNNAnalysis
+        MLIRTTNNValidation
+        TTMLIRTestUtils
+    )
+endif()

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Fixture for exercising the *real* stateful path of MockAllocatorL1Tracker:
+// liveRecords -> buildInitialState -> getOpConstraintsWithState ->
+// tt-metal build-from-records -> output_allocations -> pendingRecords/Snapshot.
+//
+// Unlike L1SpillTestFixture (which injects a synthetic backendValidator and
+// never touches the op-model), this fixture leaves backendValidator NULL so
+// MockAllocatorL1Tracker::validate() routes through the real op-model. The
+// op-model runs against a MOCK DEVICE (no silicon), configured once per binary
+// by MockDeviceEnvironment. Requires TTMLIR_ENABLE_OPMODEL.
+//
+// The test binary's main() MUST register the mock device environment:
+//   ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment());
+
+#ifndef TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H
+#define TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H
+
+#include "L1SpillTestFixture.h"
+
+#include <memory>
+
+namespace mlir::tt::ttnn::test {
+
+//===----------------------------------------------------------------------===//
+// L1SpillMockAllocatorFixture
+//
+// Reuses every IR-builder, layout, observer, and inspection helper from
+// L1SpillTestFixture unchanged. Adds runMock(), which drives
+// StatefulL1SpillManagement WITHOUT installing a fake
+// validator, so the allocator-backed (stateful op-model) path executes.
+//===----------------------------------------------------------------------===//
+class L1SpillMockAllocatorFixture : public L1SpillTestFixture {
+public:
+  struct MockRunResult {
+    RecordingObserver *observer;
+  };
+
+  /// Pass instance kept alive as a fixture member so the observer (owned by the
+  /// pass) outlives runMock() and stays reachable via the returned pointer, and
+  /// so getMockTracker() can inspect final tracker state after the run.
+  std::unique_ptr<StatefulL1SpillManagement> passMock;
+
+  /// Run the allocator-backed pass on `func`. No backendValidator is installed,
+  /// so MockAllocatorL1Tracker::validate() issues real (uncached) stateful
+  /// op-model queries against the mock device.
+  MockRunResult runMock() {
+    auto obs = std::make_unique<RecordingObserver>();
+    auto *rawObs = obs.get();
+
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
+
+    passMock = std::make_unique<StatefulL1SpillManagement>(
+        func, deviceGrid, l1BudgetPerCore, std::move(obs));
+    // Intentionally leave backendValidator unset -> real op-model path.
+    passMock->run();
+    return {rawObs};
+  }
+
+  MockAllocatorL1Tracker &getMockTracker() {
+    return passMock->getMemoryTracker();
+  }
+
+  bool mockPassFailed() const { return passMock && passMock->hasFailed(); }
+
+  /// Number of currently-live allocation records the tracker is holding.
+  /// After a completed run, this reflects tensors still resident in L1.
+  size_t liveRecordCount() { return getMockTracker().liveRecords.size(); }
+};
+
+} // namespace mlir::tt::ttnn::test
+
+#endif // TEST_UNITTESTS_OPTIMIZER_L1SPILLMOCKALLOCATORFIXTURE_H

--- a/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
+++ b/test/unittests/Optimizer/L1SpillMockAllocatorFixture.h
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Fixture for exercising the *real* stateful path of MockAllocatorL1Tracker:
-// liveRecords -> buildInitialState -> getOpConstraintsWithState ->
+// liveRecords -> buildInitialState -> getOpConstraints(..., state) ->
 // tt-metal build-from-records -> output_allocations -> pendingRecords/Snapshot.
 //
 // Unlike L1SpillTestFixture (which injects a synthetic backendValidator and

--- a/test/unittests/Optimizer/L1SpillTestFixture.h
+++ b/test/unittests/Optimizer/L1SpillTestFixture.h
@@ -127,7 +127,7 @@ public:
 //  - MLIR context with TTCore + TTNN + Func dialects loaded.
 //  - Helpers to build a func::FuncOp with typed TTNN op graphs.
 //  - Per-op test configuration (setL1Usage, forceOOM, forceNotImplemented).
-//  - run() to construct and drive L1SpillManagement<SumL1MemoryTracker> with
+//  - run() to construct and drive SumL1SpillManagement with
 //    a backend validator lambda built from perOpConfigs.
 //  - Post-run assertion helpers that inspect the mutated IR.
 //===----------------------------------------------------------------------===//
@@ -217,6 +217,15 @@ public:
         .buildWithCanonicalCorePlacement(deviceAttr);
   }
 
+  TTNNLayoutAttr makeL1Interleaved(llvm::ArrayRef<int64_t> shape) {
+    auto elemType = mlir::tt::ttcore::TileType::get(builder.getBF16Type());
+    auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
+    return TTNNLayoutAttr::Builder(&context, shape, elemType)
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .buildWithCanonicalCorePlacement(deviceAttr);
+  }
+
   mlir::RankedTensorType tensorType(llvm::ArrayRef<int64_t> shape,
                                     TTNNLayoutAttr layout) {
     return mlir::RankedTensorType::get(shape, builder.getBF16Type(), layout);
@@ -267,6 +276,35 @@ public:
     auto op = builder.create<ReshapeOp>(builder.getUnknownLoc(), outType, input,
                                         shapeAttr);
     setL1Usage(op.getOperation(), l1UsageBytes);
+    return op.getOperation();
+  }
+
+  /// Add a zero-fill PadOp matching FillCacheInputPadRewritePattern's scrub
+  /// pad. `padding` is low/high per dim (2 * rank), as in ttnn.pad.
+  mlir::Operation *addPad(mlir::Value input, mlir::RankedTensorType outType,
+                          llvm::ArrayRef<int32_t> padding) {
+    auto op = builder.create<PadOp>(builder.getUnknownLoc(), outType, input,
+                                    llvm::SmallVector<int32_t>(padding),
+                                    /*value=*/llvm::APFloat(0.0f),
+                                    /*use_multicore=*/true);
+    return op.getOperation();
+  }
+
+  /// Add a RepeatOp with the given per-dim repetition factors.
+  mlir::Operation *addRepeat(mlir::Value input, mlir::RankedTensorType outType,
+                             llvm::ArrayRef<int64_t> repeatDims) {
+    auto op = builder.create<RepeatOp>(builder.getUnknownLoc(), outType, input,
+                                       ShapeAttr::get(&context, repeatDims));
+    return op.getOperation();
+  }
+
+  /// Add a PermuteOp with the given permutation.
+  mlir::Operation *addPermute(mlir::Value input, mlir::RankedTensorType outType,
+                              llvm::ArrayRef<int64_t> permutation) {
+    auto op =
+        builder.create<PermuteOp>(builder.getUnknownLoc(), outType, input,
+                                  builder.getDenseI64ArrayAttr(permutation),
+                                  /*pad_value=*/mlir::FloatAttr());
     return op.getOperation();
   }
 
@@ -373,13 +411,13 @@ public:
   /// Pass instance kept alive as a fixture member so the observer (owned by
   /// the pass via unique_ptr) outlives run() and stays accessible through
   /// the returned raw pointer.
-  std::unique_ptr<L1SpillManagement<SumL1MemoryTracker>> pass;
+  std::unique_ptr<SumL1SpillManagement> pass;
 
   struct RunResult {
     RecordingObserver *observer;
   };
 
-  /// Run L1SpillManagement<SumL1MemoryTracker> on `func` with the test
+  /// Run SumL1SpillManagement on `func` with the test
   /// validator installed.
   RunResult run() {
     auto obs = std::make_unique<RecordingObserver>();
@@ -388,7 +426,7 @@ public:
     auto deviceAttr = mlir::tt::ttcore::lookupDevice(module.get());
     ttcore::GridAttr deviceGrid = deviceAttr.getWorkerGrid();
 
-    pass = std::make_unique<L1SpillManagement<SumL1MemoryTracker>>(
+    pass = std::make_unique<SumL1SpillManagement>(
         func, deviceGrid, l1BudgetPerCore, std::move(obs));
     pass->getMemoryTracker().backendValidator = makeValidator();
     pass->run();

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -1,0 +1,520 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the allocator-backed stateful L1 spill path
+// (MockAllocatorL1Tracker). These run against a MOCK DEVICE (no silicon),
+// configured once per binary by MockDeviceEnvironment, and exercise the real
+// op-model query path end to end:
+//
+//   liveRecords -> buildInitialState -> getOpConstraintsWithState
+//     -> tt-metal build-from-records -> output_allocations
+//     -> pendingRecords -> addTensor association -> Snapshot on eviction.
+//
+// Unlike TestL1SpillManagement.cpp (synthetic backendValidator, no device),
+// nothing is injected here: sizes and fit decisions come from the real
+// op-model / mock allocator. Each 1024x1024 bf16 tile, height-sharded on an
+// {8,1} grid, is 256 KiB per core (2 MiB / 8 cores) -- budgets below are
+// expressed as multiples of that.
+//
+// Guarded by TTMLIR_ENABLE_OPMODEL at the CMake level.
+
+#include "L1SpillMockAllocatorFixture.h"
+#include "MockDeviceFixture.h"
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h"
+#include "ttmlir/Dialect/TTNN/Validation/OpConstraintValidation.h"
+#include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+
+using namespace mlir::tt::ttnn::test;
+
+namespace {
+
+// Per-core L1 footprint of one 1024x1024 bf16 height-sharded {8,1} tensor, as
+// computed by the real mock op-model (verified empirically).
+constexpr uint64_t kOpL1 = 256 * kKiB;
+
+//===----------------------------------------------------------------------===//
+// SmallGraphNoSpill
+//
+// Baseline for the real op-model path: a small graph well under device L1 must
+// produce zero spills, and every op must report the true 256 KiB/core size
+// (proving the op-model actually ran -- the fake `l1UsageBytes` arg is
+// ignored).
+//===----------------------------------------------------------------------===//
+class MockAllocatorNoSpillTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorNoSpillTest, SmallGraphNoSpill) {
+  l1BudgetPerCore = 100u * kKiB * 1024u; // 100 MiB: fixture budget never binds
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  auto *opB = addUnary(opA->getResult(0), tt, 0);
+  auto *opC = addBinary(opA->getResult(0), opB->getResult(0), tt, 0);
+  finishFunc({opC->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  EXPECT_EQ(countSpills(), 0u) << "graph fits comfortably; no spill expected";
+  EXPECT_EQ(obs->ooms.size(), 0u);
+  // Real op-model sizes were used (not the ignored fake arg).
+  ASSERT_FALSE(obs->lives.empty());
+  for (const auto &l : obs->lives) {
+    EXPECT_EQ(l.opL1Usage, kOpL1)
+        << "op-model must report the real per-core L1 size";
+  }
+  // All three outputs stay resident in L1 (nothing was pushed out).
+  EXPECT_TRUE(resultIsL1(opA->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opB->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opC->getResult(0)));
+}
+
+//===----------------------------------------------------------------------===//
+// FarthestLastUseVictimSpilled
+//
+// Farthest-last-use eviction driven through the allocator-backed tracker.
+// Three 256 KiB producers are kept simultaneously live; a tight fixture budget
+// admits two but not three, so creating the third trips OOM and the pass evicts
+// the farthest-last-use victim (spill-to-DRAM). Exercises the full stateful
+// machinery under eviction: liveRecords flattening into each stateful query,
+// Snapshot capture, and record-restore during the eviction replay.
+//===----------------------------------------------------------------------===//
+class MockAllocatorSpillTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorSpillTest, FarthestLastUseVictimSpilled) {
+  l1BudgetPerCore = 700 * kKiB; // ~2.7 producers: 2 fit, the 3rd trips OOM
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  auto *opB = addUnary(args[0], tt, 0);
+  auto *opPressure = addUnary(args[0], tt, 0);
+  // Consumers in reverse order so opA has the farthest last-use -> evicted.
+  auto *useB = addUnary(opB->getResult(0), tt, 0);
+  auto *useA = addUnary(opA->getResult(0), tt, 0);
+  finishFunc(
+      {opPressure->getResult(0), useB->getResult(0), useA->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  ASSERT_GE(obs->evictions.size(), 1u) << "3x256 KiB > 700 KiB must spill";
+  EXPECT_EQ(obs->evictions.front().victim, opA)
+      << "farthest-last-use victim must be opA";
+  EXPECT_TRUE(wasSpilled(opA->getResult(0)));
+  EXPECT_FALSE(wasSpilled(opB->getResult(0)));
+  EXPECT_TRUE(resultIsL1(opB->getResult(0)));
+}
+
+//===----------------------------------------------------------------------===//
+// OverSubscriptionSpills
+//
+// Sixteen 256 KiB producers are kept simultaneously live (4 MiB) against a
+// realistic ~1.25 MiB per-core L1 budget (matching how a real compile sets the
+// budget to the device L1). The stateful tracker must resolve the
+// over-subscription by spilling (evict + refit), not crash and not cram
+// everything into L1. Exercises the allocator-backed tracker under heavy L1
+// pressure end to end.
+//
+// NOTE: an earlier version used a 100 MiB fixture budget to isolate the
+// device-L1 gate via the old "OOM-as-backend-error -> demote" path. That path
+// was removed by https://github.com/tenstorrent/tt-mlir/issues/9045 (a
+// fragmentation OOM from the stateful query is now classified as OOM and taken
+// through evict+refit, like the scalar tracker), so the budget is now set to a
+// realistic value where base-sim and device agree, as in a real compile.
+//===----------------------------------------------------------------------===//
+class MockAllocatorDeviceL1Test : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorDeviceL1Test, OverSubscriptionSpills) {
+  l1BudgetPerCore = 5 * kOpL1; // ~1.25 MiB: ~5 producers fit, rest must spill
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  constexpr int kNumProducers = 16; // 16 x 256 KiB = 4 MiB >> budget
+  auto args = beginFunc({tt});
+  llvm::SmallVector<mlir::Operation *> producers;
+  for (int i = 0; i < kNumProducers; ++i) {
+    producers.push_back(addUnary(args[0], tt, 0));
+  }
+  // Consume in reverse so every producer stays live through the last creation.
+  llvm::SmallVector<mlir::Value> rets;
+  for (int i = kNumProducers - 1; i >= 0; --i) {
+    rets.push_back(addUnary(producers[i]->getResult(0), tt, 0)->getResult(0));
+  }
+  finishFunc(rets);
+
+  runMock();
+
+  // A spilled producer keeps its L1 result type; the spill is a separate
+  // ToMemoryConfig(->DRAM) op, so wasSpilled() (not resultIsL1) is the right
+  // predicate for "this producer's data was pushed to DRAM".
+  size_t spilledProducers = 0;
+  for (auto *p : producers) {
+    if (wasSpilled(p->getResult(0))) {
+      ++spilledProducers;
+    }
+  }
+
+  EXPECT_FALSE(mockPassFailed());
+  // 4 MiB of live producers cannot fit a ~1.25 MiB budget -> the tracker must
+  // spill some to DRAM.
+  EXPECT_GT(countSpills(), 0u)
+      << "over-subscription (4 MiB into ~1.25 MiB) must spill to DRAM";
+  EXPECT_GT(spilledProducers, 0u)
+      << "some producers must be spilled to DRAM under over-subscription";
+}
+
+//===----------------------------------------------------------------------===//
+// DeadTensorsFreeRecordsNoSpill
+//
+// Complement to the accumulation test: a long chain where each tensor dies one
+// step after birth. If the tracker frees live records on tensor death
+// (MockAllocatorL1Tracker::removeTensor -> liveRecords.erase), at most two
+// tensors are ever live, occupancy stays ~512 KiB, and nothing leaves L1 --
+// even though the chain's total footprint (10 x 256 KiB = 2.5 MiB) exceeds
+// device L1. A broken free path would accumulate and force spills/demotions.
+//===----------------------------------------------------------------------===//
+class MockAllocatorFreeTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorFreeTest, DeadTensorsFreeRecordsNoSpill) {
+  l1BudgetPerCore = 100u * kKiB * 1024u; // 100 MiB: fixture budget never binds
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  constexpr int kChainLen = 10; // 10 x 256 KiB = 2.5 MiB total > device L1
+  auto args = beginFunc({tt});
+  mlir::Operation *prev = nullptr;
+  llvm::SmallVector<mlir::Operation *> ops;
+  for (int i = 0; i < kChainLen; ++i) {
+    mlir::Value in = prev ? prev->getResult(0) : args[0];
+    prev = addUnary(in, tt, 0);
+    ops.push_back(prev);
+  }
+  finishFunc({prev->getResult(0)});
+
+  auto [obs] = runMock();
+
+  EXPECT_FALSE(mockPassFailed());
+  EXPECT_EQ(countSpills(), 0u)
+      << "sequential chain frees each tensor before the next -> no spill";
+  EXPECT_TRUE(obs->demotions.empty());
+  // Every op stays in L1: peak residency never exceeded device capacity because
+  // dead tensors released their records.
+  for (auto *op : ops) {
+    EXPECT_TRUE(resultIsL1(op->getResult(0)))
+        << "no op should leave L1 in a self-freeing chain";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// PerCoreSizeMatchesConstant
+//
+// Pins the calibration constant: if tt-metal changes tensor sizing, this fails
+// loudly and points at the fix (update kOpL1 and re-derive the budgets above).
+//===----------------------------------------------------------------------===//
+class MockAllocatorCalibrationTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorCalibrationTest, PerCoreSizeMatchesConstant) {
+  l1BudgetPerCore = 100u * kKiB * 1024u;
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opA = addUnary(args[0], tt, 0);
+  finishFunc({opA->getResult(0)});
+
+  auto [obs] = runMock();
+
+  ASSERT_EQ(obs->lives.size(), 1u);
+  EXPECT_EQ(obs->lives.front().opL1Usage, kOpL1)
+      << "mock op-model per-core L1 changed; update kOpL1 and re-derive "
+         "budgets";
+}
+
+//===----------------------------------------------------------------------===//
+// TrackerAliasRefcountKeepsBufferLive
+//
+// Device-free unit test of MockAllocatorL1Tracker's record-level view aliasing:
+// a view output shares its source's buffer (no second record), and the buffer
+// stays live until the last aliaser dies. Exercises addTensor / addTensorAlias
+// / removeTensor / getOccupiedL1 directly, without the op-model query.
+//===----------------------------------------------------------------------===//
+class MockAllocatorTrackerTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorTrackerTest, TrackerAliasRefcountKeepsBufferLive) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+  auto args = beginFunc({tt});
+  auto *ownerOp = addUnary(args[0], tt, 0);
+  auto *viewOp = addUnary(ownerOp->getResult(0), tt, 0);
+  finishFunc({viewOp->getResult(0)});
+
+  mlir::Value owner = ownerOp->getResult(0);
+  mlir::Value view = viewOp->getResult(0);
+
+  constexpr uint64_t kBufBytes = 2048;
+  mlir::tt::ttnn::MockAllocatorL1Tracker t;
+  t.init(/*l1BudgetPerCore=*/100u * kKiB * 1024u);
+  // Seed the owner's record as if a stateful query had produced it.
+  t.pendingRecords[ownerOp] = mlir::tt::ttnn::MockAllocatorL1Tracker::RecordVec{
+      mlir::tt::ttnn::op_model::OpModelAllocationRecord{
+          mlir::tt::ttnn::BufferType::L1, /*address=*/0,
+          /*sizePerBank=*/kBufBytes}};
+
+  t.addTensor(owner, /*l1SizePerCore=*/0);
+  EXPECT_TRUE(t.hasTensor(owner));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes);
+
+  t.addTensorAlias(view, owner);
+  EXPECT_TRUE(t.hasTensor(view));
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "alias shares the owner buffer (no duplicate record)";
+
+  t.removeTensor(owner);
+  EXPECT_EQ(t.getOccupiedL1(), kBufBytes)
+      << "buffer stays live while an aliaser remains";
+  EXPECT_TRUE(t.hasTensor(view));
+
+  t.removeTensor(view);
+  EXPECT_EQ(t.getOccupiedL1(), 0u) << "last aliaser gone -> buffer freed";
+  EXPECT_FALSE(t.hasTensor(view));
+}
+
+//===----------------------------------------------------------------------===//
+// ReshardedPastConsumerTrackedDuringEviction
+//
+// Regression for tt-mlir #9087: the stateful eviction rewinds and re-runs the
+// forward sweep, and past-consumer reshards are routed through the schedule so
+// they are tracked (not the old event-log bracketing that left DRAM-output
+// consumers untracked). Build a graph where the farthest-last-use victim (opV)
+// has a PAST consumer (cPast, scheduled before the OOM-triggering op): evicting
+// opV must insert an L1 reshard before cPast, compile cleanly (no hard-fail),
+// and leave cPast reading L1.
+//===----------------------------------------------------------------------===//
+class MockAllocatorReshardTest : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorReshardTest, ReshardedPastConsumerTrackedDuringEviction) {
+  l1BudgetPerCore = 700 * kKiB; // 2 x 256 KiB fit; a 3rd trips OOM
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto tt = tensorType(shape, makeL1Sharded(shape));
+
+  auto args = beginFunc({tt});
+  auto *opV = addUnary(args[0], tt, 0);                // victim (long-lived)
+  auto *cPast = addUnary(opV->getResult(0), tt, 0);    // PAST consumer of opV
+  auto *cPastU = addUnary(cPast->getResult(0), tt, 0); // cPast dies here
+  auto *mid1 = addUnary(args[0], tt, 0);
+  auto *mid2 =
+      addUnary(mid1->getResult(0), tt, 0); // OOM trigger; mid1 dies here
+  auto *tailV = addUnary(opV->getResult(0), tt, 0); // opV's farthest use
+  finishFunc({cPastU->getResult(0), mid2->getResult(0), tailV->getResult(0)});
+
+  runMock();
+
+  // A reshard is a ToMemoryConfigOp that writes L1 (the inverse of a spill).
+  size_t reshardsToL1 = 0;
+  func.walk([&](mlir::tt::ttnn::ToMemoryConfigOp op) {
+    auto rt = mlir::dyn_cast<mlir::RankedTensorType>(op.getResult().getType());
+    auto enc = rt ? mlir::dyn_cast_or_null<mlir::tt::ttnn::TTNNLayoutAttr>(
+                        rt.getEncoding())
+                  : nullptr;
+    if (enc && enc.hasL1BufferType()) {
+      ++reshardsToL1;
+    }
+  });
+
+  EXPECT_FALSE(mockPassFailed())
+      << "past-consumer reshard must not hard-fail the pass";
+  EXPECT_TRUE(wasSpilled(opV->getResult(0)))
+      << "farthest-last-use victim opV must be spilled";
+  EXPECT_GT(reshardsToL1, 0u)
+      << "opV's past consumer must get an L1 reshard inserted";
+  // cPast reads its reshard's L1 output.
+  EXPECT_TRUE(resultIsL1(cPast->getOperand(0)))
+      << "past consumer's input must be resharded back to L1";
+}
+
+//===----------------------------------------------------------------------===//
+// View-op tripwires (https://github.com/tenstorrent/tt-mlir/issues/9054)
+//
+// The L1 spill pass classifies certain ops (reshape/pad/repeat/permute) as
+// input-aliasing views via `isAliasingViewOp` and aliases them onto their
+// source's L1 slot instead of tracking a fresh allocation. tt-metal signals
+// such a view by reporting the op's output buffer at the weightless input's
+// address 0 under the stateful op-model query. These tripwires pin that
+// contract: for each op our predicate calls a view, the mock op-model query
+// MUST report an L1 output allocation at address 0. If tt-metal drifts (a
+// classified-view op starts returning a real non-zero address), the tripwire
+// fails -- our `isAliasingViewOp` is then stale and must be adjusted, because
+// the spill pass would otherwise alias (undercount) a real allocation.
+//===----------------------------------------------------------------------===//
+
+// True if the op's stateful op-model query (empty live set = the op's own
+// query) reports an output buffer placed in L1 at address 0.
+static bool queryReportsL1Address0(mlir::Operation *op,
+                                   mlir::tt::ttnn::TTNNLayoutAttr inLayout,
+                                   mlir::tt::ttnn::TTNNLayoutAttr outLayout) {
+  auto result = mlir::tt::ttnn::op_constraint_validation::validateOperation(
+      op, /*inputLayouts=*/{inLayout}, mlir::tt::ttnn::OpConfig(outLayout),
+      /*liveRecords=*/
+      llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{},
+      /*additionalL1Usage=*/0);
+  // Fatal for this helper: a failed query has no meaningful outputAllocations,
+  // so record the failure and stop rather than falling through to `return
+  // false` (which would misreport as "no L1 address-0 output").
+  EXPECT_TRUE(result.isSuccess()) << "stateful op-model query should succeed";
+  if (!result.isSuccess()) {
+    return false;
+  }
+  for (const auto &r : result.outputAllocations) {
+    if (r.bufferType == mlir::tt::ttnn::BufferType::L1 && r.address == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+class MockAllocatorViewTripwireTest : public L1SpillMockAllocatorFixture {};
+
+// Pad: the FillCacheInputPadRewritePattern scrub pad from the llama_3_2_1b
+// repro (seq_len 18 -> 32, TILE fast-path view).
+TEST_F(MockAllocatorViewTripwireTest, PadViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> inShape = {1, 8, 18, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 8, 32, 64};
+  auto inLayout = makeL1Interleaved(inShape);
+  auto outLayout = makeL1Interleaved(outShape);
+  auto args = beginFunc({tensorType(inShape, inLayout)});
+  auto *pad = addPad(args[0], tensorType(outShape, outLayout),
+                     /*padding=*/{0, 0, 0, 0, 0, 14, 0, 0});
+  finishFunc({pad->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canPadBeView(pad));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(pad));
+  EXPECT_TRUE(queryReportsL1Address0(pad, inLayout, outLayout))
+      << "TILE-view ttnn.pad must report an L1 output at address 0";
+}
+
+// Repeat: an all-ones repetition is a strict no-op (repeat.cpp:196).
+TEST_F(MockAllocatorViewTripwireTest, RepeatAllOnesViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 32, 64};
+  auto layout = makeL1Interleaved(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *repeat = addRepeat(args[0], tt, /*repeatDims=*/{1, 1, 1, 1});
+  finishFunc({repeat->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canRepeatBeView(repeat));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(repeat));
+  EXPECT_TRUE(queryReportsL1Address0(repeat, layout, layout))
+      << "all-ones ttnn.repeat must report an L1 output at address 0";
+}
+
+// Permute: an identity permutation with unchanged memory config is a no-op.
+TEST_F(MockAllocatorViewTripwireTest, PermuteNopViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 32, 64};
+  auto layout = makeL1Interleaved(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *permute = addPermute(args[0], tt, /*permutation=*/{0, 1, 2, 3});
+  finishFunc({permute->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canPermuteBeView(permute));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(permute));
+  EXPECT_TRUE(queryReportsL1Address0(permute, layout, layout))
+      << "identity ttnn.permute must report an L1 output at address 0";
+}
+
+// Reshape: the primary view op. A reshape that keeps the last two dims (only
+// reinterpreting the leading dims) is a zero-copy view (reshape.cpp:378-384).
+TEST_F(MockAllocatorViewTripwireTest, ReshapeViewReportsL1Address0) {
+  llvm::SmallVector<int64_t> inShape = {2, 1, 32, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 2, 32, 64}; // last two dims fixed
+  auto inLayout = makeL1Interleaved(inShape);
+  auto outLayout = makeL1Interleaved(outShape);
+  auto args = beginFunc({tensorType(inShape, inLayout)});
+  auto *reshape = addReshape(args[0], tensorType(outShape, outLayout),
+                             /*l1UsageBytes=*/0);
+  finishFunc({reshape->getResult(0)});
+
+  EXPECT_TRUE(mlir::tt::ttnn::canReshapeBeView(reshape));
+  EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(reshape));
+  EXPECT_TRUE(queryReportsL1Address0(reshape, inLayout, outLayout))
+      << "view-eligible ttnn.reshape must report an L1 output at address 0";
+}
+
+// Negative: a real (non-view) pad that grows a tile dim must NOT be classified
+// a view.
+TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
+  llvm::SmallVector<int64_t> inShape = {1, 1, 32, 64};
+  llvm::SmallVector<int64_t> outShape = {1, 1, 64, 64}; // +1 full tile row
+  auto args = beginFunc({tensorType(inShape, makeL1Interleaved(inShape))});
+  auto *pad = addPad(args[0], tensorType(outShape, makeL1Interleaved(outShape)),
+                     /*padding=*/{0, 0, 0, 0, 0, 32, 0, 0});
+  finishFunc({pad->getResult(0)});
+
+  EXPECT_FALSE(mlir::tt::ttnn::canPadBeView(pad))
+      << "a pad that adds a full tile row is a real allocation, not a view";
+  // ...and it must not be picked up by the unified aliasing-view predicate the
+  // spill pass keys on (else it would alias/undercount a real allocation).
+  EXPECT_FALSE(mlir::tt::ttnn::isAliasingViewOp(pad))
+      << "a real (non-view) pad must not be classified as an aliasing view";
+}
+
+//===----------------------------------------------------------------------===//
+// StatelessUnchangedByStatefulRouting
+//
+// The stateful op-model routing must not perturb the stateless result: a query
+// with an EMPTY live-record set has to be byte-for-byte equivalent to the plain
+// stateless query (buildInitialState({}) -> null state -> constraintsDispatch
+// takes the cached stateless path). This is the invariant the whole
+// stateless-through-the-stateful-API design and the interface
+// constraintsDispatch helper rely on; assert it directly so a future change to
+// buildInitialState or the dispatch cannot silently diverge the two paths.
+//===----------------------------------------------------------------------===//
+class MockAllocatorStatelessEquivalenceTest
+    : public L1SpillMockAllocatorFixture {};
+
+TEST_F(MockAllocatorStatelessEquivalenceTest, EmptyRecordsMatchesStateless) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto layout = makeL1Sharded(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *op = addUnary(args[0], tt, 0);
+  finishFunc({op->getResult(0)});
+
+  const mlir::tt::ttnn::OpConfig config(layout);
+  const auto stateless =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config);
+  const auto statefulEmpty =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config,
+          /*liveRecords=*/
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{});
+
+  EXPECT_EQ(stateless.isSuccess(), statefulEmpty.isSuccess())
+      << "empty-records stateful query must match the stateless status";
+  ASSERT_TRUE(stateless.isSuccess())
+      << "baseline stateless query must succeed for this op";
+  EXPECT_EQ(stateless.outputL1Usage, statefulEmpty.outputL1Usage);
+  EXPECT_EQ(stateless.cbPeakUsage, statefulEmpty.cbPeakUsage);
+  EXPECT_EQ(stateless.getFirstActualOutputLayout(),
+            statefulEmpty.getFirstActualOutputLayout());
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - GTest takes ownership.
+  ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment());
+  return RUN_ALL_TESTS();
+}

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -7,7 +7,7 @@
 // configured once per binary by MockDeviceEnvironment, and exercise the real
 // op-model query path end to end:
 //
-//   liveRecords -> buildInitialState -> getOpConstraintsWithState
+//   liveRecords -> buildInitialState -> getOpConstraints(..., state)
 //     -> tt-metal build-from-records -> output_allocations
 //     -> pendingRecords -> addTensor association -> Snapshot on eviction.
 //
@@ -471,13 +471,13 @@ TEST_F(MockAllocatorViewTripwireTest, RealPadIsNotAView) {
 //===----------------------------------------------------------------------===//
 // StatelessUnchangedByStatefulRouting
 //
-// The stateful op-model routing must not perturb the stateless result: a query
-// with an EMPTY live-record set has to be byte-for-byte equivalent to the plain
-// stateless query (buildInitialState({}) -> null state -> constraintsDispatch
-// takes the cached stateless path). This is the invariant the whole
-// stateless-through-the-stateful-API design and the interface
-// constraintsDispatch helper rely on; assert it directly so a future change to
-// buildInitialState or the dispatch cannot silently diverge the two paths.
+// The stateful op-model routing must not perturb the *numbers* the stateless
+// query reports: an EMPTY live set describes an empty L1, so the fit decision
+// and the usage figures have to match the plain stateless query. Note this is
+// value equivalence only -- the two take DIFFERENT query branches (see
+// EmptyRecordsStillReportsAllocations below). Assert it directly so a future
+// change to buildInitialState or to constraintsDispatch cannot silently diverge
+// the two paths.
 //===----------------------------------------------------------------------===//
 class MockAllocatorStatelessEquivalenceTest
     : public L1SpillMockAllocatorFixture {};
@@ -508,6 +508,56 @@ TEST_F(MockAllocatorStatelessEquivalenceTest, EmptyRecordsMatchesStateless) {
   EXPECT_EQ(stateless.cbPeakUsage, statefulEmpty.cbPeakUsage);
   EXPECT_EQ(stateless.getFirstActualOutputLayout(),
             statefulEmpty.getFirstActualOutputLayout());
+}
+
+//===----------------------------------------------------------------------===//
+// EmptyRecordsStillReportsAllocations
+//
+// Tri-state selector tripwire. Both flavours of the constraint query now share
+// ONE entry point, selected by whether `liveRecords` is engaged -- NEVER by
+// whether it is empty. An empty-but-engaged live set must keep taking the
+// STATEFUL branch, because that branch is the only one that reports
+// output_allocations, and the spill path bootstraps its record set off the very
+// first op of a run, where the live set is necessarily empty.
+//
+// If someone "simplifies" the selector to `liveRecords.empty()` -- in
+// buildInitialState, constraintsDispatch, validateConstraints, or the interface
+// method -- the first op reports no allocations, so the record set never seeds,
+// every later query also sees an empty set, and the whole stateful feature
+// degrades silently to stateless. This test fails loudly instead: same op, same
+// layouts, empty live set, allocations required. Its counterpart above pins
+// that the reported values still match the stateless query.
+//===----------------------------------------------------------------------===//
+TEST_F(MockAllocatorStatelessEquivalenceTest,
+       EmptyRecordsStillReportsAllocations) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+  auto layout = makeL1Sharded(shape);
+  auto tt = tensorType(shape, layout);
+  auto args = beginFunc({tt});
+  auto *op = addUnary(args[0], tt, 0);
+  finishFunc({op->getResult(0)});
+
+  const mlir::tt::ttnn::OpConfig config(layout);
+  const auto statefulEmpty =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config,
+          /*liveRecords=*/
+          llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{});
+  ASSERT_TRUE(statefulEmpty.isSuccess())
+      << "stateful query with an empty live set must succeed";
+  EXPECT_FALSE(statefulEmpty.outputAllocations.empty())
+      << "an EMPTY-but-engaged live set is a STATEFUL query and must report "
+         "outputAllocations; reporting none means the selector degraded to "
+         "keying on liveRecords.empty()";
+
+  // ...and the stateless query (no live set at all) must keep reporting none:
+  // that is what makes its result cacheable.
+  const auto stateless =
+      mlir::tt::ttnn::op_constraint_validation::validateOperation(
+          op, /*inputLayouts=*/{layout}, config);
+  ASSERT_TRUE(stateless.isSuccess());
+  EXPECT_TRUE(stateless.outputAllocations.empty())
+      << "the stateless query must not report allocations";
 }
 
 } // namespace

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -21,6 +21,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Value.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
 
 #include "gtest/gtest.h"
 
@@ -456,6 +457,53 @@ TEST_F(OpConstraintValidationTest, ValidationStatusOutOfMemoryError) {
   EXPECT_FALSE(result.isSuccess());
   EXPECT_FALSE(result.isNotImplemented());
   EXPECT_FALSE(result.errorMessage.empty());
+}
+
+// Regression test for https://github.com/tenstorrent/tt-mlir/issues/9064:
+// The stateful (build-from-records) op-model query places live tensors at real
+// addresses, so an op whose static circular buffers overlap a still-live L1
+// input surfaces the tt-metal CB-clash exception ("Statically allocated
+// circular buffers ... clash with L1 buffers ...").  This is an L1-pressure
+// condition recoverable by evict-and-refit, so checkConstraintsResult must
+// classify it as OutOfMemoryError (routing the spill pass to handleOOM), NOT
+// MetalBackendError (which only demotes the op's output to DRAM and leaves the
+// clashing L1 input in place -> runtime crash).
+TEST_F(OpConstraintValidationTest, ClashWithL1BuffersClassifiedAsOOM) {
+  auto addOp = createMockAddOp();
+
+  llvm::Expected<op_model::OpConstraints> clashError =
+      llvm::make_error<llvm::StringError>(
+          "TT_THROW @ program.cpp:1612: tt::exception\n"
+          "Statically allocated circular buffers in program 42 clash with L1 "
+          "buffers on core range [0-0 - 7-7]. L1 buffer allocated at 253952 "
+          "and static circular buffer region ends at 646208",
+          llvm::inconvertibleErrorCode());
+
+  auto result = op_constraint_validation::checkConstraintsResult(
+      addOp.getOperation(), std::move(clashError));
+
+  EXPECT_EQ(result.status,
+            op_constraint_validation::ValidationStatus::OutOfMemoryError);
+  EXPECT_TRUE(result.isError());
+}
+
+// Companion to the above: a genuine backend constraint error (carrying neither
+// the "Out of Memory" nor the "clash with L1 buffers" marker) must remain a
+// MetalBackendError so the op is demoted rather than sent through evict-refit.
+TEST_F(OpConstraintValidationTest, GenericBackendErrorStaysBackendError) {
+  auto addOp = createMockAddOp();
+
+  llvm::Expected<op_model::OpConstraints> backendError =
+      llvm::make_error<llvm::StringError>(
+          "Unsupported data type combination for op",
+          llvm::inconvertibleErrorCode());
+
+  auto result = op_constraint_validation::checkConstraintsResult(
+      addOp.getOperation(), std::move(backendError));
+
+  EXPECT_EQ(result.status,
+            op_constraint_validation::ValidationStatus::MetalBackendError);
+  EXPECT_TRUE(result.isError());
 }
 
 // Test ValidationStatus::UnmatchedReferenceConfig


### PR DESCRIPTION
## Essence

Reland of #9069 (which this **supersedes**), rebased onto latest `main` and
squashed into a single commit.

The greedy L1 **spill** pass decides "does this op fit in L1?" with a scalar
heuristic (sum of tensor sizes + a CB cushion). This PR lets it instead ask
**tt-metal's real mock allocator** — feeding the currently-live L1 tensors (as
allocation records) into a **stateful** op-model query, so fit / fragmentation /
placement are modeled accurately. Gated behind **`use-mock-allocator-state`
(default on)**; only the **spill** path changes — beam-search keeps its cached,
stateless query.

## How the fold works (one getOpConstraints, two paths)

This PR folds the two per-op constraint-query families (`getOpConstraints` stateless + `getOpConstraintsWithState` stateful) into one function, selected purely by whether allocator state is passed:

```
                     caller decides ONE thing: pass liveRecords, or don't
                                            │
  MemoryLayoutPropagation (beam search)     │     MockAllocatorL1Tracker (L1 spill pass)
     validateOperation(op, layouts, cfg)    │     validateOperation(op, layouts, cfg, flat, 0)
                       │                    │                     │
                       └──────────► validateConstraints(..., std::optional<ArrayRef<Record>>)
                                            │        statefulQuery := liveRecords.has_value()
                                            ▼
                              ReluOp::getOpConstraints(inputs, cfg, liveRecords)
                                            ▼
                              detail::getUnaryOpConstraints(...)
                                            ▼
                              detail::constraintsDispatch(op, liveRecords, args...)
                                            │
                     ┌──────────────────────┴───────────────────────┐
             liveRecords == nullopt                       liveRecords engaged
                     │                                              │
        opConstraintsCache().getOrCompute                buildInitialState(*liveRecords)
        (lambda binds initialState=nullptr)              → non-null MockAllocatorState
                     │                                   (cache is BYPASSED)
                     └──────────────► OpModel<ReluOp>::getOpConstraints(
                                          shape, inLayout, outLayout,
                                          const MockAllocatorState *initialState)
                                            ▼
                       query_op_constraints_with_optional_state(op, dev, optState, ...)
                                            │
                     ┌──────────────────────┴───────────────────────┐
                 nullopt                                         value
        query_op_constraints                        query_op_constraints_with_initial_state
        NO_DISPATCH, nothing allocated              phase1 NO_DISPATCH + phase2 NORMAL
        output_allocations = {}                     real allocation, output_allocations = [...]
```

The selector is **tri-state**:

| `liveRecords` | flavour | cached? | tt-metal run mode | `outputAllocations` | peak-byte check in validation |
|---|---|---|---|---|---|
| `std::nullopt` | stateless | **yes** | `NO_DISPATCH` only | empty | **enforced** |
| engaged, **empty** | **stateful** | no | phase-1 `NO_DISPATCH` + phase-2 `NORMAL` | populated | skipped |
| engaged, non-empty | stateful | no | phase-1 `NO_DISPATCH` + phase-2 `NORMAL` | populated | skipped |

## Relationship to #9069

| | |
|---|---|
| Base | latest `origin/main` (`a48b1a185b`) |
| Content | the **entire** #9069 feature as of `cddc53d837` |
| Excluded | the tip commit of #9069, `16a977e89f` *"[Optimizer] Reserve static-CB headroom in the stateful L1 spill on mesh compiles"* |
| Shape | one squashed commit |

The excluded commit was a **masking** fix: it reserved static-CB headroom to
paper over the QB2 CB-vs-L1 clash rather than address it. It is deliberately
**not** relanded — see *Known limitation* below.

The old branch `rpavlovic/op-model-stateful-constraints-draft` is retained
untouched as a backup.

## Main pieces (by layer)

**1. Op-model — the new stateful query** (the bulk)
- `lib/OpModel/TTNN/TTNNOpModel.cpp` — per-op `getOpConstraintsWithState` bodies,
  `buildInitialState` (`with_allocations` from live records), allocator
  snapshot/restore, `output_allocations` → records.
- `include/ttmlir/OpModel/TTNN/TTNNOpModel.h`,
  `include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h` — declarations, the
  `OpModelAllocationRecord` POD, and `OpConstraints.outputAllocations` (all
  tt-metalium types kept behind the op_model boundary).

**2. Interface / tablegen — per-op dispatch**
- `lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp` — every op migrated.
  Bespoke per-op constraint bodies are deduplicated behind a shared
  `constraintsDispatch` (SDPA family, conv, norms, and the remaining
  elementwise / data-movement batches). The stateless `getOpConstraints` stays a
  byte-identical cache path.
- `include/ttmlir/Dialect/TTNN/IR/TTNNOps.td`,
  `include/ttmlir/Dialect/TTNN/Interfaces/TTNNOpModelInterface.td` — interface
  method + per-family `extraClassDeclaration` wiring.

**3. Optimizer — consuming it in the spill pass**
- `lib/Dialect/TTNN/Analysis/L1SpillManagement.{cpp,h}` — the spill manager is
  split into a base plus `Sum`/`Mock` subclasses behind hook seams (introduced
  first as a no-behavior-change refactor). The base is made **address-agnostic**;
  the address simulator is dropped from the stateful path in favour of op-query
  replay. `MockAllocatorL1Tracker` threads live records per query, frees on
  death, and snapshots/restores.
- **Rewind-and-re-run eviction**: per-position sweep checkpoints are captured and
  the sweep can rewind to a checkpoint and re-run, replacing the old `replayFrom`
  mechanism — including nested-rewind termination and checkpoint hygiene.
- `evictForDramCBGrowth` no longer aborts on an un-demotable op (vLLM typecast).
- `lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.{cpp,h}` —
  `canPadBeView` / `canRepeatBeView` / `canPermuteBeView` + `isAliasingViewOp`.
  View ops (`pad`/`repeat`/`permute`) that tt-metal realizes as zero-copy views
  are aliased in the tracker with **record-level view-alias refcounting**, so an
  aliased buffer is not double-counted and no phantom L1-address-0 record reaches
  `with_allocations` (`Fixes #9054`).
- `lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyL1SpillManagement.cpp` — the
  toggle branch + snapshot/restore around the spill run.

**4. Validation**
- `lib/Dialect/TTNN/Validation/OpConstraintValidation.{cpp,h}` — stateful
  `validateOperation` overload; `checkConstraintsResult` classifies allocator-OOM
  as OOM → evict+refit; `cbPeakUsage` / `outputAllocations` on the result.

**5. Pipeline plumbing**
- `TTNNPipelines.{h,cpp}`, `Passes.td` — the `use-mock-allocator-state` option.
  Rebased over main's removal of the legacy chain-based `TTNNOptimizer` path
  (#9086); the only rebase conflict, resolved by keeping main's shape and
  re-adding the new option.

**6. Tests**
- `test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp` (+
  `L1SpillMockAllocatorFixture.h`) — mock-device, HW-free spill tests and the
  view **tripwires**. Standalone binary run in CI by
  `.github/test_scripts/op_model.sh`.
- `test/unittests/Validation/TestOpConstraintValidation.cpp`,
  `test/unittests/OpModel/TTNN/{Op/TestOpModelInterface,Lib/TestOpModelLib}.cpp` —
  updates for the 6-field `OpConstraints`.

## Known limitation

On **QB2** there is a **CB-vs-L1 clash**: the static circular-buffer allocation
and the optimizer's L1 tensor budget can overlap on mesh compiles. This is **not
fixed here** and is tracked separately by **#9123**
(https://github.com/tenstorrent/tt-mlir/issues/9123). The proper fix is
per-trace-function accounting, which is future work — deliberately out of scope
for this reland, in place of the masking headroom-floor commit that was dropped.

## Validation

- **Build**: full `-DTTMLIR_ENABLE_OPMODEL=ON` Release build from scratch on the
  rebased tree — clean, 857/857 targets, zero errors.
- **Unit**: `L1SpillManagementTests`, `L1SpillManagementMockAllocatorTests`
  (mock-device, HW-free), `ValidationTests`, plus the TTNN optimizer lit suite —
  as carried from #9069.
- **Perf**: a tt-xla `manual-benchmark` sweep (all boards, all tests) is
  triggered against this head; CI on this PR covers the rest.

