### PR TITLE
[MoE] Fused moe_compute decode path (tt.moe_decode composite)

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -67,6 +67,12 @@ inline constexpr llvm::StringLiteral
 inline constexpr llvm::StringLiteral
     kTTSDPACompositeName("tenstorrent.scaled_dot_product_attention");
 
+// Composite name emitted by the frontend for the fused MoE decode block. Kept
+// as the StableHLOToTTIR conversion's custom_call target name too, so the
+// composite (after FlattenOrConvert -> custom_call) lowers to
+// ttcore.composite "moe_decode".
+inline constexpr llvm::StringLiteral kTTMoeDecodeCompositeName("tt.moe_decode");
+
 // Composite names that have custom sharding rules. These composites are
 // converted to stablehlo.custom_call ops so that Shardy can propagate shardings
 // defined by the custom sharding rule for that composite as if the composite
@@ -78,7 +84,7 @@ inline constexpr llvm::StringLiteral kCompositesWithCustomSharding[] = {
     kTTTopKValuesCustomCallTargetName, kTTTopKIndicesCustomCallTargetName,
     kTTArgMaxCustomCallTargetName,     kTTSDPACompositeName,
     kTTGatherCustomCallTargetName,     kTTGatherDimCustomCallTargetName,
-};
+    kTTMoeDecodeCompositeName};
 
 // Target name for the distributed RMS norm custom_call op.
 inline constexpr llvm::StringLiteral

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -8,6 +8,7 @@
 #include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardingUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+#include "ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
@@ -9810,6 +9811,469 @@ public:
 } // namespace
 
 namespace {
+// Device mesh shape for the module. moe_decode lowers in the same pass that
+// converts sdy.mesh -> ttcore.meshes with no guaranteed firing order, so read
+// whichever form is present. Returns {} when the module carries no mesh.
+static llvm::SmallVector<int64_t> getModuleMeshShape(ModuleOp moduleOp) {
+  if (auto meshes =
+          moduleOp->getAttrOfType<ttcore::MeshesAttr>(ttcore::MeshesAttr::name);
+      meshes && !meshes.getMeshes().empty()) {
+    return llvm::SmallVector<int64_t>(meshes.getMeshes()[0].getShape());
+  }
+  llvm::SmallVector<mlir::sdy::MeshOp> meshOps =
+      mlir::tt::shardy_utils::getMeshOps(moduleOp);
+  if (!meshOps.empty()) {
+    return mlir::tt::shardy_utils::getMeshShapeFromMeshAttr(
+        meshOps[0].getMeshAttr());
+  }
+  return {};
+}
+
+// [numMeshDevices, numExperts] uint16 expert->device mapping synthesized from
+// topology so the frontend composite stays mesh-agnostic. Experts are compound-
+// sharded across ALL mesh devices, so owner(e) = e / expertsPerDevice; this is
+// source-independent (every row identical) and the a2a dispatch reader uses the
+// entry directly as the global target device (cluster_axis selects the dispatch
+// ring, not placement).
+static Value synthesizeMoeDecodeExpertMapping(OpBuilder &builder, Location loc,
+                                              ArrayRef<int64_t> meshShape,
+                                              int64_t expertsPerDevice) {
+  int64_t numMeshDevices = 1;
+  for (int64_t dim : meshShape) {
+    numMeshDevices *= dim;
+  }
+  int64_t numExperts = expertsPerDevice * numMeshDevices;
+
+  auto u16 = builder.getIntegerType(16, /*isSigned=*/false);
+  auto mappingTy = RankedTensorType::get({numMeshDevices, numExperts}, u16);
+
+  llvm::SmallVector<llvm::APInt> values;
+  values.reserve(numMeshDevices * numExperts);
+  for (int64_t d = 0; d < numMeshDevices; ++d) {
+    for (int64_t e = 0; e < numExperts; ++e) {
+      int64_t target = e / expertsPerDevice;
+      values.emplace_back(/*numBits=*/16, static_cast<uint64_t>(target),
+                          /*isSigned=*/false);
+    }
+  }
+  return builder.create<ttir::ConstantOp>(
+      loc, mappingTy, DenseElementsAttr::get(mappingTy, values));
+}
+
+// Reference decomposition of moe_decode into primitive ops (all_gather weights
+// -> two sparse_matmuls + GLU -> one-hot top-k select), inlined only when the
+// typed composite promotion is not taken. operands: [tokens, indices, scores,
+// mapping, w0, w1, w2, (b0,b1,b2)?]; scores/mapping unused here.
+static Value buildMoeDecodeDecompositionBody(
+    ConversionPatternRewriter &rewriter, Location loc, ValueRange operands,
+    bool hasBias, int64_t numDevices, int64_t clusterAxis, uint32_t layerId,
+    ttcore::MoEActivationFunction activation, RankedTensorType outputType) {
+
+  Value tokens = operands[0];
+  Value indices = operands[1];
+  Value w0 = operands[4], w1 = operands[5], w2 = operands[6];
+  Value bias0 = hasBias ? operands[7] : Value();
+  Value bias1 = hasBias ? operands[8] : Value();
+  Value bias2 = hasBias ? operands[9] : Value();
+
+  auto tokensTy = mlir::cast<RankedTensorType>(tokens.getType());
+  auto idxTy = mlir::cast<RankedTensorType>(indices.getType());
+  auto w0Ty = mlir::cast<RankedTensorType>(w0.getType());
+  Type act = tokensTy.getElementType();
+  Type f32 = rewriter.getF32Type();
+
+  int64_t M = tokensTy.getShape()[tokensTy.getRank() - 2];
+  int64_t H = tokensTy.getShape().back();
+  int64_t K = idxTy.getShape().back();
+  int64_t N = w0Ty.getShape()[3];
+  int64_t Eg = w0Ty.getShape()[1] * numDevices; // global expert count
+
+  auto rt = [&](ArrayRef<int64_t> s, Type e) {
+    return RankedTensorType::get(s, e);
+  };
+  auto reshape = [&](Value v, ArrayRef<int64_t> s) -> Value {
+    Type e = mlir::cast<RankedTensorType>(v.getType()).getElementType();
+    return rewriter.create<ttir::ReshapeOp>(
+        loc, rt(s, e), v,
+        rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(s)));
+  };
+  // all_gather along `dim` over the cluster axis: EP-sharded -> global experts.
+  auto allGather = [&](Value v, int64_t dim) -> Value {
+    auto t = mlir::cast<RankedTensorType>(v.getType());
+    SmallVector<int64_t> s(t.getShape());
+    s[dim] *= numDevices;
+    return rewriter.create<ttir::AllGatherOp>(
+        loc, rt(s, t.getElementType()), v, static_cast<int32_t>(dim),
+        static_cast<uint32_t>(clusterAxis));
+  };
+  // Fuse gate/up into one [..., 2C] weight via a block concat [gate | up], not
+  // a stride-2 interleave (whose trailing size-2 dim tilizes to 32 -> 16x DRAM
+  // blowup). The halves are split back out before the GLU.
+  auto fuseLast = [&](Value lhs, Value rhs) -> Value {
+    auto t = mlir::cast<RankedTensorType>(lhs.getType());
+    SmallVector<int64_t> sout(t.getShape());
+    sout.back() *= 2;
+    return rewriter.create<ttir::ConcatOp>(
+        loc, rt(sout, t.getElementType()), ValueRange{lhs, rhs},
+        static_cast<int32_t>(sout.size() - 1));
+  };
+  // out[1,Eg,M,C] += bias[1,Eg,C], broadcast over the token dim.
+  auto addBias = [&](Value x, Value bias, int64_t C) -> Value {
+    return rewriter.create<ttir::AddOp>(loc, rt({1, Eg, M, C}, act), x,
+                                        reshape(bias, {1, Eg, 1, C}));
+  };
+
+  // Stacked multi-layer weights [L, E, ...]: select this op's layer via layerId
+  // (sparse_matmul needs leading dim 1; the reference body is single-layer).
+  // L==1 passes through unchanged.
+  auto sliceLayer = [&](Value w) -> Value {
+    auto t = mlir::cast<RankedTensorType>(w.getType());
+    ArrayRef<int64_t> shape = t.getShape();
+    if (shape.empty() || shape[0] <= 1) {
+      return w;
+    }
+    SmallVector<int64_t> outShape(shape.begin(), shape.end());
+    outShape[0] = 1;
+    SmallVector<int32_t> begins, ends, steps;
+    for (size_t d = 0; d < shape.size(); ++d) {
+      begins.push_back(d == 0 ? static_cast<int32_t>(layerId) : 0);
+      ends.push_back(d == 0 ? static_cast<int32_t>(layerId) + 1
+                            : static_cast<int32_t>(shape[d]));
+      steps.push_back(1);
+    }
+    return rewriter.create<ttir::SliceStaticOp>(
+        loc, rt(outShape, t.getElementType()), w,
+        rewriter.getI32ArrayAttr(begins), rewriter.getI32ArrayAttr(ends),
+        rewriter.getI32ArrayAttr(steps));
+  };
+  w0 = sliceLayer(w0);
+  w1 = sliceLayer(w1);
+  w2 = sliceLayer(w2);
+  if (hasBias) {
+    bias0 = sliceLayer(bias0);
+    bias1 = sliceLayer(bias1);
+    bias2 = sliceLayer(bias2);
+  }
+
+  // 1. all_gather weights (+ biases) to replicate every expert locally.
+  Value w0g = allGather(w0, 1); // [1, Eg, H, N]
+  Value w1g = allGather(w1, 1);
+  Value w2g = allGather(w2, 1);       // [1, Eg, N, H]
+  Value wGateUp = fuseLast(w0g, w1g); // [1, Eg, H, 2N]
+  Value bGateUp, b2g;
+  if (hasBias) {
+    bGateUp = fuseLast(allGather(bias0, 1), allGather(bias1, 1)); // [1,Eg,2N]
+    b2g = allGather(bias2, 1);                                    // [1,Eg,H]
+  }
+
+  // 2. one_hot[m,k,e] = (indices[m,k] == e), in f32 for an exact int compare.
+  Value idxB = rewriter.create<ttir::BroadcastOp>(
+      loc, rt({M, K, Eg}, f32),
+      reshape(rewriter.create<ttir::TypecastOp>(loc, rt({M, K}, f32),
+                                                reshape(indices, {M, K})),
+              {M, K, 1}),
+      rewriter.getDenseI64ArrayAttr({1, 1, Eg}));
+  Value arangeE = rewriter.create<ttir::ArangeOp>(
+      loc, rt({M, K, Eg}, f32), /*start=*/0, /*end=*/Eg, /*step=*/1,
+      /*arange_dimension=*/2);
+  Value oneHot = rewriter.create<ttir::TypecastOp>(
+      loc, rt({M, K, Eg}, act),
+      rewriter.create<ttir::EqualOp>(loc, rt({M, K, Eg}, rewriter.getI1Type()),
+                                     idxB, arangeE));
+
+  // All-ones sparsity (compute every expert): a real per-token mask lets
+  // sparse_matmul skip experts, leaving garbage the one-hot select folds in
+  // (0 * NaN). In decode nearly every expert is selected, so this is ~free.
+  Value sparsity = rewriter.create<ttir::FullOp>(
+      loc, rt({1, 1, 1, Eg}, act), rewriter.getF32FloatAttr(1.0f));
+
+  // 3. gate_up: a[1,1,M,H] . b[1,Eg,H,2N] -> [1,1,1,Eg,M,2N] -> [1,Eg,M,2N].
+  Value gateUp4d = reshape(
+      rewriter.create<ttir::SparseMatmulOp>(
+          loc, rt({1, 1, 1, Eg, M, 2 * N}, act), tokens, wGateUp, sparsity,
+          /*is_input_a_sparse=*/rewriter.getBoolAttr(false),
+          /*is_input_b_sparse=*/rewriter.getBoolAttr(true),
+          /*nnz=*/mlir::IntegerAttr()),
+      {1, Eg, M, 2 * N});
+  if (hasBias) {
+    gateUp4d = addBias(gateUp4d, bGateUp, 2 * N);
+  }
+
+  // 4. split the [gate | up] halves + GLU activation.
+  auto interTy = rt({1, Eg, M, N}, act);
+  auto half = [&](int64_t start) -> Value {
+    return rewriter.create<ttir::SliceStaticOp>(
+        loc, interTy, gateUp4d,
+        rewriter.getI32ArrayAttr({0, 0, 0, static_cast<int32_t>(start)}),
+        rewriter.getI32ArrayAttr({1, static_cast<int32_t>(Eg),
+                                  static_cast<int32_t>(M),
+                                  static_cast<int32_t>(start + N)}),
+        rewriter.getI32ArrayAttr({1, 1, 1, 1}));
+  };
+  Value gate = half(0), up = half(N);
+  Value inter;
+  if (activation == ttcore::MoEActivationFunction::SwiGLU) {
+    // (clamp(up,-7,7) + 1) * clamp(gate,_,7) * sigmoid(1.702 * gate_c).
+    Value gateC = rewriter.create<ttir::ClampScalarOp>(
+        loc, interTy, gate,
+        rewriter.getF32FloatAttr(std::numeric_limits<float>::lowest()),
+        rewriter.getF32FloatAttr(7.0f));
+    Value upC = rewriter.create<ttir::ClampScalarOp>(
+        loc, interTy, up, rewriter.getF32FloatAttr(-7.0f),
+        rewriter.getF32FloatAttr(7.0f));
+    Value sig = rewriter.create<ttir::SigmoidOp>(
+        loc, interTy,
+        rewriter.create<ttir::MultiplyOp>(
+            loc, interTy, gateC,
+            rewriter.create<ttir::FullOp>(loc, interTy,
+                                          rewriter.getF32FloatAttr(1.702f))));
+    Value up1 = rewriter.create<ttir::AddOp>(
+        loc, interTy, upC,
+        rewriter.create<ttir::FullOp>(loc, interTy,
+                                      rewriter.getF32FloatAttr(1.0f)));
+    inter = rewriter.create<ttir::MultiplyOp>(
+        loc, interTy,
+        rewriter.create<ttir::MultiplyOp>(loc, interTy, up1, gateC), sig);
+  } else {
+    inter = rewriter.create<ttir::MultiplyOp>(
+        loc, interTy, rewriter.create<ttir::SiluOp>(loc, interTy, gate), up);
+  }
+
+  // 5. down: a[1,Eg,M,N] . b[1,Eg,N,H] -> [1,Eg,M,H].
+  Value down = rewriter.create<ttir::SparseMatmulOp>(
+      loc, rt({1, Eg, M, H}, act), inter, w2g, sparsity,
+      /*is_input_a_sparse=*/rewriter.getBoolAttr(true),
+      /*is_input_b_sparse=*/rewriter.getBoolAttr(false),
+      /*nnz=*/mlir::IntegerAttr());
+  if (hasBias) {
+    down = addBias(down, b2g, H);
+  }
+
+  // 6. top-k select: one_hot[M,K,Eg] . out_all[M,Eg,H] -> [M,K,H] -> [K,M,H].
+  Value outAll = rewriter.create<ttir::PermuteOp>(
+      loc, rt({M, Eg, H}, act), reshape(down, {Eg, M, H}),
+      rewriter.getDenseI64ArrayAttr({1, 0, 2}));
+  Value combine =
+      rewriter.create<ttir::MatmulOp>(loc, rt({M, K, H}, act), oneHot, outAll);
+  return rewriter.create<ttir::PermuteOp>(
+      loc, outputType, combine, rewriter.getDenseI64ArrayAttr({1, 0, 2}));
+}
+
+// Converts stablehlo.custom_call @tt.moe_decode -> ttcore.composite
+// "moe_decode". Mirrors the flash_mla_prefill pattern.
+class StableHLOToTTCoreMoeDecodeOpConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
+  using OpConversionPattern<mlir::stablehlo::CustomCallOp>::OpConversionPattern;
+
+public:
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CustomCallOp srcOp,
+                  mlir::stablehlo::CustomCallOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (adaptor.getCallTargetNameAttr().getValue() !=
+        mlir::tt::stablehlo::utils::kTTMoeDecodeCompositeName) {
+      return failure();
+    }
+
+    // Attributes arrive either as string mhlo.frontend_attributes (Route B:
+    // direct custom_call) or typed tt.composite_attributes (Route A: composite
+    // flattened to a custom_call via kCompositesWithCustomSharding).
+    mlir::DictionaryAttr compAttrs =
+        mlir::dyn_cast_or_null<mlir::DictionaryAttr>(srcOp->getDiscardableAttr(
+            mlir::tt::stablehlo::utils::kCustomCallCompositeAttrsKey));
+    mlir::DictionaryAttr fe = mlir::dyn_cast_or_null<mlir::DictionaryAttr>(
+        srcOp->getDiscardableAttr("mhlo.frontend_attributes"));
+    if (!compAttrs && !fe) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode op must have tt.composite_attributes or "
+                 "mhlo.frontend_attributes.");
+    }
+
+    // Required integer attributes: typed IntegerAttr (Route A) or
+    // string-encoded (Route B).
+    auto readReqInt = [&](StringRef name, int64_t &out) -> LogicalResult {
+      if (compAttrs) {
+        if (auto i = compAttrs.getAs<mlir::IntegerAttr>(name)) {
+          out = i.getInt();
+          return success();
+        }
+      }
+      if (fe) {
+        if (auto s = fe.getAs<mlir::StringAttr>(name)) {
+          if (llvm::to_integer(s.getValue(), out)) {
+            return success();
+          }
+        }
+      }
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode requires integer attribute '" + name.str() + "'.");
+    };
+    // num_devices is NOT a composite attribute: the frontend composite is
+    // mesh-agnostic, so the dispatch-ring device count is derived here from the
+    // module mesh (num_devices = meshShape[cluster_axis]).
+    int64_t clusterAxis, layerId, outputHeightShardDim, intermediateSize;
+    if (failed(readReqInt("cluster_axis", clusterAxis)) ||
+        failed(readReqInt("layer_id", layerId)) ||
+        failed(readReqInt("output_height_shard_dim", outputHeightShardDim)) ||
+        failed(readReqInt("intermediate_size", intermediateSize))) {
+      return failure();
+    }
+
+    llvm::SmallVector<int64_t> meshShape =
+        getModuleMeshShape(srcOp->getParentOfType<ModuleOp>());
+    if (clusterAxis < 0 ||
+        clusterAxis >= static_cast<int64_t>(meshShape.size())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode: cluster_axis out of range for the module mesh "
+                 "(no ttcore.meshes / sdy.mesh, or bad cluster_axis).");
+    }
+    int64_t numDevices = meshShape[clusterAxis];
+
+    // activation_function (optional, default silu). StringAttr in both forms.
+    ttcore::MoEActivationFunction activation =
+        ttcore::MoEActivationFunction::Silu;
+    mlir::StringAttr actStr;
+    if (compAttrs) {
+      actStr = compAttrs.getAs<mlir::StringAttr>("activation_function");
+    }
+    if (!actStr && fe) {
+      actStr = fe.getAs<mlir::StringAttr>("activation_function");
+    }
+    if (actStr) {
+      if (auto sym =
+              ttcore::symbolizeMoEActivationFunction(actStr.getValue())) {
+        activation = *sym;
+      } else {
+        return rewriter.notifyMatchFailure(
+            srcOp, "unknown activation_function '" + actStr.getValue() + "'.");
+      }
+    }
+
+    // bh_ring_size (optional): IntegerAttr (Route A) or string (Route B).
+    std::optional<uint32_t> bhRingSize;
+    if (compAttrs) {
+      if (auto i = compAttrs.getAs<mlir::IntegerAttr>("bh_ring_size")) {
+        bhRingSize = static_cast<uint32_t>(i.getInt());
+      }
+    }
+    if (!bhRingSize && fe) {
+      if (auto brStr = fe.getAs<mlir::StringAttr>("bh_ring_size")) {
+        uint32_t br;
+        if (!llvm::to_integer(brStr.getValue(), br)) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "bh_ring_size must be an integer.");
+        }
+        bhRingSize = br;
+      }
+    }
+
+    // Mesh-agnostic composite omits expert_mapping (6/9 operands: tokens,
+    // indices, scores, w0, w1, w2, [bias0,1,2]); synthesized below and
+    // re-inserted at index 3 to restore the 7/10-operand contract.
+    auto srcOperands = adaptor.getOperands();
+    if (srcOperands.size() != 6 && srcOperands.size() != 9) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "moe_decode expects 6 (no bias) or 9 (bias) operands.");
+    }
+    bool hasBias = srcOperands.size() == 9;
+
+    RankedTensorType outputType = mlir::cast<RankedTensorType>(
+        getTypeConverter()->convertType(srcOp.getResult(0).getType()));
+
+    // w0 is operand index 3 ([L, E_local, H, N]); its expert dim is the
+    // EP-sharded experts-per-device.
+    auto w0Ty = mlir::cast<RankedTensorType>(srcOperands[3].getType());
+    int64_t expertsPerDevice = w0Ty.getShape()[1];
+    Value mapping = synthesizeMoeDecodeExpertMapping(
+        rewriter, srcOp.getLoc(), meshShape, expertsPerDevice);
+
+    // Full operand list with mapping re-inserted at index 3.
+    SmallVector<Value> operands;
+    operands.reserve(srcOperands.size() + 1);
+    operands.append(srcOperands.begin(), srcOperands.begin() + 3);
+    operands.push_back(mapping);
+    operands.append(srcOperands.begin() + 3, srcOperands.end());
+
+    // Synthesize the private decomposition function.
+    ModuleOp moduleOp = srcOp->getParentOfType<ModuleOp>();
+    std::string decompFuncName = "moe_decode_decomp";
+    {
+      unsigned counter = 0;
+      while (SymbolTable::lookupSymbolIn(moduleOp, decompFuncName)) {
+        decompFuncName = "moe_decode_decomp_" + std::to_string(counter++);
+      }
+    }
+    SmallVector<Type> argTypes =
+        llvm::to_vector(ValueRange(operands).getTypes());
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToEnd(moduleOp.getBody());
+      auto decompFunc = rewriter.create<func::FuncOp>(
+          srcOp.getLoc(), decompFuncName,
+          rewriter.getFunctionType(argTypes, {outputType}));
+      decompFunc.setPrivate();
+      Block *entry = decompFunc.addEntryBlock();
+      rewriter.setInsertionPointToStart(entry);
+      Value res = buildMoeDecodeDecompositionBody(
+          rewriter, srcOp.getLoc(), entry->getArguments(), hasBias, numDevices,
+          clusterAxis, static_cast<uint32_t>(layerId), activation, outputType);
+      rewriter.create<mlir::func::ReturnOp>(srcOp.getLoc(), res);
+    }
+
+    // Typed composite_attributes consumed by the TTNNResolveComposites
+    // "moe_decode" entry (ints as i64 IntegerAttr, activation as a StringAttr).
+    SmallVector<NamedAttribute> compositeAttrs;
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "num_devices", rewriter.getI64IntegerAttr(numDevices)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "cluster_axis", rewriter.getI64IntegerAttr(clusterAxis)));
+    compositeAttrs.push_back(
+        rewriter.getNamedAttr("layer_id", rewriter.getI64IntegerAttr(layerId)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "output_height_shard_dim",
+        rewriter.getI64IntegerAttr(outputHeightShardDim)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "intermediate_size", rewriter.getI64IntegerAttr(intermediateSize)));
+    compositeAttrs.push_back(rewriter.getNamedAttr(
+        "activation_function",
+        rewriter.getStringAttr(
+            ttcore::stringifyMoEActivationFunction(activation))));
+    if (bhRingSize) {
+      compositeAttrs.push_back(rewriter.getNamedAttr(
+          "bh_ring_size", rewriter.getI64IntegerAttr(*bhRingSize)));
+    }
+
+    auto composite = rewriter.create<ttcore::CompositeOp>(
+        srcOp.getLoc(), TypeRange{outputType}, operands,
+        rewriter.getStringAttr("moe_decode"),
+        FlatSymbolRefAttr::get(rewriter.getContext(), decompFuncName),
+        rewriter.getDictionaryAttr(compositeAttrs));
+    Value result = composite.getResult(0);
+
+    // Compound sharding: moe_compute's 1D combine reduces only the cluster
+    // axis, so each non-cluster device holds a partial; all_reduce(sum) over
+    // the non-cluster axis (unwritten slots are zero, so the sum is clean).
+    int64_t totalMeshDevices = 1;
+    for (int64_t dim : meshShape) {
+      totalMeshDevices *= dim;
+    }
+    int64_t nonClusterSize =
+        totalMeshDevices / std::max(numDevices, static_cast<int64_t>(1));
+    if (nonClusterSize > 1 && numDevices > 1) {
+      uint32_t reduceAxis = (clusterAxis == 0) ? 1 : 0;
+      result =
+          rewriter
+              .create<ttir::AllReduceOp>(srcOp.getLoc(), outputType, result,
+                                         ttcore::ReduceType::Sum, reduceAxis)
+              .getResult();
+    }
+    rewriter.replaceOp(srcOp, result);
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 // Pattern to convert mhlo.topk to ttir.topk
 class StableHLOTopKOpMHLOConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CustomCallOp> {
@@ -10429,6 +10893,7 @@ static void addScaledDotProductAttentionDecodeOpConversionPattern(
       StableHLOToTTIRScaledDotProductAttentionOpConversionPattern,
       StableHLOToTTIRPagedScaledDotProductAttentionDecodeOpConversionPattern,
       StableHLOToTTCoreFlashMlaPrefillOpConversionPattern,
+      StableHLOToTTCoreMoeDecodeOpConversionPattern,
       StableHLOToTTIRPagedFlashMLADecodeOpConversionPattern,
       StableHLOToTTCoreIndexerScoreDsaOpConversionPattern,
       StableHLOToTTIRChunkedScaledDotProductAttentionOpConversionPattern>(

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1842,12 +1842,14 @@ public:
     auto hasBiasAttr =
         rewriter.getBoolAttr(static_cast<bool>(adaptor.getBias_0()));
 
-    // Fabric-mux cores for the A2A combine; default to the 6U-test 3x3 block
-    // at (1,1)-(3,3) = 9 cores.
+    // Fabric-mux cores for the A2A combine: a 3x3 block at (5,5)-(7,7) = 9
+    // cores. Anchored bottom-right (not the top-left (1,1)-(3,3)) to stay clear
+    // of the column-0-anchored matmul ring + combine strip, so moe_compute's
+    // core placement fits on an 8x8 worker grid (e.g. n150/n300).
     MLIRContext *ctx = rewriter.getContext();
     ttnn::CoreRangeSetAttr muxCoreRangeSet = ttnn::CoreRangeSetAttr::get(
-        ctx, ttnn::CoreRangeAttr::get(ctx, ttnn::CoreCoordAttr::get(ctx, 1, 1),
-                                      ttnn::CoreCoordAttr::get(ctx, 3, 3)));
+        ctx, ttnn::CoreRangeAttr::get(ctx, ttnn::CoreCoordAttr::get(ctx, 5, 5),
+                                      ttnn::CoreCoordAttr::get(ctx, 7, 7)));
 
     // optional_output_tensor and cross_device_semaphore are left unbound here;
     // MoeComputeOp's DistributedOpInterface hooks binds them in the prelude.

--- a/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ApplyArgumentShardStatus.cpp
@@ -45,6 +45,20 @@ updateArgumentShardStatus(MLIRContext *context, mlir::ModuleOp &module,
       }
     }
 
+    // Respect a builder-set ttcore.shard_status instead of appending a
+    // duplicate (duplicate DictionaryAttr key aborts); only the pre-marked path
+    // hits this.
+    if (argAttrDict &&
+        argAttrDict.contains(mlir::tt::ttcore::ShardStatusAttr::name)) {
+      if (!shardyAnnotationsExist) {
+        mlir::NamedAttribute existing = {
+            mlir::tt::ttcore::ShardStatusAttr::name,
+            argAttrDict.get(mlir::tt::ttcore::ShardStatusAttr::name)};
+        gspmd_utils::updateShardStatusForArgument(context, arg, existing);
+      }
+      continue;
+    }
+
     mlir::NamedAttribute shardStatusNamedAttr = {
         mlir::tt::ttcore::ShardStatusAttr::name,
         mlir::tt::ttcore::ShardStatusAttr::get(context, shardStatus)};
@@ -96,6 +110,19 @@ updateResultShardStatus(MLIRContext *context, mlir::ModuleOp &module,
     if (resultAttrDict) {
       newResultAttrs =
           llvm::SmallVector<mlir::NamedAttribute>(resultAttrDict.getValue());
+    }
+
+    // Respect a pre-existing ttcore.shard_status (e.g. a builder-marked
+    // presharded result) instead of appending a duplicate DictionaryAttr key.
+    if (resultAttrDict &&
+        resultAttrDict.contains(mlir::tt::ttcore::ShardStatusAttr::name)) {
+      if (!shardy_utils::sdyAnnotationsExist(module)) {
+        mlir::NamedAttribute existing = {
+            mlir::tt::ttcore::ShardStatusAttr::name,
+            resultAttrDict.get(mlir::tt::ttcore::ShardStatusAttr::name)};
+        gspmd_utils::updateShardStatusForResult(context, funcOp, i, existing);
+      }
+      continue;
     }
 
     mlir::NamedAttribute shardStatusNamedAttr = {

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -1318,8 +1318,10 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
   }
 
   // Extract dimension sizes
-  int64_t bDim = inputType.getShape()[0];   // B
-  int64_t sDim = inputType.getShape()[1];   // S
+  int64_t bDim = inputType.getShape()[0]; // B
+  // The a2a_dispatch custom op canonicalizes operands to [B,1,S,H]/[B,1,S,K]
+  // (custom_ops.py reshape), so the token dim S is dim2, NOT dim1.
+  int64_t sDim = inputType.getShape()[2];   // S (dim2, the token dim)
   int64_t hDim = inputType.getShape()[3];   // H
   int64_t kDim = indicesType.getShape()[3]; // K
   int64_t eDim = mappingType.getShape()[2]; // E
@@ -1365,9 +1367,12 @@ getAllToAllDispatchShardingRule(mlir::stablehlo::CustomCallOp op) {
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
-  // S factor: input[0]=dim1, input[1]=dim1, input[2]=kNull,
-  //           result[0]=dim2, result[1]=dim2
-  builder.addFactor({1, 1, mlir::sdy::kNullDim}, {2, 2}, sDim,
+  // S factor: input[0]=dim2, input[1]=dim2, input[2]=kNull,
+  //           result[0]=dim2, result[1]=dim2. Tying input and indices on dim2
+  //           stops Shardy from independently resharding the indices' token dim
+  //           (96-vs-384 mismatch vs the batch-sharded input -> a2a shape
+  //           assert).
+  builder.addFactor({2, 2, mlir::sdy::kNullDim}, {2, 2}, sDim,
                     mlir::sdy::FactorType::kNeedReplication,
                     /*isBlocked=*/true);
 
@@ -1854,6 +1859,133 @@ getSamplingShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// =====================================================================
+// moe_decode sharding rule
+// =====================================================================
+// The moe_decode composite is opaque to Shardy (it hides the internal
+// dispatch/moe_compute/combine): shard the token dim on tokens/indices/scores
+// and the expert dim on weights along the cluster axis, replicate the rest.
+//
+// Operands (6 without bias, 9 with). expert_mapping is NOT an operand -- the
+// composite is mesh-agnostic; it is synthesized in StableHLOToTTIR.
+//   [0] tokens         [1, 1, M, H]
+//   [1] expert_indices [1, 1, M, K]
+//   [2] expert_scores  [1, 1, M, K]
+//   [3] w0             [L, E, H, N]
+//   [4] w1             [L, E, H, N]
+//   [5] w2             [L, E, N, H]
+//   [6] bias_0         [L, E, N]   (optional)
+//   [7] bias_1         [L, E, N]   (optional)
+//   [8] bias_2         [L, E, H]   (optional)
+// Result:
+//   [0] combine_output [K, M, H]
+static mlir::sdy::OpShardingRuleAttr
+getMoeDecodeShardingRule(mlir::stablehlo::CustomCallOp op) {
+  const int64_t numOperands = op.getNumOperands();
+  if (numOperands != 6 && numOperands != 9) {
+    op.getOperation()->emitWarning()
+        << "moe_decode expects 6 or 9 operands, got " << numOperands;
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+  const bool hasBias = numOperands == 9;
+
+  auto tokensType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto idxType = llvm::dyn_cast<RankedTensorType>(op.getOperand(1).getType());
+  auto w0Type = llvm::dyn_cast<RankedTensorType>(op.getOperand(3).getType());
+  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+
+  if (!tokensType || tokensType.getRank() != 4 || !idxType ||
+      idxType.getRank() != 4 || !w0Type || w0Type.getRank() != 4 ||
+      !resultType || resultType.getRank() != 3) {
+    op.getOperation()->emitWarning()
+        << "moe_decode: tokens/idx/w0 must be 4D and result 3D";
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  const int64_t mDim = tokensType.getShape()[2];
+  const int64_t hDim = tokensType.getShape()[3];
+  const int64_t kDim = idxType.getShape()[3];
+  const int64_t lDim = w0Type.getShape()[0];
+  const int64_t eDim = w0Type.getShape()[1];
+  const int64_t nDim = w0Type.getShape()[3];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  // Helper: build an operand-dim vector (length numOperands), all kNull except
+  // the listed (operandIdx -> dim) entries.
+  auto opDims =
+      [&](std::initializer_list<std::pair<int64_t, int64_t>> entries) {
+        SmallVector<int64_t> v(numOperands, mlir::sdy::kNullDim);
+        for (const auto &e : entries) {
+          v[e.first] = e.second;
+        }
+        return v;
+      };
+
+  // Token factor (M): tokens/idx/scr dim 2 -> result dim 1. kPassThrough so the
+  // cluster axis shards the data-parallel token dim through the composite.
+  builder.addFactor(opDims({{0, 2}, {1, 2}, {2, 2}}), {1}, mDim,
+                    mlir::sdy::FactorType::kPassThrough);
+
+  // Expert factor (E): w0/w1/w2 (and biases) dim 1. kPassThrough so the cluster
+  // axis shards the expert dim of the (global) weights into per-device experts.
+  {
+    SmallVector<int64_t> e = opDims({{3, 1}, {4, 1}, {5, 1}});
+    if (hasBias) {
+      e[6] = 1;
+      e[7] = 1;
+      e[8] = 1;
+    }
+    builder.addFactor(e, {mlir::sdy::kNullDim}, eDim,
+                      mlir::sdy::FactorType::kPassThrough);
+  }
+
+  // Hidden factor (H): tokens dim 3, w0/w1 dim 2, w2 dim 3, bias_2 dim 2 ->
+  // result dim 2. Replicated.
+  {
+    SmallVector<int64_t> h = opDims({{0, 3}, {3, 2}, {4, 2}, {5, 3}});
+    if (hasBias) {
+      h[8] = 2;
+    }
+    builder.addFactor(h, {2}, hDim, mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  // Intermediate factor (N): w0/w1 dim 3, w2 dim 2, bias_0/bias_1 dim 2.
+  // Replicated.
+  {
+    SmallVector<int64_t> n = opDims({{3, 3}, {4, 3}, {5, 2}});
+    if (hasBias) {
+      n[6] = 2;
+      n[7] = 2;
+    }
+    builder.addFactor(n, {mlir::sdy::kNullDim}, nDim,
+                      mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  // TopK factor (K): idx/scr dim 3 -> result dim 0. Replicated.
+  builder.addFactor(opDims({{1, 3}, {2, 3}}), {0}, kDim,
+                    mlir::sdy::FactorType::kNeedReplication,
+                    /*isBlocked=*/true);
+
+  // Layer factor (L): w0/w1/w2 (and biases) dim 0. Replicated.
+  {
+    SmallVector<int64_t> l = opDims({{3, 0}, {4, 0}, {5, 0}});
+    if (hasBias) {
+      l[6] = 0;
+      l[7] = 0;
+      l[8] = 0;
+    }
+    builder.addFactor(l, {mlir::sdy::kNullDim}, lDim,
+                      mlir::sdy::FactorType::kNeedReplication,
+                      /*isBlocked=*/true);
+  }
+
+  return builder.build();
+}
+
 // Sharding rule for RMS norm custom_call (converted from composite).
 //
 // Operands:
@@ -2083,6 +2215,7 @@ private:
           {allToAllDispatchTargetName, getAllToAllDispatchShardingRule},
           {allToAllCombineTargetName, getAllToAllCombineShardingRule},
           {moeExpertTokenRemapTargetName, getMoeExpertTokenRemapShardingRule},
+          {utils::kTTMoeDecodeCompositeName, getMoeDecodeShardingRule},
           {utils::kTTRMSNormCustomCallTargetName, getRMSNormShardingRule},
           {flashMlaPrefillTargetName, getFlashMlaPrefillShardingRule},
           {indexerScoreDsaTargetName, getIndexerScoreDsaShardingRule},

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -31,6 +31,7 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+#include <atomic>
 #include <cstdint>
 #include <numeric>
 #include <optional>
@@ -3340,16 +3341,32 @@ void MoeComputeOp::allocateBuffers(::mlir::RewriterBase &rewriter) {
   auto device = utils::getOrInsertDevice(rewriter, *this);
 
   // Insert in the prelude (after GetDeviceOp) so it is trace-hoistable.
-  ttnn::EmptyOp combineEmptyOp;
+  // ZerosOp (not EmptyOp): the combine writer only fills pages whose expert is
+  // local to this device, so pages for a token's experts on other non-cluster
+  // columns are never written and must read 0 for the downstream
+  // all_reduce(sum) over the non-cluster axis to aggregate cleanly.
+  ttnn::ZerosOp combineZerosOp;
   {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.setInsertionPointAfter(device);
-    combineEmptyOp = rewriter.create<ttnn::EmptyOp>(getLoc(), combineType,
+    combineZerosOp = rewriter.create<ttnn::ZerosOp>(getLoc(), combineType,
                                                     device, combineShapeAttr);
   }
 
+  // The buffer takes sparse in-place writes, so it must be re-zeroed per step
+  // and not shared across layers. Two discardable attrs enforce that:
+  //  - "ttnn.non_cacheable": keep it inline (not const-eval hoisted/cached) so
+  //    the runtime re-zeros it each step instead of retaining prior writes.
+  //  - "ttnn.combine_output_id" (unique): stop CSE from merging the per-layer
+  //    buffers.
+  combineZerosOp->setAttr("ttnn.non_cacheable", rewriter.getUnitAttr());
+  static std::atomic<int64_t> combineOutputUniquifier{0};
+  combineZerosOp->setAttr(
+      "ttnn.combine_output_id",
+      rewriter.getI64IntegerAttr(combineOutputUniquifier.fetch_add(1)));
+
   rewriter.modifyOpInPlace(*this, [&]() {
-    getOptionalOutputTensorMutable().assign(combineEmptyOp.getResult());
+    getOptionalOutputTensorMutable().assign(combineZerosOp.getResult());
   });
 }
 // NOLINTEND(clang-analyzer-core.StackAddressEscape)
@@ -3400,9 +3417,7 @@ namespace {
 // (matches tt-metal's compute_output_specs).
 TTNNLayoutAttr getA2ADrainShardedLayout(MLIRContext *ctx,
                                         RankedTensorType resultType,
-                                        CoreCoordAttr drainCore) {
-  auto drainRange = CoreRangeAttr::get(ctx, drainCore, drainCore);
-  auto drainCrs = CoreRangeSetAttr::get(ctx, {drainRange});
+                                        CoreRangeSetAttr drainCrs) {
   llvm::SmallVector<int64_t, 2> gridShape{1, 1};
   return TTNNLayoutAttr::Builder(resultType)
       .setBufferType(BufferType::L1)
@@ -3438,9 +3453,17 @@ void AllToAllDispatchMetadataOp::allocateBuffers(
 
   MLIRContext *ctx = rewriter.getContext();
 
-  // Persistent-mode drain core: the kernel derives it from the indices/scores
-  // shard spec, so we fix the shard placement to (0,0) here.
-  auto drainCore = CoreCoordAttr::get(ctx, /*x=*/0, /*y=*/0);
+  // Place the persistent indices/scores on moe_compute's tilize drain core
+  // (stashed as ttnn.moe_metadata_drain_core by
+  // TTNNAllocateDistributedOpBuffers) to avoid a cross-core reshard that
+  // deadlocks the collective. Default (0,0).
+  CoreRangeSetAttr drainCrs =
+      (*this)->getAttrOfType<CoreRangeSetAttr>("ttnn.moe_metadata_drain_core");
+  if (!drainCrs) {
+    auto drainCore = CoreCoordAttr::get(ctx, /*x=*/0, /*y=*/0);
+    drainCrs = CoreRangeSetAttr::get(
+        ctx, {CoreRangeAttr::get(ctx, drainCore, drainCore)});
+  }
 
   auto dispatchedType = cast<RankedTensorType>(getDispatched().getType());
   auto indicesType = cast<RankedTensorType>(getIndices().getType());
@@ -3449,9 +3472,9 @@ void AllToAllDispatchMetadataOp::allocateBuffers(
   auto newDispatchedType = utils::RankedTensorTypeFactory::create(
       dispatchedType, getA2ADispatchedLayout(ctx, dispatchedType));
   auto newIndicesType = utils::RankedTensorTypeFactory::create(
-      indicesType, getA2ADrainShardedLayout(ctx, indicesType, drainCore));
+      indicesType, getA2ADrainShardedLayout(ctx, indicesType, drainCrs));
   auto newScoresType = utils::RankedTensorTypeFactory::create(
-      scoresType, getA2ADrainShardedLayout(ctx, scoresType, drainCore));
+      scoresType, getA2ADrainShardedLayout(ctx, scoresType, drainCrs));
 
   auto device = utils::getOrInsertDevice(rewriter, *this);
 

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1647,6 +1647,19 @@ TTNNOperandsWorkaroundsFactory::createMoeComputeOpOperandsWorkarounds(
   rmU16.tensorLayoutWorkaround = Layout::RowMajor;
   rmU16.tensorDataTypeWorkaround = ttcore::DataType::UInt16;
 
+  // Pin indices/scores to L1 HeightSharded to match the a2a's persistent L1
+  // metadata in place (a reshard deadlocks the collective; DRAM would fail
+  // "Only L1 buffers can have an associated circular buffer").
+  TTNNOperandWorkarounds l1ShardedRmU16 = rmU16;
+  l1ShardedRmU16.tensorBufferTypeWorkaround = BufferType::L1;
+  l1ShardedRmU16.tensorMemoryLayoutWorkaround = TensorMemoryLayoutAttr::get(
+      op.getContext(), TensorMemoryLayout::HeightSharded);
+
+  TTNNOperandWorkarounds l1ShardedRmBf16 = rmBf16;
+  l1ShardedRmBf16.tensorBufferTypeWorkaround = BufferType::L1;
+  l1ShardedRmBf16.tensorMemoryLayoutWorkaround = TensorMemoryLayoutAttr::get(
+      op.getContext(), TensorMemoryLayout::HeightSharded);
+
   // combine output: ROW_MAJOR, DRAM INTERLEAVED, bfloat16.
   TTNNOperandWorkarounds combineOutput;
   combineOutput.tensorLayoutWorkaround = Layout::RowMajor;
@@ -1657,14 +1670,18 @@ TTNNOperandsWorkaroundsFactory::createMoeComputeOpOperandsWorkarounds(
 
   TTNNOperandWorkarounds none;
 
+  // Pin indices/scores ROW_MAJOR (the kernel reads them untilized) so layout
+  // propagation doesn't tilize them.
   TTNNOperandsWorkarounds w =
       TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
           .addInputOperandWorkaround(rmBf16) // tilize_input_tensor
-          .addInputOperandWorkaround(none)   // tilize_expert_indices_tensor
-          .addInputOperandWorkaround(none)   // tilize_expert_scores_tensor
-          .addInputOperandWorkaround(rmU16)  // tilize_expert_mapping_tensor
-          .addInputOperandWorkaround(none)   // matmul_w0_w1_tensor
-          .addInputOperandWorkaround(none);  // matmul_w2_tensor
+          .addInputOperandWorkaround(
+              l1ShardedRmU16) // tilize_expert_indices_tensor
+          .addInputOperandWorkaround(
+              l1ShardedRmBf16)              // tilize_expert_scores_tensor
+          .addInputOperandWorkaround(rmU16) // tilize_expert_mapping_tensor
+          .addInputOperandWorkaround(none)  // matmul_w0_w1_tensor
+          .addInputOperandWorkaround(none); // matmul_w2_tensor
 
   // optional_output_tensor, when bound, already has the correct combine spec;
   // add a no-op workaround so the count matches the tensor-input count.

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNDeduceMoEComputeLayouts.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/TTNNDeduceMoEComputeLayouts.cpp
@@ -62,47 +62,10 @@ public:
     }
   }
 
-  // Reshard a moe_compute tilize input (expert indices or scores) onto the
-  // device-derived tilize-drain core. The fused kernel allocates the indices/
-  // scores circular buffers against an L1 buffer on that single core but never
-  // checks placement, so we pin it here in IR. The reshard is ROW_MAJOR + L1 +
-  // single-core HEIGHT_SHARDED: the kernel reads these untilized, and a sharded
-  // TILE spec needs a 32x32-aligned shard the small last dim (select_experts_k)
-  // can't satisfy.
-  void reshardTilizeInputToDrainCore(ttnn::MoeComputeOp op, unsigned operandIdx,
-                                     CoreRangeSetAttr drainCoreRangeSet) {
-    mlir::IRRewriter rewriter(op.getContext());
-    rewriter.setInsertionPoint(op);
-
-    auto inputValue = mlir::cast<mlir::TypedValue<mlir::RankedTensorType>>(
-        op->getOperand(operandIdx));
-    mlir::RankedTensorType inputType = inputValue.getType();
-
-    llvm::SmallVector<int64_t, 2> gridShape{1, 1};
-    TTNNLayoutAttr drainLayout =
-        TTNNLayoutAttr::Builder(inputType)
-            .setLayout(Layout::RowMajor)
-            .setBufferType(BufferType::L1)
-            .setMemoryLayout(TensorMemoryLayoutAttr::get(
-                op.getContext(), TensorMemoryLayout::HeightSharded))
-            .setGridShape(gridShape)
-            .setCoreRangeSet(drainCoreRangeSet)
-            .build();
-    mlir::RankedTensorType drainType =
-        utils::RankedTensorTypeFactory::create(inputType, drainLayout);
-
-    auto toMemCfg = rewriter.create<ttnn::ToMemoryConfigOp>(
-        op.getLoc(), drainType, inputValue);
-
-    rewriter.modifyOpInPlace(
-        op, [&]() { op->setOperand(operandIdx, toMemCfg.getResult()); });
-  }
-
   // The weight-prep ops are created with placeholder result types. Replace them
-  // with the device-derived specs OpModel computes via graph-captured query of
-  // the matching tt-metal invocation. Consumers read the deduced types via
-  // use-def. Also reshards moe_compute's expert indices/scores inputs onto the
-  // device-derived tilize drain core.
+  // with the device-derived specs OpModel computes via a graph-captured query
+  // of the matching tt-metal invocation; consumers read the deduced types via
+  // use-def.
   void runOnOperation() final {
 #ifndef TTMLIR_ENABLE_OPMODEL
     llvm::llvm_unreachable_internal("TTNNDeduceMoEComputeLayouts requires "
@@ -123,14 +86,10 @@ public:
       refreshEnclosingFuncReturnType(op.getResult());
     });
 
-    moduleOp.walk([&](ttnn::MoeComputeOp op) {
-      CoreRangeSetAttr drainCoreRangeSet =
-          op_model::getMoeTilizeDrainCoreRangeSet(&op);
-      // Operands 1 (expert indices) and 2 (expert scores) are read by the
-      // kernel from CBs allocated on the drain core.
-      reshardTilizeInputToDrainCore(op, /*operandIdx=*/1, drainCoreRangeSet);
-      reshardTilizeInputToDrainCore(op, /*operandIdx=*/2, drainCoreRangeSet);
-    });
+    // The a2a metadata is placed directly on moe_compute's tilize drain core
+    // (TTNNAllocateDistributedOpBuffers + the L1-HeightShard operand
+    // workarounds), so the persistent buffers are not resharded here (the
+    // reshard deadlocked).
 #endif // TTMLIR_ENABLE_OPMODEL
   }
 };

--- a/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNAllocateDistributedOpBuffers.cpp
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Interfaces/TTNNDistributedOpInterface.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/OpModel/TTNN/TTNNOutputTensorInference.h"
 
 #include "mlir/IR/PatternMatch.h"
 
@@ -27,6 +30,38 @@ public:
   void runOnOperation() final {
     ModuleOp moduleOp = getOperation();
     IRRewriter rewriter(&getContext());
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+    // Align each a2a's persistent metadata drain core to the core its consumer
+    // moe_compute reads from, else the layout pipeline reshards the persistent
+    // buffers and deadlocks. Stash it as ttnn.moe_metadata_drain_core (read by
+    // AllToAllDispatchMetadataOp::allocateBuffers); done here so no pass drops
+    // it.
+    // Only open the OpModel device context if there is actually a moe_compute
+    // op to serve: constructing the guard opens a (mock) device, which is
+    // costly and, on non-MoE graphs, spuriously initializes the device and
+    // leaks tt-metal/UMD logs to stdout -- corrupting tools that consume this
+    // pass's output (e.g. the EmitC two-stage lit tests, whose second stage
+    // then fails to parse the contaminated MLIR).
+    llvm::SmallVector<ttnn::MoeComputeOp> moeComputeOps;
+    moduleOp.walk([&](ttnn::MoeComputeOp mc) { moeComputeOps.push_back(mc); });
+    if (!moeComputeOps.empty()) {
+      op_model::ScopedSingletonDeviceGuard deviceGuard(moduleOp);
+      for (ttnn::MoeComputeOp mc : moeComputeOps) {
+        CoreRangeSetAttr drainCrs =
+            op_model::getMoeTilizeDrainCoreRangeSet(&mc);
+        // The persistent metadata (dispatched/indices/scores) all originate at
+        // the producer a2a; find it via moe_compute's inputs.
+        for (mlir::Value operand : mc->getOperands()) {
+          if (auto a2a =
+                  operand.getDefiningOp<ttnn::AllToAllDispatchMetadataOp>()) {
+            a2a->setAttr("ttnn.moe_metadata_drain_core", drainCrs);
+            break;
+          }
+        }
+      }
+    }
+#endif // TTMLIR_ENABLE_OPMODEL
 
     moduleOp.walk(
         [&](DistributedOpInterface op) { op.allocateBuffers(rewriter); });

--- a/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLayout.cpp
@@ -239,10 +239,24 @@ public:
       Location newLoc =
           appendInputSuffix(op->getLoc(), operand.getOperandNumber());
 
+      // all_gather is layout-preserving: keep integer operands (e.g. ui32
+      // argmax->next-token indices) row-major so the gather's input matches its
+      // row-major result (see shouldTilizeResult); tilizing only the operand
+      // trips the AllGatherOp layout verifier.
+      bool operandTiled = true;
+      if (mlir::isa<ttir::AllGatherOp>(op)) {
+        Type operandElemTy =
+            mlir::cast<RankedTensorType>(operand.get().getType())
+                .getElementType();
+        if (operandElemTy.isInteger()) {
+          operandTiled = false;
+        }
+      }
+
       // Given the operand constraint, create the desired layout for the operand
       std::optional<Value> desiredLayout = createToLayoutOp(
           rewriter, newLoc, operand.get(), g_defaultMemorySpaceDevice,
-          /*tiled=*/true);
+          /*tiled=*/operandTiled);
 
       // If layout changed update the operand
       if (desiredLayout) {
@@ -285,6 +299,19 @@ private:
     // Conv3d produces ROW_MAJOR output at runtime (experimental op)
     if (mlir::isa<ttir::Conv3dOp>(op)) {
       return false;
+    }
+
+    // ttnn.all_gather is layout-preserving (it cannot convert between tiled and
+    // row-major). Integer tensors (e.g. the ui32 argmax->next-token index in
+    // the sampling path) are produced row-major, so keep the gather row-major
+    // too; forcing tile trips the AllGatherOp layout verifier. Float gathers
+    // stay tiled as before.
+    if (mlir::isa<ttir::AllGatherOp>(op)) {
+      Type elemTy = mlir::cast<RankedTensorType>(op->getResult(0).getType())
+                        .getElementType();
+      if (elemTy.isInteger()) {
+        return false;
+      }
     }
 
     return true;

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -7,16 +7,20 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/Transforms/OpValidator.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Passes.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/SymbolTable.h"
 
 #include "ttmlir/Asserts.h"
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -111,6 +115,71 @@ getIndexerScoreDsaClusterAxis(ttcore::CompositeOp compositeOp) {
     return {};
   }
   return attrs.getAs<mlir::IntegerAttr>("cluster_axis");
+}
+
+// Operands/attributes recovered from a "moe_decode" composite (fuses
+// all_to_all_dispatch_metadata + weight-prep + moe_compute). Device-free build;
+// the tilize-drain core is finalized later by TTNNDeduceMoEComputeLayouts.
+struct MoeDecodeCompositeArgs {
+  Value tokens;
+  Value expertIndices;
+  Value expertScores;
+  Value expertMapping;
+  Value w0, w1, w2;
+  Value bias0, bias1, bias2; // null when has_bias is false
+  bool hasBias = false;
+  int64_t numDevices = 0;
+  int64_t clusterAxis = 0;
+  int64_t layerId = 0;
+  int64_t outputHeightShardDim = 0;
+  int64_t intermediateSize = 0;
+  ttcore::MoEActivationFunction activation =
+      ttcore::MoEActivationFunction::Silu;
+};
+
+// inputs: [tokens, expert_indices, expert_scores, expert_mapping, w0, w1, w2,
+//          (bias_0, bias_1, bias_2)?]  (7 without bias, 10 with).
+static MoeDecodeCompositeArgs
+extractMoeDecodeArgs(ttcore::CompositeOp compositeOp) {
+  auto inputs = compositeOp.getInputs();
+  TT_assertv((inputs.size() == 7u || inputs.size() == 10u),
+             "moe_decode expects 7 (no bias) or 10 (bias) inputs, got {}",
+             inputs.size());
+
+  MoeDecodeCompositeArgs a;
+  a.tokens = inputs[0];
+  a.expertIndices = inputs[1];
+  a.expertScores = inputs[2];
+  a.expertMapping = inputs[3];
+  a.w0 = inputs[4];
+  a.w1 = inputs[5];
+  a.w2 = inputs[6];
+  a.hasBias = inputs.size() == 10u;
+  if (a.hasBias) {
+    a.bias0 = inputs[7];
+    a.bias1 = inputs[8];
+    a.bias2 = inputs[9];
+  }
+
+  DictionaryAttr attrs = compositeOp.getCompositeAttributes().value_or(nullptr);
+  TT_assert(attrs);
+  auto readInt = [&](StringRef name) -> int64_t {
+    auto v = attrs.getAs<mlir::IntegerAttr>(name);
+    TT_assertv(v, "moe_decode composite missing integer attribute '{}'",
+               name.str());
+    return v.getInt();
+  };
+  a.numDevices = readInt("num_devices");
+  a.clusterAxis = readInt("cluster_axis");
+  a.layerId = readInt("layer_id");
+  a.outputHeightShardDim = readInt("output_height_shard_dim");
+  a.intermediateSize = readInt("intermediate_size");
+  if (auto act = attrs.getAs<mlir::StringAttr>("activation_function")) {
+    if (auto sym = ttcore::symbolizeMoEActivationFunction(act.getValue())) {
+      a.activation = *sym;
+    }
+  }
+  return a;
 }
 
 static void registerBuiltinComposites() {
@@ -258,6 +327,110 @@ static void registerBuiltinComposites() {
         ttcore::Arch arch = sysDesc.getChipDesc(0).getArch().getValue();
         return success(arch == ttcore::Arch::Blackhole);
       }};
+
+  registry["moe_decode"] = CompositeEntry{
+      // Validate: moe_compute / all_to_all_dispatch_metadata are OpModelExempt,
+      // so the contract is enforced by extractMoeDecodeArgs + the typed ops'
+      // verifiers after build. Always promotable.
+      [](ttcore::CompositeOp compositeOp, OpBuilder &) -> OpValidationResult {
+        (void)extractMoeDecodeArgs(compositeOp);
+        return OpValidationResult::success();
+      },
+      // Build all_to_all_dispatch_metadata -> weight-prep -> moe_compute,
+      // wiring
+      // moe's dispatched/indices/scores from a2a's results. Result types are
+      // placeholders finalized by workarounds + the deduce pass.
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        MoeDecodeCompositeArgs a = extractMoeDecodeArgs(compositeOp);
+        Location loc = compositeOp.getLoc();
+        MLIRContext *ctx = compositeOp.getContext();
+
+        mlir::IRRewriter rewriter(builder);
+        rewriter.setInsertionPoint(compositeOp);
+
+        auto tokensTy = cast<RankedTensorType>(a.tokens.getType());
+        auto idxTy = cast<RankedTensorType>(a.expertIndices.getType());
+        auto scrTy = cast<RankedTensorType>(a.expertScores.getType());
+        int64_t M = tokensTy.getShape()[tokensTy.getRank() - 2];
+        int64_t H = tokensTy.getShape().back();
+        int64_t K = idxTy.getShape().back();
+        int64_t totalTokens = a.numDevices * M;
+
+        // a2a output placeholder types ([1, tokens_global, C]); deduce +
+        // workarounds finalize their layouts (indices/scores onto the drain
+        // core, dispatched to DRAM interleaved).
+        auto dispatchedTy = ttnn::utils::RankedTensorTypeFactory::create(
+            tokensTy, llvm::SmallVector<int64_t>{1, totalTokens, H});
+        auto outIdxTy = ttnn::utils::RankedTensorTypeFactory::create(
+            idxTy, llvm::SmallVector<int64_t>{1, totalTokens, K});
+        auto outScrTy = ttnn::utils::RankedTensorTypeFactory::create(
+            scrTy, llvm::SmallVector<int64_t>{1, totalTokens, K});
+
+        // Persistent-mode a2a: output buffers + cross-device semaphore left
+        // unbound (DistributedOpInterface prelude hooks materialize them).
+        // Mirrors the TTIRToTTNN a2a build.
+        auto a2a = rewriter.create<ttnn::AllToAllDispatchMetadataOp>(
+            loc, dispatchedTy, outIdxTy, outScrTy, a.tokens, a.expertIndices,
+            a.expertScores, a.expertMapping, /*dispatched_buffer=*/Value(),
+            /*indices_buffer=*/Value(), /*scores_buffer=*/Value(),
+            /*cross_device_semaphore=*/Value(),
+            rewriter.getI64IntegerAttr(a.numDevices),
+            rewriter.getI64IntegerAttr(a.clusterAxis));
+
+        Value device =
+            ttnn::utils::getOrInsertDevice(rewriter, compositeOp).getResult();
+
+        // Prepack weights. Result types are placeholders refined by the deduce
+        // pass via OpModel (mirrors MoeComputeOpConversionPattern). hidden_size
+        // = w0 K dim (logical shape (L, E, K, N)).
+        auto w0Ty = cast<RankedTensorType>(a.w0.getType());
+        auto w2Ty = cast<RankedTensorType>(a.w2.getType());
+        auto hiddenSizeAttr = rewriter.getUI32IntegerAttr(w0Ty.getShape()[2]);
+        auto intermediateSizeAttr =
+            rewriter.getUI32IntegerAttr(a.intermediateSize);
+
+        auto w0w1Prepared =
+            rewriter.create<ttnn::PrepareMoEComputeW0W1WeightsOp>(
+                loc, /*placeholder=*/w0Ty, a.w0, a.w1, a.bias0, a.bias1, device,
+                hiddenSizeAttr, intermediateSizeAttr);
+        auto w2Prepared = rewriter.create<ttnn::PrepareMoEComputeW2WeightsOp>(
+            loc, /*placeholder=*/w2Ty, a.w2, a.bias2, device, hiddenSizeAttr,
+            intermediateSizeAttr);
+
+        // Fabric-mux cores: 3x3 pool at (3,6)-(5,8) (bottom-center). The
+        // default (1,1) top-left block collides with the matmul ring / combine
+        // strip on the harvested 8x9 grid for large-hidden MoE (DeepSeek
+        // hidden=7168); bottom-center frees the top rows so the layout fits.
+        // gpt-oss unaffected.
+        ttnn::CoreRangeSetAttr muxCoreRangeSet = ttnn::CoreRangeSetAttr::get(
+            ctx,
+            ttnn::CoreRangeAttr::get(ctx, ttnn::CoreCoordAttr::get(ctx, 3, 6),
+                                     ttnn::CoreCoordAttr::get(ctx, 5, 8)));
+
+        auto activationAttr =
+            ttcore::MoEActivationFunctionAttr::get(ctx, a.activation);
+
+        // optional_output_tensor + cross_device_semaphore are left unbound; the
+        // MoeComputeOp DistributedOpInterface hooks bind them in the prelude.
+        return rewriter.create<ttnn::MoeComputeOp>(
+            loc, compositeOp.getResultTypes()[0], a2a.getDispatched(),
+            a2a.getIndices(), a2a.getScores(), a.expertMapping,
+            w0w1Prepared.getResult(), w2Prepared.getResult(),
+            /*optional_output_tensor=*/Value(),
+            /*cross_device_semaphore=*/Value(), device,
+            rewriter.getUI32IntegerAttr(a.layerId),
+            rewriter.getUI32IntegerAttr(a.outputHeightShardDim),
+            intermediateSizeAttr, rewriter.getBoolAttr(a.hasBias),
+            activationAttr, rewriter.getUI32IntegerAttr(a.clusterAxis),
+            /*num_links=*/mlir::IntegerAttr(),
+            // combine kernel supports only Linear/Ring; a null attr defaults to
+            // Mesh (rejected). Pin Ring to match the FABRIC_1D_RING galaxy
+            // fabric.
+            /*topology=*/
+            ttcore::TopologyAttr::get(ctx, ttcore::Topology::Ring),
+            muxCoreRangeSet);
+      },
+      /*promotionGuard=*/nullptr};
 }
 
 // Inline the decomposition function body at the composite ops location,
@@ -336,6 +509,32 @@ static Operation *tryCreateTypedOp(ttcore::CompositeOp compositeOp,
   return entry.build(compositeOp, builder);
 }
 
+// Collapse duplicate weight-prep ops: with stacked all-layer weights every
+// layer's moe_decode emits an identical PrepareMoECompute*WeightsOp, so fold
+// them onto the first occurrence -- else each layer const-evals its own
+// full-model buffer and DRAM scales as L x weights (OOM at full depth).
+template <typename OpT>
+static void dedupeIdenticalWeightPreps(ModuleOp moduleOp) {
+  SmallVector<OpT> kept;
+  SmallVector<Operation *> toErase;
+  moduleOp.walk([&](OpT op) {
+    for (OpT k : kept) {
+      if (k->getBlock() == op->getBlock() &&
+          llvm::equal(k->getOperands(), op->getOperands()) &&
+          k->getAttrDictionary() == op->getAttrDictionary() &&
+          k.getResult().getType() == op.getResult().getType()) {
+        op.getResult().replaceAllUsesWith(k.getResult());
+        toErase.push_back(op.getOperation());
+        return;
+      }
+    }
+    kept.push_back(op);
+  });
+  for (Operation *op : toErase) {
+    op->erase();
+  }
+}
+
 class TTNNResolveComposites
     : public impl::TTNNResolveCompositesBase<TTNNResolveComposites> {
 public:
@@ -384,6 +583,12 @@ public:
       signalPassFailure();
       return;
     }
+
+    // Fold the per-layer moe_decode weight-prep ops that share the same stacked
+    // all-layer weight into one, so the packed weight buffer is const-evaled
+    // and resident exactly once (indexed per layer by moe_compute's layer_id).
+    dedupeIdenticalWeightPreps<PrepareMoEComputeW0W1WeightsOp>(moduleOp);
+    dedupeIdenticalWeightPreps<PrepareMoEComputeW2WeightsOp>(moduleOp);
 
     // Clean up decomposition functions that are no longer referenced.
     for (func::FuncOp func : decompositionFuncsToDelete) {

--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -201,8 +201,12 @@ private:
       return;
     }
 
-    // Non-cacheable ops cannot be part of const-eval subgraphs.
-    if (op->hasTrait<mlir::tt::ttcore::Trait::TTCoreNonCacheableTrait>()) {
+    // Non-cacheable via op-class trait OR a per-instance "ttnn.non_cacheable"
+    // attr (lets one instance, e.g. the moe_compute combine zero buffer, opt
+    // out of const-eval so it is re-zeroed every step instead of cached and
+    // reused).
+    if (op->hasTrait<mlir::tt::ttcore::Trait::TTCoreNonCacheableTrait>() ||
+        op->hasAttr("ttnn.non_cacheable")) {
       return;
     }
 

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/moe_decode.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/moe_decode.mlir
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --split-input-file --stablehlo-to-ttir-pipeline %s | FileCheck %s
+
+// stablehlo.custom_call @tt.moe_decode -> ttcore.composite "moe_decode" + a
+// synthesized private decomposition (all_gather weights -> two sparse_matmuls +
+// GLU -> one-hot top-k select). The frontend composite is mesh-agnostic:
+// num_devices is derived from the module mesh (num_devices =
+// meshShape[cluster_axis]) and the expert_mapping is synthesized here.
+
+// Single-axis mesh: the combine already reduces the whole mesh, so no trailing
+// all_reduce is inserted.
+module @moe_decode_single_axis attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x8>]>} {
+  func.func public @main(
+      %tokens: tensor<1x1x32x64xbf16>,
+      %indices: tensor<1x1x32x2xui16>,
+      %scores: tensor<1x1x32x2xbf16>,
+      %w0: tensor<1x1x64x64xbf16>,
+      %w1: tensor<1x1x64x64xbf16>,
+      %w2: tensor<1x1x64x64xbf16>) -> tensor<2x32x64xbf16> {
+    // CHECK-LABEL: @main
+    // The synthesized expert_mapping constant is re-inserted at operand 3.
+    // CHECK: "ttcore.composite"(%arg0, %arg1, %arg2, %{{[0-9]+}}, %arg3, %arg4, %arg5)
+    // CHECK-SAME: cluster_axis = 1 : i64
+    // CHECK-SAME: composite_name = "moe_decode"
+    // CHECK-SAME: decomposition = @moe_decode_decomp
+    // No compound sharding on a single-axis mesh.
+    // CHECK-NOT: "ttir.all_reduce"
+    %0 = stablehlo.custom_call @tt.moe_decode(%tokens, %indices, %scores, %w0, %w1, %w2) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", layer_id = "0", output_height_shard_dim = "4", intermediate_size = "64", activation_function = "silu"}} : (tensor<1x1x32x64xbf16>, tensor<1x1x32x2xui16>, tensor<1x1x32x2xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<2x32x64xbf16>
+    return %0 : tensor<2x32x64xbf16>
+  }
+  // The decomposition holds the primitive reference lowering.
+  // CHECK: func.func private @moe_decode_decomp
+  // CHECK: "ttir.all_gather"
+  // CHECK: "ttir.sparse_matmul"
+  // CHECK: "ttir.silu"
+  // CHECK: "ttir.matmul"
+}
+
+// -----
+
+// Compound sharding: a 2x4 mesh with cluster_axis=1 leaves 2 non-cluster
+// devices each holding a partial, so an all_reduce(sum) over the non-cluster
+// axis (0) aggregates the combine output. bh_ring_size rides along on the
+// composite as (currently unconsumed) metadata.
+module @moe_decode_compound attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 2x4>]>} {
+  func.func public @main(
+      %tokens: tensor<1x1x32x64xbf16>,
+      %indices: tensor<1x1x32x2xui16>,
+      %scores: tensor<1x1x32x2xbf16>,
+      %w0: tensor<1x1x64x64xbf16>,
+      %w1: tensor<1x1x64x64xbf16>,
+      %w2: tensor<1x1x64x64xbf16>) -> tensor<2x32x64xbf16> {
+    // CHECK-LABEL: @main
+    // CHECK: "ttcore.composite"(%arg0, %arg1, %arg2, %{{[0-9]+}}, %arg3, %arg4, %arg5)
+    // CHECK-SAME: bh_ring_size = 8 : i64
+    // CHECK-SAME: composite_name = "moe_decode"
+    // The trailing reduce over the non-cluster axis aggregates the partials.
+    // CHECK: "ttir.all_reduce"
+    %0 = stablehlo.custom_call @tt.moe_decode(%tokens, %indices, %scores, %w0, %w1, %w2) {api_version = 0 : i32, mhlo.frontend_attributes = {cluster_axis = "1", layer_id = "0", output_height_shard_dim = "4", intermediate_size = "64", activation_function = "silu", bh_ring_size = "8"}} : (tensor<1x1x32x64xbf16>, tensor<1x1x32x2xui16>, tensor<1x1x32x2xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<2x32x64xbf16>
+    return %0 : tensor<2x32x64xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/TTIRToTTNN/ccl/moe_compute.mlir
+++ b/test/ttmlir/Conversion/TTIRToTTNN/ccl/moe_compute.mlir
@@ -1,17 +1,20 @@
 // RUN: ttmlir-opt --split-input-file --ttir-to-ttnn-backend-pipeline="mesh-shape=1,1" %s | FileCheck %s
 // Serialization round-trip: the prelude ttnn.allocate_moe_compute_semaphore +
-// ttnn.empty and the wired ttnn.moe_compute must serialize to a flatbuffer
-// (covers TTNNToFlatbuffer + the op-output-ref switches in runtime.cpp). Runs
-// in CI with no device (moe_compute is OpModelExempt).
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=1,1" %s | ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn
+// ttnn.zeros and the wired ttnn.moe_compute must serialize to a flatbuffer
+// (covers TTNNToFlatbuffer + the op-output-ref switches in runtime.cpp). Write
+// the pipeline output with -o instead of piping stdout: with OpModel enabled the
+// backend runs device placement, which emits tt-metal/UMD logs to stdout that
+// would otherwise corrupt the MLIR fed to ttmlir-translate.
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="mesh-shape=1,1" %s -o %t_rt.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer %t_rt.mlir -o %t.ttnn
 // SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
 // ttir.moe_compute takes raw per-expert weights; TTIRToTTNN inserts
 // ttnn.prepare_moe_compute_w0_w1_weights + ttnn.prepare_moe_compute_w2_weights
-// and a default mux_core_range_set ((1,1)-(3,3)). The combine output buffer
-// (ttnn.empty) and semaphore (ttnn.allocate_moe_compute_semaphore) are bound in
+// and a default mux_core_range_set ((5,5)-(7,7)). The combine output buffer
+// (ttnn.zeros) and semaphore (ttnn.allocate_moe_compute_semaphore) are bound in
 // the prelude by MoeComputeOp's DistributedOpInterface hooks.
 module attributes {} {
   func.func @moe_compute_inserts_weight_prep(
@@ -44,7 +47,7 @@ module attributes {} {
 // CHECK-SAME: mux_core_range_set = #ttnn.core_range_set
 // CHECK-SAME: output_height_shard_dim = 4 : ui32
 // CHECK-SAME: -> !ttnn.global_semaphore
-// CHECK: %[[OUT:[0-9]+]] = "ttnn.empty"(%[[DEV]])
+// CHECK: %[[OUT:[0-9]+]] = "ttnn.zeros"(%[[DEV]])
 // CHECK: "ttnn.prepare_moe_compute_w0_w1_weights"
 // CHECK: "ttnn.prepare_moe_compute_w2_weights"
 // moe_compute consumes the prelude-allocated output buffer + semaphore.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8534

### Problem description
moe_compute op support for multiple layers, sharding rule

### What's changed
Adds the fused-decode path that lowers the tt.moe_decode composite to all_to_all_dispatch_metadata + moe_compute on top of main's moe_compute / persistent-a2a (#8910) foundation:

- StableHLO: moe_decode composite op + StableHLO->TTIR decomposition, composite resolution (TTNNResolveComposites) synthesizing the a2a-dispatch + weight-prep
  + moe_compute chain, and its Shardy custom sharding rule.
- gpt-oss compound-decode wiring + per-layer combine zero buffer.
- TTNNLayout: all_gather is layout-preserving -- keep integer (ui32) gathers row-major on operand and result so the gpt-oss argmax->next-token sampling gather doesn't trip the AllGatherOp tile/row-major verifier on current main.

Also enables the large routed-MoE models (DeepSeek-V3.1 / GLM-4 / Kimi-K2):

- TTNNResolveComposites: place the moe_decode fabric-mux 3x3 pool at (3,6)-(5,8) (bottom-center) instead of the (1,1) default, which collides with the matmul ring / combine strip on the 8x9 grid for large hidden (DeepSeek 7168) and fails core placement. gpt-oss (smaller combine) is unaffected.
- RegisterCustomShardingRule: the a2a_dispatch custom op canonicalizes operands to [B,1,S,H]/[B,1,S,K], so tie input and indices on the token dim2 (not dim1). Without this the indices' token dim is resharded independently of the batch-sharded input -> all_to_all_dispatch shape assert in sparse-EP prefill (DeepSeek 4L / Kimi).

### Checklist
- [ ] New/Existing tests provide coverage for changes
