### PR TITLE
Add semantic profile-region attribution via MLIR locations

### DIFF
--- a/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
+++ b/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
@@ -136,11 +136,12 @@ public:
 
     ModuleOp module = getOperation();
 
-    // Step 1: print the host module to text.
+    // Step 1: print the host module to text with locations preserved.
     std::string inputText;
     {
       llvm::raw_string_ostream os(inputText);
       OpPrintingFlags flags;
+      flags.enableDebugInfo(/*enable=*/true, /*pretty=*/false);
       // Generic form is portable across C++/Python MLIR runtimes.
       module.print(os, flags);
     }
@@ -182,8 +183,9 @@ public:
       PyList_SET_ITEM(pathsList.get(), static_cast<Py_ssize_t>(i), path);
     }
 
-    PyRef resultPy(PyObject_CallFunctionObjArgs(applyText.get(), inputPy.get(),
-                                                pathsList.get(), nullptr));
+    PyRef resultPy(PyObject_CallFunctionObjArgs(
+        applyText.get(), inputPy.get(), pathsList.get(),
+        /*preserveDebugInfo=*/Py_True, nullptr));
     if (!resultPy) {
       emitPyError("d2m_jit apply_patterns_text raised");
       return;

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -458,6 +458,11 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
   }
 
   if (perf::Env::get().enablePerfTrace) {
+    // Associate the next device profiler operation with this command.
+    if (loc) {
+      perf::Env::get().tracyLogOpLocation(std::string(loc));
+    }
+
     auto devices = meshDevice->get_devices();
     auto meshShape = meshDevice->shape();
 

--- a/test/d2m-jit/lit/python_rewrites_pass.py
+++ b/test/d2m-jit/lit/python_rewrites_pass.py
@@ -30,7 +30,7 @@ import tempfile
 TTIR_INPUT = """\
 module {
   func.func @forward(%x: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32> loc(fused<{tt.profile.region = "test.exp"}>["input.mlir":1:1])
     return %r : tensor<32x32xf32>
   }
 }
@@ -68,6 +68,7 @@ def main():
         result = subprocess.run(
             [
                 ttmlir_opt,
+                "--mlir-print-debuginfo",
                 f"--d2m-python-rewrites=module-path={pattern_file}",
                 tmp_path,
             ],
@@ -91,3 +92,4 @@ if __name__ == "__main__":
 # CHECK:        d2m.generic
 # CHECK:        d2m.tile_exp
 # CHECK:        return %{{.*}} : tensor<32x32xf32>
+# CHECK:        tt.profile.region = "test.exp"

--- a/test/d2m-jit/runner.py
+++ b/test/d2m-jit/runner.py
@@ -292,7 +292,7 @@ def assert_pcc(golden, actual, threshold: float = 0.99):
 # ----------------------------------------------------------------------
 
 
-def run_rewrite(spec: PatternTest) -> str:
+def run_rewrite(spec: PatternTest, *, preserve_debug_info: bool = False) -> str:
     """Apply just this pattern file's rewrites to the spec's TTIR module.
 
     Uses ``apply_patterns_text``, which snapshots/clears/restores the global
@@ -305,7 +305,11 @@ def run_rewrite(spec: PatternTest) -> str:
         raise ValueError(
             f"PatternTest {spec.name!r} has no source_file (discovery sets it)"
         )
-    return apply_patterns_text(spec.ttir, [spec.source_file])
+    return apply_patterns_text(
+        spec.ttir,
+        [spec.source_file],
+        preserve_debug_info=preserve_debug_info,
+    )
 
 
 def _filecheck_bin() -> str:
@@ -483,8 +487,7 @@ def compile_spec_to_fbb(spec: PatternTest):
     from _ttmlir_runtime import binary as _rt_binary
     from d2m_jit._src.builder import _get_system_desc_path, _pipeline_passes
 
-    # run_rewrite already applies *only* this file's pattern(s), in isolation.
-    rewritten = run_rewrite(spec)
+    rewritten = run_rewrite(spec, preserve_debug_info=True)
     ctx = ir.Context()
     ctx.load_all_available_dialects()
     module = ir.Module.parse(rewritten, ctx)

--- a/test/python/golden/d2m/test_profile_region_loc.py
+++ b/test/python/golden/d2m/test_profile_region_loc.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify TTMetal enqueue-program location serialization preserves semantic tags."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+import _ttmlir_runtime as tt_runtime
+from ttmlir.ir import Context, Location, Module
+from ttmlir.passmanager import PassManager
+from ttmlir.passes import ttmetal_to_flatbuffer_bin
+
+pytestmark = pytest.mark.frontend("ttir")
+
+# The finish location ensures the enqueue-program location is selected.
+_PROFILE_REGION_MLIR = """\
+module {
+  func.func @test_profile_region_loc(%arg0: i32) {
+    "ttmetal.enqueue_program"(%arg0) <{
+      cb_ports = array<i64>,
+      kernelConfigs = [
+        #ttmetal.noc_config<@scalar_kernel,
+          #ttmetal.core_range<0x0, 1x1>,
+          #ttmetal.kernel_args<ct_args = [<scalar[0]>]>,
+          dm_core = 1, noc0>
+      ],
+      operandSegmentSizes = array<i32: 1, 0>
+    }> : (i32) -> () loc(fused<{tt.profile.region = "test.region"}>["tagged.mlir":1:1])
+    "ttmetal.finish"() : () -> () loc("finish.mlir":2:2)
+    return
+  }
+  func.func private @scalar_kernel() attributes {
+    ttkernel.arg_spec = #ttkernel.arg_spec<
+      ct_args = [<arg_type = scalar, operand_index = 0>]>,
+    ttkernel.thread = #ttkernel.thread<noc>
+  } {
+    return
+  }
+}
+"""
+
+_PROFILE_REGION_MLIR_LEGACY = _PROFILE_REGION_MLIR.replace(
+    "dm_core = 1, noc0>", "noc0>"
+)
+
+
+def _parse_json(raw: str) -> object:
+    return json.loads(re.sub(r"\binf\b", "Infinity", re.sub(r"\bnan\b", "NaN", raw)))
+
+
+def _walk(value):
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _parse_module(mlir: str) -> Module:
+    ctx = Context()
+    loc = Location.unknown(ctx)
+    with ctx, loc:
+        module = Module.parse(mlir)
+    pm = PassManager.parse(
+        "builtin.module("
+        "ttcore-register-device,"
+        "ttcore-mark-functions-as-forward,"
+        "ttcore-wrap-device-module"
+        ")",
+        ctx,
+    )
+    pm.run(module.operation)
+    return module
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_ttmetal_enqueue_program_serializes_profile_region(target: str):
+    """FlatBuffer Command.loc for enqueue-program retains tt.profile.region."""
+    last_error = None
+    module = None
+    for mlir in (_PROFILE_REGION_MLIR, _PROFILE_REGION_MLIR_LEGACY):
+        try:
+            module = _parse_module(mlir)
+            break
+        except Exception as exc:  # noqa: BLE001 - retry alternate assembly syntax
+            last_error = exc
+    if module is None:
+        raise last_error
+
+    capsule = ttmetal_to_flatbuffer_bin(module)
+    fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+    data = _parse_json(fbb.as_json())
+
+    enqueue_locs = []
+    finish_locs = []
+    for node in _walk(data):
+        if not isinstance(node, dict):
+            continue
+        type_type = str(node.get("type_type", ""))
+        if "EnqueueProgram" in type_type:
+            enqueue_locs.append(node.get("loc"))
+        if type_type.endswith("FinishCommand") or type_type == "FinishCommand":
+            finish_locs.append(node.get("loc"))
+
+    assert enqueue_locs, "expected at least one EnqueueProgramCommand"
+    assert any(
+        isinstance(loc, str) and 'tt.profile.region = "test.region"' in loc
+        for loc in enqueue_locs
+    ), enqueue_locs
+    assert any(
+        isinstance(loc, str) and "finish.mlir" in loc for loc in finish_locs
+    ), finish_locs

--- a/test/python/test_d2m_preserve_debug_info.py
+++ b/test/python/test_d2m_preserve_debug_info.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: d2m-jit
+# RUN: %python -m pytest -q %s
+
+"""Verify d2m-jit text rewrite APIs can preserve MLIR debug locations."""
+
+from __future__ import annotations
+
+from d2m_jit._src.rewrite import apply_patterns_text
+
+_INPUT = """\
+module {
+  func.func @forward(%arg0: f32) -> f32 {
+    %0 = arith.addf %arg0, %arg0 : f32 loc(fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1])
+    return %0 : f32
+  }
+}
+"""
+
+
+def test_apply_patterns_text_drops_debug_info_by_default():
+    out = apply_patterns_text(_INPUT, pattern_paths=[])
+    assert "tt.profile.region" not in out
+    assert "arith.addf" in out
+
+
+def test_apply_patterns_text_preserve_debug_info_keeps_profile_region():
+    out = apply_patterns_text(_INPUT, pattern_paths=[], preserve_debug_info=True)
+    assert 'tt.profile.region = "decoder.sdpa"' in out
+    # Round-trip: re-parse and confirm the region is still attached.
+    out2 = apply_patterns_text(out, pattern_paths=[], preserve_debug_info=True)
+    assert 'tt.profile.region = "decoder.sdpa"' in out2

--- a/test/python/test_profile_regions.py
+++ b/test/python/test_profile_regions.py
@@ -97,12 +97,18 @@ def test_extract_device_op_global_call_count_current_tracy_format():
         '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
         "6579250399439280527, 0, false, 2048 ->"
     )
-    single_line = (
+    single_line_semicolon = (
         '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
         "6579250399439280527, 0, false, 3072`;12167960701"
     )
+    # tracy-csvexport sometimes uses a comma after the closing backtick.
+    single_line_comma = (
+        '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
+        "9338796516898729965, 0, false, 3072`,8326920549"
+    )
     assert extract_device_op_global_call_count(multiline) == 2048
-    assert extract_device_op_global_call_count(single_line) == 3072
+    assert extract_device_op_global_call_count(single_line_semicolon) == 3072
+    assert extract_device_op_global_call_count(single_line_comma) == 3072
     assert extract_device_op_global_call_count("MLIR_OP_LOCATION;loc(unknown)") is None
 
 

--- a/test/python/test_profile_regions.py
+++ b/test/python/test_profile_regions.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest -q %s
+
+"""Unit tests for semantic profile-region extraction and CSV export."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROFILE_REGIONS_PATH = _REPO_ROOT / "tools" / "ttrt" / "common" / "profile_regions.py"
+
+
+def _load_profile_regions():
+    # Load by path so these tests do not require importing the full ttrt package.
+    spec = importlib.util.spec_from_file_location(
+        "profile_regions", _PROFILE_REGIONS_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+profile_regions = _load_profile_regions()
+PROFILE_REGIONS_COLUMN = profile_regions.PROFILE_REGIONS_COLUMN
+annotate_ops_perf_csv = profile_regions.annotate_ops_perf_csv
+annotate_ops_perf_rows = profile_regions.annotate_ops_perf_rows
+extract_profile_regions = profile_regions.extract_profile_regions
+extract_device_op_global_call_count = (
+    profile_regions.extract_device_op_global_call_count
+)
+format_profile_regions = profile_regions.format_profile_regions
+profile_regions_from_loc = profile_regions.profile_regions_from_loc
+
+
+def test_extract_single_fused_region():
+    loc = 'loc(fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1])'
+    assert extract_profile_regions(loc) == ["decoder.sdpa"]
+
+
+def test_extract_quoted_attr_name():
+    loc = 'loc(fused<{"tt.profile.region" = "decoder.mlp"}>[...])'
+    assert extract_profile_regions(loc) == ["decoder.mlp"]
+
+
+def test_extract_nested_fused_and_callsite_order():
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.mlp"}>'
+        '[fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1], '
+        'callsite("b.mlir":2:2 at fused<{tt.profile.region = "decoder.attn"}>'
+        '["c.mlir":3:3])])'
+    )
+    assert extract_profile_regions(loc) == [
+        "decoder.mlp",
+        "decoder.sdpa",
+        "decoder.attn",
+    ]
+
+
+def test_extract_deduplicates_preserving_order():
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.sdpa"}>'
+        '[fused<{tt.profile.region = "decoder.mlp"}>[...], '
+        'fused<{tt.profile.region = "decoder.sdpa"}>[...]])'
+    )
+    assert extract_profile_regions(loc) == ["decoder.sdpa", "decoder.mlp"]
+
+
+def test_extract_multiple_regions_on_one_op():
+    # Fusion may retain several contributing semantic labels on one emit.
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.qkv"}>'
+        '[fused<{tt.profile.region = "decoder.sdpa"}>[...]])'
+    )
+    assert extract_profile_regions(loc) == ["decoder.qkv", "decoder.sdpa"]
+    assert format_profile_regions(extract_profile_regions(loc)) == (
+        "decoder.qkv;decoder.sdpa"
+    )
+
+
+def test_untagged_location_yields_empty():
+    assert extract_profile_regions('loc("file.mlir":10:4)') == []
+    assert extract_profile_regions("loc(unknown)") == []
+    assert extract_profile_regions(None) == []
+    assert extract_profile_regions("") == []
+    assert profile_regions_from_loc('loc("file.mlir":10:4)') == ""
+
+
+def test_extract_device_op_global_call_count_current_tracy_format():
+    multiline = (
+        '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
+        "6579250399439280527, 0, false, 2048 ->"
+    )
+    single_line = (
+        '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
+        "6579250399439280527, 0, false, 3072`;12167960701"
+    )
+    assert extract_device_op_global_call_count(multiline) == 2048
+    assert extract_device_op_global_call_count(single_line) == 3072
+    assert extract_device_op_global_call_count("MLIR_OP_LOCATION;loc(unknown)") is None
+
+
+def test_annotate_rows_preserves_loc():
+    rows = [
+        {
+            "GLOBAL CALL COUNT": "1",
+            "LOC": 'loc(fused<{tt.profile.region = "decoder.sdpa"}>[...])',
+        },
+        {
+            "GLOBAL CALL COUNT": "2",
+            "LOC": 'loc("untagged.mlir":1:1)',
+        },
+    ]
+    annotated = annotate_ops_perf_rows(rows)
+    assert annotated[0]["LOC"] == rows[0]["LOC"]
+    assert annotated[0][PROFILE_REGIONS_COLUMN] == "decoder.sdpa"
+    assert annotated[1]["LOC"] == rows[1]["LOC"]
+    assert annotated[1][PROFILE_REGIONS_COLUMN] == ""
+
+
+def test_annotate_ops_perf_csv_from_synthetic_tracy_style_input(tmp_path):
+    input_csv = tmp_path / "ops_perf_results.csv"
+    output_csv = tmp_path / "ops_perf_annotated.csv"
+    with open(input_csv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "GLOBAL CALL COUNT",
+                "OP CODE",
+                "DEVICE KERNEL DURATION [ns]",
+                "LOC",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "GLOBAL CALL COUNT": "7",
+                "OP CODE": "ttnn.add",
+                "DEVICE KERNEL DURATION [ns]": "1000",
+                "LOC": (
+                    'loc(fused<{tt.profile.region = "decoder.sdpa"}>' '["x.mlir":1:1])'
+                ),
+            }
+        )
+        writer.writerow(
+            {
+                "GLOBAL CALL COUNT": "8",
+                "OP CODE": "ttnn.matmul",
+                "DEVICE KERNEL DURATION [ns]": "2000",
+                "LOC": 'loc("y.mlir":2:2)',
+            }
+        )
+
+    annotate_ops_perf_csv(str(input_csv), str(output_csv))
+
+    with open(output_csv, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert PROFILE_REGIONS_COLUMN in reader.fieldnames
+        assert "LOC" in reader.fieldnames
+        rows = list(reader)
+
+    assert rows[0]["LOC"].startswith("loc(fused<{tt.profile.region")
+    assert rows[0][PROFILE_REGIONS_COLUMN] == "decoder.sdpa"
+    assert rows[1]["LOC"] == 'loc("y.mlir":2:2)'
+    assert rows[1][PROFILE_REGIONS_COLUMN] == ""

--- a/tools/d2m-jit/_src/rewrite.py
+++ b/tools/d2m-jit/_src/rewrite.py
@@ -395,7 +395,11 @@ def _build_pdl_text(patterns: Sequence[_Pattern]) -> str:
     return f"module {{\n{body}\n}}\n"
 
 
-def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
+def apply_patterns_text(
+    input_text: str,
+    pattern_paths: Sequence[str],
+    preserve_debug_info: bool = False,
+) -> str:
     """Text-IO entrypoint for the d2m-jit pattern framework.
 
     Parses `input_text` (textual MLIR) in a fresh ir.Context, imports each
@@ -407,6 +411,9 @@ def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
     the C++/Python "two MLIRs" problem (ttmlir-opt is statically linked
     against MLIR while ttmlir's Python bindings have their own shared
     copy, so capsule pointers can't cross the boundary safely).
+
+    When `preserve_debug_info` is true, the rewritten module retains location
+    metadata. The default output omits debug locations.
 
     Pattern registration is process-global; we snapshot and restore so
     repeated calls don't accumulate stale entries.
@@ -433,6 +440,8 @@ def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
 
         apply_patterns(module)
         module.operation.verify()
+        if preserve_debug_info:
+            return module.operation.get_asm(enable_debug_info=True)
         return str(module)
     finally:
         _registry.clear()

--- a/tools/d2m-jit/_src/rewrite.py
+++ b/tools/d2m-jit/_src/rewrite.py
@@ -441,7 +441,9 @@ def apply_patterns_text(
         apply_patterns(module)
         module.operation.verify()
         if preserve_debug_info:
-            return module.operation.get_asm(enable_debug_info=True)
+            return module.operation.get_asm(
+                enable_debug_info=True, assume_verified=True
+            )
         return str(module)
     finally:
         _registry.clear()

--- a/tools/explorer/test/run_tests.py
+++ b/tools/explorer/test/run_tests.py
@@ -11,6 +11,7 @@ import glob
 import os
 import logging
 import portpicker
+from tt_adapter.mlir import parse_loc_string
 
 HOST = "localhost"
 # Use portpicker to pick a port for us. (say that 10 times fast)
@@ -160,6 +161,17 @@ def convert_command_and_assert(model_path):
         print(result.json())
         assert False
     return result.json()
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        'loc("relu_3"("MNISTLinear":4294967295:6))',
+        'loc(fused<{tt.profile.region = "decoder.mlp"}>["model.mlir":1:2])',
+    ],
+)
+def test_parse_nested_mlir_location(location):
+    assert parse_loc_string(location) == location.removeprefix("loc(").removesuffix(")")
 
 
 @pytest.mark.parametrize("model_path", get_test_files(TEST_LOAD_MODEL_PATHS))

--- a/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
+++ b/tools/explorer/tt_adapter/src/tt_adapter/mlir.py
@@ -17,16 +17,17 @@ OVERRIDE_PARAMETER_DISABLED_STR = "None"
 
 
 def parse_loc_string(loc_str):
-    """
-    This can be replaced by ttmlir.ir.Module.parse, but requires some further work to extract the actual location object from the module.
-    """
+    """Return the contents of a printed MLIR location, or ``None``."""
     if not isinstance(loc_str, str):
         logging.error(
             "Invalid LOC type in perf_trace: %s, expected string", type(loc_str)
         )
         # raise IndexError("Invalid LOC type in perf_trace: %s, expected string", type(loc_str))
         return None
-    match = re.match(r'^loc\("?([^")]+)"?\)', loc_str)
+    # Named, callsite, and fused locations may nest parentheses. The parsed
+    # contents are only used to validate that this is a printed MLIR location;
+    # callers retain the complete string when correlating profiler rows.
+    match = re.fullmatch(r"loc\((.+)\)", loc_str)
     if not match:
         logging.error("Failed to match location string: %s", loc_str)
         return None

--- a/tools/ttrt/CMakeLists.txt
+++ b/tools/ttrt/CMakeLists.txt
@@ -60,6 +60,7 @@ declare_mlir_python_sources(TTRTSources
     common/callback.py
     common/check.py
     common/perf.py
+    common/profile_regions.py
     common/query.py
     common/read.py
     common/run.py

--- a/tools/ttrt/common/perf.py
+++ b/tools/ttrt/common/perf.py
@@ -14,6 +14,11 @@ import csv
 import ast
 
 from ttrt.common.util import *
+from ttrt.common.profile_regions import (
+    PROFILE_REGIONS_COLUMN,
+    annotate_row_with_profile_regions,
+    extract_device_op_global_call_count,
+)
 
 
 class Perf:
@@ -586,19 +591,11 @@ class Perf:
 
                                     # Process the collected block. Find it's global call count and add it to the loc
                                     for bline in block:
-                                        parts = bline.split(",")
-                                        # Strip and split part[3] on semicolon or space, and grab the number
-                                        num_part = parts[3].strip()
-                                        digits = ""
-                                        for c in num_part:
-                                            if c.isdigit():
-                                                digits += c
-                                            else:
-                                                break
                                         global_call_count = (
-                                            int(digits) if digits else None
+                                            extract_device_op_global_call_count(bline)
                                         )
-                                        call_count_mapping[global_call_count] = data
+                                        if global_call_count is not None:
+                                            call_count_mapping[global_call_count] = data
 
                         return call_count_mapping
 
@@ -627,6 +624,7 @@ class Perf:
                         reader = csv.DictReader(infile)
                         fieldnames = reader.fieldnames + [
                             "LOC",
+                            PROFILE_REGIONS_COLUMN,
                             "CONST_EVAL_OP",
                             "INPUT_LAYOUT_CONVERSION_OP",
                             "PROGRAM_METADATA",
@@ -646,6 +644,8 @@ class Perf:
                                 ]
                             else:
                                 row["LOC"] = "loc(unknown)"
+
+                            annotate_row_with_profile_regions(row)
 
                             # Append the const_eval_op column with its const_eval_op data
                             if (

--- a/tools/ttrt/common/profile_regions.py
+++ b/tools/ttrt/common/profile_regions.py
@@ -33,9 +33,9 @@ _REGION_PATTERN = re.compile(
 # GLOBAL CALL COUNT is the final comma-separated field before either ``->``
 # (multiline op text) or the closing backtick (single-line op text). Earlier
 # fields vary with the profiler metadata and cannot be indexed reliably.
-_DEVICE_OP_CALL_COUNT_PATTERN = re.compile(
-    r"TT_DNN_DEVICE_OP:.*?,\s*(\d+)\s*(?:->|`(?:;|$))"
-)
+# After the closing backtick, tracy-csvexport may emit either ``;`` or ``,``
+# before the host timestamp, so do not require a specific trailer.
+_DEVICE_OP_CALL_COUNT_PATTERN = re.compile(r"TT_DNN_DEVICE_OP:.*?,\s*(\d+)\s*(?:->|`)")
 
 
 def extract_profile_regions(loc: Optional[str]) -> List[str]:

--- a/tools/ttrt/common/profile_regions.py
+++ b/tools/ttrt/common/profile_regions.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract semantic profile regions from MLIR location strings.
+
+Region labels are attached to high-level ops as fused-location metadata:
+
+    loc(fused<{tt.profile.region = "decoder.sdpa"}>[...])
+
+After lowering and fusion, an emitted op may carry an ordered,
+de-duplicated set of labels from multiple source regions. This module
+parses those labels from the printed location text that already flows
+through FlatBuffer ``loc`` / ``loc_info`` and Tracy ``MLIR_OP_LOCATION``.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+PROFILE_REGION_ATTR = "tt.profile.region"
+PROFILE_REGIONS_COLUMN = "PROFILE_REGIONS"
+
+# Matches both quoted and bare dictionary keys:
+#   tt.profile.region = "decoder.sdpa"
+#   "tt.profile.region" = "decoder.sdpa"
+_REGION_PATTERN = re.compile(
+    r'(?:"tt\.profile\.region"|tt\.profile\.region)\s*=\s*"((?:\\.|[^"\\])*)"'
+)
+
+# GLOBAL CALL COUNT is the final comma-separated field before either ``->``
+# (multiline op text) or the closing backtick (single-line op text). Earlier
+# fields vary with the profiler metadata and cannot be indexed reliably.
+_DEVICE_OP_CALL_COUNT_PATTERN = re.compile(
+    r"TT_DNN_DEVICE_OP:.*?,\s*(\d+)\s*(?:->|`(?:;|$))"
+)
+
+
+def extract_profile_regions(loc: Optional[str]) -> List[str]:
+    """Return ordered, de-duplicated ``tt.profile.region`` labels from ``loc``.
+
+    Nested fused and callsite locations are handled by scanning the printed
+    location left-to-right, which matches MLIR's pre-order print of fused
+    metadata before child locations. Operations without the attribute yield
+    an empty list.
+    """
+    if not loc:
+        return []
+
+    regions: List[str] = []
+    seen = set()
+    for match in _REGION_PATTERN.finditer(loc):
+        region = bytes(match.group(1), "utf-8").decode("unicode_escape")
+        if region in seen:
+            continue
+        seen.add(region)
+        regions.append(region)
+    return regions
+
+
+def extract_device_op_global_call_count(line: str) -> Optional[int]:
+    """Extract ``GLOBAL CALL COUNT`` from a Tracy TT_DNN_DEVICE_OP line."""
+    match = _DEVICE_OP_CALL_COUNT_PATTERN.search(line)
+    return int(match.group(1)) if match else None
+
+
+def format_profile_regions(regions: Sequence[str]) -> str:
+    """Join region labels for the ``PROFILE_REGIONS`` CSV column."""
+    return ";".join(regions)
+
+
+def profile_regions_from_loc(loc: Optional[str]) -> str:
+    """Convenience: extract and format regions from a location string."""
+    return format_profile_regions(extract_profile_regions(loc))
+
+
+def annotate_row_with_profile_regions(
+    row: MutableMapping[str, str], loc_column: str = "LOC"
+) -> None:
+    """Set ``PROFILE_REGIONS`` on ``row`` from its ``LOC`` column."""
+    row[PROFILE_REGIONS_COLUMN] = profile_regions_from_loc(row.get(loc_column))
+
+
+def annotate_ops_perf_rows(
+    rows: Iterable[Mapping[str, str]], loc_column: str = "LOC"
+) -> List[dict]:
+    """Return copies of profiler rows with ``PROFILE_REGIONS`` populated."""
+    annotated: List[dict] = []
+    for row in rows:
+        out = dict(row)
+        annotate_row_with_profile_regions(out, loc_column=loc_column)
+        annotated.append(out)
+    return annotated
+
+
+def annotate_ops_perf_csv(
+    input_csv_path: str,
+    output_csv_path: str,
+    loc_column: str = "LOC",
+) -> None:
+    """Rewrite an ops-perf CSV, adding ``PROFILE_REGIONS`` from ``LOC``.
+
+    Existing columns, including ``LOC``, are preserved unchanged.
+    """
+    with open(input_csv_path, mode="r", newline="", encoding="utf-8") as infile:
+        reader = csv.DictReader(infile)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header: {input_csv_path}")
+        if loc_column not in reader.fieldnames:
+            raise ValueError(f"CSV missing {loc_column!r} column: {input_csv_path}")
+
+        fieldnames = list(reader.fieldnames)
+        if PROFILE_REGIONS_COLUMN not in fieldnames:
+            fieldnames.append(PROFILE_REGIONS_COLUMN)
+
+        rows = annotate_ops_perf_rows(reader, loc_column=loc_column)
+
+    with open(output_csv_path, mode="w", newline="", encoding="utf-8") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)


### PR DESCRIPTION
## Summary
- Carry stable `tt.profile.region` labels through existing MLIR locations so D2M and TTNN device-profiler rows can be compared at semantic boundaries even when program counts differ.
- Align TTMetal enqueue-program profiling with the existing TTNN `MLIR_OP_LOCATION` contract and derive `PROFILE_REGIONS` from the unchanged `LOC` field in `ttrt perf`.
- Preserve debug locations through both the D2M Python rewrite pass and the D2M-JIT binary compilation path.
- Parse the current Tracy `TT_DNN_DEVICE_OP` global-call-count field without relying on a fixed comma index.

## Design
Region tags use ordinary fused-location metadata:

```mlir
loc(fused<{tt.profile.region = "decoder.sdpa"}>[...])
```

No FlatBuffer schema or new Tracy message is introduced. TTNN logs each runtime operation location immediately before execution; TTMetal now does the same at `EnqueueProgramCommand`, the boundary that produces a device-profiler operation. Fused locations may contribute multiple ordered, de-duplicated labels.

## Test plan
- [x] `pre-commit run --files <changed files>`
- [x] `cmake --build build`
- [x] `cmake --build build --target check-ttmlir` (1,902 passed, 300 unsupported)
- [x] `python -m pytest -q test/python/test_profile_regions.py test/python/test_d2m_preserve_debug_info.py` (11 passed)
- [x] `python -m pytest -q test/python/golden/d2m/test_profile_region_loc.py --sys-desc <system_desc.ttsys>` (1 passed)
- [x] `llvm-lit -sv test/d2m-jit/lit/python_rewrites_pass.py`
- [x] Manual D2M rewrite check: generated `d2m.generic` retains `tt.profile.region`