### PR TITLE
Generalize Scatter conversion

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7138,9 +7138,10 @@ private:
                                   static_cast<int64_t>(updateWindowDims.size());
     if (!multiDimensionalScatter && indexBatchRank > nonWindowUpdateRank) {
       return rewriter.notifyMatchFailure(
-          op, "TTIR single-dimensional scatter requires the index scatter-batch "
-              "rank (index rank excluding index_vector_dim) to not exceed the "
-              "update non-window rank.");
+          op,
+          "TTIR single-dimensional scatter requires the index scatter-batch "
+          "rank (index rank excluding index_vector_dim) to not exceed the "
+          "update non-window rank.");
     }
 
     if (!multiDimensionalScatter && indexVectorDim != 1u) {

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7122,10 +7122,25 @@ private:
 
     // Checks that apply to single dimensional scatter.
 
-    if (!multiDimensionalScatter && indexShape.size() > updateShape.size()) {
+    // extractElementWiseScatterIndices drops the index_vector_dim and maps the
+    // remaining (scatter-batch) dims onto the update tensor's non-window dims,
+    // so require batch rank <= non-window rank. Here index_vector_dim has
+    // length 1 (StableHLO ties it to scatter_dims_to_operand_dims.size(), which
+    // is 1 in this branch), so dropping it preserves volume. This admits e.g.
+    // indices <256x1> into updates <256>.
+    int64_t indexBatchRank = static_cast<int64_t>(indexShape.size());
+    if (indexVectorDim < static_cast<uint32_t>(indexShape.size())) {
+      --indexBatchRank;
+    }
+    ArrayRef<int64_t> updateWindowDims =
+        adaptor.getScatterDimensionNumbers().getUpdateWindowDims();
+    int64_t nonWindowUpdateRank = static_cast<int64_t>(updateShape.size()) -
+                                  static_cast<int64_t>(updateWindowDims.size());
+    if (!multiDimensionalScatter && indexBatchRank > nonWindowUpdateRank) {
       return rewriter.notifyMatchFailure(
-          op, "TTIR scatter requires indices.rank <= updates.rank. Please add "
-              "support for rank promotion if needed.");
+          op, "TTIR single-dimensional scatter requires the index scatter-batch "
+              "rank (index rank excluding index_vector_dim) to not exceed the "
+              "update non-window rank.");
     }
 
     if (!multiDimensionalScatter && indexVectorDim != 1u) {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -165,6 +165,30 @@ module @jit_scatter attributes {} {
         return %0 : tensor<3x394xi64>
     }
 
+    // Single-dimensional scatter-add where the indices carry an explicit
+    // size-1 index_vector_dim, making indices.rank (2) exceed updates.rank (1).
+    // The degenerate index_vector_dim must be squeezed and the op must still
+    // lower to a scatter-add along dim 0.
+    func.func public @test_scatter_index_vector_dim_rank_promotion(%operand: tensor<2xi64>, %indices: tensor<256x1xi64>, %updates: tensor<256xi64>) -> tensor<2xi64> {
+        // CHECK-LABEL: func.func public @test_scatter_index_vector_dim_rank_promotion
+        // CHECK: [[RS:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: (tensor<256x1xi64>) -> tensor<256xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[RS]], %arg2)
+        // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
+        // CHECK-SAME: (tensor<2xi64>, tensor<256xi64>, tensor<256xi64>) -> tensor<2xi64>
+        %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{
+          scatter_dimension_numbers = #stablehlo.scatter<
+            inserted_window_dims = [0],
+            scatter_dims_to_operand_dims = [0],
+            index_vector_dim = 1>
+        }> ({
+        ^bb0(%a: tensor<i64>, %b: tensor<i64>):
+          %r = stablehlo.add %a, %b : tensor<i64>
+          stablehlo.return %r : tensor<i64>
+        }) : (tensor<2xi64>, tensor<256x1xi64>, tensor<256xi64>) -> tensor<2xi64>
+        return %0 : tensor<2xi64>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>


### PR DESCRIPTION
### Ticket
No GH ticket AFAIK, but there is an external request that is blocked by this bug

### Problem description
There is an unhandled case where indices and updates are of differing ranks but where they can be squeezed to be compatible.

### What's changed
Most of the existing machinery seems to already handle this okay. Fudged a check to make my case pass.

### Checklist
- [X] New/Existing tests provide coverage for changes


VIbed, thanks claude