### PR TITLE
[Optimizer] Fix unsigned underflow in the stateful op-model peak-L1 query

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
@@ -9,6 +9,8 @@
 
 #include "llvm/ADT/SmallVector.h"
 
+#include <limits>
+
 namespace mlir::tt::ttnn::op_model {
 
 // tt-mlir-side mirror of tt-metal's experimental::AllocationRecord. Kept as a
@@ -59,6 +61,72 @@ struct OpConstraints {
       : cbL1PeakSize(0), tensorL1PeakSize(0), peakL1MemorySize(0),
         outputL1BufferSize(0), outputLayouts({}), outputAllocations({}) {}
 };
+
+// Per-core L1 usage as reported by a backend constraints query. Mirrors the
+// four scalars of tt-metal's graph::ResourceUsage, kept metal-free so the
+// underflow repair below can be unit tested without a device.
+struct L1PeakUsage {
+  size_t cbL1PeakSize = 0;       // CB L1 peak allocation in bytes
+  size_t tensorL1PeakSize = 0;   // Tensor L1 peak allocation in bytes
+  size_t peakL1MemorySize = 0;   // Peak memory (CB+L1) allocation in bytes
+  size_t outputL1BufferSize = 0; // Output L1 buffer allocation in bytes
+};
+
+// True when a reported per-core L1 usage has wrapped around zero. Real per-core
+// L1 is a few MiB, so the high bit can only be set by an unsigned underflow.
+inline bool isUnderflowedL1Usage(size_t value) {
+  return value > std::numeric_limits<size_t>::max() / 2;
+}
+
+// Repairs the L1 peaks of a *stateful* (build-from-records) query that
+// tt-metal's graph-trace walker underflowed. Peaks that did not wrap are
+// returned untouched.
+//
+// tt-metal derives the per-core peaks by walking the captured graph trace with
+// unsigned running counters, subtracting on every buffer-deallocate node
+// without a guard (`extract_resource_usage_per_core` in
+// ttnn/core/graph/graph_trace_utils.cpp):
+//
+//     } else {  // kNodeBufferDeallocate
+//       current_l1 -= alloc_size;
+//       current_total -= alloc_size;
+//     }
+//
+// On a stateless query the counters always balance: every buffer freed inside
+// the trace was also allocated inside it. A stateful query pre-seeds the
+// allocator with the caller's live L1 records, so the trace legitimately frees
+// buffers it never allocated -- the counters wrap below zero and the next
+// allocate latches the wrapped value through `peak = std::max(peak, current)`.
+// The peak then comes back as 2^64 - N, with N a live per-core record size.
+// Compared against the L1 limit as-is, such a peak reports an out-of-memory for
+// any op holding live L1 inputs, at ~1% real occupancy, which the L1 spill pass
+// then "recovers" from by spilling an activation to DRAM
+// (https://github.com/tenstorrent/tt-mlir/issues/9069).
+//
+// The counters are deltas above the pre-seeded baseline, so a negative
+// excursion means the op's trace-local footprint never rose above the buffers
+// that were already live: zero, not 2^64, is the intended reading. The pre-wrap
+// peak is not recoverable from the response, so substitute the tightest bound
+// that cannot itself have wrapped:
+//   - tensor peak  -> the output L1 buffer size, which is measured directly
+//                     from the output tensors and never accumulated;
+//   - overall peak -> cbL1PeakSize + tensor peak, the usual upper bound on
+//                     max(current_cb + current_l1). cbL1PeakSize cannot wrap:
+//                     its only subtraction (`current_total -= current_cb` on a
+//                     CB-deallocate-all node) is exact by construction.
+// No capacity check is lost by this: on the stateful path the pre-seeded
+// allocator either places the op's own allocations or throws, and that
+// exception is classified as an OOM by OpConstraintValidation -- it, not the
+// byte comparison, is the authoritative verdict on this path.
+inline L1PeakUsage repairUnderflowedL1Peaks(L1PeakUsage usage) {
+  if (isUnderflowedL1Usage(usage.tensorL1PeakSize)) {
+    usage.tensorL1PeakSize = usage.outputL1BufferSize;
+  }
+  if (isUnderflowedL1Usage(usage.peakL1MemorySize)) {
+    usage.peakL1MemorySize = usage.cbL1PeakSize + usage.tensorL1PeakSize;
+  }
+  return usage;
+}
 
 } // namespace mlir::tt::ttnn::op_model
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -292,10 +292,19 @@ llvm::Expected<OpConstraints> getOpConstraintsWithState(MLIRContext *context,
                                 static_cast<uint64_t>(record.size_per_bank)});
   }
 
-  return OpConstraints(out.response.resource_usage.cb_peak_size_per_core,
-                       out.response.resource_usage.l1_buffers_peak_per_core,
-                       out.response.resource_usage.peak_memory_usage_per_core,
-                       out.response.resource_usage.l1_output_buffer_per_core,
+  // The stateful query pre-seeds the allocator with the caller's live records,
+  // so the captured trace frees buffers it never allocated and tt-metal's
+  // unguarded running-counter subtraction can report a peak that has wrapped
+  // below zero. Repair those before anyone compares them against an L1 limit
+  // (see repairUnderflowedL1Peaks).
+  const L1PeakUsage l1Usage = repairUnderflowedL1Peaks(
+      L1PeakUsage{out.response.resource_usage.cb_peak_size_per_core,
+                  out.response.resource_usage.l1_buffers_peak_per_core,
+                  out.response.resource_usage.peak_memory_usage_per_core,
+                  out.response.resource_usage.l1_output_buffer_per_core});
+
+  return OpConstraints(l1Usage.cbL1PeakSize, l1Usage.tensorL1PeakSize,
+                       l1Usage.peakL1MemorySize, l1Usage.outputL1BufferSize,
                        layoutAttrs, std::move(outputAllocations));
 }
 

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Error.h"
 
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <tuple>
 #include <variant>
@@ -59,6 +60,74 @@ const TestTensor inerleaved2048X2048L1 = {{2048, 2048},
                                           BufferType::L1,
                                           llvm::SmallVector<int64_t>{8, 8}};
 } // namespace detail
+
+// ==== Stateful peak-L1 underflow repair ====
+// tt-metal's graph-trace walker subtracts without a guard on buffer-deallocate
+// nodes, so a stateful (build-from-records) query -- whose trace frees
+// pre-seeded live buffers it never allocated -- can report a peak that wrapped
+// around zero. These are pure arithmetic tests of the repair; no device needed.
+
+TEST(RepairUnderflowedL1Peaks, SanePeaksArePreserved) {
+  const L1PeakUsage usage = repairUnderflowedL1Peaks(
+      L1PeakUsage{/*cbL1PeakSize=*/137280, /*tensorL1PeakSize=*/151552,
+                  /*peakL1MemorySize=*/288832, /*outputL1BufferSize=*/20480});
+  EXPECT_EQ(usage.cbL1PeakSize, 137280u);
+  EXPECT_EQ(usage.tensorL1PeakSize, 151552u);
+  EXPECT_EQ(usage.peakL1MemorySize, 288832u);
+  EXPECT_EQ(usage.outputL1BufferSize, 20480u);
+}
+
+TEST(RepairUnderflowedL1Peaks, ZeroPeaksArePreserved) {
+  const L1PeakUsage usage = repairUnderflowedL1Peaks(L1PeakUsage{});
+  EXPECT_EQ(usage.cbL1PeakSize, 0u);
+  EXPECT_EQ(usage.tensorL1PeakSize, 0u);
+  EXPECT_EQ(usage.peakL1MemorySize, 0u);
+  EXPECT_EQ(usage.outputL1BufferSize, 0u);
+}
+
+// The values observed on mobilenetv2 bs12 / n150 in
+// https://github.com/tenstorrent/tt-mlir/issues/9069: the overall peak came
+// back as 2^64 - 20480, 20480 being the size of a live per-core L1 record that
+// the op's trace deallocated. Unrepaired, that peak exceeds any L1 limit and
+// forces a spurious spill at ~1% real occupancy.
+TEST(RepairUnderflowedL1Peaks, WrappedOverallPeakIsRebuiltFromComponents) {
+  constexpr size_t wrapped = std::numeric_limits<size_t>::max() - 20480 + 1;
+  ASSERT_TRUE(isUnderflowedL1Usage(wrapped));
+
+  const L1PeakUsage usage = repairUnderflowedL1Peaks(
+      L1PeakUsage{/*cbL1PeakSize=*/137280, /*tensorL1PeakSize=*/18432,
+                  /*peakL1MemorySize=*/wrapped, /*outputL1BufferSize=*/20480});
+  EXPECT_FALSE(isUnderflowedL1Usage(usage.peakL1MemorySize));
+  // cbL1PeakSize + tensorL1PeakSize: the tightest bound on the true peak that
+  // cannot itself have wrapped.
+  EXPECT_EQ(usage.peakL1MemorySize, 137280u + 18432u);
+  // Untouched: only the wrapped fields are repaired.
+  EXPECT_EQ(usage.cbL1PeakSize, 137280u);
+  EXPECT_EQ(usage.tensorL1PeakSize, 18432u);
+}
+
+TEST(RepairUnderflowedL1Peaks, WrappedTensorPeakFallsBackToOutputSize) {
+  constexpr size_t wrappedTensor =
+      std::numeric_limits<size_t>::max() - 6144 + 1;
+  constexpr size_t wrappedTotal =
+      std::numeric_limits<size_t>::max() - 18432 + 1;
+
+  const L1PeakUsage usage = repairUnderflowedL1Peaks(L1PeakUsage{
+      /*cbL1PeakSize=*/137280, /*tensorL1PeakSize=*/wrappedTensor,
+      /*peakL1MemorySize=*/wrappedTotal, /*outputL1BufferSize=*/20480});
+  EXPECT_EQ(usage.tensorL1PeakSize, 20480u);
+  EXPECT_EQ(usage.peakL1MemorySize, 137280u + 20480u);
+}
+
+// A peak just under the wrap threshold is not treated as an underflow, and one
+// just over it is. Guards the detection bound itself.
+TEST(RepairUnderflowedL1Peaks, DetectionBound) {
+  constexpr size_t half = std::numeric_limits<size_t>::max() / 2;
+  EXPECT_FALSE(isUnderflowedL1Usage(half));
+  EXPECT_TRUE(isUnderflowedL1Usage(half + 1));
+  EXPECT_FALSE(isUnderflowedL1Usage(0));
+  EXPECT_FALSE(isUnderflowedL1Usage(1325166));
+}
 
 // ==== Unary Eltwise Ops Starts ====
 


### PR DESCRIPTION
### What

Fixes an unsigned underflow in the **stateful** op-model peak-L1 query that makes the L1 spill optimizer
declare spurious out-of-memory verdicts and spill hot convnet activations to DRAM.

Base branch is `rpavlovic/op-model-stateful-constraints-draft` (the stateful-constraints work, PR #9124);
this is defect B(i) from the RCA of that feature's convnet throughput regression.

### Root cause

tt-metal derives the per-core L1 peaks by walking the captured graph trace with unsigned running counters
and subtracting **without a guard** on every buffer-deallocate node
(`extract_resource_usage_per_core`, `ttnn/core/graph/graph_trace_utils.cpp`):

```cpp
} else {  // kNodeBufferDeallocate
    current_l1 -= alloc_size;
    current_total -= alloc_size;
}
```

On a **stateless** query this always balances: every buffer freed inside the trace was also allocated
inside it. The **stateful** (build-from-records) query pre-seeds the allocator with the caller's live L1
records, so the trace legitimately frees buffers it never allocated — the counters wrap below zero and the
next allocate latches the wrapped value through `peak = std::max(peak, current)`. The peak comes back as
`2^64 - N`, with `N` a live per-core record size:

```
op=ttnn.conv2d total=18446744073709531136 peak=18446744073709531136 additional=0 cb=137280 limit=1324142
                     ^^^^^^^^^^^^^^^^^^^ = 2^64 - 20480   (20480 = a live per-core L1 record)
```

The plain byte check in `OpConstraintValidation.cpp` then sees "L1 hugely over capacity" for any op that
holds live L1 inputs, no matter the real pressure, and the spill pass "recovers" by evicting an activation
to DRAM. On `mobilenetv2` bs12 / n150, **10 of the 13** OOM verdicts were this wrap, firing at **1.4–7 %**
of the 1.29 MB L1 budget and adding **11.4 MiB** of L1→DRAM activation traffic per inference.

### The fix

Repair the wrapped peaks at the op-model boundary, in `getOpConstraintsWithState` — the only path that can
produce them. The counters are deltas above the pre-seeded baseline, so a negative excursion means the op's
trace-local footprint never rose above what was already live: zero, not `2^64`, is the intended reading.
The pre-wrap peak is not recoverable from the response, so substitute the tightest bound that cannot itself
have wrapped — the output buffer size for the tensor peak, `cbPeak + tensorPeak` for the overall peak.
Peaks that did not wrap pass through untouched.

Genuine spill decisions are unaffected: the real backend verdicts (`Out of Memory`, `clash with L1
buffers`) arrive as tt-metal exceptions on a different branch entirely and never reach this arithmetic.

### Verification (n150, `TTMLIR_ENABLE_OPMODEL=ON`)

Same input TTIR as the RCA (`mobilenetv2` bs12, md5 `126ba065936f7df139341c491fc5c837`),
`optimization-level=2`, real n150 system desc, with `enable-decision-trace=true`:

| | draft (per RCA) | with this fix |
|---|---|---|
| `spillManagement` `oom` events | **13** | **3** |
| `oom` occupancies | 45 %, 11 %, 34 % + 10× at 1.4–7 % | 45 %, 11 %, 34 % only |
| `to_memory_config` **L1→DRAM** | 14 (85.2 MiB) | **4 (73.8 MiB)** |
| `to_memory_config` DRAM→L1 (restores) | 4 | **0** |
| `to_memory_config` L1→L1 (reshards) | 9 | 9 — unchanged |
| every other op count | — | **identical** |

The 3 surviving OOMs are exactly the 3 genuine backend verdicts (pos 6 / 7 / 10, at 602112 / 151552 /
454656 B live L1) — the real CB-vs-L1 and allocator-exhaustion spills, which must stay. The 11.4 MiB
recovered matches the RCA's underflow attribution exactly. Op-count diff vs the RCA's stored dumps shows
only `to_memory_config` (27 → 13) and its `deallocate`s (907 → 887) change; nothing else in the module.

Tests:
- **New**: 5 unit tests for the repair in `TestOpModelLib` (`RepairUnderflowedL1Peaks.*`), including the
  exact `2^64 - 20480` value observed on mobilenetv2 and a detection-bound guard — all pass.
- `L1SpillManagementTests` 23/23, `L1SpillManagementMockAllocatorTests` (the stateful spill path) 13/13,
  `OptimizerTests` 305/305 — green.
- lit `test/ttmlir/Dialect/TTNN` — 445/445 green.
- lit `Silicon/TTNN/n150/optimizer` — 60/60 green (needs a freshly regenerated `system_desc.ttsys`;
  a stale one fails `conv3d_optimizer.mlir` in `ttrt`'s descriptor comparison, before any of this code runs).
- `OpModelStrategyTests` aborts on `OpModelStrategyTest.ShouldExploreReshardsReshapeFalse`
  (`deriveCanonicalL1CoreRangeSet` grid assertion) — **verified identical on the base branch**, pre-existing
  and unrelated.

### Notes

The upstream `extract_resource_usage_per_core` subtraction is the true root and is worth fixing in tt-metal
too; this change is the tt-mlir-side repair, which is needed regardless since tt-mlir must not treat a
`2^64`-scale value as a legitimate peak. It does not address defect B(ii) — the eviction strategy that pays
for a genuine CB clash with the largest live activation (85 % of the added traffic); that is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
