### PR TITLE
[d2m] mutlicore topk support

### DIFF
--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <memory>
@@ -75,6 +76,11 @@ public:
   // input's selected grid and padded/materialized tensor type so apply-time
   // rewriting does not re-run grid selection.
   llvm::SmallVector<CompositeInputGridInfo> compositeInputInfos;
+
+  // Set when the grid was pinned rather than computed. The apply phase would
+  // otherwise short-circuit on "already at the target grid" and skip stamping
+  // the virtual grid mapping.
+  bool forceRebuild = false;
 };
 
 /// Effective target grid range for a GenericOp.
@@ -118,9 +124,17 @@ struct GridAnalysis {
 
 private:
   /// Analyze a single GenericOp and compute grid decisions for all operands.
+  /// `pinned` generics keep the grid their producers already encoded.
   GenericGridAnalysisResult
   analyzeGenericOp(GenericOp genericOp,
-                   const EffectiveTargetGridRange &effectiveTargetGridRange);
+                   const EffectiveTargetGridRange &effectiveTargetGridRange,
+                   bool pinned);
+
+  /// Collect every GenericOp belonging to a topk expansion. A topk's band split
+  /// is a semantic property of the lowering, not an optimization, so these
+  /// grids are honored and only their mapping onto physical cores is decided
+  /// here.
+  static llvm::DenseSet<Operation *> collectTopKPinnedGenerics(Operation *root);
 
   /// Compute the effective target grid range for a generic, accounting for
   /// spatial region grid ranges.

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -10,7 +10,6 @@
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 
 #include <memory>
@@ -77,10 +76,9 @@ public:
   // rewriting does not re-run grid selection.
   llvm::SmallVector<CompositeInputGridInfo> compositeInputInfos;
 
-  // Set when the grid was pinned rather than computed. The apply phase would
-  // otherwise short-circuit on "already at the target grid" and skip stamping
-  // the virtual grid mapping.
-  bool forceRebuild = false;
+  // The operand's type is final: its grid was fixed by the lowering that built
+  // the generic. Apply-time rewrites keep the type and only stamp placement.
+  bool pinned = false;
 };
 
 /// Effective target grid range for a GenericOp.
@@ -124,17 +122,15 @@ struct GridAnalysis {
 
 private:
   /// Analyze a single GenericOp and compute grid decisions for all operands.
-  /// `pinned` generics keep the grid their producers already encoded.
   GenericGridAnalysisResult
   analyzeGenericOp(GenericOp genericOp,
-                   const EffectiveTargetGridRange &effectiveTargetGridRange,
-                   bool pinned);
+                   const EffectiveTargetGridRange &effectiveTargetGridRange);
 
-  /// Collect every GenericOp belonging to a topk expansion. A topk's band split
-  /// is a semantic property of the lowering, not an optimization, so these
-  /// grids are honored and only their mapping onto physical cores is decided
-  /// here.
-  static llvm::DenseSet<Operation *> collectTopKPinnedGenerics(Operation *root);
+  /// Record the grids a pinned generic's operands already carry, so the apply
+  /// phase can stamp physical placement without reselecting a split.
+  GenericGridAnalysisResult analyzePinnedGenericOp(
+      GenericOp genericOp,
+      const EffectiveTargetGridRange &effectiveTargetGridRange);
 
   /// Compute the effective target grid range for a generic, accounting for
   /// spatial region grid ranges.

--- a/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/GridAnalysis.h
@@ -75,10 +75,6 @@ public:
   // input's selected grid and padded/materialized tensor type so apply-time
   // rewriting does not re-run grid selection.
   llvm::SmallVector<CompositeInputGridInfo> compositeInputInfos;
-
-  // The operand's type is final: its grid was fixed by the lowering that built
-  // the generic. Apply-time rewrites keep the type and only stamp placement.
-  bool pinned = false;
 };
 
 /// Effective target grid range for a GenericOp.
@@ -98,6 +94,11 @@ struct GenericGridAnalysisResult {
   // default, or the range scoped by an enclosing d2m.spatial region.
   EffectiveTargetGridRange effectiveTargetGridRange;
 };
+
+/// Determines where on the device grid a generic op is allowed to place its
+/// grid.
+EffectiveTargetGridRange getTargetGridRange(GenericOp genericOp,
+                                            ArrayRef<int64_t> deviceGridShape);
 
 /// Module-level analysis that computes optimal grid assignments for all
 /// d2m.generic ops before any IR modification.
@@ -125,16 +126,6 @@ private:
   GenericGridAnalysisResult
   analyzeGenericOp(GenericOp genericOp,
                    const EffectiveTargetGridRange &effectiveTargetGridRange);
-
-  /// Record the grids a pinned generic's operands already carry, so the apply
-  /// phase can stamp physical placement without reselecting a split.
-  GenericGridAnalysisResult analyzePinnedGenericOp(
-      GenericOp genericOp,
-      const EffectiveTargetGridRange &effectiveTargetGridRange);
-
-  /// Compute the effective target grid range for a generic, accounting for
-  /// spatial region grid ranges.
-  EffectiveTargetGridRange getTargetGridRange(GenericOp genericOp) const;
 
   /// Normalize operand grids within a generic to ensure consistency across
   /// operands sharing loop dimensions. Physical shapes are required to ensure

--- a/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
@@ -5,74 +5,96 @@
 #ifndef TTMLIR_DIALECT_D2M_ANALYSIS_TOPKSHARDINGSTRATEGY_H
 #define TTMLIR_DIALECT_D2M_ANALYSIS_TOPKSHARDINGSTRATEGY_H
 
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
 namespace mlir::tt::d2m {
 
-/// How a 2D topk is split across the worker grid.
+/// Which axis the reduction occupies at each granularity, for a 2D topk
+/// reducing along `dim`. A device shape is `[grid..., shard...]`, so the same
+/// axis has a different index depending on which half is indexed.
+struct TopKGeometry {
+  /// Reduction axis within one half; grid-level maps are built on this.
+  std::size_t genRedDim = 0;
+  /// Reduction axis in the shard half, where reduction tiles live.
+  std::size_t deviceRedDim = 0;
+  /// Grid axis the bands spread across.
+  std::size_t deviceGridDim = 0;
+  /// Axis the extract collapses to tile 0.
+  std::size_t extractProjectDim = 0;
+};
+
+TopKGeometry getTopKGeometry(int32_t dim, std::size_t physicalRank);
+
+/// How a 2D topk is split across the worker grid: the reduction dim (`dim`)
+/// banded `numShards` ways and merged back by a tree, the non-target dim
+/// (`1 - dim`) sliced `ntShards` independent ways, or both.
 ///
-/// The reduction dim (`dim`) may be banded `numShards` ways, with each band's
-/// partial result merged back by a tree; the non-target dim (`1 - dim`) may be
-/// sliced `ntShards` ways, which needs no merge because the slices are
-/// independent. `twoDim` sets both at once.
-///
-/// Tile counts are per-core unless named `padded*`, which are the whole-tensor
-/// extents after rounding up to a multiple of the shard count. The padding tail
-/// is masked to -inf by the caller.
+/// The `padded*` extents are whole-tensor tile counts rounded up to a multiple
+/// of the shard count; the caller masks the padding tail to -inf.
 struct TopKShardingStrategy {
-  /// Reduction tiles one output partial occupies: ceil(k / 32). k > 32 spans
-  /// two tiles and folds through the large-k path.
+  /// Reduction tiles one output partial occupies: ceil(k / 32).
   int64_t outputReductionTiles = 1;
 
-  /// True when the non-target dim is sliced across cores. Triggered by the
-  /// per-core tile product, not by either dim's extent alone.
+  /// The non-target dim is sliced across cores.
   bool dataParallel = false;
-  /// True when the reduction dim is banded across cores and merged by a tree.
+  /// The reduction dim is banded across cores and merged by a tree.
   bool multiCore = false;
-  /// True when both dims are split. The resulting virtual grid is already a
-  /// physical one, so the caller leaves the fold maps null.
-  bool twoDim = false;
 
   /// Bands the reduction dim is split into; 1 when not banded.
   int64_t numShards = 1;
-  /// Reduction tiles per band.
-  int64_t bandTiles = 1;
-  /// numShards * bandTiles, i.e. the reduction extent including padding.
+  /// Reduction tiles across all bands.
   int64_t paddedReductionTiles = 1;
 
   /// Slices the non-target dim is split into; 1 when not sliced.
   int64_t ntShards = 1;
-  /// Non-target tiles per slice.
-  int64_t ntTilesPerCore = 1;
-  /// ntShards * ntTilesPerCore, i.e. the non-target extent including padding.
+  /// Non-target tiles across all slices.
   int64_t paddedNonTargetTiles = 1;
 
-  /// Bands one core can absorb in a single merge round. Consumed by
-  /// pickMergeGroupCount while walking the merge tree.
-  int64_t mergeCap = 0;
+  /// Group count per merge round, outermost first, collapsing `numShards` bands
+  /// to 1; empty when `multiCore` is false.
+  llvm::SmallVector<int64_t> mergeSchedule;
 };
 
-/// Picks the smallest legal group count for one merge round (divides `bands`,
-/// <= `mergeCap` bands/group, valid core count); smallest groups keeps the tree
-/// shallow. Returns 0 when no legal group count exists.
-int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
-                            llvm::ArrayRef<int64_t> workerGridShape);
+/// What one topk costs in L1, measured off `leaf`'s own operands. A split is
+/// legal when the leaf's per-core shard and the widest merge round fit
+/// together: leafTiles * bytesPerLeafTile + mergeTiles * bytesPerMergeTile +
+/// fixedBytes <= usableBytes.
+struct TopKL1Budget {
+  /// Chip L1 the function may allocate in.
+  int64_t usableBytes = 0;
+  /// Per reduction tile a leaf core holds, across its shard-sized buffers.
+  int64_t bytesPerLeafTile = 0;
+  /// Per partial tile a merge core gathers: the leaf's outputs, values paired
+  /// with indices.
+  int64_t bytesPerMergeTile = 0;
+  /// Buffers a constant indexing map pins to one shard, so independent of the
+  /// split; counted for both the leaf and the rebuild's own leaf.
+  int64_t fixedBytes = 0;
+};
+
+/// Reads the above off `leaf`'s operand types. `numBuffers` is the CB buffering
+/// factor the generic will be allocated with.
+TopKL1Budget topKL1Budget(GenericOp leaf, ttcore::ChipDescAttr chipDesc,
+                          int64_t numBuffers);
 
 /// Chooses how to split a 2D topk of `inputShape` reducing along `dim` across
-/// `workerGridShape`, keeping every core's shard within the L1 tile budget and
-/// requiring that any merge tree it implies can actually close on this grid.
-///
-/// On failure, writes an explanation into `failureReason` and returns failure;
-/// the caller is expected to forward it to notifyMatchFailure.
-///
-/// Pure: depends only on its arguments, touches no IR.
+/// `workerGridShape`, keeping every core's shard within `maxTilesPerCore` and
+/// requiring that any merge tree it implies both fits `budget` alongside the
+/// leaf and can close on this grid. Touches no IR. On failure writes an
+/// explanation into `failureReason`.
 mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
     int64_t k, int32_t dim, llvm::ArrayRef<int64_t> inputShape,
-    llvm::ArrayRef<int64_t> workerGridShape, std::string &failureReason);
+    llvm::ArrayRef<int64_t> workerGridShape, const TopKL1Budget &budget,
+    std::string &failureReason);
 
 } // namespace mlir::tt::d2m
 

--- a/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
@@ -22,8 +22,6 @@ namespace mlir::tt::d2m {
 /// reducing along `dim`. A device shape is `[grid..., shard...]`, so the same
 /// axis has a different index depending on which half is indexed.
 struct TopKGeometry {
-  /// Reduction axis within one half; grid-level maps are built on this.
-  std::size_t genRedDim = 0;
   /// Reduction axis in the shard half, where reduction tiles live.
   std::size_t deviceRedDim = 0;
   /// Grid axis the bands spread across.

--- a/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
@@ -18,33 +18,16 @@
 
 namespace mlir::tt::d2m {
 
-/// Which axis the reduction occupies at each granularity, for a 2D topk
-/// reducing along `dim`. A device shape is `[grid..., shard...]`, so the same
-/// axis has a different index depending on which half is indexed.
-struct TopKGeometry {
-  /// Reduction axis in the shard half, where reduction tiles live.
-  std::size_t deviceRedDim = 0;
-  /// Grid axis the bands spread across.
-  std::size_t deviceGridDim = 0;
-  /// Axis the extract collapses to tile 0.
-  std::size_t extractProjectDim = 0;
-};
-
-TopKGeometry getTopKGeometry(int32_t dim, std::size_t physicalRank);
-
-/// How a 2D topk is split across the worker grid: the reduction dim (`dim`)
-/// banded `numShards` ways and merged back by a tree, the non-target dim
-/// (`1 - dim`) sliced `ntShards` independent ways, or both.
-///
-/// The `padded*` extents are whole-tensor tile counts rounded up to a multiple
-/// of the shard count; the caller masks the padding tail to -inf.
+/// A band is a slice of the reduction dim: each core gets some of the elements
+/// being reduced, so its top-k is partial. Data-parallel slices the non-target
+/// dim instead: each core gets whole rows to reduce, so its top-k is final.
 struct TopKShardingStrategy {
   /// Reduction tiles one output partial occupies: ceil(k / 32).
   int64_t outputReductionTiles = 1;
 
-  /// The non-target dim is sliced across cores.
+  /// Data-parallel: the non-target dim is sliced across cores.
   bool dataParallel = false;
-  /// The reduction dim is banded across cores and merged by a tree.
+  /// Banded: the reduction dim is split across cores and merged by a tree.
   bool multiCore = false;
 
   /// Bands the reduction dim is split into; 1 when not banded.
@@ -79,10 +62,46 @@ struct TopKL1Budget {
   int64_t fixedBytes = 0;
 };
 
-/// Reads the above off `leaf`'s operand types. `numBuffers` is the CB buffering
-/// factor the generic will be allocated with.
+/// Reads TopKL1Budget's fields off `leaf`'s operand types. `numBuffers` is the
+/// CB buffering factor the generic will be allocated with.
 TopKL1Budget topKL1Budget(GenericOp leaf, ttcore::ChipDescAttr chipDesc,
                           int64_t numBuffers);
+
+/// The placeholder `ttir-to-d2m` leaves behind for one topk.
+struct SingleCoreTopK {
+  GenericOp leaf;
+  /// Pre-layout input, so a rebuild shards it rather than re-sharding a layout.
+  Value logicalInput;
+  /// The index element type the user asked for; every planned index buffer is
+  /// i32 regardless, so the extract or a following cast converts to this.
+  Type indexElementType;
+};
+
+/// Reads the placeholder's operand chain and attributes. Touches nothing
+/// downstream of `leaf`, which is where the planned chain gets built.
+SingleCoreTopK readSingleCoreTopK(GenericOp leaf);
+
+/// One buffer a split topk needs.
+struct TopKBufferPlan {
+  mlir::RankedTensorType type;
+};
+
+/// A topk's buffers, split by the pass that materializes them.
+struct TopKBufferPlans {
+  /// The leaf's laid-out operand, placed onto the leaf by d2m-grid-selection.
+  TopKBufferPlan input;
+  /// Its padding tail's fill; a null type means the layout leaves no tail.
+  TopKBufferPlan inputMask;
+  /// Built by d2m-lower-topk, and all the plan attribute carries.
+  llvm::SmallVector<TopKBufferPlan> lowered;
+};
+
+/// The sole definition of what buffers a topk needs. `lowered` is in the order
+/// d2m-lower-topk consumes it, which is the whole contract between the two.
+/// Touches no IR beyond reading `chain`'s types.
+TopKBufferPlans planTopKBuffers(SingleCoreTopK chain,
+                                const TopKShardingStrategy &strategy, int64_t k,
+                                int32_t dim);
 
 /// Chooses how to split a 2D topk of `inputShape` reducing along `dim` across
 /// `workerGridShape`, keeping every core's shard within `maxTilesPerCore` and

--- a/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
@@ -92,13 +92,13 @@ struct TopKBufferPlans {
   TopKBufferPlan input;
   /// Its padding tail's fill; a null type means the layout leaves no tail.
   TopKBufferPlan inputMask;
-  /// Built by d2m-lower-topk, and all the plan attribute carries.
+  /// Built by d2m-build-topk-chain, and all the plan attribute carries.
   llvm::SmallVector<TopKBufferPlan> lowered;
 };
 
 /// The sole definition of what buffers a topk needs. `lowered` is in the order
-/// d2m-lower-topk consumes it, which is the whole contract between the two.
-/// Touches no IR beyond reading `chain`'s types.
+/// d2m-build-topk-chain consumes it, which is the whole contract between the
+/// two. Touches no IR beyond reading `chain`'s types.
 TopKBufferPlans planTopKBuffers(SingleCoreTopK chain,
                                 const TopKShardingStrategy &strategy, int64_t k,
                                 int32_t dim);

--- a/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_ANALYSIS_TOPKSHARDINGSTRATEGY_H
+#define TTMLIR_DIALECT_D2M_ANALYSIS_TOPKSHARDINGSTRATEGY_H
+
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+
+#include <cstdint>
+#include <string>
+
+namespace mlir::tt::d2m {
+
+/// How a 2D topk is split across the worker grid.
+///
+/// The reduction dim (`dim`) may be banded `numShards` ways, with each band's
+/// partial result merged back by a tree; the non-target dim (`1 - dim`) may be
+/// sliced `ntShards` ways, which needs no merge because the slices are
+/// independent. `twoDim` sets both at once.
+///
+/// Tile counts are per-core unless named `padded*`, which are the whole-tensor
+/// extents after rounding up to a multiple of the shard count. The padding tail
+/// is masked to -inf by the caller.
+struct TopKShardingStrategy {
+  /// Reduction tiles one output partial occupies: ceil(k / 32). k > 32 spans
+  /// two tiles and folds through the large-k path.
+  int64_t outputReductionTiles = 1;
+
+  /// True when the non-target dim is sliced across cores. Triggered by the
+  /// per-core tile product, not by either dim's extent alone.
+  bool dataParallel = false;
+  /// True when the reduction dim is banded across cores and merged by a tree.
+  bool multiCore = false;
+  /// True when both dims are split. The resulting virtual grid is already a
+  /// physical one, so the caller leaves the fold maps null.
+  bool twoDim = false;
+
+  /// Bands the reduction dim is split into; 1 when not banded.
+  int64_t numShards = 1;
+  /// Reduction tiles per band.
+  int64_t bandTiles = 1;
+  /// numShards * bandTiles, i.e. the reduction extent including padding.
+  int64_t paddedReductionTiles = 1;
+
+  /// Slices the non-target dim is split into; 1 when not sliced.
+  int64_t ntShards = 1;
+  /// Non-target tiles per slice.
+  int64_t ntTilesPerCore = 1;
+  /// ntShards * ntTilesPerCore, i.e. the non-target extent including padding.
+  int64_t paddedNonTargetTiles = 1;
+
+  /// Bands one core can absorb in a single merge round. Consumed by
+  /// pickMergeGroupCount while walking the merge tree.
+  int64_t mergeCap = 0;
+};
+
+/// Picks the smallest legal group count for one merge round (divides `bands`,
+/// <= `mergeCap` bands/group, valid core count); smallest groups keeps the tree
+/// shallow. Returns 0 when no legal group count exists.
+int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
+                            llvm::ArrayRef<int64_t> workerGridShape);
+
+/// Chooses how to split a 2D topk of `inputShape` reducing along `dim` across
+/// `workerGridShape`, keeping every core's shard within the L1 tile budget and
+/// requiring that any merge tree it implies can actually close on this grid.
+///
+/// On failure, writes an explanation into `failureReason` and returns failure;
+/// the caller is expected to forward it to notifyMatchFailure.
+///
+/// Pure: depends only on its arguments, touches no IR.
+mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
+    int64_t k, int32_t dim, llvm::ArrayRef<int64_t> inputShape,
+    llvm::ArrayRef<int64_t> workerGridShape, std::string &failureReason);
+
+} // namespace mlir::tt::d2m
+
+#endif // TTMLIR_DIALECT_D2M_ANALYSIS_TOPKSHARDINGSTRATEGY_H

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3369,18 +3369,16 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
       decomposed post-bufferization by `d2m-decompose-topk` into
       `tile_topk_local_sort`, `tile_topk_merge`, and `tile_topk_rebuild`.
 
-      `generate_indices` selects where the index buffer the LLKs pair with the
-      value tiles comes from:
+      `generate_indices` selects where the index buffer paired with the value
+      tiles comes from:
 
       - false (the default): scratch_idx_tile IS that buffer, already holding
         one index tile per value tile. Merge stages use this, since the indices
-        they carry are real results from an earlier stage and cannot be
-        recomputed.
+        they carry are results of an earlier stage and cannot be recomputed.
       - true: scratch_idx_tile is only a 1x1 scratch tile, and
         `d2m-decompose-topk` builds the full index buffer in-kernel from this
-        core's grid coordinate. A leaf topk over raw input uses this: its
-        indices are just the reduction coordinate, so every core can derive
-        its own slice without an upstream arange.
+        core's grid coordinate. A leaf topk over raw input uses this, its
+        indices being just the reduction coordinate.
   }];
 
   let arguments = (ins

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3369,10 +3369,18 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
       decomposed post-bufferization by `d2m-decompose-topk` into
       `tile_topk_local_sort`, `tile_topk_merge`, and `tile_topk_rebuild`.
 
-      The scratch_idx_tile is a pre-filled full-shape index buffer containing
-      the arange of original element indices (generated upstream in TTIRToD2M
-      via arange + broadcast generics). `d2m-decompose-topk` consumes this
-      buffer directly.
+      `generate_indices` selects where the index buffer the LLKs pair with the
+      value tiles comes from:
+
+      - false (the default): scratch_idx_tile IS that buffer, already holding
+        one index tile per value tile. Merge stages use this, since the indices
+        they carry are real results from an earlier stage and cannot be
+        recomputed.
+      - true: scratch_idx_tile is only a 1x1 scratch tile, and
+        `d2m-decompose-topk` builds the full index buffer in-kernel from this
+        core's grid coordinate. A leaf topk over raw input uses this: its
+        indices are just the reduction coordinate, so every core can derive
+        its own slice without an upstream arange.
   }];
 
   let arguments = (ins
@@ -3383,7 +3391,8 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
       I32Attr:$k,
       I64Attr:$num_elements,
       BoolAttr:$stable_sort,
-      I32Attr:$dim);
+      I32Attr:$dim,
+      DefaultValuedAttr<BoolAttr, "false">:$generate_indices);
 
   let results = (outs
       AnyRankedTensorOrMemRef:$result_values,
@@ -3393,14 +3402,16 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
     OpBuilder<(ins "Value":$inputValues, "Value":$scratchIdxTile,
                     "Value":$outValues, "Value":$outIndices,
                     "int32_t":$k, "int64_t":$numElements,
-                    "bool":$stableSort, "int32_t":$dim), [{
+                    "bool":$stableSort, "int32_t":$dim,
+                    CArg<"bool", "false">:$generateIndices), [{
       build($_builder, $_state,
             outValues.getType(), outIndices.getType(),
             inputValues, scratchIdxTile, outValues, outIndices,
             $_builder.getI32IntegerAttr(k),
             $_builder.getI64IntegerAttr(numElements),
             $_builder.getBoolAttr(stableSort),
-            $_builder.getI32IntegerAttr(dim));
+            $_builder.getI32IntegerAttr(dim),
+            $_builder.getBoolAttr(generateIndices));
     }]>
   ];
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3372,13 +3372,12 @@ def D2M_TopkBlockOp : D2M_GenericRegionComputeOp<"topk_block",
       `generate_indices` selects where the index buffer paired with the value
       tiles comes from:
 
-      - false (the default): scratch_idx_tile IS that buffer, already holding
-        one index tile per value tile. Merge stages use this, since the indices
-        they carry are results of an earlier stage and cannot be recomputed.
-      - true: scratch_idx_tile is only a 1x1 scratch tile, and
-        `d2m-decompose-topk` builds the full index buffer in-kernel from this
-        core's grid coordinate. A leaf topk over raw input uses this, its
-        indices being just the reduction coordinate.
+      - false (the default): scratch_idx_tile already holds one index tile
+        per value tile. Used by merge stages, whose indices can't be
+        recomputed.
+      - true: scratch_idx_tile is just a 1x1 scratch tile, and
+        `d2m-decompose-topk` builds the index buffer in-kernel from the
+        core's grid coordinate. Used by a leaf topk over raw input.
   }];
 
   let arguments = (ins

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
@@ -86,10 +86,11 @@ def D2M_TopKPlanAttr : AttrDef<D2M_Dialect, "TopKPlan", [], "::mlir::Attribute">
   let summary = "How a topk is split across the worker grid, and where every buffer lands.";
   let description = [{
     Written by `d2m-grid-selection` onto the placeholder leaf `d2m.generic`, and
-    consumed by `d2m-lower-topk`, which erases that leaf and re-emits the whole
-    chain from here. It is the whole handoff, so lower-topk derives no shape and
-    folds nothing, single core or not. The laid-out input grid selection emits
-    itself stays out of it, since only what is left to build travels here.
+    consumed by `d2m-build-topk-chain`, which erases that leaf and re-emits the
+    whole chain from here. It is the whole handoff, so the chain build derives
+    no shape and folds nothing, single core or not. The laid-out input grid
+    selection emits itself stays out of it, since only what is left to build
+    travels here.
 
     `numShards` bands the reduction dim, `ntShards` slices the non-target dim.
     `mergeSchedule` holds the group count surviving *after* each merge round,

--- a/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MOpsAttrs.td
@@ -56,4 +56,56 @@ def D2M_ThreadAttr : AttrDef<D2M_Dialect, "Thread", [], "::mlir::Attribute"> {
 
 def D2M_ThreadArrayAttr : TypedArrayAttrBase<D2M_ThreadAttr, "">;
 
+def D2M_TopKPlacementAttr : AttrDef<D2M_Dialect, "TopKPlacement", [], "::mlir::Attribute"> {
+  let mnemonic = "topk_placement";
+  let summary = "One buffer of a multi-core topk, already placed on cores.";
+  let description = [{
+    A single buffer of a planned topk, with its grid already folded onto
+    physical cores by `d2m-grid-selection`.
+
+    `type` is the finished device type, carried verbatim because its dim
+    alignments come from a grid-dependent search that a logical shape plus a
+    grid cannot reproduce.
+
+    `grid` is the consuming `d2m.generic`'s grid. `vgmForward`/`vgmInverse` are
+    the wider `d2m.empty` virtual grid mapping over grid and shard dims, absent
+    when the grid needs neither virtualization nor a spatial-region offset.
+  }];
+  let parameters = (ins
+    "RankedTensorType":$type,
+    "::mlir::tt::ttcore::GridAttr":$grid,
+    OptionalParameter<"::mlir::AffineMapAttr">:$vgmForward,
+    OptionalParameter<"::mlir::AffineMapAttr">:$vgmInverse
+  );
+
+  let assemblyFormat = [{ `<` struct(params) `>` }];
+}
+
+def D2M_TopKPlanAttr : AttrDef<D2M_Dialect, "TopKPlan", [], "::mlir::Attribute"> {
+  let mnemonic = "topk_plan";
+  let summary = "How a topk is split across the worker grid, and where every buffer lands.";
+  let description = [{
+    Written by `d2m-grid-selection` onto the placeholder leaf `d2m.generic`, and
+    consumed by `d2m-lower-topk`, which erases that leaf and re-emits the whole
+    chain from here. It is the whole handoff, so lower-topk derives no shape and
+    folds nothing, single core or not. The laid-out input grid selection emits
+    itself stays out of it, since only what is left to build travels here.
+
+    `numShards` bands the reduction dim, `ntShards` slices the non-target dim.
+    `mergeSchedule` holds the group count surviving *after* each merge round,
+    outermost first, so its last element is always 1.
+
+    `placements` is consumed in order, so it must stay in the order
+    `planTopKBuffers` builds it.
+  }];
+  let parameters = (ins
+    "int64_t":$numShards,
+    "int64_t":$ntShards,
+    ArrayRefParameter<"int64_t">:$mergeSchedule,
+    ArrayRefParameter<"TopKPlacementAttr">:$placements
+  );
+
+  let assemblyFormat = [{ `<` struct(params) `>` }];
+}
+
 #endif // TTMLIR_D2M_DIALECT_D2M_IR_D2MOPSATTRS_TD

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -924,7 +924,7 @@ def D2MDecomposeArange : Pass<"d2m-decompose-arange", "::mlir::ModuleOp"> {
   ];
 }
 
-def D2MLowerTopk : Pass<"d2m-lower-topk", "::mlir::ModuleOp"> {
+def D2MBuildTopkChain : Pass<"d2m-build-topk-chain", "::mlir::ModuleOp"> {
   let summary = "Build a `topk_block` chain from its placement plan";
   let description = [{
     Replaces every placeholder `topk_block` carrying a `d2m.topk_plan` with the

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -925,20 +925,17 @@ def D2MDecomposeArange : Pass<"d2m-decompose-arange", "::mlir::ModuleOp"> {
 }
 
 def D2MLowerTopk : Pass<"d2m-lower-topk", "::mlir::ModuleOp"> {
-  let summary = "Spread a single-core `topk_block` across the worker grid";
+  let summary = "Build a `topk_block` chain from its placement plan";
   let description = [{
-    Starts from every leaf `topk_block` (`generate_indices = true`, i.e.
-    reducing raw input rather than merging partials), recovers the layout chain
-    feeding it and the extracts consuming it, and asks
-    `selectTopKShardingStrategy` how to split the reduction. One core means the
-    single-core lowering is already final. Otherwise it re-lays the input out
-    banded and/or data-parallel, runs a leaf topk per core, collapses the bands
-    with a merge tree (`mergeSchedule`) built on `d2m.composite_view` gathers,
-    and rebuilds the extracts.
+    Replaces every placeholder `topk_block` carrying a `d2m.topk_plan` with the
+    chain that plan describes: the input laid out banded and/or data-parallel,
+    a leaf topk per core, the bands collapsed by a merge tree (`mergeSchedule`)
+    built on `d2m.composite_view` gathers, and the extracts that narrow the
+    result to `k` and cast its indices to the type the user asked for.
 
-    Must run after `ttir-to-d2m` and before `d2m-grid-selection`, which folds
-    the logical grids emitted here onto physical cores. A shape the strategy
-    cannot place is a hard error: D2M has no fallback path for it.
+    Must run after `d2m-grid-selection`, which is what chose the split, folded
+    every buffer's grid onto physical cores, and wrote the plan. Every buffer
+    built here comes from the plan, including the single-core case.
   }];
   let dependentDialects = [
     "::mlir::tt::d2m::D2MDialect",

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -924,6 +924,30 @@ def D2MDecomposeArange : Pass<"d2m-decompose-arange", "::mlir::ModuleOp"> {
   ];
 }
 
+def D2MLowerTopk : Pass<"d2m-lower-topk", "::mlir::ModuleOp"> {
+  let summary = "Spread a single-core `topk_block` across the worker grid";
+  let description = [{
+    Starts from every leaf `topk_block` (`generate_indices = true`, i.e.
+    reducing raw input rather than merging partials), recovers the layout chain
+    feeding it and the extracts consuming it, and asks
+    `selectTopKShardingStrategy` how to split the reduction. One core means the
+    single-core lowering is already final. Otherwise it re-lays the input out
+    banded and/or data-parallel, runs a leaf topk per core, collapses the bands
+    with a merge tree (`mergeSchedule`) built on `d2m.composite_view` gathers,
+    and rebuilds the extracts.
+
+    Must run after `ttir-to-d2m` and before `d2m-grid-selection`, which folds
+    the logical grids emitted here onto physical cores. A shape the strategy
+    cannot place is a hard error: D2M has no fallback path for it.
+  }];
+  let dependentDialects = [
+    "::mlir::tt::d2m::D2MDialect",
+    "::mlir::linalg::LinalgDialect",
+    "::mlir::tensor::TensorDialect",
+    "::mlir::arith::ArithDialect"
+  ];
+}
+
 def D2MDecomposeTopk : Pass<"d2m-decompose-topk", "::mlir::ModuleOp"> {
   let summary = "Decompose topk_block ops into low-level tile operations";
   let description = [{

--- a/include/ttmlir/Dialect/D2M/Utils/TopKUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/TopKUtils.h
@@ -18,11 +18,12 @@ constexpr llvm::StringLiteral kTopkIndexTypeAttr = "d2m.topk_index_type";
 // d2m-decompose-topk.
 constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
 constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
-// Set on a leaf generic by d2m-grid-selection and consumed by d2m-lower-topk.
+// Set on a leaf generic by d2m-grid-selection and consumed by
+// d2m-build-topk-chain.
 constexpr llvm::StringLiteral kTopKPlanAttr = "d2m.topk_plan";
 // Set by d2m-grid-selection on the op ending the laid-out (and masked) input
-// chain it emits, so d2m-lower-topk can find it without the placeholder leaf
-// having to hold it as an operand.
+// chain it emits, so d2m-build-topk-chain can find it without the placeholder
+// leaf having to hold it as an operand.
 constexpr llvm::StringLiteral kTopKInputAttr = "d2m.topk_input";
 // Must exceed 1: a single row folds arange_block's compute root loop away.
 constexpr int64_t kTopkLaneTileRows = 2;

--- a/include/ttmlir/Dialect/D2M/Utils/TopKUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/TopKUtils.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_UTILS_TOPKUTILS_H
+#define TTMLIR_DIALECT_D2M_UTILS_TOPKUTILS_H
+
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+
+#include <utility>
+
+namespace mlir::tt::d2m::utils {
+
+// The index element type the topk's user asked for, set by ttir-to-d2m because
+// every topk buffer the lowering builds carries i32 indices regardless.
+constexpr llvm::StringLiteral kTopkIndexTypeAttr = "d2m.topk_index_type";
+// Topk scratch allocations, set by d2m-insert-scratch-buffers and consumed by
+// d2m-decompose-topk.
+constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
+constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
+// Set on a leaf generic by d2m-grid-selection and consumed by d2m-lower-topk.
+constexpr llvm::StringLiteral kTopKPlanAttr = "d2m.topk_plan";
+// Set by d2m-grid-selection on the op ending the laid-out (and masked) input
+// chain it emits, so d2m-lower-topk can find it without the placeholder leaf
+// having to hold it as an operand.
+constexpr llvm::StringLiteral kTopKInputAttr = "d2m.topk_input";
+// Must exceed 1: a single row folds arange_block's compute root loop away.
+constexpr int64_t kTopkLaneTileRows = 2;
+
+inline void setTopkIndexType(Operation *op, Type indexElementType) {
+  op->setAttr(kTopkIndexTypeAttr, TypeAttr::get(indexElementType));
+}
+
+// Any field left unplaced is computed from `layoutedInput`'s own type instead.
+struct LeafTopKBuffers {
+  // Placed only when `dim == 1`; leaving it unplaced skips the transpose.
+  PlacedBuffer transpose;
+  PlacedBuffer scratch;
+  PlacedBuffer values;
+  PlacedBuffer indices;
+};
+
+// Emits the per-core topk over an already tiled+layouted `layoutedInput`. A
+// placed `buffers.transpose` transposes first, since `topk_block` sorts down
+// tile columns and `dim == 1` puts the sort dim on tile rows.
+std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
+                                     Value layoutedInput, int32_t k,
+                                     int32_t dim, int64_t reductionDimSize,
+                                     const LeafTopKBuffers &buffers = {});
+
+} // namespace mlir::tt::d2m::utils
+
+#endif

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -38,6 +38,12 @@ constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
 // Marks a generic whose operand grids are dictated by its lowering; grid
 // selection folds them onto physical cores instead of choosing a split.
 constexpr llvm::StringLiteral kPinnedGridAttr = "d2m.pinned_grid";
+// Topk scratch allocations, set by d2m-insert-scratch-buffers and consumed by
+// d2m-decompose-topk.
+constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
+constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
+// Must exceed 1: a single row folds arange_block's compute root loop away.
+constexpr int64_t kTopkLaneTileRows = 2;
 
 inline bool isReductionScalerBuffer(Operation *op) {
   return op && op->hasAttr(kReductionScalerAttr);
@@ -109,15 +115,19 @@ void buildParallelGenericRegion(
     llvm::function_ref<SmallVector<Value>(ArrayRef<Value>)> body);
 
 // Emits a one-in/one-out all-parallel `d2m.generic` mapping each tile of `src`
-// through `makeTile`. `gridMap`/`shardMap` index the input, null = identity.
+// through `makeTile`, indexed by identity maps of `out`'s device rank.
 Value emitUnaryGeneric(
     RewriterBase &rewriter, Location loc, Value src, Value out,
-    AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
-    llvm::function_ref<AffineMap(std::size_t)> shardMap,
     llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile);
 
 // Copies `value` into a fresh buffer of its own type via `d2m.to_layout`
 Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value);
+
+// Lays `value` out over `grid`, sharded so dim i spans `tilesPerDim[i]` tiles,
+// and masks whatever padding tail that leaves to -inf.
+Value layoutAndMask(RewriterBase &rewriter, Location loc, Value value,
+                    ArrayRef<int64_t> tilesPerDim, ArrayRef<int64_t> grid,
+                    ttcore::MemorySpace memorySpace);
 
 // Emits the per-core topk over an already tiled+layouted `layoutedInput`;
 // `dim == 1` tile-transposes the shard first, since `topk_block` sorts down

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -13,17 +13,12 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 
-#include <optional>
 #include <utility>
 #include <variant>
 
 namespace mlir::tt::ttcore {
 class DeviceAttr;
 } // namespace mlir::tt::ttcore
-
-namespace mlir::linalg {
-class GenericOp;
-} // namespace mlir::linalg
 
 namespace mlir::tt::d2m {
 class GenericOp;
@@ -40,9 +35,20 @@ constexpr llvm::StringLiteral kVirtualGridInverseMappingAttr =
 constexpr llvm::StringLiteral kVirtualGridForwardMappingAttr =
     "d2m.virtualGridForwardMapping";
 constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
+// Marks a generic whose operand grids are dictated by its lowering; grid
+// selection folds them onto physical cores instead of choosing a split.
+constexpr llvm::StringLiteral kPinnedGridAttr = "d2m.pinned_grid";
 
 inline bool isReductionScalerBuffer(Operation *op) {
   return op && op->hasAttr(kReductionScalerAttr);
+}
+
+inline void markPinnedGrid(Operation *op) {
+  op->setAttr(kPinnedGridAttr, UnitAttr::get(op->getContext()));
+}
+
+inline bool hasPinnedGrid(Operation *op) {
+  return op && op->hasAttr(kPinnedGridAttr);
 }
 
 // Return a new shaped type by reblocking its device shape to match a new grid
@@ -50,25 +56,12 @@ inline bool isReductionScalerBuffer(Operation *op) {
 ShapedType reblockShapedType(ShapedType oldType,
                              ArrayRef<int64_t> newGridShape);
 
-// Rebuild `layout`'s logical shape from a [grid..., shard...] device shape, so
-// that a re-split device shape keeps the same total extent (which the composite
-// view and reblocking checks compare against). Every other layout field is
-// carried over unchanged. `deviceShape` must have even rank.
-ttcore::MetalLayoutAttr
-rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
-                            ArrayRef<int64_t> deviceShape);
-
 // Build a sharded L1 MetalLayoutAttr for `logicalShape` where dim i is padded
 // out to `tilesPerDim[i]` tiles. Uses default collapsed intervals.
 ttcore::MetalLayoutAttr buildShardedTileLayout(MLIRContext *ctx,
                                                ArrayRef<int64_t> logicalShape,
                                                ArrayRef<int64_t> tilesPerDim,
                                                ttcore::MemorySpace memorySpace);
-
-// True when `deviceShape` allocates more elements than `logicalShape` occupies
-// along any dim, i.e. the shard carries a padding tail that must be masked.
-bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
-                             ArrayRef<int64_t> logicalShape);
 
 // Clone a local shard type using the shard shape implied by a reference
 // operand's device layout.
@@ -108,27 +101,38 @@ SmallVector<int64_t> deriveBlockFactorsFromOperandGrids(
 SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
                                     AffineMap indexingMap);
 
-// Build this core's own coordinate as one `d2m.core_index` per grid dim.
-// Unlike buildGridIndices, which projects loop indices through an indexing map,
-// these address the core itself -- what a remote_load/remote_store wants when
-// the access is local rather than a gather.
-SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
-                                    std::size_t gridRank);
+// Populates `generic`'s region: `remote_load` per input, `tensor.empty` per
+// output, `body`'s results stored back. `generic` must be all-parallel.
+void buildParallelGenericRegion(
+    RewriterBase &rewriter, Location loc, GenericOp generic, ValueRange inputs,
+    ValueRange outputs,
+    llvm::function_ref<SmallVector<Value>(ArrayRef<Value>)> body);
 
-// Opt `generic` out of reblocking by clearing the attrs that pass keys off of.
-// Needed for hand-built datamovement regions, whose constant operand maps
-// reblocking would otherwise read as broadcasts and rebuild, discarding the
-// hand-built region. Call after the region is fully populated.
-void makeExplicitDatamovementForm(OpBuilder &builder, GenericOp generic);
+// Emits a one-in/one-out all-parallel `d2m.generic` mapping each tile of `src`
+// through `makeTile`. `gridMap`/`shardMap` index the input, null = identity.
+Value emitUnaryGeneric(
+    RewriterBase &rewriter, Location loc, Value src, Value out,
+    AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
+    llvm::function_ref<AffineMap(std::size_t)> shardMap,
+    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile);
 
-// Emit a `linalg.generic` copying `input` into `output` tile-by-tile via
-// TileTypecastOp. With `shardRedDim` set, a non-invertible `dim mod extent` map
-// on that dim takes the loop bound from the narrow output while reading the
-// wide input, copying only the leading tiles; without it the map is an identity
-// over the whole shard.
-linalg::GenericOp emitLeadingTileCopy(OpBuilder &builder, Location loc,
-                                      Value input, Value output,
-                                      std::optional<std::size_t> shardRedDim);
+// Copies `value` into a fresh buffer of its own type via `d2m.to_layout`
+Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value);
+
+// Emits the per-core topk over an already tiled+layouted `layoutedInput`;
+// `dim == 1` tile-transposes the shard first, since `topk_block` sorts down
+// tile columns. Returns the generic's (values, indices), not yet materialized.
+std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
+                                     Value layoutedInput, int32_t k,
+                                     int32_t dim, int64_t reductionDimSize);
+
+// Collapses `topkResult`'s `extractProjectDim` to tile 0, undoing the
+// pre-transpose (`dim == 1`) or typecasting (`dim == 0`) that
+// `emitLeafTopk` performed. `outputReductionTiles` is ceil(k / 32).
+GenericOp emitTopKExtract(RewriterBase &rewriter, Location loc,
+                          Value topkResult, Value extractOutput,
+                          std::size_t extractProjectDim,
+                          int64_t outputReductionTiles, int32_t dim);
 
 // Gets the underlying physical grid shape corresponding to the tensor or
 // memref. For views/streams, this 'physical' grid corresponds to the compute

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -13,12 +13,21 @@
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 
+#include <optional>
 #include <utility>
 #include <variant>
 
 namespace mlir::tt::ttcore {
 class DeviceAttr;
 } // namespace mlir::tt::ttcore
+
+namespace mlir::linalg {
+class GenericOp;
+} // namespace mlir::linalg
+
+namespace mlir::tt::d2m {
+class GenericOp;
+} // namespace mlir::tt::d2m
 
 namespace mlir::tt::d2m::utils {
 
@@ -40,6 +49,26 @@ inline bool isReductionScalerBuffer(Operation *op) {
 // shape.
 ShapedType reblockShapedType(ShapedType oldType,
                              ArrayRef<int64_t> newGridShape);
+
+// Rebuild `layout`'s logical shape from a [grid..., shard...] device shape, so
+// that a re-split device shape keeps the same total extent (which the composite
+// view and reblocking checks compare against). Every other layout field is
+// carried over unchanged. `deviceShape` must have even rank.
+ttcore::MetalLayoutAttr
+rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
+                            ArrayRef<int64_t> deviceShape);
+
+// Build a sharded L1 MetalLayoutAttr for `logicalShape` where dim i is padded
+// out to `tilesPerDim[i]` tiles. Uses default collapsed intervals.
+ttcore::MetalLayoutAttr buildShardedTileLayout(MLIRContext *ctx,
+                                               ArrayRef<int64_t> logicalShape,
+                                               ArrayRef<int64_t> tilesPerDim,
+                                               ttcore::MemorySpace memorySpace);
+
+// True when `deviceShape` allocates more elements than `logicalShape` occupies
+// along any dim, i.e. the shard carries a padding tail that must be masked.
+bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
+                             ArrayRef<int64_t> logicalShape);
 
 // Clone a local shard type using the shard shape implied by a reference
 // operand's device layout.
@@ -78,6 +107,28 @@ SmallVector<int64_t> deriveBlockFactorsFromOperandGrids(
 // expressions including binary operations (add, mul, floordiv, ceildiv, mod).
 SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
                                     AffineMap indexingMap);
+
+// Build this core's own coordinate as one `d2m.core_index` per grid dim.
+// Unlike buildGridIndices, which projects loop indices through an indexing map,
+// these address the core itself -- what a remote_load/remote_store wants when
+// the access is local rather than a gather.
+SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
+                                    std::size_t gridRank);
+
+// Opt `generic` out of reblocking by clearing the attrs that pass keys off of.
+// Needed for hand-built datamovement regions, whose constant operand maps
+// reblocking would otherwise read as broadcasts and rebuild, discarding the
+// hand-built region. Call after the region is fully populated.
+void makeExplicitDatamovementForm(OpBuilder &builder, GenericOp generic);
+
+// Emit a `linalg.generic` copying `input` into `output` tile-by-tile via
+// TileTypecastOp. With `shardRedDim` set, a non-invertible `dim mod extent` map
+// on that dim takes the loop bound from the narrow output while reading the
+// wide input, copying only the leading tiles; without it the map is an identity
+// over the whole shard.
+linalg::GenericOp emitLeadingTileCopy(OpBuilder &builder, Location loc,
+                                      Value input, Value output,
+                                      std::optional<std::size_t> shardRedDim);
 
 // Gets the underlying physical grid shape corresponding to the tensor or
 // memref. For views/streams, this 'physical' grid corresponds to the compute

--- a/include/ttmlir/Dialect/D2M/Utils/Utils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/Utils.h
@@ -35,39 +35,15 @@ constexpr llvm::StringLiteral kVirtualGridInverseMappingAttr =
 constexpr llvm::StringLiteral kVirtualGridForwardMappingAttr =
     "d2m.virtualGridForwardMapping";
 constexpr llvm::StringLiteral kReductionScalerAttr = "d2m.reduction_scaler";
-// Marks a generic whose operand grids are dictated by its lowering; grid
-// selection folds them onto physical cores instead of choosing a split.
-constexpr llvm::StringLiteral kPinnedGridAttr = "d2m.pinned_grid";
-// Topk scratch allocations, set by d2m-insert-scratch-buffers and consumed by
-// d2m-decompose-topk.
-constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
-constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
-// Must exceed 1: a single row folds arange_block's compute root loop away.
-constexpr int64_t kTopkLaneTileRows = 2;
 
 inline bool isReductionScalerBuffer(Operation *op) {
   return op && op->hasAttr(kReductionScalerAttr);
-}
-
-inline void markPinnedGrid(Operation *op) {
-  op->setAttr(kPinnedGridAttr, UnitAttr::get(op->getContext()));
-}
-
-inline bool hasPinnedGrid(Operation *op) {
-  return op && op->hasAttr(kPinnedGridAttr);
 }
 
 // Return a new shaped type by reblocking its device shape to match a new grid
 // shape.
 ShapedType reblockShapedType(ShapedType oldType,
                              ArrayRef<int64_t> newGridShape);
-
-// Build a sharded L1 MetalLayoutAttr for `logicalShape` where dim i is padded
-// out to `tilesPerDim[i]` tiles. Uses default collapsed intervals.
-ttcore::MetalLayoutAttr buildShardedTileLayout(MLIRContext *ctx,
-                                               ArrayRef<int64_t> logicalShape,
-                                               ArrayRef<int64_t> tilesPerDim,
-                                               ttcore::MemorySpace memorySpace);
 
 // Clone a local shard type using the shard shape implied by a reference
 // operand's device layout.
@@ -114,35 +90,28 @@ void buildParallelGenericRegion(
     ValueRange outputs,
     llvm::function_ref<SmallVector<Value>(ArrayRef<Value>)> body);
 
-// Emits a one-in/one-out all-parallel `d2m.generic` mapping each tile of `src`
-// through `makeTile`, indexed by identity maps of `out`'s device rank.
+// Maps each tile of `src` through `makeTile` under identity maps of `out`'s
+// device rank. A null `grid` leaves the grid derived from the operands.
 Value emitUnaryGeneric(
     RewriterBase &rewriter, Location loc, Value src, Value out,
-    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile);
+    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile,
+    ttcore::GridAttr grid = nullptr);
 
-// Copies `value` into a fresh buffer of its own type via `d2m.to_layout`
-Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value);
+// A buffer whose type and placement grid selection decided. A null `type` means
+// unplaced: the emitter sizes the buffer off its own input instead.
+struct PlacedBuffer {
+  RankedTensorType type;
+  // Null when the grid needs neither virtualization nor a spatial offset.
+  AffineMapAttr vgmForward;
+  AffineMapAttr vgmInverse;
+  ttcore::GridAttr grid;
 
-// Lays `value` out over `grid`, sharded so dim i spans `tilesPerDim[i]` tiles,
-// and masks whatever padding tail that leaves to -inf.
-Value layoutAndMask(RewriterBase &rewriter, Location loc, Value value,
-                    ArrayRef<int64_t> tilesPerDim, ArrayRef<int64_t> grid,
-                    ttcore::MemorySpace memorySpace);
+  bool isPlaced() const { return static_cast<bool>(type); }
+};
 
-// Emits the per-core topk over an already tiled+layouted `layoutedInput`;
-// `dim == 1` tile-transposes the shard first, since `topk_block` sorts down
-// tile columns. Returns the generic's (values, indices), not yet materialized.
-std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
-                                     Value layoutedInput, int32_t k,
-                                     int32_t dim, int64_t reductionDimSize);
-
-// Collapses `topkResult`'s `extractProjectDim` to tile 0, undoing the
-// pre-transpose (`dim == 1`) or typecasting (`dim == 0`) that
-// `emitLeafTopk` performed. `outputReductionTiles` is ceil(k / 32).
-GenericOp emitTopKExtract(RewriterBase &rewriter, Location loc,
-                          Value topkResult, Value extractOutput,
-                          std::size_t extractProjectDim,
-                          int64_t outputReductionTiles, int32_t dim);
+// Copies `value` into an explicitly placed destination of its own type.
+Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value,
+                          const PlacedBuffer &destination);
 
 // Gets the underlying physical grid shape corresponding to the tensor or
 // memref. For views/streams, this 'physical' grid corresponds to the compute
@@ -184,6 +153,12 @@ std::optional<AffineMap> getVirtualGridForwardMapping(Value val);
 // when the stored mapping belongs to a different-rank view of the value.
 std::optional<std::pair<AffineMap, AffineMap>>
 getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape);
+
+// Folds `gridShape` from a mapping pair held directly rather than read off a
+// value, so a buffer that does not exist yet can still be folded.
+std::optional<std::pair<AffineMap, AffineMap>>
+getGridMapsFromVirtualGridMapping(AffineMap forwardMap, AffineMap inverseMap,
+                                  ArrayRef<int64_t> gridShape);
 
 // Returns the effective affine map for a memref-typed value by resolving
 // ViewLayoutAttr remappings (via applyViews) and falling back to the layout's

--- a/lib/Conversion/TTIRToD2M/CMakeLists.txt
+++ b/lib/Conversion/TTIRToD2M/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_conversion_library(TTMLIRTTIRToD2M
   LINK_LIBS PUBLIC
   MLIRTTCoreDialect
   MLIRTTIRDialect
+  MLIRD2MAnalysis
   MLIRD2MDialect
   MLIRIR
   MLIRPass

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3728,6 +3728,14 @@ public:
     constexpr int64_t kTileWidth = 32;
     constexpr int64_t kMaxShardTiles = 32; // L1-safe shard width.
     int64_t fullReductionElems = inputType.getShape()[dim];
+
+    // Index element type for the arange / topk index buffers. The topk SFPU
+    // LLK reads the index lane only as INT32 (when fp32_dest_acc is on) or as a
+    // 16-bit integer (LO16, otherwise) -- never as a float. Int32 makes any
+    // 32-bit operand force fp32_dest_acc on the compute kernel, selecting the
+    // INT32 index path, so indices round-trip losslessly for any reduction
+    // size.
+    Type idxElemType = rewriter.getI32Type();
     int64_t fullReductionTiles =
         (fullReductionElems + kTileWidth - 1) / kTileWidth;
     // Minimum cores needed so each band is <= kMaxShardTiles tiles. This is a
@@ -3959,11 +3967,11 @@ public:
       // tiles (winner=0, loser=1) for any tile count, so no power-of-2 padding
       // (and no -inf mask) is needed on the reduction dim.
 
-      Type f32Type = f32TileType.getElementType();
+      auto topkIdxTileType = ttcore::TileType::get(idxElemType);
       auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
           loc, deviceShape, f32TileType, metalLayout);
       auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, f32TileType, metalLayout);
+          loc, deviceShape, topkIdxTileType, metalLayout);
       attachFold(topkValsEmpty);
       attachFold(topkIdxEmpty);
 
@@ -4035,6 +4043,100 @@ public:
         return wrapInToLayout(transposeGeneric->getResult(0));
       };
 
+      // Full (grid-level) transpose: swaps the shard's last two tile-grid dims
+      // AND transposes within each tile, so an R-row x C-col buffer becomes a
+      // genuine C x R buffer (unlike transposeTiles, which keeps the grid shape
+      // and only transposes within each tile). Used to build the dim==0 index
+      // buffer: fill the arange into a [C, R] buffer (so the [0..R-1] sequence
+      // runs along the R-long axis, spanning all tiles), then transpose here to
+      // [R, C] so idxBuf[r][c] == r == the global dim-0 index.
+      auto transposeTilesGrid = [&](Value src) -> Value {
+        auto srcType = cast<RankedTensorType>(src.getType());
+        auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
+        auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
+        ArrayRef<int64_t> srcDeviceShape = srcType.getShape();
+        std::size_t deviceRank = srcDeviceShape.size();
+        // Output device shape swaps the last two (shard) tile dims.
+        SmallVector<int64_t> dstDeviceShape(srcDeviceShape.begin(),
+                                            srcDeviceShape.end());
+        std::swap(dstDeviceShape[deviceRank - 1],
+                  dstDeviceShape[deviceRank - 2]);
+        // Output logical shape (the layout carries a logical shape whose tile
+        // extents must track the swapped physical tile counts).
+        constexpr int64_t kTileDim = 32;
+        SmallVector<int64_t> dstLogical = {
+            dstDeviceShape[deviceRank - 2] * kTileDim,
+            dstDeviceShape[deviceRank - 1] * kTileDim};
+        auto dstLayout = ttcore::MetalLayoutAttr::get(
+            ctx, dstLogical, srcLayout.getDimAlignments(),
+            srcLayout.getCollapsedIntervals(), srcLayout.getMemorySpace(),
+            srcLayout.getMemoryLayout());
+        auto dstType =
+            RankedTensorType::get(dstDeviceShape, srcTileType, dstLayout);
+        auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, dstType.getShape(), srcTileType, dstLayout);
+        attachFold(transposeEmpty);
+        SmallVector<Value> transposeInputs = {src};
+        SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
+        // Input map permutes the last two shard dims so tile [.., i, j] reads
+        // from source tile [.., j, i]; output map is identity.
+        SmallVector<AffineExpr> inExprs;
+        for (std::size_t i = 0; i < physicalRank; ++i) {
+          inExprs.push_back(rewriter.getAffineDimExpr(i));
+        }
+        std::swap(inExprs[physicalRank - 1], inExprs[physicalRank - 2]);
+        AffineMap permInMap = AffineMap::get(physicalRank, 0, inExprs, ctx);
+        auto transposeGeneric = rewriter.create<d2m::GenericOp>(
+            loc, transposeInputs, transposeOutputs,
+            /*additionalArgs=*/ValueRange(),
+            rewriter.getAffineMapArrayAttr(
+                SmallVector<AffineMap>{permInMap, identityMap}),
+            rewriter.getArrayAttr(iteratorTypes));
+        transposeGeneric->setAttr("d2m.skip_grid_selection",
+                                  rewriter.getUnitAttr());
+
+        withD2MGenericRegion(
+            rewriter, loc, transposeGeneric, transposeInputs, transposeOutputs,
+            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+              Value input = blockArgs[0];
+              Value output = blockArgs[1];
+              std::size_t shardRank =
+                  cast<RankedTensorType>(output.getType()).getRank();
+              // The input and output shards have TRANSPOSED grid shapes here
+              // ([1,8] vs [8,1]): withD2MGenericRegion hands each block arg its
+              // own operand's shard shape, so the maps must reconcile them. The
+              // iteration domain follows the OUTPUT (identity map); the INPUT
+              // map permutes the last two shard dims so output tile [d0,d1]
+              // reads input tile [d1,d0]. A single identity on both (as for a
+              // shape-preserving per-tile transpose) would make linalg infer
+              // conflicting extents for the swapped dim and fail verification.
+              AffineMap shardIdentity =
+                  rewriter.getMultiDimIdentityMap(shardRank);
+              SmallVector<AffineExpr> shardInExprs;
+              for (std::size_t i = 0; i < shardRank; ++i) {
+                shardInExprs.push_back(rewriter.getAffineDimExpr(i));
+              }
+              std::swap(shardInExprs[shardRank - 1],
+                        shardInExprs[shardRank - 2]);
+              AffineMap shardPermMap =
+                  AffineMap::get(shardRank, 0, shardInExprs, ctx);
+              SmallVector<mlir::utils::IteratorType> linalgIters(
+                  shardRank, mlir::utils::IteratorType::parallel);
+              auto linalgOp = rewriter.create<linalg::GenericOp>(
+                  loc, output.getType(), input, output,
+                  SmallVector<AffineMap>{shardPermMap, shardIdentity},
+                  linalgIters,
+                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                    Value transposed = b.create<d2m::TileTransposeOp>(
+                        bodyLoc, args[1].getType(), args[0]);
+                    b.create<linalg::YieldOp>(bodyLoc, transposed);
+                  });
+              return {linalgOp->getResult(0)};
+            });
+
+        return wrapInToLayout(transposeGeneric->getResult(0));
+      };
+
       // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
       // operates on tile columns, so we transpose the tiles first.
       Value topkInput = layoutedInput;
@@ -4043,9 +4145,51 @@ public:
       }
 
       // Setting up the arange op.
+      //
+      // dim==0 index construction: the reduction runs along tile ROWS, but the
+      // arange primitive naturally sequences indices along tile COLUMNS (and
+      // spanning multiple column tiles). So for dim==0 we build the ENTIRE
+      // arange+broadcast on a shape-SWAPPED [wt, ht] buffer -- reusing the same
+      // column-sequencing/Row-broadcast the dim==1 path uses -- then grid-
+      // transpose the result back to [ht, wt] via transposeTilesGrid. After the
+      // transpose idxBuf[r][c] == r == the global dim-0 index, across ALL
+      // tiles. (Multi-core is dim==1 only, so this swap only ever runs
+      // single-core.)
+      bool swapArange = (dim == 0);
 
-      auto f32InputType = RankedTensorType::get(topkLogicalShape, f32Type,
+      // Arange emits integer indices; allocate its buffers with the index
+      // element type (bf16 for small reduction dims, Int32 otherwise) rather
+      // than f32.
+      auto idxTileType = ttcore::TileType::get(idxElemType);
+      // Logical shape for the arange/bcast buffers: swapped for dim==0 so the
+      // sequence axis lands on columns, matching the dim==1-style construction.
+      SmallVector<int64_t> arangeLogicalShape(topkLogicalShape.begin(),
+                                              topkLogicalShape.end());
+      if (swapArange) {
+        std::swap(arangeLogicalShape[rank - 1], arangeLogicalShape[rank - 2]);
+      }
+      auto idxInputType = RankedTensorType::get(arangeLogicalShape, idxElemType,
                                                 inputType.getEncoding());
+
+      // For the swapped dim==0 buffer we must allocate the arange/bcast tensors
+      // DIRECTLY at the swapped physical [wt, ht] device shape. Routing through
+      // createOptimalLayoutOp instead re-derives the tile grid from the
+      // encoding collapse intervals and hands back the UN-swapped [ht, wt]
+      // shard, which makes the broadcast's linalg maps mismatch (expects [1,8],
+      // gets [8,1]). Build a swapped device shape + matching MetalLayoutAttr
+      // (mirrors the dst-side construction in transposeTilesGrid).
+      SmallVector<int64_t> swappedDeviceShape(deviceShape.begin(),
+                                              deviceShape.end());
+      std::swap(swappedDeviceShape[deviceShape.size() - 1],
+                swappedDeviceShape[deviceShape.size() - 2]);
+      constexpr int64_t kArangeTileDim = 32;
+      SmallVector<int64_t> swappedLogical = {
+          swappedDeviceShape[deviceShape.size() - 2] * kArangeTileDim,
+          swappedDeviceShape[deviceShape.size() - 1] * kArangeTileDim};
+      auto swappedMetalLayout = ttcore::MetalLayoutAttr::get(
+          ctx, swappedLogical, metalLayout.getDimAlignments(),
+          metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
+          metalLayout.getMemoryLayout());
       // Shard the index buffer across the same gridCols cores as the input.
       // For gridCols==1, toLayoutOperandsAndResults builds the unit-grid
       // EmptyOp + to_layout as usual. For gridCols>1 we must NOT call it: it
@@ -4058,12 +4202,19 @@ public:
       SmallVector<Value> arangeOutputs;
       if (gridCols > 1) {
         auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, deviceShape, f32TileType, metalLayout);
+            loc, deviceShape, idxTileType, metalLayout);
+        attachFold(arangeEmpty);
+        arangeOutputs.push_back(arangeEmpty.getResult());
+      } else if (swapArange) {
+        // Direct-allocate at the swapped [wt, ht] device shape (see above);
+        // going through the layout infra would collapse it back to [ht, wt].
+        auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, swappedDeviceShape, idxTileType, swappedMetalLayout);
         attachFold(arangeEmpty);
         arangeOutputs.push_back(arangeEmpty.getResult());
       } else {
         auto arangeOrigOutputs =
-            createDpsOutputs(loc, rewriter, {f32InputType});
+            createDpsOutputs(loc, rewriter, {idxInputType});
         auto [arangeins, laidOut] = toLayoutOperandsAndResults(
             rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
             /*noCollapse=*/false);
@@ -4124,17 +4275,18 @@ public:
                                .create<d2m::ArangeBlockOp>(
                                    loc, idxTile, outTile, numElements,
                                    /*start=*/arangeStart,
-                                   /*step=*/1,
-                                   /*colMajor=*/(dim == 0))
+                                   /*step=*/1)
                                .getResult();
             return {result};
           });
 
       // Setting up the broadcast after arange.
 
-      // Broadcast first row or column to full shape.
-      d2m::TileBcastType postArangeBcastType =
-          (dim == 1) ? d2m::TileBcastType::Row : d2m::TileBcastType::Col;
+      // Broadcast first row or column to full shape. Both dim==1 and the
+      // swapped dim==0 buffer sequence indices along COLUMNS, so both broadcast
+      // row 0 DOWN the rows (Row broadcast). (dim==0 is handled on its swapped
+      // [wt, ht] buffer here and grid-transposed to [ht, wt] afterwards.)
+      d2m::TileBcastType postArangeBcastType = d2m::TileBcastType::Row;
       d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
           d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
       SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
@@ -4145,13 +4297,20 @@ public:
       // grid matches the sharded arange input (and topkInput).
       if (gridCols > 1) {
         auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, deviceShape, f32TileType, metalLayout);
+            loc, deviceShape, idxTileType, metalLayout);
+        attachFold(bcastEmpty);
+        postArangeBcastOutputs.push_back(bcastEmpty.getResult());
+      } else if (swapArange) {
+        // Match the swapped [wt, ht] arange input so the broadcast's linalg
+        // maps line up (see the swappedDeviceShape rationale above).
+        auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, swappedDeviceShape, idxTileType, swappedMetalLayout);
         attachFold(bcastEmpty);
         postArangeBcastOutputs.push_back(bcastEmpty.getResult());
       } else {
         // For single-core, use the standard layout wrapping.
         auto postArangeBcastOrigOutputs =
-            createDpsOutputs(loc, rewriter, {f32InputType});
+            createDpsOutputs(loc, rewriter, {idxInputType});
         auto [postArangeBcastins, laidOut] = toLayoutOperandsAndResults(
             rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
             /*noCollapse=*/false);
@@ -4237,12 +4396,21 @@ public:
       Value indexOperand = postArangeBcast->getResult(0);
       Value idxBuf = wrapInToLayout(indexOperand);
 
-      // TopkBlockOp reads value and index tiles in lockstep, so transpose the
-      // index buffer the same way as the value input for dim==1. For dim==1,
-      // arange+bcast yields idxBuf[row][col] = col, so after transpose the
-      // column index varies along the tile's row axis, matching the value tile.
+      // TopkBlockOp reads value and index tiles in lockstep, so bring the index
+      // buffer into the same orientation as the value input.
+      //   dim==1: arange+bcast yields idxBuf[row][col] = col; a per-tile
+      //     transpose makes the column index vary along the tile's row axis,
+      //     matching the transposed value tile.
+      //   dim==0: idxBuf was built on the swapped [wt, ht] buffer with the
+      //     [0..R-1] sequence running along its columns; a GRID transpose swaps
+      //     the tile-grid dims AND transposes within each tile, producing the
+      //     genuine [ht, wt] buffer where idxBuf[r][c] == r (the global dim-0
+      //     index) across all tiles. A per-tile transpose alone would be wrong
+      //     for ht>1 because it cannot move the sequence across tile rows.
       if (dim == 1) {
         idxBuf = transposeTiles(idxBuf);
+      } else {
+        idxBuf = transposeTilesGrid(idxBuf);
       }
 
       SmallVector<Value> topkInputs = {topkInput, idxBuf};
@@ -4459,7 +4627,9 @@ public:
     // left-fold keeps the accumulator at canonical tiles (winner=0, loser=1),
     // so the extract reads tile j from input tile j (lastStride=1) for any tile
     // count, with no power-of-2 padding. For k<=32 lastStride is unused.
-    Type elemF32Type = rewriter.getF32Type();
+    // Extract/merge index buffers carry the same index element type chosen
+    // above (bf16 for small reduction dims, else Int32).
+    Type extractIdxElemType = idxElemType;
     std::size_t physicalRank = static_cast<std::size_t>(rank);
     int64_t outputReductionTiles = (k + 31) / 32;
     int64_t lastStride = 1;
@@ -4602,9 +4772,13 @@ public:
         int64_t groupTiles = static_cast<int64_t>(group.size());
 
         // Build a groupTiles-tile buffer type along the reduction dim from a
-        // 1-tile partial's layout.
+        // 1-tile partial's layout. Values and indices carry different element
+        // types (f32 vs Int32), so build a wide type per side.
         auto partialType = cast<RankedTensorType>(group[0].first.getType());
         auto tileType = cast<ttcore::TileType>(partialType.getElementType());
+        auto idxPartialType = cast<RankedTensorType>(group[0].second.getType());
+        auto idxTileType =
+            cast<ttcore::TileType>(idxPartialType.getElementType());
         auto partialLayout =
             cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
         SmallVector<int64_t> wideShape(partialType.getShape().begin(),
@@ -4612,6 +4786,8 @@ public:
         wideShape[deviceRedDim] = groupTiles;
         auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
         auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
+        auto wideIdxType =
+            RankedTensorType::get(wideShape, idxTileType, wideLayout);
 
         // Separate CompositeViews for values and indices (the DMA-expansion
         // pass supports only one composite view per GenericOp, #7600), each
@@ -4625,7 +4801,7 @@ public:
             loc, wideType, valComposites, static_cast<int32_t>(dim),
             /*logicalSizes=*/nullptr);
         auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
-            loc, wideType, idxComposites, static_cast<int32_t>(dim),
+            loc, wideIdxType, idxComposites, static_cast<int32_t>(dim),
             /*logicalSizes=*/nullptr);
 
         // Materialize each composite into a genuinely-allocated L1 buffer via
@@ -4683,8 +4859,8 @@ public:
         int64_t mergeReductionElems = groupTiles * 32;
         auto mergeValsOut =
             rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
-        auto mergeIdxOut =
-            rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
+        auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
+            loc, wideShape, idxTileType, wideLayout);
         SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
         SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
                                            mergeIdxOut.getResult()};
@@ -4732,16 +4908,16 @@ public:
       topkIdxRelayouted = merged.second;
     }
 
-    // Index extract uses fp32 topk tiles; a typecast generic below converts
-    // to the user index output element type (uint16) for width-preserving
-    // untilize.
-    auto f32IndicesType =
-        RankedTensorType::get(indicesType.getShape(), elemF32Type);
+    // Index extract uses the index-element-type topk tiles; a typecast generic
+    // below converts to the user index output element type (uint16) for
+    // width-preserving untilize.
+    auto extractIdxIndicesType =
+        RankedTensorType::get(indicesType.getShape(), extractIdxElemType);
 
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
     SmallVector<Value> origIdxOutputs =
-        createDpsOutputs(loc, rewriter, {f32IndicesType});
+        createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
     Value extractValsLayout = createOptimalLayoutOp(
         origValOutputs[0], memorySpaces[1], /*tiled=*/true,
         /*noCollapse=*/false, rewriter);
@@ -4761,7 +4937,7 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
-    // Typecast extracted fp32 indices to the output element type (uint16)
+    // Typecast extracted indices to the output element type (uint16)
     // before untilize. One tile op per region so D2M->TTKernel store/DST-index
     // lookup finds a single terminal compute op.
     Value extractedIdx = extractIdxGeneric->getResult(0);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3730,10 +3730,13 @@ public:
     int64_t fullReductionElems = inputType.getShape()[dim];
     int64_t fullReductionTiles =
         (fullReductionElems + kTileWidth - 1) / kTileWidth;
-    // G = number of slices needed so each slice is <= kMaxShardTiles tiles.
-    int64_t numShards =
+    // Minimum cores needed so each band is <= kMaxShardTiles tiles. This is a
+    // lower bound; the actual band count is the physical grid area chosen below
+    // (which must divide fullReductionTiles evenly and fit the worker grid), so
+    // it may exceed this minimum.
+    int64_t minShards =
         (fullReductionTiles + kMaxShardTiles - 1) / kMaxShardTiles;
-    bool multiCore = numShards > 1;
+    bool multiCore = minShards > 1;
 
     if (fullReductionTiles < 1) {
       return rewriter.notifyMatchFailure(
@@ -3745,6 +3748,13 @@ public:
       // 2-tile output with no second input tile to source it from.
       assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
+    // The reduction bands are distributed one per core: numShards bands, each a
+    // logical shard at grid position [0, g]. The tensor keeps a 1xnumShards
+    // device grid; a virtual-grid map (attached in emitShardTopk) folds those
+    // numShards logical positions onto the 2D physical worker grid. numShards
+    // is 1 for single-core, chosen below for multi-core.
+    SmallVector<int64_t> workerGridShape;
+    int64_t numShards = 1;
     if (multiCore) {
       // Hard-fail (no TTNN fallback) for configs outside the first-cut scope.
       assert(k <= 32 && "multi-core topk first cut only supports k <= 32");
@@ -3752,9 +3762,39 @@ public:
       assert(inputType.getShape()[0] == kTileWidth &&
              "multi-core topk first cut only supports a single tile row "
              "(ht == 1)");
-      assert(fullReductionElems % (kTileWidth * numShards) == 0 &&
-             "multi-core topk first cut requires the reduction dim to divide "
-             "evenly across shards");
+
+      auto device = ttcore::lookupDevice(op);
+      workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
+      assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
+
+      // Pick the band count. It must (1) be >= minShards so each band holds
+      // <= kMaxShardTiles reduction tiles, (2) divide fullReductionTiles evenly
+      // so getDeviceShape can shard the tile plane cleanly, and (3) have a
+      // legal 2D factorization within the worker grid so the 1xnumShards
+      // logical grid can be folded onto physical cores
+      // (findLegalPhysicalGridForVolume). Pinning numShards to minShards (=
+      // ceil(tiles/32)) fails whenever that count is prime-ish (e.g. 23 or 27,
+      // which have no <=8x<=8 factor pair); searching upward for the first
+      // divisor that also factors legally always finds one when
+      // fullReductionTiles has a suitable divisor.
+      for (int64_t cand = minShards; cand <= fullReductionTiles; ++cand) {
+        if (fullReductionTiles % cand != 0) {
+          continue;
+        }
+        if (fullReductionTiles / cand > kMaxShardTiles) {
+          continue;
+        }
+        if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+                .empty()) {
+          continue;
+        }
+        numShards = cand;
+        break;
+      }
+      assert(numShards > 1 &&
+             "multi-core topk: no band count divides the reduction tile count "
+             "with <= kMaxShardTiles tiles per core and a legal worker-grid "
+             "factorization");
     }
 
     // Emits the full single-shard topk (layout -> transpose -> arange/index ->
@@ -3790,10 +3830,40 @@ public:
       // buffer already tilized whole-on-one -core, so that staging buffer would
       // overflow L1 for wide reduction dims.
       Value layoutedInput;
+      // Virtual-grid fold maps for the multi-core path. Set when gridCols>1 and
+      // attached (via attachFold below) to EVERY EmptyOp allocated at the
+      // 1xgridCols device grid, so their buffers place on the same folded
+      // physical cores as the input. Without the map a 1xgridCols buffer would
+      // request physical core columns 0..gridCols-1 and crash for gridCols>8.
+      AffineMapAttr foldForwardMapAttr, foldInverseMapAttr;
+      auto attachFold = [&](d2m::EmptyOp emptyOp) {
+        if (foldForwardMapAttr) {
+          emptyOp.setVirtualGridForwardMappingAttr(foldForwardMapAttr);
+          emptyOp.setVirtualGridInverseMappingAttr(foldInverseMapAttr);
+        }
+      };
       if (gridCols > 1) {
-        // Build the same collapsed, sharded L1 layout createOptimalLayoutOp
-        // produces for the 2D case, but target a 1xgridCols device grid so each
-        // core owns wt/gridCols reduction tiles.
+        // Distribute the gridCols reduction bands (one band = kMaxShardTiles
+        // reduction tiles) across the worker grid, one band per core. The
+        // tensor keeps a 1xgridCols device grid -- band g == reduction tiles
+        // [g*shardTiles, (g+1)*shardTiles), so each core holds all ht rows and
+        // a distinct COLUMN band. This is the tile-correct sharding: topk is
+        // per-row, so every core must see the full row (ht) over its column
+        // band. (Reshaping the logical shape to a 2D tensor grid is WRONG: it
+        // would tile-group different elements and split each row across cores.)
+        //
+        // A literal 1xgridCols placement asks for physical core columns
+        // 0..gridCols-1, which exceeds the worker width once gridCols > worker
+        // cols (e.g. 1x32 on 8x8 asks for col 31 -> the coordinate manager
+        // cannot translate it). So attach a virtual-grid mapping that folds the
+        // gridCols logical shard positions onto the 2D physical grid (the same
+        // createCoreVirtMaps machinery GridSelection uses). Logical shard [0,
+        // g] lands on physical core findLegalPhysicalGridForVolume-folded from
+        // g, while the tensor grid, generic maps, and gather indices all stay
+        // 1xgridCols. The buffer placement (flatbuffer) and the DMA address
+        // path both read this same forward map, so they agree; the physical
+        // grid MUST be the one findLegalPhysicalGridForVolume picks (that is
+        // what both consumers recompute deterministically).
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
@@ -3808,6 +3878,18 @@ public:
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
+        // Fold the 1xgridCols logical shard grid onto the 2D physical grid.
+        SmallVector<int64_t> physicalGrid =
+            d2m::utils::findLegalPhysicalGridForVolume(gridCols,
+                                                       workerGridShape);
+        assert(!physicalGrid.empty() &&
+               "band count has no legal worker-grid factorization");
+        auto [forwardMap, inverseMap] =
+            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
+                                                          physicalGrid);
+        foldForwardMapAttr = AffineMapAttr::get(forwardMap);
+        foldInverseMapAttr = AffineMapAttr::get(inverseMap);
+        attachFold(shardedEmpty);
         layoutedInput =
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
@@ -3882,12 +3964,15 @@ public:
           loc, deviceShape, f32TileType, metalLayout);
       auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
           loc, deviceShape, f32TileType, metalLayout);
+      attachFold(topkValsEmpty);
+      attachFold(topkIdxEmpty);
 
       auto wrapInToLayout = [&](Value genericResult) -> Value {
         auto resultType = cast<RankedTensorType>(genericResult.getType());
         auto emptyOp = rewriter.create<d2m::EmptyOp>(
             loc, resultType.getShape(), resultType.getElementType(),
             resultType.getEncoding());
+        attachFold(emptyOp);
         return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
             .getResult(0);
       };
@@ -3906,6 +3991,7 @@ public:
         auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
         auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
             loc, srcType.getShape(), srcTileType, srcLayout);
+        attachFold(transposeEmpty);
         SmallVector<Value> transposeInputs = {src};
         SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
         auto transposeGeneric = rewriter.create<d2m::GenericOp>(
@@ -3971,11 +4057,10 @@ public:
       // each core owns only its band.
       SmallVector<Value> arangeOutputs;
       if (gridCols > 1) {
-        arangeOutputs.push_back(rewriter
-                                    .create<d2m::EmptyOp>(loc, deviceShape,
-                                                          f32TileType,
-                                                          metalLayout)
-                                    .getResult());
+        auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, deviceShape, f32TileType, metalLayout);
+        attachFold(arangeEmpty);
+        arangeOutputs.push_back(arangeEmpty.getResult());
       } else {
         auto arangeOrigOutputs =
             createDpsOutputs(loc, rewriter, {f32InputType});
@@ -4059,11 +4144,10 @@ public:
       // device shape so its L1 buffer is split across cores and its operand
       // grid matches the sharded arange input (and topkInput).
       if (gridCols > 1) {
-        postArangeBcastOutputs.push_back(
-            rewriter
-                .create<d2m::EmptyOp>(loc, deviceShape, f32TileType,
-                                      metalLayout)
-                .getResult());
+        auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, deviceShape, f32TileType, metalLayout);
+        attachFold(bcastEmpty);
+        postArangeBcastOutputs.push_back(bcastEmpty.getResult());
       } else {
         // For single-core, use the standard layout wrapping.
         auto postArangeBcastOrigOutputs =
@@ -4291,8 +4375,12 @@ public:
                     .create<tensor::EmptyOp>(loc, srcShardType.getShape(),
                                              srcShardType.getElementType())
                     .getResult();
-            // remote_load source band g: grid index [0, g] (dim==1 shards along
-            // columns) into loadBuf.
+            // remote_load source band g: LOGICAL grid index [0, g]. The source
+            // buffer carries a virtual-grid forward map (attached where its
+            // 1xgridCols layout is built), and the DMA address path composes
+            // that map to fold [0, g] onto the physical core band g actually
+            // lives on. So we address the logical position, not the folded
+            // physical core.
             Value zeroGrid = rewriter.create<arith::ConstantIndexOp>(loc, 0);
             Value colGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
             SmallVector<Value> srcIndices = {zeroGrid, colGrid};

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -35,6 +35,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 
@@ -3789,7 +3790,7 @@ public:
     // kMaxMultiCoreTilesPerCore is the smaller, measured-safe cap used only for
     // sizing multi-core bands.
     constexpr int64_t kMaxTilesPerCore = 43;
-    constexpr int64_t kMaxMultiCoreTilesPerCore = 32;
+    constexpr int64_t kMaxMultiCoreTilesPerCore = 43;
     int64_t fullReductionElems = inputType.getShape()[dim];
     int64_t nonTargetElems = inputType.getShape()[1 - dim];
     int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
@@ -4196,12 +4197,6 @@ public:
       // (and no -inf mask) is needed on the reduction dim.
 
       auto topkIdxTileType = ttcore::TileType::get(idxElemType);
-      auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, f32TileType, metalLayout);
-      auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, topkIdxTileType, metalLayout);
-      attachFold(topkValsEmpty);
-      attachFold(topkIdxEmpty);
 
       auto wrapInToLayout = [&](Value genericResult) -> Value {
         auto resultType = cast<RankedTensorType>(genericResult.getType());
@@ -4674,6 +4669,13 @@ public:
         idxBuf = transposeTilesGrid(idxBuf);
       }
 
+      auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, deviceShape, f32TileType, metalLayout);
+      auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, deviceShape, topkIdxTileType, metalLayout);
+      attachFold(topkValsEmpty);
+      attachFold(topkIdxEmpty);
+
       SmallVector<Value> topkInputs = {topkInput, idxBuf};
       SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
                                         topkIdxEmpty.getResult()};
@@ -4777,6 +4779,22 @@ public:
         for (int64_t g = 0; g < gridCols; ++g) {
           auto outEmpty = rewriter.create<d2m::EmptyOp>(
               loc, perCorePartialShape, tileType, perCorePartialLayout);
+          // Place partial g's collector output at physical linear index g
+          // (same offset-core fold idiom as the remainder band and the merge
+          // tree) so the gridCols collected partials live on gridCols distinct
+          // cores instead of all piling onto core (0,0): without this, every
+          // one of the gridCols collector generics below defaults to an
+          // unfolded unit grid, so all their live buffers colocate on one core
+          // and blow the L1 budget for wide numShards.
+          {
+            SmallVector<int64_t> unitGrid = {1, 1};
+            auto [gatherFwd, gatherInv] =
+                createOffsetCoreVirtMaps(ctx, unitGrid, workerGridShape, g);
+            outEmpty.setVirtualGridForwardMappingAttr(
+                AffineMapAttr::get(gatherFwd));
+            outEmpty.setVirtualGridInverseMappingAttr(
+                AffineMapAttr::get(gatherInv));
+          }
           SmallVector<Value> ins = {gridResult};
           SmallVector<Value> outs = {outEmpty.getResult()};
           // Grid-1x1 collector generic. The input is the whole [1,gridCols]
@@ -4899,13 +4917,182 @@ public:
             rewriter.finalizeOpModification(generic);
             rewriter.restoreInsertionPoint(insertPoint);
           }
-          gathered.push_back(wrapInToLayout(generic->getResult(0)));
+          // Relayout to a fresh buffer at partial g's OWN per-g fold (built
+          // above for outEmpty), NOT emitShardTopk's input-band fold (which
+          // wrapInToLayout would apply and is a gridCols-wide fold, wrong for
+          // this single-core partial).
+          auto relayoutEmpty = rewriter.create<d2m::EmptyOp>(
+              loc, perCorePartialShape, tileType, perCorePartialLayout);
+          relayoutEmpty.setVirtualGridForwardMappingAttr(
+              outEmpty.getVirtualGridForwardMappingAttr());
+          relayoutEmpty.setVirtualGridInverseMappingAttr(
+              outEmpty.getVirtualGridInverseMappingAttr());
+          gathered.push_back(rewriter
+                                 .create<d2m::ToLayoutOp>(
+                                     loc, generic->getResult(0), relayoutEmpty)
+                                 .getResult(0));
         }
         return gathered;
       };
 
-      SmallVector<Value> valPartials = gatherPerCore(topkGeneric->getResult(0));
-      SmallVector<Value> idxPartials = gatherPerCore(topkGeneric->getResult(1));
+      // Per-band pre-compaction (multi-core only): copy each band's leading
+      // outputReductionTiles reduction tiles into a narrow fresh buffer,
+      // grid-preserving ([1,gridCols] / gridColsx1), BEFORE the cross-core
+      // gather. Without this the wide leaf topk result (bandTiles reduction
+      // tiles per core, for BOTH values and indices) stays live across all
+      // gridCols collector reads -- every band core holds ~2*bandTiles tiles
+      // for the whole gather phase, which overflows L1 for wide reductions
+      // (e.g. 32x65536 -> 64 bands of 32 tiles). Compacting first drops that
+      // sustained-across-gather footprint to ~2*outputReductionTiles
+      // tiles/core; the wide leaf result dies at this generic's read.
+      //
+      // Grid-preserving: input and output both live on the [1,gridCols] (or
+      // gridColsx1) band grid, so output band g must read INPUT band g (its own
+      // core's wide leaf result), narrow it to outputReductionTiles tiles, and
+      // keep it resident on that same core. Correctness hinges on band-g-reads-
+      // band-g: we canNOT express that with an affine input map, because the
+      // reduction dim is simultaneously the grid-partition dim (gridCols) and
+      // the shard tile dim (bandTiles). An identity map on that dim would read
+      // band g correctly at the grid level, but re-enables the shard-shape
+      // verifier check (which then fails: input shard bandTiles !=
+      // outputReductionTiles). A constant-0 map exempts the shard check
+      // (hasOperandBroadcasting), but then reads band 0 for every cell.
+      //
+      // Resolution (same idiom as gatherPerCore): give the input a constant
+      // grid map so BOTH verifier checks (grid + shard) are bypassed, then
+      // drive the real per-cell read with an EXPLICIT remote_load whose grid
+      // index is this cell's own position (buildGridIndices over the identity
+      // map -> BlockIndexOp per dim). Cell g thus loads band g, narrows the
+      // leading outputReductionTiles tiles via the inner linalg's
+      // `dim mod extent`, and stores back to its own cell.
+      auto compactBands = [&](Value wideResult) -> Value {
+        auto wideType = cast<RankedTensorType>(wideResult.getType());
+        auto tileType = cast<ttcore::TileType>(wideType.getElementType());
+        auto wideMetalLayout =
+            cast<ttcore::MetalLayoutAttr>(wideType.getEncoding());
+        SmallVector<int64_t> narrowShape(wideType.getShape().begin(),
+                                         wideType.getShape().end());
+        narrowShape[deviceRedDimLocal] = outputReductionTiles;
+        auto narrowLayout = ttcore::MetalLayoutAttr::get(
+            ctx,
+            SmallVector<int64_t>{
+                narrowShape[narrowShape.size() - 2] * kTileDimLocal,
+                narrowShape[narrowShape.size() - 1] * kTileDimLocal},
+            wideMetalLayout.getDimAlignments(),
+            wideMetalLayout.getCollapsedIntervals(),
+            wideMetalLayout.getMemorySpace(),
+            wideMetalLayout.getMemoryLayout());
+        auto narrowEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, narrowShape, tileType, narrowLayout);
+        attachFold(narrowEmpty);
+
+        std::size_t genRedDim =
+            (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+        // Constant grid map on the input: makes hasOperandBroadcasting true so
+        // the verifier skips BOTH the grid-equality and the shard-shape checks
+        // for this operand. The real read is the explicit remote_load below;
+        // the output keeps the identity map.
+        AffineMap constInMap =
+            AffineMap::get(physicalRank, 0,
+                           SmallVector<AffineExpr>(
+                               physicalRank, rewriter.getAffineConstantExpr(0)),
+                           ctx);
+        SmallVector<Value> ins = {wideResult};
+        SmallVector<Value> outs = {narrowEmpty.getResult()};
+        auto generic = rewriter.create<d2m::GenericOp>(
+            loc, ins, outs, /*additionalArgs=*/ValueRange(),
+            rewriter.getAffineMapArrayAttr(
+                SmallVector<AffineMap>{constInMap, identityMap}),
+            rewriter.getArrayAttr(iteratorTypes));
+        generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+
+        // Build the region manually: the auto-generated region would
+        // remote_load at the constant input map's grid index (band 0) -- the
+        // bug. We instead load from THIS cell's own grid position (identity),
+        // narrow, and store.
+        {
+          auto insertPoint = rewriter.saveInsertionPoint();
+          rewriter.startOpModification(generic);
+          mlir::Region &region = generic->getRegions().front();
+          mlir::Block *block = rewriter.createBlock(&region);
+          rewriter.setInsertionPointToStart(block);
+
+          auto inShardType = RankedTensorType::get(
+              wideType.getShape().take_back(physicalRank), tileType);
+          auto outShardType = RankedTensorType::get(
+              ArrayRef<int64_t>(narrowShape).take_back(physicalRank), tileType);
+          std::size_t shardRank = outShardType.getRank();
+          std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
+          int64_t inShardReductionExtent = inShardType.getShape()[shardRedDim];
+
+          // remote_load band g: grid index = this cell's own position (identity
+          // map -> BlockIndexOp per dim), so band g reads band g. The source
+          // buffer carries a virtual-grid fold, composed by the DMA address
+          // path onto the physical core band g lives on -- addressed via the
+          // logical position, same as gatherPerCore.
+          Value loadBuf =
+              rewriter
+                  .create<tensor::EmptyOp>(loc, inShardType.getShape(),
+                                           inShardType.getElementType())
+                  .getResult();
+          SmallVector<Value> srcIndices =
+              d2m::utils::buildGridIndices(rewriter, loc, identityMap);
+          Value loaded =
+              rewriter
+                  .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
+                                             wideResult, srcIndices)
+                  .getResult();
+
+          // Copy the loaded band's leading outputReductionTiles reduction tiles
+          // into the narrow output shard. `dim mod extent` clamps the loop
+          // bound to the output while reading the leading tiles of the input.
+          Value outBuf =
+              rewriter
+                  .create<tensor::EmptyOp>(loc, outShardType.getShape(),
+                                           outShardType.getElementType())
+                  .getResult();
+          SmallVector<AffineExpr> shardInExprs;
+          for (std::size_t i = 0; i < shardRank; ++i) {
+            shardInExprs.push_back(i == shardRedDim
+                                       ? rewriter.getAffineDimExpr(i) %
+                                             inShardReductionExtent
+                                       : rewriter.getAffineDimExpr(i));
+          }
+          AffineMap shardInMap =
+              AffineMap::get(shardRank, 0, shardInExprs, ctx);
+          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
+          SmallVector<mlir::utils::IteratorType> linalgIters(
+              shardRank, mlir::utils::IteratorType::parallel);
+          auto linalgOp = rewriter.create<linalg::GenericOp>(
+              loc, outBuf.getType(), loaded, outBuf,
+              SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
+              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                Value copied = b.create<d2m::TileTypecastOp>(
+                    bodyLoc, args[1].getType(), args[0]);
+                b.create<linalg::YieldOp>(bodyLoc, copied);
+              });
+
+          // Store into this cell's own grid position (identity output map).
+          SmallVector<Value> outIndices =
+              d2m::utils::buildGridIndices(rewriter, loc, identityMap);
+          Value storeResult =
+              rewriter
+                  .create<d2m::RemoteStoreOp>(
+                      loc, narrowEmpty.getType(), narrowEmpty.getResult(),
+                      outIndices, linalgOp->getResult(0))
+                  .getResult();
+          rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
+          rewriter.finalizeOpModification(generic);
+          rewriter.restoreInsertionPoint(insertPoint);
+        }
+        return wrapInToLayout(generic->getResult(0));
+      };
+
+      Value valCompacted = compactBands(topkGeneric->getResult(0));
+      Value idxCompacted = compactBands(topkGeneric->getResult(1));
+
+      SmallVector<Value> valPartials = gatherPerCore(valCompacted);
+      SmallVector<Value> idxPartials = gatherPerCore(idxCompacted);
       for (int64_t g = 0; g < gridCols; ++g) {
         partials.push_back({valPartials[g], idxPartials[g]});
       }
@@ -4929,12 +5116,28 @@ public:
     std::size_t physicalRank = static_cast<std::size_t>(rank);
     int64_t lastStride = 1;
 
+    // Fold maps for the CURRENTLY-EMITTING merge group, so every buffer a
+    // mergePartials call allocates lands on that group's assigned physical
+    // core (see the merge-tree loop, which assigns one core per group per
+    // round). Null outside a mergePartials call (single-core path, or between
+    // groups) -- then EmptyOps stay unit-grid on core (0,0), the original
+    // behavior. Set/cleared by mergePartials; the outer relayout/compactToTile
+    // helpers read them so their EmptyOps co-locate with the merge.
+    AffineMapAttr mergeFoldForwardAttr, mergeFoldInverseAttr;
+    auto attachMergeFold = [&](d2m::EmptyOp emptyOp) {
+      if (mergeFoldForwardAttr) {
+        emptyOp.setVirtualGridForwardMappingAttr(mergeFoldForwardAttr);
+        emptyOp.setVirtualGridInverseMappingAttr(mergeFoldInverseAttr);
+      }
+    };
+
     // to_layout wrapper usable at this (outer) scope for the merge tree.
     auto relayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
       auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
                                                    resultType.getElementType(),
                                                    resultType.getEncoding());
+      attachMergeFold(emptyOp);
       return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
           .getResult(0);
     };
@@ -5001,6 +5204,7 @@ public:
       auto compactLayout = layoutForDeviceShape(layout, compactShape);
       auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, compactShape, tileType,
                                                     compactLayout);
+      attachMergeFold(outEmpty);
       std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       // Generic-level input map: constant-0 on the reduction dim, identity
@@ -5096,8 +5300,33 @@ public:
       // above). For numShards > maxMultiCoreReductionTilesPerCore the driver
       // below feeds this into a multi-level merge tree so no core ever holds
       // more than the budget in tiles.
-      auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group)
-          -> std::pair<Value, Value> {
+      // foldColBase >= 0 places this whole merge (all its buffers and the
+      // topk_block) on the worker core at physical linear index foldColBase,
+      // via the same offset-core virtual-grid fold the remainder band uses.
+      // The group's input partials already carry their own fold maps (pointing
+      // at whatever cores they were produced on), so the CompositeView's
+      // DMA-read expansion gathers them onto this merge's core. foldColBase < 0
+      // leaves the merge unit-grid on core (0,0) (the original behavior).
+      auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group,
+                               int64_t foldColBase =
+                                   -1) -> std::pair<Value, Value> {
+        // Set the group's fold maps (read by relayout/compactToTile and the
+        // local EmptyOps below); clear them on return so buffers emitted
+        // between groups stay unit-grid.
+        mergeFoldForwardAttr = nullptr;
+        mergeFoldInverseAttr = nullptr;
+        if (foldColBase >= 0) {
+          SmallVector<int64_t> unitGrid = {1, 1};
+          auto [fwd, inv] = createOffsetCoreVirtMaps(
+              ctx, unitGrid, workerGridShape, foldColBase);
+          mergeFoldForwardAttr = AffineMapAttr::get(fwd);
+          mergeFoldInverseAttr = AffineMapAttr::get(inv);
+        }
+        auto clearFold = llvm::make_scope_exit([&] {
+          mergeFoldForwardAttr = nullptr;
+          mergeFoldInverseAttr = nullptr;
+        });
+
         int64_t groupTiles = static_cast<int64_t>(group.size());
 
         // Build a (groupTiles * outputReductionTiles)-tile buffer type along
@@ -5150,6 +5379,7 @@ public:
           auto copyOut = rewriter.create<d2m::EmptyOp>(
               loc, compType.getShape(), compType.getElementType(),
               compType.getEncoding());
+          attachMergeFold(copyOut);
           SmallVector<Value> ins = {composite};
           SmallVector<Value> outs = {copyOut.getResult()};
           auto copyGeneric = rewriter.create<d2m::GenericOp>(
@@ -5193,6 +5423,8 @@ public:
             rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
         auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
             loc, wideShape, idxTileType, wideLayout);
+        attachMergeFold(mergeValsOut);
+        attachMergeFold(mergeIdxOut);
         SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
         SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
                                            mergeIdxOut.getResult()};
@@ -5236,15 +5468,32 @@ public:
       // trailing group of size 1 is carried forward unmerged rather than run
       // through a degenerate single-input topk_block.
       int64_t mergeCap =
-          maxMultiCoreReductionTilesPerCore / outputReductionTiles;
+          (maxMultiCoreReductionTilesPerCore / outputReductionTiles);
+      if (k > 32) {
+        // k > 32 has a greater footprint so we put less tiles on each merge
+        // core
+        mergeCap /= 4;
+      }
       assert(mergeCap >= 2 &&
              "merge tree needs a cap of at least 2 partials per group");
+      // Distribute a round's groups across worker cores: group g's merge runs
+      // on the worker core at physical linear index g (row-major), so the
+      // numGroups merges in a round execute in parallel rather than serializing
+      // on core (0,0). Each merge's input partials carry their own fold maps
+      // (from the previous round's per-group placement, or the leaf gather), so
+      // the CompositeView DMA-read expansion gathers them onto group g's core.
+      // A round's numGroups is bounded by mergeCap <= the worker-grid area
+      // (mergeCap derives from the per-core tile budget, which is < grid area),
+      // so linear index g always maps to a real worker core.
+      int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
       SmallVector<std::pair<Value, Value>> level = std::move(partials);
       while (level.size() > 1) {
         int64_t count = static_cast<int64_t>(level.size());
         // Balanced fan-in: spread partials over ceil(count / cap) groups so
         // each group is <= cap and groups differ in size by at most one.
         int64_t numGroups = (count + mergeCap - 1) / mergeCap;
+        assert(numGroups <= maxGridCores &&
+               "merge round has more groups than worker cores");
         int64_t baseSize = count / numGroups;
         int64_t extra = count % numGroups; // first `extra` groups get +1.
         SmallVector<std::pair<Value, Value>> next;
@@ -5254,12 +5503,13 @@ public:
           int64_t groupSize = baseSize + (g < extra ? 1 : 0);
           assert(groupSize <= mergeCap && "merge group exceeds the L1 cap");
           if (groupSize == 1) {
-            // Nothing to merge; carry this partial into the next round.
+            // Nothing to merge; carry this partial into the next round (it
+            // keeps its existing core placement).
             next.push_back(level[pos]);
           } else {
-            next.push_back(
-                mergePartials(ArrayRef<std::pair<Value, Value>>(level).slice(
-                    pos, groupSize)));
+            next.push_back(mergePartials(
+                ArrayRef<std::pair<Value, Value>>(level).slice(pos, groupSize),
+                /*foldColBase=*/g));
           }
           pos += groupSize;
         }

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3728,16 +3728,22 @@ public:
     constexpr int64_t kTileWidth = 32;
     constexpr int64_t kMaxShardTiles = 32; // L1-safe shard width.
     int64_t fullReductionElems = inputType.getShape()[dim];
-    int64_t fullReductionTiles = fullReductionElems / kTileWidth;
+    int64_t fullReductionTiles =
+        (fullReductionElems + kTileWidth - 1) / kTileWidth;
     // G = number of slices needed so each slice is <= kMaxShardTiles tiles.
     int64_t numShards =
         (fullReductionTiles + kMaxShardTiles - 1) / kMaxShardTiles;
     bool multiCore = numShards > 1;
 
-    if (fullReductionTiles < 2) {
+    if (fullReductionTiles < 1) {
       return rewriter.notifyMatchFailure(
           op,
-          "D2M topk requires at least 2 tiles along the reduction dimension");
+          "D2M topk requires at least 1 tile along the reduction dimension");
+    }
+    if (fullReductionTiles == 1) {
+      // A single tile holds at most kTileWidth elements; k>32 would need a
+      // 2-tile output with no second input tile to source it from.
+      assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
     if (multiCore) {
       // Hard-fail (no TTNN fallback) for configs outside the first-cut scope.
@@ -3751,41 +3757,21 @@ public:
              "evenly across shards");
     }
 
-    // Reblocks a unit-grid ([1,1,ht,wt]) device tensor to grid 1xG
-    // ([1,G,ht,wt/G]) via a ViewLayoutOp so the G reduction-dim bands land on G
-    // distinct cores. createOptimalLayoutOp always builds a unit grid; this
-    // splits the shard's reduction-dim tiles across grid columns without moving
-    // data. GenericOp::build then auto-derives grid 1xG from the operand's grid
-    // shape, distributing the local topk compute across cores. Same idiom as
-    // the TTNN unit-grid reblock in createOptimalLayoutOp.
-    auto reblockToGrid = [&](Value value, int64_t gridCols) -> Value {
-      auto type = cast<RankedTensorType>(value.getType());
-      // No-op if already at the requested grid (also covers the single-core
-      // gridCols==1 path where the tensor is already unit grid).
-      ArrayRef<int64_t> curShape = type.getShape();
-      int64_t curGridCols = curShape[curShape.size() / 2 - 1];
-      if (curGridCols == gridCols) {
-        return value;
-      }
-      SmallVector<int64_t> newGrid = {1, gridCols};
-      auto [newShape, reblockMap] = ttmlir::utils::calculateReblockMapForGrid(
-          type.getShape(), newGrid, ctx);
-      auto newType = RankedTensorType::get(newShape, type.getElementType(),
-                                           type.getEncoding());
-      return rewriter
-          .create<d2m::ViewLayoutOp>(loc, newType, value, reblockMap,
-                                     /*reinterpretLayout=*/false)
-          .getResult();
-    };
-
     // Emits the full single-shard topk (layout -> transpose -> arange/index ->
     // TopkBlockOp -> relayout) over a raw [ht, shardWidth] input, returning the
     // (values, indices) partials still in device layout (pre-extract).
     // arangeStart offsets the index buffer so slice g yields GLOBAL indices.
     // gridCols > 1 distributes the local topk compute across that many cores by
     // reblocking the reduction-dim tiles into grid columns (one band per core).
+    // Returns one (values, indices) partial per source core: a single grid-1x1
+    // partial for the single-core path (gridCols==1), or gridCols grid-1x1
+    // partials for the multi-core path (one per band). Each partial is a
+    // grid-1x1 buffer holding that band's local top-k (pre-extract, global
+    // indices). The caller CompositeViews the multi-core partials and runs a
+    // final merge topk_block to pick the global top-k.
     auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols = 1) -> std::pair<Value, Value> {
+                             int64_t gridCols =
+                                 1) -> SmallVector<std::pair<Value, Value>> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
@@ -3796,15 +3782,82 @@ public:
       SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                             inputType.getShape().end());
 
-      Value layoutedInput =
-          createOptimalLayoutOp(rawInput, memorySpaces[0], /*tiled=*/true,
-                                /*noCollapse=*/false, rewriter);
-      // Shard the input across gridCols cores up front: reblock the unit-grid
-      // [1,1,ht,wt] layout to [1,gridCols,ht,wt/gridCols] so each core owns a
-      // wt/gridCols-tile band. Deriving deviceShape/metalLayout from this
-      // reblocked type makes the whole local-topk chain (transpose, arange,
-      // bcast, topk_block) allocate and compute per-core on its band.
-      layoutedInput = reblockToGrid(layoutedInput, gridCols);
+      // Lay out the input in L1 tiled form. For gridCols>1 the reduction dim is
+      // split into gridCols bands, one per core: the input is tilized DIRECTLY
+      // into a [1,gridCols,ht,wt/gridCols] buffer so the to_layout/tilize
+      // itself is sharded per-core. Reblocking a unit-grid
+      // createOptimalLayoutOp result instead would only add a view over a
+      // buffer already tilized whole-on-one -core, so that staging buffer would
+      // overflow L1 for wide reduction dims.
+      Value layoutedInput;
+      if (gridCols > 1) {
+        // Build the same collapsed, sharded L1 layout createOptimalLayoutOp
+        // produces for the 2D case, but target a 1xgridCols device grid so each
+        // core owns wt/gridCols reduction tiles.
+        constexpr std::array<int64_t, 2> defaultTileShape =
+            ttcore::TileType::getDefaultShape();
+        SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
+                                          defaultTileShape.end());
+        auto tileElemType =
+            ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
+        auto shardedLayout = ttcore::MetalLayoutAttr::get(
+            ctx, inputType.getShape(), memorySpaces[0],
+            ttcore::TensorMemoryLayout::Sharded);
+        SmallVector<int64_t> shardedGrid = {1, gridCols};
+        SmallVector<int64_t> shardedDeviceShape =
+            shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
+        auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, shardedDeviceShape, tileElemType, shardedLayout);
+        layoutedInput =
+            rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
+                .getResult(0);
+      } else if (reductionDimSize <= kTileWidth) {
+        // A single-tile reduction dim has no room for the merge tree (it
+        // needs >=2 tiles). Force the physical buffer to 2 tiles along dim
+        // via dimAlignments while keeping the layout's logical_shape truthful
+        // (still reductionDimSize), so the mask op below fills exactly the
+        // extra tile with -inf (it never wins topk). Built manually rather
+        // than through createOptimalLayoutOp, whose oobVal masking derives
+        // the physical size from the same logical shape it masks against, so
+        // it cannot express "physical > logical-rounded-to-tile" on its own.
+        constexpr std::array<int64_t, 2> defaultTileShape =
+            ttcore::TileType::getDefaultShape();
+        SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
+                                          defaultTileShape.end());
+        auto tileElemType =
+            ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
+        SmallVector<int64_t> paddedDimAlignments(inputType.getShape().size(),
+                                                 kTileWidth);
+        paddedDimAlignments[dim] = 2 * kTileWidth;
+        auto paddedLayout = ttcore::MetalLayoutAttr::get(
+            ctx, inputType.getShape(), memorySpaces[0],
+            ttcore::TensorMemoryLayout::Sharded,
+            ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+                ctx, inputType.getShape().size()),
+            paddedDimAlignments);
+        SmallVector<int64_t> unitGrid(inputType.getShape().size(), 1);
+        SmallVector<int64_t> paddedDeviceShape =
+            paddedLayout.getDeviceShape(unitGrid, tileShapeVec);
+        auto paddedEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, paddedDeviceShape, tileElemType, paddedLayout);
+        Value toLayouted =
+            rewriter.create<d2m::ToLayoutOp>(loc, rawInput, paddedEmpty)
+                .getResult(0);
+        auto maskOutput = rewriter.create<d2m::EmptyOp>(
+            loc, paddedDeviceShape, tileElemType, paddedLayout);
+        layoutedInput = rewriter
+                            .create<d2m::MaskOp>(loc, toLayouted, maskOutput,
+                                                 paddedLayout.getLogicalShape(),
+                                                 ttcore::OOBVal::NegInf)
+                            .getResult();
+        // The arange/index buffer built below must share this padded shard
+        // shape, since the topk d2m.generic requires both operands to match.
+        topkLogicalShape[dim] = 2 * kTileWidth;
+      } else {
+        layoutedInput =
+            createOptimalLayoutOp(rawInput, memorySpaces[0], /*tiled=*/true,
+                                  /*noCollapse=*/false, rewriter);
+      }
       auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
       auto metalLayout =
           cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
@@ -3815,11 +3868,11 @@ public:
       int64_t ht = deviceShape[deviceShape.size() - 2];
       int64_t wt = deviceShape[deviceShape.size() - 1];
       int64_t numReductionTiles = (dim == 1) ? wt : ht;
-      // The >=2 reduction-tile requirement is enforced on the full input before
+      // The >=1 reduction-tile requirement is enforced on the full input before
       // this lambda runs (single-core) / guaranteed by 32-tile shards
       // (multi-core), so it is an invariant here.
-      assert(numReductionTiles >= 2 &&
-             "shard must have at least 2 tiles along the reduction dimension");
+      assert(numReductionTiles >= 1 &&
+             "shard must have at least 1 tile along the reduction dimension");
       // D2MDecomposeTopk's large-k left-fold keeps the accumulator at canonical
       // tiles (winner=0, loser=1) for any tile count, so no power-of-2 padding
       // (and no -inf mask) is needed on the reduction dim.
@@ -3907,16 +3960,30 @@ public:
 
       auto f32InputType = RankedTensorType::get(topkLogicalShape, f32Type,
                                                 inputType.getEncoding());
-      auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {f32InputType});
-      auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
-          rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
-          /*noCollapse=*/false);
-
-      // Shard the index buffer across the same gridCols cores as the input so
-      // arange/bcast allocate and run per-core. toLayoutOperandsAndResults
-      // always builds a unit grid, so reblock to 1xgridCols here; the scratch
-      // and downstream empties derive their grid from this output.
-      arangeOutputs[0] = reblockToGrid(arangeOutputs[0], gridCols);
+      // Shard the index buffer across the same gridCols cores as the input.
+      // For gridCols==1, toLayoutOperandsAndResults builds the unit-grid
+      // EmptyOp + to_layout as usual. For gridCols>1 we must NOT call it: it
+      // would materialize a full-width unit-grid buffer (e.g. 1x1x1x256 tiles =
+      // 1MB) on a single core, and overwriting the returned handle leaves that
+      // dead buffer in the IR where it still gets L1-allocated and overflows.
+      // Instead allocate the arange output directly at the sharded 1xgridCols
+      // device shape (same deviceShape / metalLayout as the value buffers) so
+      // each core owns only its band.
+      SmallVector<Value> arangeOutputs;
+      if (gridCols > 1) {
+        arangeOutputs.push_back(rewriter
+                                    .create<d2m::EmptyOp>(loc, deviceShape,
+                                                          f32TileType,
+                                                          metalLayout)
+                                    .getResult());
+      } else {
+        auto arangeOrigOutputs =
+            createDpsOutputs(loc, rewriter, {f32InputType});
+        auto [arangeins, laidOut] = toLayoutOperandsAndResults(
+            rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
+            /*noCollapse=*/false);
+        arangeOutputs = std::move(laidOut);
+      }
       auto arangeOutput = arangeOutputs[0];
       auto arangeTensorType =
           mlir::cast<RankedTensorType>(arangeOutput.getType());
@@ -3987,17 +4054,25 @@ public:
           d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
       SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
                                                arange.getResults().end());
-      auto postArangeBcastOrigOutputs =
-          createDpsOutputs(loc, rewriter, {f32InputType});
-      auto [postArangeBcastins, postArangeBcastOutputs] =
-          toLayoutOperandsAndResults(
-              rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs},
-              true,
-              /*noCollapse=*/false);
-      // Match the sharded (1xgridCols) arange input grid so the bcast generic's
-      // operand grids agree and it too runs per-core.
-      postArangeBcastOutputs[0] =
-          reblockToGrid(postArangeBcastOutputs[0], gridCols);
+      SmallVector<Value> postArangeBcastOutputs;
+      // For multicore, allocate the broadcast output at the sharded 1xgridCols
+      // device shape so its L1 buffer is split across cores and its operand
+      // grid matches the sharded arange input (and topkInput).
+      if (gridCols > 1) {
+        postArangeBcastOutputs.push_back(
+            rewriter
+                .create<d2m::EmptyOp>(loc, deviceShape, f32TileType,
+                                      metalLayout)
+                .getResult());
+      } else {
+        // For single-core, use the standard layout wrapping.
+        auto postArangeBcastOrigOutputs =
+            createDpsOutputs(loc, rewriter, {f32InputType});
+        auto [postArangeBcastins, laidOut] = toLayoutOperandsAndResults(
+            rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
+            /*noCollapse=*/false);
+        postArangeBcastOutputs = std::move(laidOut);
+      }
 
       // Build affine maps: input is reduced, output is identity.
       mlir::MutableAffineMap postArangeInMap(
@@ -4105,16 +4180,186 @@ public:
             return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
           });
 
-      // Gather the per-core (1xgridCols) topk results back to a unit grid so
-      // the downstream extract/merge path (which assumes 1x1) is unchanged.
-      // This is the single cross-core boundary; distributing the merge is
-      // future work.
-      Value topkValsRelayouted =
-          reblockToGrid(wrapInToLayout(topkGeneric->getResult(0)), 1);
-      Value topkIdxRelayouted =
-          reblockToGrid(wrapInToLayout(topkGeneric->getResult(1)), 1);
+      // Single-core: return the whole topk result as one grid-1x1 partial; the
+      // driver's extract reads its tile 0 (k<=32) / leading tiles (k>32).
+      if (gridCols == 1) {
+        return {{wrapInToLayout(topkGeneric->getResult(0)),
+                 wrapInToLayout(topkGeneric->getResult(1))}};
+      }
 
-      return {topkValsRelayouted, topkIdxRelayouted};
+      // Multi-core gather (mirrors the reference D2MLowerGatherCore pattern:
+      // one collector core DMA-reads one payload per source core). Each source
+      // core's local top-k lives in tile 0 of its band shard. We produce
+      // gridCols separate grid-1x1 single-tile partials -- one per source core
+      // -- so the driver can CompositeView them and run a final merge
+      // topk_block. Building them as separate SSAs (rather than one wide
+      // buffer) is what lets ExpandDMAReadCompositeView later expand the
+      // merge's DMA read into gridCols per-source reads (a plain multi-tile
+      // ViewLayoutOp does NOT gather across cores; only a CompositeView does).
+      //
+      // The collector is a single grid-1x1 generic. Its region loops over the
+      // gridCols source grid columns issuing a remote_load from grid [0, g]
+      // (which lowers to a shard-level DMA read from source core g), copies
+      // that band's tile 0 into a fresh 1-tile buffer, and stores it.
+      // remote_load's grid index is loop-varying, so each iteration pulls a
+      // distinct core.
+      SmallVector<std::pair<Value, Value>> partials;
+      // A grid-1x1 single-tile device layout for each gathered partial. Derive
+      // it from the topk output's shard by shrinking the reduction dim to 1.
+      std::size_t redPhys =
+          (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+      std::size_t deviceRedDimLocal =
+          deviceShape.size() - (physicalRank - redPhys);
+      SmallVector<int64_t> oneTilePerCoreShape(deviceShape.begin(),
+                                               deviceShape.end());
+      oneTilePerCoreShape[0] = 1;
+      oneTilePerCoreShape[1] = 1;
+      oneTilePerCoreShape[deviceRedDimLocal] = 1;
+
+      // Each partial is a grid-1x1 single tile, so its layout's logical shape
+      // must be the 1-tile extent (32x32), NOT the original input's 32x8192.
+      // The downstream CompositeViewOp verifier sums the partials' logical
+      // reduction extents and requires the total to equal the composite
+      // output's logical reduction extent (numShards*32); with the original
+      // logical shape each partial would report 8192 and the sum would blow up.
+      constexpr int64_t kTileDimLocal = 32;
+      ttcore::MetalLayoutAttr oneTileLayout = ttcore::MetalLayoutAttr::get(
+          ctx,
+          SmallVector<int64_t>{
+              oneTilePerCoreShape[oneTilePerCoreShape.size() - 2] *
+                  kTileDimLocal,
+              oneTilePerCoreShape[oneTilePerCoreShape.size() - 1] *
+                  kTileDimLocal},
+          metalLayout.getDimAlignments(), metalLayout.getCollapsedIntervals(),
+          metalLayout.getMemorySpace(), metalLayout.getMemoryLayout());
+
+      // Emits the collector generic for one topk result (values or indices),
+      // returning gridCols grid-1x1 partials (partial g == source core g's
+      // tile 0).
+      auto gatherPerCore = [&](Value gridResult) -> SmallVector<Value> {
+        auto gridType = cast<RankedTensorType>(gridResult.getType());
+        auto tileType = cast<ttcore::TileType>(gridType.getElementType());
+        SmallVector<Value> gathered;
+        for (int64_t g = 0; g < gridCols; ++g) {
+          auto outEmpty = rewriter.create<d2m::EmptyOp>(
+              loc, oneTilePerCoreShape, tileType, oneTileLayout);
+          SmallVector<Value> ins = {gridResult};
+          SmallVector<Value> outs = {outEmpty.getResult()};
+          // Grid-1x1 collector generic. The input is the whole [1,gridCols]
+          // grid result but this generic runs on a single core and gathers
+          // across cores via an explicit remote_load in its region (below), so
+          // the input's grid must NOT be required to match the [1,1] output.
+          // Give the input a constant (0,0) map so the grid verifier exempts it
+          // from the identity-map grid-equality check (same idiom as arange's
+          // scratch operand); the output keeps the identity map.
+          AffineMap collectorInputMap = AffineMap::get(
+              physicalRank, 0,
+              SmallVector<AffineExpr>(physicalRank,
+                                      rewriter.getAffineConstantExpr(0)),
+              ctx);
+          auto generic = rewriter.create<d2m::GenericOp>(
+              loc, ins, outs, /*additionalArgs=*/ValueRange(),
+              rewriter.getAffineMapArrayAttr(
+                  SmallVector<AffineMap>{collectorInputMap, identityMap}),
+              rewriter.getArrayAttr(iteratorTypes));
+          generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+
+          // Build the region manually: the auto-generated region would emit a
+          // single remote_load at the block index; we instead want an explicit
+          // load from source grid column g.
+          {
+            auto insertPoint = rewriter.saveInsertionPoint();
+            rewriter.startOpModification(generic);
+            mlir::Region &region = generic->getRegions().front();
+            mlir::Block *block = rewriter.createBlock(&region);
+            rewriter.setInsertionPointToStart(block);
+
+            // Local buffers: shard buffer to load a source band into, and the
+            // output shard buffer.
+            auto srcShardType = RankedTensorType::get(
+                cast<RankedTensorType>(gridResult.getType())
+                    .getShape()
+                    .take_back(physicalRank),
+                tileType);
+            auto outShardType =
+                RankedTensorType::get(cast<RankedTensorType>(outEmpty.getType())
+                                          .getShape()
+                                          .take_back(physicalRank),
+                                      tileType);
+            Value loadBuf =
+                rewriter
+                    .create<tensor::EmptyOp>(loc, srcShardType.getShape(),
+                                             srcShardType.getElementType())
+                    .getResult();
+            // remote_load source band g: grid index [0, g] (dim==1 shards along
+            // columns) into loadBuf.
+            Value zeroGrid = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+            Value colGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
+            SmallVector<Value> srcIndices = {zeroGrid, colGrid};
+            Value loaded =
+                rewriter
+                    .create<d2m::RemoteLoadOp>(loc, srcShardType, loadBuf,
+                                               gridResult, srcIndices)
+                    .getResult();
+
+            // Copy tile 0 of the loaded band into the 1-tile output shard.
+            Value outBuf =
+                rewriter
+                    .create<tensor::EmptyOp>(loc, outShardType.getShape(),
+                                             outShardType.getElementType())
+                    .getResult();
+            std::size_t shardRank = outShardType.getShape().size();
+            std::size_t shardRedDim = shardRank - (physicalRank - redPhys);
+            int64_t inReductionExtent = srcShardType.getShape()[shardRedDim];
+            // Non-invertible input map on the reduction dim (`dim mod extent`)
+            // so linalg takes the loop bound from the 1-tile output, not the
+            // full band. Same idiom as the extract generic.
+            SmallVector<AffineExpr> shardInExprs;
+            for (std::size_t i = 0; i < shardRank; ++i) {
+              shardInExprs.push_back(i == shardRedDim
+                                         ? rewriter.getAffineDimExpr(i) %
+                                               inReductionExtent
+                                         : rewriter.getAffineDimExpr(i));
+            }
+            AffineMap shardInMap =
+                AffineMap::get(shardRank, 0, shardInExprs, ctx);
+            AffineMap shardIdentity =
+                rewriter.getMultiDimIdentityMap(shardRank);
+            SmallVector<mlir::utils::IteratorType> linalgIters(
+                shardRank, mlir::utils::IteratorType::parallel);
+            auto linalgOp = rewriter.create<linalg::GenericOp>(
+                loc, outBuf.getType(), loaded, outBuf,
+                SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
+                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                  Value copied = b.create<d2m::TileTypecastOp>(
+                      bodyLoc, args[1].getType(), args[0]);
+                  b.create<linalg::YieldOp>(bodyLoc, copied);
+                });
+
+            // Store into grid [0,0] of the grid-1x1 output.
+            SmallVector<Value> outIndices =
+                d2m::utils::buildGridIndices(rewriter, loc, identityMap);
+            Value storeResult =
+                rewriter
+                    .create<d2m::RemoteStoreOp>(
+                        loc, outEmpty.getType(), outEmpty.getResult(),
+                        outIndices, linalgOp->getResult(0))
+                    .getResult();
+            rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
+            rewriter.finalizeOpModification(generic);
+            rewriter.restoreInsertionPoint(insertPoint);
+          }
+          gathered.push_back(wrapInToLayout(generic->getResult(0)));
+        }
+        return gathered;
+      };
+
+      SmallVector<Value> valPartials = gatherPerCore(topkGeneric->getResult(0));
+      SmallVector<Value> idxPartials = gatherPerCore(topkGeneric->getResult(1));
+      for (int64_t g = 0; g < gridCols; ++g) {
+        partials.push_back({valPartials[g], idxPartials[g]});
+      }
+      return partials;
     }; // emitShardTopk
 
     // ----- Drive the shard topk(s): single-core or the multi-core tree. -----
@@ -4151,8 +4396,8 @@ public:
     // Device-tensor index of the reduction dim. The device layout is rank
     // 2*physicalRank ([grid..., shard...]); the reduction tiles live in the
     // shard portion, i.e. the last shard dim for dim==1 and the first shard dim
-    // for dim==0. compactToTile/mergePair reshape the device tensor, so they
-    // must index here, not in shard space.
+    // for dim==0. compactToTile reshapes the device tensor, so it must index
+    // here, not in shard space.
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
@@ -4239,50 +4484,109 @@ public:
       return relayout(generic->getResult(0));
     };
 
-    // Merges two 1-tile (vals, idx) partials into one 1-tile partial by
-    // CompositeView-ing them into a 2-tile buffer and running a TopkBlockOp
-    // generic over it (result lands in tile 0), then compacting back to 1 tile.
-    // Indices are CARRIED (not regenerated) so global indices propagate.
-    auto mergePair = [&](std::pair<Value, Value> a,
-                         std::pair<Value, Value> b) -> std::pair<Value, Value> {
-      auto tileType = cast<ttcore::TileType>(
-          cast<RankedTensorType>(a.first.getType()).getElementType());
-      auto layout = cast<ttcore::MetalLayoutAttr>(
-          cast<RankedTensorType>(a.first.getType()).getEncoding());
-      SmallVector<int64_t> twoTileShape(
-          cast<RankedTensorType>(a.first.getType()).getShape().begin(),
-          cast<RankedTensorType>(a.first.getType()).getShape().end());
-      twoTileShape[deviceRedDim] = 2;
-      // Fresh layout whose logical shape matches the 2-tile physical shape so
-      // the CompositeViewOp logical-shape verifier is satisfied (inputs are
-      // 1 tile each along the composite dim; sum == 2 tiles == output).
-      auto twoTileLayout = layoutForDeviceShape(layout, twoTileShape);
-      auto twoTileType =
-          RankedTensorType::get(twoTileShape, tileType, twoTileLayout);
+    Value topkValsRelayouted, topkIdxRelayouted;
+    if (!multiCore) {
+      auto partials =
+          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0);
+      topkValsRelayouted = partials[0].first;
+      topkIdxRelayouted = partials[0].second;
+    } else {
+      // Distributed local topk: each of numShards cores runs topk_block on its
+      // own reduction-dim band. emitShardTopk gathers the per-core results into
+      // numShards separate grid-1x1 single-tile partials (one per source core,
+      // values + global indices), using an explicit per-source DMA collector
+      // (see emitShardTopk). CompositeView all numShards value partials (and,
+      // separately, index partials) into one numShards-tile buffer along the
+      // reduction dim, materialize, then run ONE final topk_block over those
+      // tiles to select the global top-k. The composite view is what makes
+      // ExpandDMAReadCompositeView pull each partial from its source core.
+      SmallVector<std::pair<Value, Value>> partials = emitShardTopk(
+          adaptor.getInputTensor(), /*arangeStart=*/0, /*gridCols=*/numShards);
 
-      // CompositeViewOp's dim indexes the layout's logical shape (rank
-      // physicalRank), so the composite axis is the logical reduction dim.
+      // Build a numShards-tile buffer type along the reduction dim from a
+      // 1-tile partial's layout.
+      auto partialType = cast<RankedTensorType>(partials[0].first.getType());
+      auto tileType = cast<ttcore::TileType>(partialType.getElementType());
+      auto partialLayout =
+          cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
+      SmallVector<int64_t> wideShape(partialType.getShape().begin(),
+                                     partialType.getShape().end());
+      wideShape[deviceRedDim] = numShards;
+      auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
+      auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
+
+      // Separate CompositeViews for values and indices (the DMA-expansion pass
+      // supports only one composite view per GenericOp, #7600), each
+      // materialized before the merge.
+      SmallVector<Value> valComposites, idxComposites;
+      for (auto &p : partials) {
+        valComposites.push_back(p.first);
+        idxComposites.push_back(p.second);
+      }
       auto valsComposite = rewriter.create<d2m::CompositeViewOp>(
-          loc, twoTileType, ValueRange{a.first, b.first},
-          static_cast<int32_t>(dim), /*logicalSizes=*/nullptr);
+          loc, wideType, valComposites, static_cast<int32_t>(dim),
+          /*logicalSizes=*/nullptr);
       auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
-          loc, twoTileType, ValueRange{a.second, b.second},
-          static_cast<int32_t>(dim), /*logicalSizes=*/nullptr);
+          loc, wideType, idxComposites, static_cast<int32_t>(dim),
+          /*logicalSizes=*/nullptr);
 
-      // Materialize both composites into real 2-tile buffers before the merge
-      // generic. The DMA-expansion pass supports only one composite view per
-      // GenericOp (#7600); the merge needs both values and indices, so we copy
-      // each composite into a plain buffer here and feed those to the generic.
-      Value valsMaterialized = relayout(valsComposite.getResult());
-      Value idxMaterialized = relayout(idxComposite.getResult());
+      // Materialize each composite into a genuinely-allocated L1 buffer via its
+      // OWN copy generic. ExpandDMAReadCompositeView allows only one composite
+      // view per generic (#7600); a plain to_layout on the composite bufferizes
+      // to a view_layout chain that getCompositeViewSource walks straight back
+      // to the composite, so feeding both composites into the merge generic
+      // would leave it with two composite-backed DMA reads and trip that
+      // assert. A dedicated copy generic per composite reads exactly one
+      // composite (so it DMA-expands cleanly) and yields a real buffer; the
+      // merge then reads two plain allocs.
+      auto materializeComposite = [&](Value composite) -> Value {
+        auto compType = cast<RankedTensorType>(composite.getType());
+        auto copyOut = rewriter.create<d2m::EmptyOp>(loc, compType.getShape(),
+                                                     compType.getElementType(),
+                                                     compType.getEncoding());
+        SmallVector<Value> ins = {composite};
+        SmallVector<Value> outs = {copyOut.getResult()};
+        auto copyGeneric = rewriter.create<d2m::GenericOp>(
+            loc, ins, outs, /*additionalArgs=*/ValueRange(),
+            rewriter.getAffineMapArrayAttr(
+                SmallVector<AffineMap>{mergeIdentity, mergeIdentity}),
+            rewriter.getArrayAttr(mergeIters));
+        copyGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+        withD2MGenericRegion(
+            rewriter, loc, copyGeneric, ins, outs,
+            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+              Value input = blockArgs[0];
+              Value output = blockArgs[1];
+              std::size_t shardRank =
+                  cast<RankedTensorType>(output.getType()).getRank();
+              AffineMap shardIdentity =
+                  rewriter.getMultiDimIdentityMap(shardRank);
+              SmallVector<mlir::utils::IteratorType> linalgIters(
+                  shardRank, mlir::utils::IteratorType::parallel);
+              auto linalgOp = rewriter.create<linalg::GenericOp>(
+                  loc, output.getType(), input, output,
+                  SmallVector<AffineMap>{shardIdentity, shardIdentity},
+                  linalgIters,
+                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                    Value copied = b.create<d2m::TileTypecastOp>(
+                        bodyLoc, args[1].getType(), args[0]);
+                    b.create<linalg::YieldOp>(bodyLoc, copied);
+                  });
+              return {linalgOp->getResult(0)};
+            });
+        return relayout(copyGeneric->getResult(0));
+      };
+      Value valsMaterialized = materializeComposite(valsComposite.getResult());
+      Value idxMaterialized = materializeComposite(idxComposite.getResult());
 
-      auto valsOut = rewriter.create<d2m::EmptyOp>(loc, twoTileShape, tileType,
-                                                   twoTileLayout);
-      auto idxOut = rewriter.create<d2m::EmptyOp>(loc, twoTileShape, tileType,
-                                                  twoTileLayout);
+      int64_t mergeReductionElems = numShards * 32;
+      auto mergeValsOut =
+          rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
+      auto mergeIdxOut =
+          rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
       SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
-      SmallVector<Value> mergeOutputs = {valsOut.getResult(),
-                                         idxOut.getResult()};
+      SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
+                                         mergeIdxOut.getResult()};
       auto mergeGeneric = rewriter.create<d2m::GenericOp>(
           loc, mergeInputs, mergeOutputs, /*additionalArgs=*/ValueRange(),
           rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
@@ -4294,47 +4598,12 @@ public:
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
             auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
                 loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-                /*reductionDimSize=*/2 * 32, /*stableSort=*/false, dim);
+                /*reductionDimSize=*/mergeReductionElems, /*stableSort=*/false,
+                dim);
             return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
           });
-      Value mergedVals = relayout(mergeGeneric->getResult(0));
-      Value mergedIdx = relayout(mergeGeneric->getResult(1));
-      return {compactToTile(mergedVals), compactToTile(mergedIdx)};
-    };
-
-    Value topkValsRelayouted, topkIdxRelayouted;
-    if (!multiCore) {
-      std::tie(topkValsRelayouted, topkIdxRelayouted) =
-          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0);
-    } else {
-      // Run one local topk over the full input, distributed across numShards
-      // cores: the reduction-dim tile bands are reblocked into grid columns so
-      // each core runs topk_block on its own band. The per-core partials are
-      // gathered back to a unit grid inside emitShardTopk; the merge across
-      // bands is handled by the existing reduction tree below.
-      SmallVector<std::pair<Value, Value>> partials;
-      {
-        auto [pv, pi] =
-            emitShardTopk(adaptor.getInputTensor(),
-                          /*arangeStart=*/0, /*gridCols=*/numShards);
-        partials.push_back({compactToTile(pv), compactToTile(pi)});
-      }
-
-      // Reduction tree: fold pairs level by level; a ragged (odd) tail element
-      // is carried unchanged to the next level (top-k merge is associative, so
-      // any pairing order yields the same global top-k).
-      while (partials.size() > 1) {
-        SmallVector<std::pair<Value, Value>> next;
-        for (std::size_t i = 0; i + 1 < partials.size(); i += 2) {
-          next.push_back(mergePair(partials[i], partials[i + 1]));
-        }
-        if (partials.size() % 2 == 1) {
-          next.push_back(partials.back());
-        }
-        partials = std::move(next);
-      }
-      topkValsRelayouted = partials[0].first;
-      topkIdxRelayouted = partials[0].second;
+      topkValsRelayouted = compactToTile(relayout(mergeGeneric->getResult(0)));
+      topkIdxRelayouted = compactToTile(relayout(mergeGeneric->getResult(1)));
     }
 
     // Index extract uses fp32 topk tiles; a typecast generic below converts

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -707,119 +707,6 @@ protected:
     rewriter.restoreInsertionPoint(insertPoint);
   }
 
-  /// Emits a one-in/one-out `d2m.generic` whose region maps every tile of `src`
-  /// through `makeTile`. `gridMap` is the input's grid-level indexing map (the
-  /// output's is identity); `shardMap` builds the input's shard-level map from
-  /// the region's shard rank, or is null for identity.
-  Value emitUnaryGeneric(
-      ConversionPatternRewriter &rewriter, Location loc, Value src, Value out,
-      AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
-      llvm::function_ref<AffineMap(std::size_t)> shardMap,
-      llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile)
-      const {
-    std::size_t physicalRank = iteratorTypes.size();
-    AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
-    SmallVector<Value> ins = {src};
-    SmallVector<Value> outs = {out};
-    auto generic = rewriter.create<d2m::GenericOp>(
-        loc, ins, outs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(
-            SmallVector<AffineMap>{gridMap, identityMap}),
-        rewriter.getArrayAttr(iteratorTypes));
-    withD2MGenericRegion(
-        rewriter, loc, generic, ins, outs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          Value input = blockArgs[0];
-          Value output = blockArgs[1];
-          std::size_t shardRank =
-              cast<RankedTensorType>(output.getType()).getRank();
-          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
-          AffineMap shardIn = shardMap ? shardMap(shardRank) : shardIdentity;
-          SmallVector<mlir::utils::IteratorType> linalgIters(
-              shardRank, mlir::utils::IteratorType::parallel);
-          auto linalgOp = rewriter.create<linalg::GenericOp>(
-              loc, output.getType(), input, output,
-              SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
-              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                b.create<linalg::YieldOp>(bodyLoc, makeTile(b, bodyLoc, args));
-              });
-          return {linalgOp->getResult(0)};
-        });
-    return generic->getResult(0);
-  }
-
-  /// Narrows `wide` in place to `narrowEmpty`'s shape, every core keeping its
-  /// own shard: each core remote_loads its own tile, copies the leading
-  /// `genRedDim` tiles, and remote_stores back to itself.
-  d2m::GenericOp emitInPlaceNarrowing(
-      ConversionPatternRewriter &rewriter, Location loc, Value wide,
-      d2m::EmptyOp narrowEmpty, std::size_t physicalRank, std::size_t genRedDim,
-      AffineMap identityMap, ArrayRef<Attribute> iteratorTypes) const {
-    MLIRContext *ctx = rewriter.getContext();
-    auto wideType = cast<RankedTensorType>(wide.getType());
-    auto narrowType = cast<RankedTensorType>(narrowEmpty.getType());
-    auto tileType = cast<ttcore::TileType>(wideType.getElementType());
-
-    AffineMap constInMap =
-        AffineMap::get(physicalRank, 0,
-                       SmallVector<AffineExpr>(
-                           physicalRank, rewriter.getAffineConstantExpr(0)),
-                       ctx);
-    SmallVector<Value> ins = {wide};
-    SmallVector<Value> outs = {narrowEmpty.getResult()};
-    auto generic = rewriter.create<d2m::GenericOp>(
-        loc, ins, outs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(
-            SmallVector<AffineMap>{constInMap, identityMap}),
-        rewriter.getArrayAttr(iteratorTypes));
-
-    auto insertPoint = rewriter.saveInsertionPoint();
-    rewriter.startOpModification(generic);
-    mlir::Region &region = generic->getRegions().front();
-    mlir::Block *block = rewriter.createBlock(&region);
-    rewriter.setInsertionPointToStart(block);
-
-    auto inShardType = RankedTensorType::get(
-        wideType.getShape().take_back(physicalRank), tileType);
-    auto outShardType = RankedTensorType::get(
-        narrowType.getShape().take_back(physicalRank), tileType);
-    std::size_t shardRank = outShardType.getRank();
-    std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-
-    Value loadBuf = rewriter
-                        .create<tensor::EmptyOp>(loc, inShardType.getShape(),
-                                                 inShardType.getElementType())
-                        .getResult();
-    SmallVector<Value> srcIndices =
-        d2m::utils::buildCoreIndices(rewriter, loc, physicalRank);
-    Value loaded = rewriter
-                       .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
-                                                  wide, srcIndices)
-                       .getResult();
-
-    Value outBuf = rewriter
-                       .create<tensor::EmptyOp>(loc, outShardType.getShape(),
-                                                outShardType.getElementType())
-                       .getResult();
-    auto linalgOp = d2m::utils::emitLeadingTileCopy(rewriter, loc, loaded,
-                                                    outBuf, shardRedDim);
-
-    SmallVector<Value> outIndices =
-        d2m::utils::buildCoreIndices(rewriter, loc, physicalRank);
-    Value storeResult =
-        rewriter
-            .create<d2m::RemoteStoreOp>(loc, narrowEmpty.getType(),
-                                        narrowEmpty.getResult(), outIndices,
-                                        linalgOp->getResult(0))
-            .getResult();
-    rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
-    rewriter.finalizeOpModification(generic);
-    rewriter.restoreInsertionPoint(insertPoint);
-
-    d2m::utils::makeExplicitDatamovementForm(rewriter, generic);
-    return generic;
-  }
-
   /// Fills a single tile tensor with `fillValue` (e.g. mean scaler 1/N).
   mlir::Value createScaler(mlir::ConversionPatternRewriter &rewriter,
                            mlir::Location loc, mlir::RankedTensorType inputType,
@@ -3710,6 +3597,9 @@ public:
   }
 };
 
+/// Lowers `ttir.topk` single-core: lay the input out, run one `d2m.topk_block`
+/// over the whole reduction, extract the surviving k elements. `d2m-lower-topk`
+/// rewrites this output across the grid when the shape calls for it.
 class D2MTopKRewriter : public OpConversionPattern<ttir::TopKOp>,
                         D2MNamedRewriterCommon {
 public:
@@ -3722,89 +3612,6 @@ public:
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
 
-  // Extracts top-k results from topkResult into extractOutput, collapsing
-  // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
-  // each tile to handle row/column orientation.
-  d2m::GenericOp createExtractGeneric(ConversionPatternRewriter &rewriter,
-                                      Location loc, MLIRContext *ctx,
-                                      Value topkResult, Value extractOutput,
-                                      std::size_t extractProjectDim,
-                                      int64_t outputReductionTiles,
-                                      int32_t dim) const {
-    std::size_t extractRank =
-        ttcore::getDeviceLayout(extractOutput).getRank() / 2;
-    AffineMap extractIdentity = rewriter.getMultiDimIdentityMap(extractRank);
-    SmallVector<Attribute> extractIters(
-        extractRank,
-        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-    SmallVector<AffineExpr> inputMapExprs;
-    for (std::size_t i = 0; i < extractRank; ++i) {
-      inputMapExprs.push_back(i == extractProjectDim
-                                  ? rewriter.getAffineConstantExpr(0)
-                                  : rewriter.getAffineDimExpr(i));
-    }
-    AffineMap inputProjectedMap =
-        AffineMap::get(extractRank, 0, inputMapExprs, ctx);
-
-    SmallVector<Value> extractInputs = {topkResult};
-    SmallVector<Value> extractOutputs = {extractOutput};
-    auto generic = rewriter.create<d2m::GenericOp>(
-        loc, extractInputs, extractOutputs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(
-            SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
-        rewriter.getArrayAttr(extractIters));
-
-    withD2MGenericRegion(
-        rewriter, loc, generic, extractInputs, extractOutputs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          Value input = blockArgs[0];
-          Value output = blockArgs[1];
-          std::size_t outShardRank =
-              cast<RankedTensorType>(output.getType()).getRank();
-          int64_t inReductionExtent = cast<RankedTensorType>(input.getType())
-                                          .getShape()[extractProjectDim];
-
-          // The input map must stay non-invertible, or linalg infers the loop
-          // bound from the full input extent and rejects the smaller output
-          // shard; `mod inReductionExtent` keeps in-range reads unchanged.
-          AffineExpr projExpr =
-              outputReductionTiles == 1
-                  ? rewriter.getAffineConstantExpr(0)
-                  : rewriter.getAffineDimExpr(extractProjectDim) %
-                        inReductionExtent;
-          SmallVector<AffineExpr> mapFirstExprs;
-          for (std::size_t i = 0; i < outShardRank; ++i) {
-            mapFirstExprs.push_back(i == extractProjectDim
-                                        ? projExpr
-                                        : rewriter.getAffineDimExpr(i));
-          }
-          AffineMap mapFirst =
-              AffineMap::get(outShardRank, 0, mapFirstExprs, ctx);
-          AffineMap outIdentity = rewriter.getMultiDimIdentityMap(outShardRank);
-          SmallVector<mlir::utils::IteratorType> linalgIters(
-              outShardRank, mlir::utils::IteratorType::parallel);
-
-          auto linalgOp = rewriter.create<linalg::GenericOp>(
-              loc, output.getType(), input, output,
-              SmallVector<AffineMap>{mapFirst, outIdentity}, linalgIters,
-              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                Value result;
-                if (dim == 1) {
-                  result = b.create<d2m::TileTransposeOp>(
-                      bodyLoc, args[1].getType(), args[0]);
-                } else {
-                  result = b.create<d2m::TileTypecastOp>(
-                      bodyLoc, args[1].getType(), args[0]);
-                }
-                b.create<linalg::YieldOp>(bodyLoc, result);
-              });
-          return {linalgOp->getResult(0)};
-        });
-
-    return generic;
-  }
-
   LogicalResult
   matchAndRewrite(ttir::TopKOp op, ttir::TopKOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
@@ -3815,489 +3622,94 @@ public:
     auto valuesType = cast<RankedTensorType>(op.getValues().getType());
     auto indicesType = cast<RankedTensorType>(op.getIndices().getType());
 
-    int32_t k = op.getK();
-    assert(k <= 64 && "D2M topk only supports k <= 64");
-    int32_t dim = op.getDim();
     int64_t rank = inputType.getRank();
+    int32_t dim = op.getDim();
     if (dim < 0) {
       dim += rank;
     }
-
     if (rank != 2 || (dim != 0 && dim != 1)) {
       return rewriter.notifyMatchFailure(
           op, "D2M topk only supports 2D reduction on dim 0 or dim 1");
     }
 
-    constexpr int64_t kTileWidth = 32;
-    int64_t fullReductionTiles =
-        (inputType.getShape()[dim] + kTileWidth - 1) / kTileWidth;
-    if (fullReductionTiles == 1) {
+    constexpr int64_t kTileWidth = ttcore::TileType::getDefaultShape()[1];
+    const int32_t k = op.getK();
+    assert(k <= 64 && "D2M topk only supports k <= 64");
+    const int64_t reductionDimSize = inputType.getShape()[dim];
+    if ((reductionDimSize + kTileWidth - 1) / kTileWidth == 1) {
       assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
-    Type idxElemType = rewriter.getI32Type();
 
-    auto device = ttcore::lookupDevice(op);
-    SmallVector<int64_t> workerGridShape =
-        llvm::to_vector(device.getWorkerGrid().getShape());
-    assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
+    // Reduction tiles one output partial occupies.
+    const int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
+    const d2m::TopKGeometry geometry =
+        d2m::getTopKGeometry(dim, static_cast<std::size_t>(rank));
 
-    std::string strategyFailure;
-    auto strategyOr = d2m::selectTopKShardingStrategy(
-        k, dim, inputType.getShape(), workerGridShape, strategyFailure);
-    if (failed(strategyOr)) {
-      return rewriter.notifyMatchFailure(op, strategyFailure);
-    }
-    const d2m::TopKShardingStrategy &strategy = *strategyOr;
-
-    // Whether each dim is split, and how: `dataParallel` slices the non-target
-    // dim ntShards ways (no merge needed), `multiCore` bands the reduction dim
-    // numShards ways (merged back by a tree). The 2D split sets both.
-    const bool dataParallel = strategy.dataParallel;
-    const bool multiCore = strategy.multiCore;
-    const int64_t outputReductionTiles = strategy.outputReductionTiles;
-    const int64_t ntShards = strategy.ntShards;
-    const int64_t paddedNonTargetTiles = strategy.paddedNonTargetTiles;
-    const int64_t numShards = strategy.numShards;
-    const int64_t paddedReductionTiles = strategy.paddedReductionTiles;
-    const int64_t mergeCap = strategy.mergeCap;
-
-    // Buffers below carry logical grid shapes only; GridSelection folds them
-    // onto physical cores.
-    //
-    // Emits a topk over a raw input, returning (values, indices) still in
-    // device layout. gridCols > 1 bands the topk across that many cores for the
-    // caller's merge tree; ntCores > 1 slices the non-target dim instead.
-    auto emitShardTopk = [&](Value rawInput, int64_t gridCols = 1,
-                             int64_t ntCores = 1) -> std::pair<Value, Value> {
-      auto inputType = cast<RankedTensorType>(rawInput.getType());
-      int64_t reductionDimSize = inputType.getShape()[dim];
-      bool isDataParallel = ntCores > 1;
-      bool isBanded = gridCols > 1;
-
-      Value layoutedInput;
-
+    Value layoutedInput;
+    if (reductionDimSize <= kTileWidth) {
+      // topk_block merges reduction tiles pairwise, so it needs at least two;
+      // dimAlignments pads the buffer and the mask below fills the tail.
       constexpr std::array<int64_t, 2> defaultTileShape =
           ttcore::TileType::getDefaultShape();
       SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
                                         defaultTileShape.end());
       auto tileElemType =
           ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-      std::size_t logicalRank = inputType.getShape().size();
-
-      if (isBanded || isDataParallel) {
-        SmallVector<int64_t> shardTiles(logicalRank, 1);
-        shardTiles[dim] = paddedReductionTiles;
-        shardTiles[1 - dim] = paddedNonTargetTiles;
-        auto shardedLayout = d2m::utils::buildShardedTileLayout(
-            ctx, inputType.getShape(), shardTiles, memorySpaces[0]);
-        SmallVector<int64_t> shardedGrid =
-            (dim == 1) ? SmallVector<int64_t>{ntCores, gridCols}
-                       : SmallVector<int64_t>{gridCols, ntCores};
-        SmallVector<int64_t> shardedDeviceShape =
-            shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
-        bool needsPad = d2m::utils::deviceShapeNeedsPadding(
-            shardedDeviceShape, inputType.getShape());
-
-        auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, shardedDeviceShape, tileElemType, shardedLayout);
-
-        Value tilized =
-            rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
-                .getResult(0);
-        if (needsPad) {
-          auto maskOutput = rewriter.create<d2m::EmptyOp>(
-              loc, shardedDeviceShape, tileElemType, shardedLayout);
-          layoutedInput =
-              rewriter
-                  .create<d2m::MaskOp>(loc, tilized, maskOutput,
-                                       shardedLayout.getLogicalShape(),
-                                       ttcore::OOBVal::NegInf)
-                  .getResult();
-        } else {
-          layoutedInput = tilized;
-        }
-      } else if (reductionDimSize <= kTileWidth) {
-        // topk_block merges reduction tiles pairwise and so needs >=2, so pad
-        // the buffer out via dimAlignments and let the mask below fill the
-        // extra tile with -inf.
-        SmallVector<int64_t> paddedTiles(logicalRank, 1);
-        paddedTiles[dim] = 2;
-        auto paddedLayout = d2m::utils::buildShardedTileLayout(
-            ctx, inputType.getShape(), paddedTiles, memorySpaces[0]);
-        SmallVector<int64_t> unitGrid(logicalRank, 1);
-        SmallVector<int64_t> paddedDeviceShape =
-            paddedLayout.getDeviceShape(unitGrid, tileShapeVec);
-        auto paddedEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, paddedDeviceShape, tileElemType, paddedLayout);
-        Value toLayouted =
-            rewriter.create<d2m::ToLayoutOp>(loc, rawInput, paddedEmpty)
-                .getResult(0);
-        auto maskOutput = rewriter.create<d2m::EmptyOp>(
-            loc, paddedDeviceShape, tileElemType, paddedLayout);
-        layoutedInput = rewriter
-                            .create<d2m::MaskOp>(loc, toLayouted, maskOutput,
-                                                 paddedLayout.getLogicalShape(),
-                                                 ttcore::OOBVal::NegInf)
-                            .getResult();
-      } else {
-        layoutedInput =
-            createOptimalLayoutOp(rawInput, memorySpaces[0], /*tiled=*/true,
-                                  /*noCollapse=*/false, rewriter);
-      }
-      auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
-      auto metalLayout =
-          cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
-      auto f32TileType = cast<ttcore::TileType>(layoutedType.getElementType());
-      ArrayRef<int64_t> deviceShape = layoutedType.getShape();
-      std::size_t physicalRank = deviceShape.size() / 2;
-
-      auto wrapInToLayout = [&](Value genericResult) -> Value {
-        auto resultType = cast<RankedTensorType>(genericResult.getType());
-        auto emptyOp = rewriter.create<d2m::EmptyOp>(
-            loc, resultType.getShape(), resultType.getElementType(),
-            resultType.getEncoding());
-        return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
-            .getResult(0);
-      };
-
-      auto parallel =
-          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
-      SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
-      AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
-
-      auto emitUnary =
-          [&](Value src, Value out, AffineMap gridMap,
-              llvm::function_ref<AffineMap(std::size_t)> shardMap,
-              llvm::function_ref<Value(OpBuilder &, Location, ValueRange)>
-                  makeTile) -> Value {
-        return emitUnaryGeneric(rewriter, loc, src, out, gridMap, iteratorTypes,
-                                shardMap, makeTile);
-      };
-
-      auto tileTranspose = [&](OpBuilder &b, Location l, ValueRange args) {
-        return b.create<d2m::TileTransposeOp>(l, args[1].getType(), args[0])
-            .getResult();
-      };
-
-      auto transposeTiles = [&](Value src) -> Value {
-        auto srcType = cast<RankedTensorType>(src.getType());
-        auto empty = rewriter.create<d2m::EmptyOp>(
-            loc, srcType.getShape(),
-            cast<ttcore::TileType>(srcType.getElementType()),
-            cast<ttcore::MetalLayoutAttr>(srcType.getEncoding()));
-        return wrapInToLayout(emitUnary(src, empty.getResult(), identityMap,
-                                        /*shardMap=*/nullptr, tileTranspose));
-      };
-
-      // TopkBlockOp sorts along tile columns, but dim=1 puts the sort
-      // dimension on tile rows.
-      Value topkInput = layoutedInput;
-      if (dim == 1) {
-        topkInput = transposeTiles(layoutedInput);
-      }
-
-      auto idxTileType = ttcore::TileType::get(idxElemType);
-
-      // The kernel builds its own index tiles from this core's grid
-      // coordinate (see d2m-decompose-topk), so all that has to be handed in
-      // is one scratch tile per core for the lane pattern. A leaf topk's
-      // indices are just the reduction coordinate, so nothing upstream has to
-      // materialize, broadcast or transpose a full arange -- and a banded or
-      // data-parallel shard needs no cross-core index traffic at all.
-      ArrayRef<int64_t> idxGridShape = metalLayout.getGridShape(layoutedType);
-      SmallVector<int64_t> idxScratchShape(idxGridShape.begin(),
-                                           idxGridShape.end());
-      idxScratchShape.append({1, 1});
-      auto idxScratchLayout = ttcore::MetalLayoutAttr::get(
-          ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
-          ttcore::TensorMemoryLayout::Sharded);
-      auto idxScratchEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, idxScratchShape, idxTileType, idxScratchLayout);
-      Value idxBuf = idxScratchEmpty.getResult();
-
-      auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, f32TileType, metalLayout);
-      auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, idxTileType, metalLayout);
-
-      SmallVector<Value> topkInputs = {topkInput, idxBuf};
-      SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
-                                        topkIdxEmpty.getResult()};
-      // The scratch tile carries no per-core data (the kernel overwrites it
-      // before reading), and a constant map is what lets its 1x1 shard sit
-      // alongside the full-shard operands: an identity map would put it in the
-      // generic's shard-extent comparison and fail verification.
-      SmallVector<AffineExpr> idxConstExprs(physicalRank,
-                                            rewriter.getAffineConstantExpr(0));
-      AffineMap idxConstMap =
-          AffineMap::get(physicalRank, 0, idxConstExprs, ctx);
-      auto topkGeneric = rewriter.create<d2m::GenericOp>(
-          loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-              identityMap, idxConstMap, identityMap, identityMap}),
-          rewriter.getArrayAttr(iteratorTypes));
-
-      withD2MGenericRegion(
-          rewriter, loc, topkGeneric, topkInputs, topkOutputs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
-                loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-                reductionDimSize, /*stableSort=*/false, dim,
-                /*generateIndices=*/true);
-            return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
-          });
-
-      if (!isBanded) {
-        return {wrapInToLayout(topkGeneric->getResult(0)),
-                wrapInToLayout(topkGeneric->getResult(1))};
-      }
-
-      std::size_t genRedDim =
-          (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      std::size_t deviceRedDimLocal =
-          deviceShape.size() - (physicalRank - genRedDim);
-
-      // Narrow each band in place before the cross-core gather, or the wide
-      // leaf result stays live on every core and overflows L1.
-      auto compactBands = [&](Value wideResult) -> Value {
-        auto wideType = cast<RankedTensorType>(wideResult.getType());
-        auto tileType = cast<ttcore::TileType>(wideType.getElementType());
-        SmallVector<int64_t> narrowShape(wideType.getShape().begin(),
-                                         wideType.getShape().end());
-        narrowShape[deviceRedDimLocal] = outputReductionTiles;
-        auto narrowLayout = d2m::utils::rebuildLayoutForDeviceShape(
-            cast<ttcore::MetalLayoutAttr>(wideType.getEncoding()), narrowShape);
-        auto narrowEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, narrowShape, tileType, narrowLayout);
-
-        auto generic = emitInPlaceNarrowing(
-            rewriter, loc, wideResult, narrowEmpty, physicalRank, genRedDim,
-            identityMap, iteratorTypes);
-        return wrapInToLayout(generic->getResult(0));
-      };
-
-      return {compactBands(topkGeneric->getResult(0)),
-              compactBands(topkGeneric->getResult(1))};
-    };
-
-    std::size_t physicalRank = static_cast<std::size_t>(rank);
-
-    auto relayout = [&](Value genericResult) -> Value {
-      auto resultType = cast<RankedTensorType>(genericResult.getType());
-      auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
-                                                   resultType.getElementType(),
-                                                   resultType.getEncoding());
-      return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
-          .getResult(0);
-    };
-    auto parallelAttr =
-        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
-    SmallVector<Attribute> mergeIters(physicalRank, parallelAttr);
-    AffineMap mergeIdentity = rewriter.getMultiDimIdentityMap(physicalRank);
-    // Reduction tiles live in the shard half of the [grid..., shard...] device
-    // shape: last shard dim for dim==1, first for dim==0.
-    std::size_t deviceRedDim =
-        (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
-
-    // Narrows a merge result back to its leading outputReductionTiles on every
-    // core, restoring the one-band-per-core shape the next round consumes.
-    auto compactToTile = [&](Value fullPartial) -> Value {
-      auto fullType = cast<RankedTensorType>(fullPartial.getType());
-      auto tileType = cast<ttcore::TileType>(fullType.getElementType());
-      SmallVector<int64_t> compactShape(fullType.getShape().begin(),
-                                        fullType.getShape().end());
-      compactShape[deviceRedDim] = outputReductionTiles;
-      auto compactLayout = d2m::utils::rebuildLayoutForDeviceShape(
-          cast<ttcore::MetalLayoutAttr>(fullType.getEncoding()), compactShape);
-      auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, compactShape, tileType,
-                                                    compactLayout);
-      std::size_t genRedDim =
-          (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      auto generic = emitInPlaceNarrowing(rewriter, loc, fullPartial, outEmpty,
-                                          physicalRank, genRedDim,
-                                          mergeIdentity, mergeIters);
-      return relayout(generic->getResult(0));
-    };
-
-    Value topkValsRelayouted, topkIdxRelayouted;
-    if (!multiCore) {
-      std::pair<Value, Value> single =
-          emitShardTopk(adaptor.getInputTensor(), /*gridCols=*/1,
-                        /*ntCores=*/ntShards);
-      topkValsRelayouted = single.first;
-      topkIdxRelayouted = single.second;
+      SmallVector<int64_t> paddedTiles(inputType.getShape().size(), 1);
+      paddedTiles[dim] = 2;
+      auto paddedLayout = d2m::utils::buildShardedTileLayout(
+          ctx, inputType.getShape(), paddedTiles, memorySpaces[0]);
+      SmallVector<int64_t> unitGrid(inputType.getShape().size(), 1);
+      SmallVector<int64_t> paddedDeviceShape =
+          paddedLayout.getDeviceShape(unitGrid, tileShapeVec);
+      auto paddedEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, paddedDeviceShape, tileElemType, paddedLayout);
+      Value toLayouted = rewriter
+                             .create<d2m::ToLayoutOp>(
+                                 loc, adaptor.getInputTensor(), paddedEmpty)
+                             .getResult(0);
+      auto maskOutput = rewriter.create<d2m::EmptyOp>(
+          loc, paddedDeviceShape, tileElemType, paddedLayout);
+      layoutedInput = rewriter
+                          .create<d2m::MaskOp>(loc, toLayouted, maskOutput,
+                                               paddedLayout.getLogicalShape(),
+                                               ttcore::OOBVal::NegInf)
+                          .getResult();
     } else {
-      // Each of the ntShards non-target slices merges down its own band row
-      // without ever exchanging data with the others.
-      std::pair<Value, Value> level =
-          emitShardTopk(adaptor.getInputTensor(), /*gridCols=*/numShards,
-                        /*ntCores=*/ntShards);
-
-      // Grid dim the bands spread across: columns for dim==1, rows for dim==0,
-      // matching emitShardTopk's shardedGrid.
-      std::size_t deviceGridDim = static_cast<std::size_t>(dim);
-
-      // Collapses `bands` partials, one per core, down to `numGroups`: core g
-      // merges the groupTiles bands starting at g * groupTiles, via one
-      // composite view that D2MExpandDMAReadCompositeView resolves per tile
-      // into a DMA read off the source core.
-      auto mergeRound = [&](Value valsIn, Value idxIn, int64_t bands,
-                            int64_t numGroups) -> std::pair<Value, Value> {
-        int64_t groupTiles = bands / numGroups;
-        assert(groupTiles * numGroups == bands &&
-               "merge round must divide the band count evenly");
-
-        auto valsInType = cast<RankedTensorType>(valsIn.getType());
-        auto idxInType = cast<RankedTensorType>(idxIn.getType());
-        auto valTileType = cast<ttcore::TileType>(valsInType.getElementType());
-        auto idxTileType = cast<ttcore::TileType>(idxInType.getElementType());
-
-        // Same total extent as the input, re-split: numGroups cores each
-        // holding groupTiles bands' worth of reduction tiles.
-        SmallVector<int64_t> wideShape(valsInType.getShape().begin(),
-                                       valsInType.getShape().end());
-        wideShape[deviceGridDim] = numGroups;
-        wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
-
-        // Re-splitting preserves the grid x shard product, so the wide layout
-        // carries the same logical extent as the input's.
-        auto valWideLayout = d2m::utils::rebuildLayoutForDeviceShape(
-            cast<ttcore::MetalLayoutAttr>(valsInType.getEncoding()), wideShape);
-        auto idxWideLayout = d2m::utils::rebuildLayoutForDeviceShape(
-            cast<ttcore::MetalLayoutAttr>(idxInType.getEncoding()), wideShape);
-        auto valWideType =
-            RankedTensorType::get(wideShape, valTileType, valWideLayout);
-        auto idxWideType =
-            RankedTensorType::get(wideShape, idxTileType, idxWideLayout);
-
-        // Values and indices gather through separate generics, since the
-        // DMA-expansion pass supports only one composite view per GenericOp
-        // (#7600).
-        auto gatherComposite = [&](Value in,
-                                   RankedTensorType wideType) -> Value {
-          auto composite = rewriter.create<d2m::CompositeViewOp>(
-              loc, wideType, ValueRange{in}, static_cast<int32_t>(dim),
-              /*logicalSizes=*/nullptr);
-          auto copyOut = rewriter.create<d2m::EmptyOp>(
-              loc, wideType.getShape(), wideType.getElementType(),
-              wideType.getEncoding());
-          SmallVector<Value> ins = {composite.getResult()};
-          SmallVector<Value> outs = {copyOut.getResult()};
-          auto copyGeneric = rewriter.create<d2m::GenericOp>(
-              loc, ins, outs, /*additionalArgs=*/ValueRange(),
-              rewriter.getAffineMapArrayAttr(
-                  SmallVector<AffineMap>{mergeIdentity, mergeIdentity}),
-              rewriter.getArrayAttr(mergeIters));
-          withD2MGenericRegion(
-              rewriter, loc, copyGeneric, ins, outs,
-              [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-                auto linalgOp = d2m::utils::emitLeadingTileCopy(
-                    rewriter, loc, blockArgs[0], blockArgs[1],
-                    /*shardRedDim=*/std::nullopt);
-                return {linalgOp->getResult(0)};
-              });
-          return relayout(copyGeneric->getResult(0));
-        };
-        Value valsMaterialized = gatherComposite(valsIn, valWideType);
-        Value idxMaterialized = gatherComposite(idxIn, idxWideType);
-
-        int64_t mergeReductionElems =
-            groupTiles * outputReductionTiles * kTileWidth;
-        auto mergeValsOut = rewriter.create<d2m::EmptyOp>(
-            loc, wideShape, valTileType, valWideType.getEncoding());
-        auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
-            loc, wideShape, idxTileType, idxWideType.getEncoding());
-        SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
-        SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
-                                           mergeIdxOut.getResult()};
-        auto mergeGeneric = rewriter.create<d2m::GenericOp>(
-            loc, mergeInputs, mergeOutputs, /*additionalArgs=*/ValueRange(),
-            rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-                mergeIdentity, mergeIdentity, mergeIdentity, mergeIdentity}),
-            rewriter.getArrayAttr(mergeIters));
-        withD2MGenericRegion(
-            rewriter, loc, mergeGeneric, mergeInputs, mergeOutputs,
-            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-              auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
-                  loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3],
-                  k,
-                  /*reductionDimSize=*/mergeReductionElems,
-                  /*stableSort=*/false, dim);
-              return {topkBlock.getResultValues(),
-                      topkBlock.getResultIndices()};
-            });
-        return {compactToTile(relayout(mergeGeneric->getResult(0))),
-                compactToTile(relayout(mergeGeneric->getResult(1)))};
-      };
-
-      // Merge in rounds until one band remains. The shard search already proved
-      // this chain closes for numShards, so every round has a legal move, and
-      // pickMergeGroupCount only ever returns a count below the current one.
-      int64_t bands = numShards;
-      while (bands > 1) {
-        int64_t numGroups =
-            d2m::pickMergeGroupCount(bands, mergeCap, workerGridShape);
-        assert(numGroups > 0 &&
-               "merge chain was validated during shard selection");
-        level = mergeRound(level.first, level.second, bands, numGroups);
-        bands = numGroups;
-      }
-      topkValsRelayouted = level.first;
-      topkIdxRelayouted = level.second;
+      layoutedInput = createOptimalLayoutOp(adaptor.getInputTensor(),
+                                            memorySpaces[0], /*tiled=*/true,
+                                            /*noCollapse=*/false, rewriter);
     }
+
+    auto [topkVals, topkIdx] = d2m::utils::emitLeafTopk(
+        rewriter, loc, layoutedInput, k, dim, reductionDimSize);
 
     Type idxOutElemType = indicesType.getElementType();
     bool fuseIdxCast = (dim == 0);
+    // Must match the index element type emitLeafTopk picks.
+    Type leafIdxElemType = rewriter.getI32Type();
     auto extractIdxIndicesType = RankedTensorType::get(
-        indicesType.getShape(), fuseIdxCast ? idxOutElemType : idxElemType);
+        indicesType.getShape(), fuseIdxCast ? idxOutElemType : leafIdxElemType);
 
-    // Must be split like its input, on the same core count, or the extract
-    // gathers the whole result onto one core.
-    auto createDataParallelExtractOutput =
-        [&](RankedTensorType logicalType) -> Value {
-      constexpr std::array<int64_t, 2> defaultTileShape =
-          ttcore::TileType::getDefaultShape();
-      SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
-                                        defaultTileShape.end());
-      auto tileElemType =
-          ttcore::TileType::get(logicalType.getElementType(), tileShapeVec);
-      SmallVector<int64_t> shardTiles(logicalType.getRank(), 1);
-      shardTiles[1 - dim] = paddedNonTargetTiles;
-      auto layout = d2m::utils::buildShardedTileLayout(
-          ctx, logicalType.getShape(), shardTiles, memorySpaces[1]);
-      SmallVector<int64_t> grid = (dim == 1)
-                                      ? SmallVector<int64_t>{ntShards, 1}
-                                      : SmallVector<int64_t>{1, ntShards};
-      auto emptyOp = rewriter.create<d2m::EmptyOp>(
-          loc, layout.getDeviceShape(grid, tileShapeVec), tileElemType, layout);
-      return emptyOp.getResult();
-    };
+    SmallVector<Value> origValOutputs =
+        createDpsOutputs(loc, rewriter, {valuesType});
+    SmallVector<Value> origIdxOutputs =
+        createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
+    Value extractValsLayout =
+        createOptimalLayoutOp(origValOutputs[0], memorySpaces[1],
+                              /*tiled=*/true, /*noCollapse=*/false, rewriter);
+    Value extractIdxLayout =
+        createOptimalLayoutOp(origIdxOutputs[0], memorySpaces[1],
+                              /*tiled=*/true, /*noCollapse=*/false, rewriter);
 
-    Value extractValsLayout, extractIdxLayout;
-    if (dataParallel) {
-      extractValsLayout = createDataParallelExtractOutput(valuesType);
-      extractIdxLayout = createDataParallelExtractOutput(extractIdxIndicesType);
-    } else {
-      SmallVector<Value> origValOutputs =
-          createDpsOutputs(loc, rewriter, {valuesType});
-      SmallVector<Value> origIdxOutputs =
-          createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
-      extractValsLayout = createOptimalLayoutOp(origValOutputs[0],
-                                                memorySpaces[1], /*tiled=*/true,
-                                                /*noCollapse=*/false, rewriter);
-      extractIdxLayout = createOptimalLayoutOp(origIdxOutputs[0],
-                                               memorySpaces[1], /*tiled=*/true,
-                                               /*noCollapse=*/false, rewriter);
-    }
-
-    std::size_t extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
-
-    auto extractValsGeneric = createExtractGeneric(
-        rewriter, loc, ctx, topkValsRelayouted, extractValsLayout,
-        extractProjectDim, outputReductionTiles, dim);
-    auto extractIdxGeneric = createExtractGeneric(
-        rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
-        extractProjectDim, outputReductionTiles, dim);
+    auto extractValsGeneric = d2m::utils::emitTopKExtract(
+        rewriter, loc, d2m::utils::materializeToLayout(rewriter, loc, topkVals),
+        extractValsLayout, geometry.extractProjectDim, outputReductionTiles,
+        dim);
+    auto extractIdxGeneric = d2m::utils::emitTopKExtract(
+        rewriter, loc, d2m::utils::materializeToLayout(rewriter, loc, topkIdx),
+        extractIdxLayout, geometry.extractProjectDim, outputReductionTiles,
+        dim);
 
     Value idxFinal = extractIdxGeneric->getResult(0);
     if (!fuseIdxCast) {
@@ -4315,13 +3727,14 @@ public:
       SmallVector<Attribute> castIters(
           castRank,
           ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-      idxFinal = emitUnaryGeneric(
+      idxFinal = d2m::utils::emitUnaryGeneric(
           rewriter, loc, idxFinal, idxCastEmpty.getResult(), castIdentity,
           castIters, /*shardMap=*/nullptr,
           [&](OpBuilder &b, Location l, ValueRange args) {
             return b.create<d2m::TileTypecastOp>(l, args[1].getType(), args[0])
                 .getResult();
           });
+      d2m::utils::markPinnedGrid(idxFinal.getDefiningOp());
     }
 
     Operation *valResult =

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3616,7 +3616,6 @@ public:
   matchAndRewrite(ttir::TopKOp op, ttir::TopKOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    MLIRContext *ctx = rewriter.getContext();
 
     auto inputType = cast<RankedTensorType>(adaptor.getInputTensor().getType());
     auto valuesType = cast<RankedTensorType>(op.getValues().getType());
@@ -3647,38 +3646,16 @@ public:
 
     Value layoutedInput;
     if (reductionDimSize <= kTileWidth) {
-      // topk_block merges reduction tiles pairwise, so it needs at least two;
-      // dimAlignments pads the buffer and the mask below fills the tail.
-      constexpr std::array<int64_t, 2> defaultTileShape =
-          ttcore::TileType::getDefaultShape();
-      SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
-                                        defaultTileShape.end());
-      auto tileElemType =
-          ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-      SmallVector<int64_t> paddedTiles(inputType.getShape().size(), 1);
+      // topk_block merges reduction tiles pairwise, so it needs at least two.
+      SmallVector<int64_t> paddedTiles(rank, 1);
       paddedTiles[dim] = 2;
-      auto paddedLayout = d2m::utils::buildShardedTileLayout(
-          ctx, inputType.getShape(), paddedTiles, memorySpaces[0]);
-      SmallVector<int64_t> unitGrid(inputType.getShape().size(), 1);
-      SmallVector<int64_t> paddedDeviceShape =
-          paddedLayout.getDeviceShape(unitGrid, tileShapeVec);
-      auto paddedEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, paddedDeviceShape, tileElemType, paddedLayout);
-      Value toLayouted = rewriter
-                             .create<d2m::ToLayoutOp>(
-                                 loc, adaptor.getInputTensor(), paddedEmpty)
-                             .getResult(0);
-      auto maskOutput = rewriter.create<d2m::EmptyOp>(
-          loc, paddedDeviceShape, tileElemType, paddedLayout);
-      layoutedInput = rewriter
-                          .create<d2m::MaskOp>(loc, toLayouted, maskOutput,
-                                               paddedLayout.getLogicalShape(),
-                                               ttcore::OOBVal::NegInf)
-                          .getResult();
+      layoutedInput = d2m::utils::layoutAndMask(
+          rewriter, loc, adaptor.getInputTensor(), paddedTiles,
+          SmallVector<int64_t>(rank, 1), memorySpaces[0]);
     } else {
-      layoutedInput = createOptimalLayoutOp(adaptor.getInputTensor(),
-                                            memorySpaces[0], /*tiled=*/true,
-                                            /*noCollapse=*/false, rewriter);
+      layoutedInput = createOptimalLayoutOp(
+          adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
+          /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);
     }
 
     auto [topkVals, topkIdx] = d2m::utils::emitLeafTopk(
@@ -3722,14 +3699,8 @@ public:
       auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
           loc, extractedIdxType.getShape(), idxCastTileType,
           extractedIdxType.getEncoding());
-      std::size_t castRank = extractedIdxType.getShape().size() / 2;
-      AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
-      SmallVector<Attribute> castIters(
-          castRank,
-          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
       idxFinal = d2m::utils::emitUnaryGeneric(
-          rewriter, loc, idxFinal, idxCastEmpty.getResult(), castIdentity,
-          castIters, /*shardMap=*/nullptr,
+          rewriter, loc, idxFinal, idxCastEmpty.getResult(),
           [&](OpBuilder &b, Location l, ValueRange args) {
             return b.create<d2m::TileTypecastOp>(l, args[1].getType(), args[0])
                 .getResult();

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3800,7 +3800,8 @@ public:
         rewriter.getAffineMapArrayAttr(
             SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
         rewriter.getArrayAttr(extractIters));
-    // Keep the extract on one core: it reads the full topk partial shard.
+    // Keep the output's declared grid; grid selection would otherwise re-place
+    // this against the full topk partial shard it reads.
     generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
     withD2MGenericRegion(
@@ -3876,12 +3877,9 @@ public:
           op, "D2M topk only supports 2D reduction on dim 0 or dim 1");
     }
 
-    // Multi-core sharding splits whichever dim overflows one core's L1: the
-    // reduction dim into bands merged back by a tree, or the non-target dim
-    // into independent slices needing no merge.
     constexpr int64_t kTileWidth = 32;
     int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
-    // L1-safe tile budget per core; values and indices share it.
+    // L1-safe tile budget for one core's shard of a single buffer.
     constexpr int64_t kMaxTilesPerCore = 43;
     int64_t fullReductionElems = inputType.getShape()[dim];
     int64_t nonTargetElems = inputType.getShape()[1 - dim];
@@ -3904,118 +3902,196 @@ public:
       maxGridCores = workerGridShape[0] * workerGridShape[1];
     };
 
-    bool dataParallel = nonTargetTiles > kMaxTilesPerCore;
+    // A joint 2D split is the only option left once the non-target dim
+    // overflows a core AND the reduction dim is too big to ride along whole on
+    // every core, which is what the data-parallel split needs.
+    bool twoDim = nonTargetTiles > kMaxTilesPerCore &&
+                  localReductionTiles >= kMaxTilesPerCore;
+
+    // Whether each dim is split, and how: `dataParallel` slices the non-target
+    // dim ntShards ways (no merge needed), `multiCore` bands the reduction dim
+    // numShards ways (merged back by a tree). The 2D split sets both.
+    bool dataParallel = false;
+    bool multiCore = false;
     int64_t ntShards = 1;
+    int64_t ntTilesPerCore = nonTargetTiles;
     int64_t paddedNonTargetTiles = nonTargetTiles;
-    if (dataParallel) {
-      loadWorkerGrid();
-      // Every core keeps the whole reduction dim, so it must fit alongside at
-      // least one non-target tile.
-      if (localReductionTiles >= kMaxTilesPerCore) {
-        return rewriter.notifyMatchFailure(
-            op, "D2M topk: both dimensions exceed the per-core tile budget; "
-                "splitting them jointly is unsupported");
-      }
-      int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
-      int64_t minNtShards =
-          (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
-      std::optional<int64_t> legalNtShards;
-      for (int64_t cand = minNtShards; cand <= maxGridCores; ++cand) {
-        if (!d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-                 .empty()) {
-          legalNtShards = cand;
-          break;
-        }
-      }
-      if (!legalNtShards) {
-        return rewriter.notifyMatchFailure(
-            op, "D2M topk: no core count splits the non-target dimension "
-                "within the per-core tile budget on this worker grid");
-      }
-      ntShards = *legalNtShards;
-      paddedNonTargetTiles =
-          ntShards * ((nonTargetTiles + ntShards - 1) / ntShards);
-    }
-
-    int64_t maxReductionTilesPerCore =
-        dataParallel ? fullReductionTiles : kMaxTilesPerCore / nonTargetTiles;
-
-    // Bands one merge core can absorb in a round
-    int64_t mergeCap = maxReductionTilesPerCore / outputReductionTiles;
-    if (k > 32) {
-      // Greater per-partial footprint, so put fewer tiles on each merge core.
-      mergeCap /= 4;
-    }
-
-    int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
-                        maxReductionTilesPerCore;
-    bool multiCore = !dataParallel && minShards > 1;
-
-    if (fullReductionTiles == 1) {
-      assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
-    }
-    // Bands are distributed one per core and folded onto the 2D worker grid
-    // by a virtual-grid map attached in emitShardTopk. They need not divide
-    // fullReductionTiles evenly; the padding tail out to paddedReductionTiles
-    // is masked to -inf.
+    // Bands need not divide fullReductionTiles evenly; the padding tail out to
+    // paddedReductionTiles is masked to -inf, as is the non-target tail out to
+    // paddedNonTargetTiles.
     int64_t numShards = 1;
     int64_t bandTiles = fullReductionTiles;
     int64_t paddedReductionTiles = fullReductionTiles;
-    if (multiCore) {
+    // Bands one merge core can absorb in a round.
+    int64_t mergeCap = 0;
+
+    // k > kTileWidth partials span two tiles and fold through the large-k
+    // path, so they get a fraction of the budget.
+    constexpr int64_t kLargeKMergeDivisor = 4;
+    auto mergeCapFor = [&](int64_t reductionTilesPerCore) -> int64_t {
+      int64_t cap = reductionTilesPerCore / outputReductionTiles;
+      return (k > kTileWidth) ? cap / kLargeKMergeDivisor : cap;
+    };
+
+    if (twoDim) {
       loadWorkerGrid();
-      // Two passes: powers of two first (always close, shallowest tree)
-      // then any count whose chain closes, which
-      // is what reaches past 64 bands on larger grids.
-      for (int pass = 0; pass < 2 && numShards == 1; ++pass) {
+      // Bands occupy the reduction dim's grid axis and non-target slices the
+      // other, placed directly so every core index is a real coordinate.
+      // dim==0 transposes the index grid, so its band count must fit both axes.
+      int64_t bandGridLimit =
+          (dim == 1) ? workerGridShape[1]
+                     : std::min(workerGridShape[0], workerGridShape[1]);
+      int64_t ntGridLimit =
+          (dim == 1) ? workerGridShape[0] : workerGridShape[1];
+
+      // Fewest bands first: non-target slices are independent, while every
+      // extra band level costs a merge round. Powers of two close the
+      // shallowest chains, so try those before any other count.
+      for (int pass = 0; pass < 2 && !multiCore; ++pass) {
         bool powerOfTwoOnly = (pass == 0);
-        for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
-          if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
+        for (int64_t bands = 2; bands <= bandGridLimit; ++bands) {
+          if (powerOfTwoOnly && (bands & (bands - 1)) != 0) {
             continue;
           }
-          if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-                  .empty()) {
+          int64_t candBandTiles = (fullReductionTiles + bands - 1) / bands;
+          // topk_block merges reduction tiles pairwise, so a band needs two.
+          if (candBandTiles < 2) {
             continue;
           }
-          int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
-          if (candBandTiles > maxReductionTilesPerCore) {
+          int64_t maxNtPerCore = kMaxTilesPerCore / candBandTiles;
+          if (maxNtPerCore < 1) {
             continue;
           }
-          if (!mergeChainCloses(cand, mergeCap, workerGridShape)) {
+          int64_t minNtShards =
+              (nonTargetTiles + maxNtPerCore - 1) / maxNtPerCore;
+          if (minNtShards > ntGridLimit) {
             continue;
           }
-          numShards = cand;
-          bandTiles = candBandTiles;
-          break;
+          // More non-target slices shrink each core's slice, which frees tile
+          // budget for the merge rounds, so walk up until the chain closes.
+          for (int64_t ntSh = minNtShards; ntSh <= ntGridLimit; ++ntSh) {
+            int64_t candNtTiles = (nonTargetTiles + ntSh - 1) / ntSh;
+            int64_t candMergeCap = mergeCapFor(kMaxTilesPerCore / candNtTiles);
+            if (candMergeCap < 2 ||
+                !mergeChainCloses(bands, candMergeCap, workerGridShape)) {
+              continue;
+            }
+            numShards = bands;
+            bandTiles = candBandTiles;
+            ntShards = ntSh;
+            ntTilesPerCore = candNtTiles;
+            mergeCap = candMergeCap;
+            dataParallel = true;
+            multiCore = true;
+            break;
+          }
+          if (multiCore) {
+            break;
+          }
         }
       }
-      if (numShards == 1) {
+      if (!multiCore) {
         return rewriter.notifyMatchFailure(
-            op, "D2M topk: no band count fits the reduction dim within the "
+            op, "D2M topk: no 2D split fits both dimensions within the "
                 "per-core tile budget with a merge tree this worker grid can "
-                "split evenly");
+                "hold");
       }
       paddedReductionTiles = numShards * bandTiles;
-    }
-    if (dataParallel) {
-      paddedReductionTiles = localReductionTiles;
+      paddedNonTargetTiles = ntShards * ntTilesPerCore;
+    } else {
+      dataParallel = nonTargetTiles > kMaxTilesPerCore;
+      if (dataParallel) {
+        loadWorkerGrid();
+        int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
+        int64_t minNtShards =
+            (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
+        std::optional<int64_t> legalNtShards;
+        for (int64_t cand = minNtShards; cand <= maxGridCores; ++cand) {
+          if (!d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+                   .empty()) {
+            legalNtShards = cand;
+            break;
+          }
+        }
+        if (!legalNtShards) {
+          return rewriter.notifyMatchFailure(
+              op, "D2M topk: no core count splits the non-target dimension "
+                  "within the per-core tile budget on this worker grid");
+        }
+        ntShards = *legalNtShards;
+        ntTilesPerCore = (nonTargetTiles + ntShards - 1) / ntShards;
+        paddedNonTargetTiles = ntShards * ntTilesPerCore;
+      }
+
+      int64_t maxReductionTilesPerCore =
+          dataParallel ? fullReductionTiles : kMaxTilesPerCore / nonTargetTiles;
+
+      mergeCap = mergeCapFor(maxReductionTilesPerCore);
+
+      int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
+                          maxReductionTilesPerCore;
+      multiCore = !dataParallel && minShards > 1;
+
+      if (fullReductionTiles == 1) {
+        assert(k <= kTileWidth &&
+               "single-tile topk input only supports k <= 32");
+      }
+      // Bands are distributed one per core and folded onto the 2D worker grid
+      // by a virtual-grid map attached in emitShardTopk.
+      if (multiCore) {
+        loadWorkerGrid();
+        // Two passes: powers of two first (always close, shallowest tree)
+        // then any count whose chain closes, which
+        // is what reaches past 64 bands on larger grids.
+        for (int pass = 0; pass < 2 && numShards == 1; ++pass) {
+          bool powerOfTwoOnly = (pass == 0);
+          for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
+            if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
+              continue;
+            }
+            if (d2m::utils::findLegalPhysicalGridForVolume(cand,
+                                                           workerGridShape)
+                    .empty()) {
+              continue;
+            }
+            int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
+            if (candBandTiles > maxReductionTilesPerCore) {
+              continue;
+            }
+            if (!mergeChainCloses(cand, mergeCap, workerGridShape)) {
+              continue;
+            }
+            numShards = cand;
+            bandTiles = candBandTiles;
+            break;
+          }
+        }
+        if (numShards == 1) {
+          return rewriter.notifyMatchFailure(
+              op, "D2M topk: no band count fits the reduction dim within the "
+                  "per-core tile budget with a merge tree this worker grid can "
+                  "split evenly");
+        }
+        paddedReductionTiles = numShards * bandTiles;
+      }
+      if (dataParallel) {
+        paddedReductionTiles = localReductionTiles;
+      }
     }
 
     AffineMapAttr dataParallelFoldForwardAttr, dataParallelFoldInverseAttr;
 
     // Emits a topk over a raw input, returning (values, indices) still in
-    // device layout. arangeStart offsets indices so band g yields global
-    // indices; gridCols > 1 splits the topk across that many cores, each band
-    // narrowed to its leading outputReductionTiles for the caller's merge
-    // tree to gather. ntCores > 1 splits the non-target dim instead, leaving
-    // every core's slice already final with nothing to merge.
-    auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols = 1,
+    // device layout. gridCols > 1 bands the topk across that many cores for the
+    // caller's merge tree; ntCores > 1 slices the non-target dim instead.
+    auto emitShardTopk = [&](Value rawInput, int64_t gridCols = 1,
                              int64_t ntCores = 1) -> std::pair<Value, Value> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
       bool isDataParallel = ntCores > 1;
       bool isBanded = gridCols > 1;
+      bool directGrid = isBanded && isDataParallel;
 
       SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                             inputType.getShape().end());
@@ -4028,9 +4104,8 @@ public:
           emptyOp.setVirtualGridInverseMappingAttr(foldInverseMapAttr);
         }
       };
-      // Fold maps for the dim==0 arange/index buffers, which live shape-swapped
-      // on a 1xgridCols grid and so need bands across grid COLUMNS rather than
-      // down the value input's ROWS
+      // dim==0 index buffers live shape-swapped and so need bands across grid
+      // COLUMNS, not down the value input's ROWS.
       AffineMapAttr arangeFoldForwardMapAttr, arangeFoldInverseMapAttr;
       auto attachArangeFold = [&](d2m::EmptyOp emptyOp) {
         if (arangeFoldForwardMapAttr) {
@@ -4052,8 +4127,6 @@ public:
                                           defaultTileShape.end());
         auto tileElemType =
             ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-        bool needsPad = paddedReductionTiles > fullReductionTiles ||
-                        paddedNonTargetTiles > nonTargetTiles;
         SmallVector<int64_t> shardDimAlignments(inputType.getShape().size(),
                                                 kTileWidth);
         shardDimAlignments[dim] = paddedReductionTiles * kTileWidth;
@@ -4069,30 +4142,50 @@ public:
                        : SmallVector<int64_t>{gridCols, ntCores};
         SmallVector<int64_t> shardedDeviceShape =
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
+
+        std::size_t shardRank = inputType.getShape().size();
+        bool needsPad = false;
+        for (std::size_t i = 0; i < shardRank; ++i) {
+          int64_t allocatedElems = shardedDeviceShape[i] *
+                                   shardedDeviceShape[shardRank + i] *
+                                   kTileWidth;
+          if (allocatedElems > inputType.getShape()[i]) {
+            needsPad = true;
+            break;
+          }
+        }
+
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
 
-        SmallVector<int64_t> physicalGrid =
-            d2m::utils::findLegalPhysicalGridForVolume(ntCores * gridCols,
-                                                       workerGridShape);
-        assert(!physicalGrid.empty() &&
-               "shard count has no legal worker-grid factorization");
-        auto [forwardMap, inverseMap] =
-            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
-                                                          physicalGrid);
-        foldForwardMapAttr = AffineMapAttr::get(forwardMap);
-        foldInverseMapAttr = AffineMapAttr::get(inverseMap);
-        if (isBanded) {
-          // Swapped for dim==0, matching the arange buffer's orientation.
-          SmallVector<int64_t> arangeGrid =
-              (dim == 1) ? shardedGrid
-                         : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
-          auto [arangeForwardMap, arangeInverseMap] =
-              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
+        // A 2D split's virtual grid already IS a physical one, so leave the
+        // fold maps null: the broadcast index read, the in-place narrowings and
+        // the merge gathers all assume d2m.core_index is a real coordinate.
+        if (!directGrid) {
+          SmallVector<int64_t> physicalGrid =
+              d2m::utils::findLegalPhysicalGridForVolume(ntCores * gridCols,
+                                                         workerGridShape);
+          assert(!physicalGrid.empty() &&
+                 "shard count has no legal worker-grid factorization");
+          auto [forwardMap, inverseMap] =
+              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
                                                             physicalGrid);
-          arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
-          arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
-        } else {
+          foldForwardMapAttr = AffineMapAttr::get(forwardMap);
+          foldInverseMapAttr = AffineMapAttr::get(inverseMap);
+          if (isBanded) {
+            // Swapped for dim==0, matching the arange buffer's orientation.
+            SmallVector<int64_t> arangeGrid =
+                (dim == 1)
+                    ? shardedGrid
+                    : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
+            auto [arangeForwardMap, arangeInverseMap] =
+                ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
+                                                              physicalGrid);
+            arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
+            arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
+          }
+        }
+        if (isDataParallel) {
           dataParallelFoldForwardAttr = foldForwardMapAttr;
           dataParallelFoldInverseAttr = foldInverseMapAttr;
         }
@@ -4101,7 +4194,6 @@ public:
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
         if (needsPad) {
-          // -inf so the padding lanes never win top-k, and are never NaN.
           auto maskOutput = rewriter.create<d2m::EmptyOp>(
               loc, shardedDeviceShape, tileElemType, shardedLayout);
           attachFold(maskOutput);
@@ -4119,9 +4211,9 @@ public:
           topkLogicalShape[dim] = paddedReductionTiles * kTileWidth;
         }
       } else if (reductionDimSize <= kTileWidth) {
-        // A single-tile reduction dim leaves no room for the merge tree, which
-        // needs >=2 tiles, so force the buffer to 2 tiles via dimAlignments and
-        // let the mask op below fill the extra tile with -inf
+        // topk_block merges reduction tiles pairwise and so needs >=2, so pad
+        // the buffer out via dimAlignments and let the mask below fill the
+        // extra tile with -inf.
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
@@ -4165,19 +4257,25 @@ public:
       ArrayRef<int64_t> deviceShape = layoutedType.getShape();
       std::size_t physicalRank = deviceShape.size() / 2;
 
+      // Grid dim the non-target slices spread over; bands take the other one.
+      std::size_t ntGridDim =
+          (dim == 1) ? (physicalRank - 2) : (physicalRank - 1);
+
       SmallVector<int64_t> idxDeviceShape(deviceShape.begin(),
                                           deviceShape.end());
       ttcore::MetalLayoutAttr idxMetalLayout = metalLayout;
       if (isDataParallel) {
-        // In data-parallel path, each core gets the same index buffer
-        SmallVector<int64_t> shardLogicalShape;
+        // Slices of a band share an index range, so collapse only the slice
+        // grid dim. Keeping the band dim is what lets the arange derive its
+        // global indices from the core position.
+        idxDeviceShape[ntGridDim] = 1;
+        SmallVector<int64_t> idxLogicalShape;
         for (std::size_t i = 0; i < physicalRank; ++i) {
-          idxDeviceShape[i] = 1;
-          shardLogicalShape.push_back(deviceShape[physicalRank + i] *
-                                      kTileWidth);
+          idxLogicalShape.push_back(idxDeviceShape[i] *
+                                    deviceShape[physicalRank + i] * kTileWidth);
         }
         idxMetalLayout = ttcore::MetalLayoutAttr::get(
-            ctx, shardLogicalShape, metalLayout.getMemorySpace(),
+            ctx, idxLogicalShape, metalLayout.getMemorySpace(),
             ttcore::TensorMemoryLayout::Sharded);
       }
       bool idxChainFold = (dim == 0) || isDataParallel;
@@ -4201,133 +4299,104 @@ public:
       SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
       AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
-      // Applies TileTransposeOp to every tile in the shard.
-      auto transposeTiles = [&](Value src, bool arangeFold = false) -> Value {
-        auto srcType = cast<RankedTensorType>(src.getType());
-        auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
-        auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
-        auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, srcType.getShape(), srcTileType, srcLayout);
-        attachChainFold(transposeEmpty, arangeFold);
-        SmallVector<Value> transposeInputs = {src};
-        SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
-        auto transposeGeneric = rewriter.create<d2m::GenericOp>(
-            loc, transposeInputs, transposeOutputs,
-            /*additionalArgs=*/ValueRange(),
+      // One-in/one-out generic mapping every tile through `makeTile`. A null
+      // `shardMap` means identity at the region's shard rank.
+      auto emitUnaryGeneric =
+          [&](Value src, Value out, AffineMap gridMap,
+              llvm::function_ref<AffineMap(std::size_t)> shardMap,
+              llvm::function_ref<Value(OpBuilder &, Location, ValueRange)>
+                  makeTile) -> Value {
+        SmallVector<Value> ins = {src};
+        SmallVector<Value> outs = {out};
+        auto generic = rewriter.create<d2m::GenericOp>(
+            loc, ins, outs, /*additionalArgs=*/ValueRange(),
             rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{identityMap, identityMap}),
+                SmallVector<AffineMap>{gridMap, identityMap}),
             rewriter.getArrayAttr(iteratorTypes));
-        transposeGeneric->setAttr("d2m.skip_grid_selection",
-                                  rewriter.getUnitAttr());
-
+        generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
         withD2MGenericRegion(
-            rewriter, loc, transposeGeneric, transposeInputs, transposeOutputs,
-            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-              Value input = blockArgs[0];
-              Value output = blockArgs[1];
-              std::size_t shardRank =
-                  cast<RankedTensorType>(input.getType()).getRank();
-              AffineMap shardIdentity =
-                  rewriter.getMultiDimIdentityMap(shardRank);
-              SmallVector<mlir::utils::IteratorType> linalgIters(
-                  shardRank, mlir::utils::IteratorType::parallel);
-              auto linalgOp = rewriter.create<linalg::GenericOp>(
-                  loc, output.getType(), input, output,
-                  SmallVector<AffineMap>{shardIdentity, shardIdentity},
-                  linalgIters,
-                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                    Value transposed = b.create<d2m::TileTransposeOp>(
-                        bodyLoc, args[1].getType(), args[0]);
-                    b.create<linalg::YieldOp>(bodyLoc, transposed);
-                  });
-              return {linalgOp->getResult(0)};
-            });
-
-        return wrapInToLayout(transposeGeneric->getResult(0), arangeFold);
-      };
-
-      // Full transpose (grid + tile): undoes the shape-swapped arange
-      // orientation, moving index data onto the reduction-row axis.
-      auto fullTranspose = [&](Value src) -> Value {
-        auto srcType = cast<RankedTensorType>(src.getType());
-        auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
-        // Device rank is 2*physicalRank, laid out [grid..., shard...]; swap the
-        // last two of each.
-        ArrayRef<int64_t> srcDevShape = srcType.getShape();
-        SmallVector<int64_t> dstDevShape(srcDevShape.begin(),
-                                         srcDevShape.end());
-        std::swap(dstDevShape[physicalRank - 2], dstDevShape[physicalRank - 1]);
-        std::swap(dstDevShape[2 * physicalRank - 2],
-                  dstDevShape[2 * physicalRank - 1]);
-        auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, dstDevShape, srcTileType,
-            isDataParallel ? idxMetalLayout : metalLayout);
-        attachChainFold(transposeEmpty, isDataParallel);
-        SmallVector<AffineExpr> permExprs;
-        for (std::size_t i = 0; i < physicalRank; ++i) {
-          permExprs.push_back(rewriter.getAffineDimExpr(i));
-        }
-        std::swap(permExprs[physicalRank - 2], permExprs[physicalRank - 1]);
-        AffineMap gridPermMap = AffineMap::get(physicalRank, 0, permExprs, ctx);
-        SmallVector<Value> transposeInputs = {src};
-        SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
-        auto transposeGeneric = rewriter.create<d2m::GenericOp>(
-            loc, transposeInputs, transposeOutputs,
-            /*additionalArgs=*/ValueRange(),
-            rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{gridPermMap, identityMap}),
-            rewriter.getArrayAttr(iteratorTypes));
-        transposeGeneric->setAttr("d2m.skip_grid_selection",
-                                  rewriter.getUnitAttr());
-
-        withD2MGenericRegion(
-            rewriter, loc, transposeGeneric, transposeInputs, transposeOutputs,
+            rewriter, loc, generic, ins, outs,
             [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
               Value input = blockArgs[0];
               Value output = blockArgs[1];
               std::size_t shardRank =
                   cast<RankedTensorType>(output.getType()).getRank();
-              // Permute the last two shard dims so output tile (r, c) reads
-              // input tile (c, r).
-              SmallVector<AffineExpr> shardPermExprs;
-              for (std::size_t i = 0; i < shardRank; ++i) {
-                shardPermExprs.push_back(rewriter.getAffineDimExpr(i));
-              }
-              std::swap(shardPermExprs[shardRank - 2],
-                        shardPermExprs[shardRank - 1]);
-              AffineMap shardInputMap =
-                  AffineMap::get(shardRank, 0, shardPermExprs, ctx);
               AffineMap shardIdentity =
                   rewriter.getMultiDimIdentityMap(shardRank);
+              AffineMap shardIn =
+                  shardMap ? shardMap(shardRank) : shardIdentity;
               SmallVector<mlir::utils::IteratorType> linalgIters(
                   shardRank, mlir::utils::IteratorType::parallel);
               auto linalgOp = rewriter.create<linalg::GenericOp>(
                   loc, output.getType(), input, output,
-                  SmallVector<AffineMap>{shardInputMap, shardIdentity},
-                  linalgIters,
+                  SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
                   [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                    Value transposed = b.create<d2m::TileTransposeOp>(
-                        bodyLoc, args[1].getType(), args[0]);
-                    b.create<linalg::YieldOp>(bodyLoc, transposed);
+                    b.create<linalg::YieldOp>(bodyLoc,
+                                              makeTile(b, bodyLoc, args));
                   });
               return {linalgOp->getResult(0)};
             });
-
-        return wrapInToLayout(transposeGeneric->getResult(0), isDataParallel);
+        return generic->getResult(0);
       };
 
-      // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
-      // operates on tile columns, so we transpose the tiles first.
+      auto tileTranspose = [&](OpBuilder &b, Location l, ValueRange args) {
+        return b.create<d2m::TileTransposeOp>(l, args[1].getType(), args[0])
+            .getResult();
+      };
+      auto permuteLast2 = [&](std::size_t rank) {
+        SmallVector<AffineExpr> exprs;
+        for (std::size_t i = 0; i < rank; ++i) {
+          exprs.push_back(rewriter.getAffineDimExpr(i));
+        }
+        std::swap(exprs[rank - 2], exprs[rank - 1]);
+        return AffineMap::get(rank, 0, exprs, ctx);
+      };
+
+      auto transposeTiles = [&](Value src, bool arangeFold = false) -> Value {
+        auto srcType = cast<RankedTensorType>(src.getType());
+        auto empty = rewriter.create<d2m::EmptyOp>(
+            loc, srcType.getShape(),
+            cast<ttcore::TileType>(srcType.getElementType()),
+            cast<ttcore::MetalLayoutAttr>(srcType.getEncoding()));
+        attachChainFold(empty, arangeFold);
+        return wrapInToLayout(
+            emitUnaryGeneric(src, empty.getResult(), identityMap,
+                             /*shardMap=*/nullptr, tileTranspose),
+            arangeFold);
+      };
+
+      // Grid + tile transpose: undoes the shape-swapped arange orientation,
+      // moving index data onto the reduction-row axis.
+      auto fullTranspose = [&](Value src) -> Value {
+        auto srcType = cast<RankedTensorType>(src.getType());
+        // Device shape is [grid..., shard...]; swap the last two of each half.
+        SmallVector<int64_t> dstDevShape(srcType.getShape().begin(),
+                                         srcType.getShape().end());
+        std::swap(dstDevShape[physicalRank - 2], dstDevShape[physicalRank - 1]);
+        std::swap(dstDevShape[2 * physicalRank - 2],
+                  dstDevShape[2 * physicalRank - 1]);
+        auto empty = rewriter.create<d2m::EmptyOp>(
+            loc, dstDevShape, cast<ttcore::TileType>(srcType.getElementType()),
+            isDataParallel ? idxMetalLayout : metalLayout);
+        attachChainFold(empty, isDataParallel);
+        return wrapInToLayout(emitUnaryGeneric(src, empty.getResult(),
+                                               permuteLast2(physicalRank),
+                                               permuteLast2, tileTranspose),
+                              isDataParallel);
+      };
+
+      // TopkBlockOp sorts along tile columns, but dim=1 puts the sort
+      // dimension on tile rows.
       Value topkInput = layoutedInput;
       if (dim == 1) {
         topkInput = transposeTiles(layoutedInput);
       }
 
-      bool isFoldedShard = isBanded || isDataParallel;
+      bool isShardedInput = isBanded || isDataParallel;
 
       auto idxTileType = ttcore::TileType::get(idxElemType);
-      // dim==0 swaps the last two dims so the reduction lands on the column
-      // axis, which fullTranspose undoes afterwards
+      // dim==0 builds the arange shape-swapped so the reduction lands on the
+      // column axis; fullTranspose reorients it below.
       SmallVector<int64_t> arangeLogicalShape(topkLogicalShape.begin(),
                                               topkLogicalShape.end());
       if (dim == 0) {
@@ -4355,7 +4424,7 @@ public:
       }
 
       SmallVector<Value> arangeOutputs;
-      if (isFoldedShard) {
+      if (isShardedInput) {
         auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
             loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
         attachArangeFold(arangeEmpty);
@@ -4391,11 +4460,10 @@ public:
                                     arangeScratchTileType, arangeScratchLayout)
               .getResult();
 
-      // DecomposeArange derives the global index purely from tile grid position
-      // and ignores numElements, so this is cosmetic, but keep it truthful.
+      // DecomposeArange derives the global index from tile grid position and
+      // ignores numElements.
       int64_t numElements = topkLogicalShape[dim];
 
-      // Scratch input always at (0,0), output is identity.
       AffineExpr zero = rewriter.getAffineConstantExpr(0);
       AffineMap arangeConstMap =
           AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
@@ -4420,10 +4488,10 @@ public:
             Value idxTile = blockArgs[0];
             Value outTile = blockArgs[1];
             Value result = rewriter
-                               .create<d2m::ArangeBlockOp>(
-                                   loc, idxTile, outTile, numElements,
-                                   /*start=*/arangeStart,
-                                   /*step=*/1)
+                               .create<d2m::ArangeBlockOp>(loc, idxTile,
+                                                           outTile, numElements,
+                                                           /*start=*/0,
+                                                           /*step=*/1)
                                .getResult();
             return {result};
           });
@@ -4438,7 +4506,7 @@ public:
       SmallVector<Value> postArangeBcastOutputs;
       // Allocate at the sharded arange device shape so the L1 buffer splits
       // across cores and the operand grid matches the sharded arange input.
-      if (isFoldedShard) {
+      if (isShardedInput) {
         auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
             loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
         attachArangeFold(bcastEmpty);
@@ -4452,62 +4520,25 @@ public:
         postArangeBcastOutputs = std::move(laidOut);
       }
 
-      mlir::MutableAffineMap postArangeInMap(
-          rewriter.getMultiDimIdentityMap(physicalRank));
-      postArangeInMap.setResult(physicalRank - 2, zero);
-      AffineMap postArangeBcastInputMap = postArangeInMap.getAffineMap();
-      AffineMap postArangeBcastOutputMap =
-          rewriter.getMultiDimIdentityMap(physicalRank);
-      SmallVector<AffineMap> postArangeBcastMaps = {postArangeBcastInputMap,
-                                                    postArangeBcastOutputMap};
-
-      SmallVector<Attribute> postArangeBcastIters(
-          physicalRank,
-          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-      d2m::GenericOp postArangeBcast = rewriter.create<d2m::GenericOp>(
-          loc, postArangeBcastInputs, postArangeBcastOutputs,
-          /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(postArangeBcastMaps),
-          rewriter.getArrayAttr(postArangeBcastIters));
-      postArangeBcast->setAttr("d2m.skip_grid_selection",
-                               rewriter.getUnitAttr());
-
-      withD2MGenericRegion(
-          rewriter, loc, postArangeBcast, postArangeBcastInputs,
-          postArangeBcastOutputs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            Value input = blockArgs[0];
-            Value output = blockArgs[1];
-            std::size_t shardRank =
-                cast<RankedTensorType>(output.getType()).getRank();
-            // Must zero the broadcast axis: an identity map would make linalg
-            // infer that axis's extent from the iteration domain, mismatching
-            // the collapsed input shard when the non-target dim spans >1 tile.
-            mlir::MutableAffineMap shardInMap(
-                rewriter.getMultiDimIdentityMap(shardRank));
-            shardInMap.setResult(shardRank - 2,
-                                 rewriter.getAffineConstantExpr(0));
-            AffineMap shardInputMap = shardInMap.getAffineMap();
-            AffineMap shardIdentity =
-                rewriter.getMultiDimIdentityMap(shardRank);
-            SmallVector<mlir::utils::IteratorType> linalgIters(
-                shardRank, mlir::utils::IteratorType::parallel);
-            auto linalgOp = rewriter.create<linalg::GenericOp>(
-                loc, output.getType(), input, output,
-                SmallVector<AffineMap>{shardInputMap, shardIdentity},
-                linalgIters,
-                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                  Value bcast = b.create<d2m::TileBcastOp>(
-                      bodyLoc, args[1].getType(), args[0],
-                      postArangeBcastTypeAttr);
-                  b.create<linalg::YieldOp>(bodyLoc, bcast);
-                });
-            return {linalgOp->getResult(0)};
+      // Zeroing the broadcast axis is required: an identity map would make
+      // linalg infer that axis's extent from the iteration domain, mismatching
+      // the collapsed input shard when the non-target dim spans >1 tile.
+      auto zeroLast2 = [&](std::size_t rank) {
+        mlir::MutableAffineMap m(rewriter.getMultiDimIdentityMap(rank));
+        m.setResult(rank - 2, rewriter.getAffineConstantExpr(0));
+        return m.getAffineMap();
+      };
+      Value postArangeBcast = emitUnaryGeneric(
+          postArangeBcastInputs[0], postArangeBcastOutputs[0],
+          zeroLast2(physicalRank), zeroLast2,
+          [&](OpBuilder &b, Location l, ValueRange args) {
+            return b
+                .create<d2m::TileBcastOp>(l, args[1].getType(), args[0],
+                                          postArangeBcastTypeAttr)
+                .getResult();
           });
 
-      Value idxBuf = wrapInToLayout(postArangeBcast->getResult(0),
-                                    /*useArangeFold=*/idxChainFold);
+      Value idxBuf = wrapInToLayout(postArangeBcast, idxChainFold);
       if (dim == 1) {
         idxBuf = transposeTiles(idxBuf, /*arangeFold=*/idxChainFold);
       } else {
@@ -4521,12 +4552,10 @@ public:
       attachFold(topkValsEmpty);
       attachFold(topkIdxEmpty);
 
-      // The operand map drops the dim the slices spread over, so every core
-      // reads the one unit-grid index buffer.
+      // Drops the dim the slices spread over, so every slice of a band reads
+      // that band's one index buffer.
       AffineMap idxGridMap = identityMap;
       if (isDataParallel) {
-        std::size_t ntGridDim =
-            (dim == 1) ? (physicalRank - 2) : (physicalRank - 1);
         mlir::MutableAffineMap broadcastMap(identityMap);
         broadcastMap.setResult(ntGridDim, rewriter.getAffineConstantExpr(0));
         idxGridMap = broadcastMap.getAffineMap();
@@ -4562,9 +4591,8 @@ public:
           deviceShape.size() - (physicalRank - redPhys);
       constexpr int64_t kTileDimLocal = 32;
 
-      // Per-band pre-compaction: narrow each band in place, before the
-      // cross-core gather, or the wide leaf result stays live on every core
-      // and overflows L1
+      // Narrow each band in place before the cross-core gather, or the wide
+      // leaf result stays live on every core and overflows L1.
       auto compactBands = [&](Value wideResult) -> Value {
         auto wideType = cast<RankedTensorType>(wideResult.getType());
         auto tileType = cast<ttcore::TileType>(wideType.getElementType());
@@ -4573,10 +4601,6 @@ public:
         SmallVector<int64_t> narrowShape(wideType.getShape().begin(),
                                          wideType.getShape().end());
         narrowShape[deviceRedDimLocal] = outputReductionTiles;
-        // Logical shape spans the whole distributed result, grid x shard, not
-        // one core's share. The merge rounds hold that product invariant while
-        // re-splitting it, which is what lets a single composite view over this
-        // value verify against its own re-split output.
         SmallVector<int64_t> narrowLogical;
         for (std::size_t i = 0; i < physicalRank; ++i) {
           narrowLogical.push_back(
@@ -4626,15 +4650,13 @@ public:
         ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
     SmallVector<Attribute> mergeIters(physicalRank, parallelAttr);
     AffineMap mergeIdentity = rewriter.getMultiDimIdentityMap(physicalRank);
-    // Reduction tiles live in the shard portion of the [grid..., shard...]
-    // layout: the last shard dim for dim==1 and the first for dim==0.
-    // compactToTile reshapes the device tensor, so it indexes here, not in
-    // shard space.
+    // Reduction tiles live in the shard half of the [grid..., shard...] device
+    // shape: last shard dim for dim==1, first for dim==0.
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // A merge round re-splits that product without changing it, so its
-    // composite view sees the same logical extent on both sides.
+    // Rebuilds the logical shape as grid x shard so a re-split device shape
+    // keeps the same total extent, which the composite view checks.
     auto layoutForDeviceShape =
         [&](ttcore::MetalLayoutAttr layout,
             ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
@@ -4674,16 +4696,16 @@ public:
     Value topkValsRelayouted, topkIdxRelayouted;
     if (!multiCore) {
       std::pair<Value, Value> single =
-          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
-                        /*gridCols=*/1, /*ntCores=*/ntShards);
+          emitShardTopk(adaptor.getInputTensor(), /*gridCols=*/1,
+                        /*ntCores=*/ntShards);
       topkValsRelayouted = single.first;
       topkIdxRelayouted = single.second;
     } else {
-      // Each of numShards cores runs topk_block on its own band, leaving the
-      // partials distributed one band per core.
+      // Each of the ntShards non-target slices merges down its own band row
+      // without ever exchanging data with the others.
       std::pair<Value, Value> level =
-          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
-                        /*gridCols=*/numShards);
+          emitShardTopk(adaptor.getInputTensor(), /*gridCols=*/numShards,
+                        /*ntCores=*/ntShards);
 
       // Grid dim the bands spread across: columns for dim==1, rows for dim==0,
       // matching emitShardTopk's shardedGrid.
@@ -4711,8 +4733,8 @@ public:
         wideShape[deviceGridDim] = numGroups;
         wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
 
-        // Re-splitting leaves grid x shard alone, so the wide layout carries
-        // the same logical extent as the input's
+        // Re-splitting preserves the grid x shard product, so the wide layout
+        // carries the same logical extent as the input's.
         auto valWideLayout = layoutForDeviceShape(
             cast<ttcore::MetalLayoutAttr>(valsInType.getEncoding()), wideShape);
         auto idxWideLayout = layoutForDeviceShape(
@@ -4722,10 +4744,11 @@ public:
         auto idxWideType =
             RankedTensorType::get(wideShape, idxTileType, idxWideLayout);
 
-        // Spread the round's buffers over numGroups distinct cores.
+        // A 2D split already occupies a real ntShards x numGroups grid, so it
+        // stays unfolded like the leaf buffers it re-splits.
         mergeFoldForwardAttr = nullptr;
         mergeFoldInverseAttr = nullptr;
-        if (numGroups > 1) {
+        if (!twoDim && numGroups > 1) {
           SmallVector<int64_t> roundGrid(physicalRank, 1);
           roundGrid[deviceGridDim] = numGroups;
           SmallVector<int64_t> physicalGrid =
@@ -4738,7 +4761,7 @@ public:
           mergeFoldForwardAttr = AffineMapAttr::get(fwd);
           mergeFoldInverseAttr = AffineMapAttr::get(inv);
         }
-        // Cleared on return so later buffers stay unit-grid.
+        // Cleared on return so later buffers carry no fold.
         auto clearFold = llvm::make_scope_exit([&] {
           mergeFoldForwardAttr = nullptr;
           mergeFoldInverseAttr = nullptr;
@@ -4832,8 +4855,8 @@ public:
     auto extractIdxIndicesType = RankedTensorType::get(
         indicesType.getShape(), fuseIdxCast ? idxOutElemType : idxElemType);
 
-    // The extract output must be split like its input on the same folded
-    // cores, or the extract gathers the whole result onto one core.
+    // Must be split like its input, on the same cores and with the same fold,
+    // or the extract gathers the whole result onto one core.
     auto createDataParallelExtractOutput =
         [&](RankedTensorType logicalType) -> Value {
       constexpr std::array<int64_t, 2> defaultTileShape =
@@ -4855,8 +4878,10 @@ public:
                                       : SmallVector<int64_t>{1, ntShards};
       auto emptyOp = rewriter.create<d2m::EmptyOp>(
           loc, layout.getDeviceShape(grid, tileShapeVec), tileElemType, layout);
-      emptyOp.setVirtualGridForwardMappingAttr(dataParallelFoldForwardAttr);
-      emptyOp.setVirtualGridInverseMappingAttr(dataParallelFoldInverseAttr);
+      if (dataParallelFoldForwardAttr) {
+        emptyOp.setVirtualGridForwardMappingAttr(dataParallelFoldForwardAttr);
+        emptyOp.setVirtualGridInverseMappingAttr(dataParallelFoldInverseAttr);
+      }
       return emptyOp.getResult();
     };
 
@@ -4897,7 +4922,7 @@ public:
       auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
           loc, extractedIdxType.getShape(), idxCastTileType,
           extractedIdxType.getEncoding());
-      if (dataParallel) {
+      if (dataParallel && dataParallelFoldForwardAttr) {
         idxCastEmpty.setVirtualGridForwardMappingAttr(
             dataParallelFoldForwardAttr);
         idxCastEmpty.setVirtualGridInverseMappingAttr(

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -6,6 +6,7 @@
 
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
@@ -35,7 +36,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/LogicalResult.h"
 
@@ -705,6 +705,119 @@ protected:
     }
     rewriter.finalizeOpModification(generic);
     rewriter.restoreInsertionPoint(insertPoint);
+  }
+
+  /// Emits a one-in/one-out `d2m.generic` whose region maps every tile of `src`
+  /// through `makeTile`. `gridMap` is the input's grid-level indexing map (the
+  /// output's is identity); `shardMap` builds the input's shard-level map from
+  /// the region's shard rank, or is null for identity.
+  Value emitUnaryGeneric(
+      ConversionPatternRewriter &rewriter, Location loc, Value src, Value out,
+      AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
+      llvm::function_ref<AffineMap(std::size_t)> shardMap,
+      llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile)
+      const {
+    std::size_t physicalRank = iteratorTypes.size();
+    AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+    SmallVector<Value> ins = {src};
+    SmallVector<Value> outs = {out};
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, ins, outs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(
+            SmallVector<AffineMap>{gridMap, identityMap}),
+        rewriter.getArrayAttr(iteratorTypes));
+    withD2MGenericRegion(
+        rewriter, loc, generic, ins, outs,
+        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+          Value input = blockArgs[0];
+          Value output = blockArgs[1];
+          std::size_t shardRank =
+              cast<RankedTensorType>(output.getType()).getRank();
+          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
+          AffineMap shardIn = shardMap ? shardMap(shardRank) : shardIdentity;
+          SmallVector<mlir::utils::IteratorType> linalgIters(
+              shardRank, mlir::utils::IteratorType::parallel);
+          auto linalgOp = rewriter.create<linalg::GenericOp>(
+              loc, output.getType(), input, output,
+              SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
+              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                b.create<linalg::YieldOp>(bodyLoc, makeTile(b, bodyLoc, args));
+              });
+          return {linalgOp->getResult(0)};
+        });
+    return generic->getResult(0);
+  }
+
+  /// Narrows `wide` in place to `narrowEmpty`'s shape, every core keeping its
+  /// own shard: each core remote_loads its own tile, copies the leading
+  /// `genRedDim` tiles, and remote_stores back to itself.
+  d2m::GenericOp emitInPlaceNarrowing(
+      ConversionPatternRewriter &rewriter, Location loc, Value wide,
+      d2m::EmptyOp narrowEmpty, std::size_t physicalRank, std::size_t genRedDim,
+      AffineMap identityMap, ArrayRef<Attribute> iteratorTypes) const {
+    MLIRContext *ctx = rewriter.getContext();
+    auto wideType = cast<RankedTensorType>(wide.getType());
+    auto narrowType = cast<RankedTensorType>(narrowEmpty.getType());
+    auto tileType = cast<ttcore::TileType>(wideType.getElementType());
+
+    AffineMap constInMap =
+        AffineMap::get(physicalRank, 0,
+                       SmallVector<AffineExpr>(
+                           physicalRank, rewriter.getAffineConstantExpr(0)),
+                       ctx);
+    SmallVector<Value> ins = {wide};
+    SmallVector<Value> outs = {narrowEmpty.getResult()};
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, ins, outs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(
+            SmallVector<AffineMap>{constInMap, identityMap}),
+        rewriter.getArrayAttr(iteratorTypes));
+
+    auto insertPoint = rewriter.saveInsertionPoint();
+    rewriter.startOpModification(generic);
+    mlir::Region &region = generic->getRegions().front();
+    mlir::Block *block = rewriter.createBlock(&region);
+    rewriter.setInsertionPointToStart(block);
+
+    auto inShardType = RankedTensorType::get(
+        wideType.getShape().take_back(physicalRank), tileType);
+    auto outShardType = RankedTensorType::get(
+        narrowType.getShape().take_back(physicalRank), tileType);
+    std::size_t shardRank = outShardType.getRank();
+    std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
+
+    Value loadBuf = rewriter
+                        .create<tensor::EmptyOp>(loc, inShardType.getShape(),
+                                                 inShardType.getElementType())
+                        .getResult();
+    SmallVector<Value> srcIndices =
+        d2m::utils::buildCoreIndices(rewriter, loc, physicalRank);
+    Value loaded = rewriter
+                       .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
+                                                  wide, srcIndices)
+                       .getResult();
+
+    Value outBuf = rewriter
+                       .create<tensor::EmptyOp>(loc, outShardType.getShape(),
+                                                outShardType.getElementType())
+                       .getResult();
+    auto linalgOp = d2m::utils::emitLeadingTileCopy(rewriter, loc, loaded,
+                                                    outBuf, shardRedDim);
+
+    SmallVector<Value> outIndices =
+        d2m::utils::buildCoreIndices(rewriter, loc, physicalRank);
+    Value storeResult =
+        rewriter
+            .create<d2m::RemoteStoreOp>(loc, narrowEmpty.getType(),
+                                        narrowEmpty.getResult(), outIndices,
+                                        linalgOp->getResult(0))
+            .getResult();
+    rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
+    rewriter.finalizeOpModification(generic);
+    rewriter.restoreInsertionPoint(insertPoint);
+
+    d2m::utils::makeExplicitDatamovementForm(rewriter, generic);
+    return generic;
   }
 
   /// Fills a single tile tensor with `fillValue` (e.g. mean scaler 1/N).
@@ -3597,41 +3710,6 @@ public:
   }
 };
 
-// Picks the smallest legal group count for one merge round (divides `bands`,
-// <= mergeCap bands/group, valid core count); smallest groups keeps the tree
-// shallow
-static int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
-                                   ArrayRef<int64_t> workerGridShape) {
-  for (int64_t groups = 1; groups < bands; ++groups) {
-    if (bands % groups != 0) {
-      continue;
-    }
-    if (bands / groups > mergeCap) {
-      continue;
-    }
-    if (d2m::utils::findLegalPhysicalGridForVolume(groups, workerGridShape)
-            .empty()) {
-      continue;
-    }
-    return groups;
-  }
-  return 0;
-}
-
-// True when repeatedly applying pickMergeGroupCount reduces `bands` to 1.
-// Fails if any level has no divisor in [2, mergeCap] that is also grid-legal.
-static bool mergeChainCloses(int64_t bands, int64_t mergeCap,
-                             ArrayRef<int64_t> workerGridShape) {
-  while (bands > 1) {
-    int64_t groups = pickMergeGroupCount(bands, mergeCap, workerGridShape);
-    if (groups == 0) {
-      return false;
-    }
-    bands = groups;
-  }
-  return true;
-}
-
 class D2MTopKRewriter : public OpConversionPattern<ttir::TopKOp>,
                         D2MNamedRewriterCommon {
 public:
@@ -3643,130 +3721,6 @@ public:
         D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
-
-  SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
-                                      std::size_t gridRank) const {
-    SmallVector<Value> indices;
-    for (std::size_t i = 0; i < gridRank; ++i) {
-      indices.push_back(builder.create<d2m::CoreIndexOp>(
-          loc, builder.getIndexType(), builder.getI64IntegerAttr(i),
-          /*virtual_grid_map=*/nullptr));
-    }
-    return indices;
-  }
-
-  // Opts a generic out of reblocking, which would otherwise read the narrowing
-  // generics' constant input map as a broadcast and rebuild their regions.
-  void makeExplicitDatamovementForm(ConversionPatternRewriter &rewriter,
-                                    d2m::GenericOp generic) const {
-    generic.setBlockFactorsAttr(rewriter.getI64ArrayAttr({}));
-    generic.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr({}));
-    generic.setIteratorTypesAttr(rewriter.getArrayAttr({}));
-  }
-
-  // Emits a linalg.generic copying `input` into `output` tile-by-tile via
-  // TileTypecastOp. With `shardRedDim` set, a non-invertible `dim mod extent`
-  // map on it takes the loop bound from the narrow output, copying only the
-  // leading tiles; without it the map is an identity over the whole shard.
-  linalg::GenericOp
-  emitLeadingTileCopy(OpBuilder &builder, Location loc, MLIRContext *ctx,
-                      Value input, Value output,
-                      std::optional<std::size_t> shardRedDim) const {
-    auto inShardType = cast<RankedTensorType>(input.getType());
-    std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
-    SmallVector<AffineExpr> inExprs;
-    for (std::size_t i = 0; i < shardRank; ++i) {
-      AffineExpr idx = builder.getAffineDimExpr(i);
-      inExprs.push_back(i == shardRedDim ? idx % inShardType.getShape()[i]
-                                         : idx);
-    }
-    AffineMap shardInMap = AffineMap::get(shardRank, 0, inExprs, ctx);
-    AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
-    SmallVector<mlir::utils::IteratorType> linalgIters(
-        shardRank, mlir::utils::IteratorType::parallel);
-    return builder.create<linalg::GenericOp>(
-        loc, output.getType(), input, output,
-        SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
-        [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-          Value copied = b.create<d2m::TileTypecastOp>(
-              bodyLoc, args[1].getType(), args[0]);
-          b.create<linalg::YieldOp>(bodyLoc, copied);
-        });
-  }
-
-  // Narrows `wide` in place to `narrowEmpty`'s shape, every core keeping its
-  // own shard
-  d2m::GenericOp emitInPlaceNarrowing(ConversionPatternRewriter &rewriter,
-                                      Location loc, MLIRContext *ctx,
-                                      Value wide, d2m::EmptyOp narrowEmpty,
-                                      std::size_t physicalRank,
-                                      std::size_t genRedDim,
-                                      AffineMap identityMap,
-                                      ArrayRef<Attribute> iteratorTypes) const {
-    auto wideType = cast<RankedTensorType>(wide.getType());
-    auto narrowType = cast<RankedTensorType>(narrowEmpty.getType());
-    auto tileType = cast<ttcore::TileType>(wideType.getElementType());
-
-    AffineMap constInMap =
-        AffineMap::get(physicalRank, 0,
-                       SmallVector<AffineExpr>(
-                           physicalRank, rewriter.getAffineConstantExpr(0)),
-                       ctx);
-    SmallVector<Value> ins = {wide};
-    SmallVector<Value> outs = {narrowEmpty.getResult()};
-    auto generic = rewriter.create<d2m::GenericOp>(
-        loc, ins, outs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(
-            SmallVector<AffineMap>{constInMap, identityMap}),
-        rewriter.getArrayAttr(iteratorTypes));
-    generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-
-    auto insertPoint = rewriter.saveInsertionPoint();
-    rewriter.startOpModification(generic);
-    mlir::Region &region = generic->getRegions().front();
-    mlir::Block *block = rewriter.createBlock(&region);
-    rewriter.setInsertionPointToStart(block);
-
-    auto inShardType = RankedTensorType::get(
-        wideType.getShape().take_back(physicalRank), tileType);
-    auto outShardType = RankedTensorType::get(
-        narrowType.getShape().take_back(physicalRank), tileType);
-    std::size_t shardRank = outShardType.getRank();
-    std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-
-    Value loadBuf = rewriter
-                        .create<tensor::EmptyOp>(loc, inShardType.getShape(),
-                                                 inShardType.getElementType())
-                        .getResult();
-    SmallVector<Value> srcIndices =
-        buildCoreIndices(rewriter, loc, physicalRank);
-    Value loaded = rewriter
-                       .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
-                                                  wide, srcIndices)
-                       .getResult();
-
-    Value outBuf = rewriter
-                       .create<tensor::EmptyOp>(loc, outShardType.getShape(),
-                                                outShardType.getElementType())
-                       .getResult();
-    auto linalgOp =
-        emitLeadingTileCopy(rewriter, loc, ctx, loaded, outBuf, shardRedDim);
-
-    SmallVector<Value> outIndices =
-        buildCoreIndices(rewriter, loc, physicalRank);
-    Value storeResult =
-        rewriter
-            .create<d2m::RemoteStoreOp>(loc, narrowEmpty.getType(),
-                                        narrowEmpty.getResult(), outIndices,
-                                        linalgOp->getResult(0))
-            .getResult();
-    rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
-    rewriter.finalizeOpModification(generic);
-    rewriter.restoreInsertionPoint(insertPoint);
-
-    makeExplicitDatamovementForm(rewriter, generic);
-    return generic;
-  }
 
   // Extracts top-k results from topkResult into extractOutput, collapsing
   // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
@@ -3800,9 +3754,6 @@ public:
         rewriter.getAffineMapArrayAttr(
             SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
         rewriter.getArrayAttr(extractIters));
-    // Keep the output's declared grid; grid selection would otherwise re-place
-    // this against the full topk partial shard it reads.
-    generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
     withD2MGenericRegion(
         rewriter, loc, generic, extractInputs, extractOutputs,
@@ -3878,325 +3829,84 @@ public:
     }
 
     constexpr int64_t kTileWidth = 32;
-    int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
-    // L1-safe tile budget for one core's shard of a single buffer.
-    constexpr int64_t kMaxTilesPerCore = 43;
-    int64_t fullReductionElems = inputType.getShape()[dim];
-    int64_t nonTargetElems = inputType.getShape()[1 - dim];
-    int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
     int64_t fullReductionTiles =
-        (fullReductionElems + kTileWidth - 1) / kTileWidth;
-
-    int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
+        (inputType.getShape()[dim] + kTileWidth - 1) / kTileWidth;
+    if (fullReductionTiles == 1) {
+      assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
+    }
     Type idxElemType = rewriter.getI32Type();
 
-    SmallVector<int64_t> workerGridShape;
-    int64_t maxGridCores = 1;
-    auto loadWorkerGrid = [&]() {
-      if (!workerGridShape.empty()) {
-        return;
-      }
-      auto device = ttcore::lookupDevice(op);
-      workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
-      assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
-      maxGridCores = workerGridShape[0] * workerGridShape[1];
-    };
+    auto device = ttcore::lookupDevice(op);
+    SmallVector<int64_t> workerGridShape =
+        llvm::to_vector(device.getWorkerGrid().getShape());
+    assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
 
-    // A joint 2D split is the only option left once the non-target dim
-    // overflows a core AND the reduction dim is too big to ride along whole on
-    // every core, which is what the data-parallel split needs.
-    bool twoDim = nonTargetTiles > kMaxTilesPerCore &&
-                  localReductionTiles >= kMaxTilesPerCore;
+    std::string strategyFailure;
+    auto strategyOr = d2m::selectTopKShardingStrategy(
+        k, dim, inputType.getShape(), workerGridShape, strategyFailure);
+    if (failed(strategyOr)) {
+      return rewriter.notifyMatchFailure(op, strategyFailure);
+    }
+    const d2m::TopKShardingStrategy &strategy = *strategyOr;
 
     // Whether each dim is split, and how: `dataParallel` slices the non-target
     // dim ntShards ways (no merge needed), `multiCore` bands the reduction dim
     // numShards ways (merged back by a tree). The 2D split sets both.
-    bool dataParallel = false;
-    bool multiCore = false;
-    int64_t ntShards = 1;
-    int64_t ntTilesPerCore = nonTargetTiles;
-    int64_t paddedNonTargetTiles = nonTargetTiles;
-    // Bands need not divide fullReductionTiles evenly; the padding tail out to
-    // paddedReductionTiles is masked to -inf, as is the non-target tail out to
-    // paddedNonTargetTiles.
-    int64_t numShards = 1;
-    int64_t bandTiles = fullReductionTiles;
-    int64_t paddedReductionTiles = fullReductionTiles;
-    // Bands one merge core can absorb in a round.
-    int64_t mergeCap = 0;
+    const bool dataParallel = strategy.dataParallel;
+    const bool multiCore = strategy.multiCore;
+    const int64_t outputReductionTiles = strategy.outputReductionTiles;
+    const int64_t ntShards = strategy.ntShards;
+    const int64_t paddedNonTargetTiles = strategy.paddedNonTargetTiles;
+    const int64_t numShards = strategy.numShards;
+    const int64_t paddedReductionTiles = strategy.paddedReductionTiles;
+    const int64_t mergeCap = strategy.mergeCap;
 
-    // k > kTileWidth partials span two tiles and fold through the large-k
-    // path, so they get a fraction of the budget.
-    constexpr int64_t kLargeKMergeDivisor = 4;
-    auto mergeCapFor = [&](int64_t reductionTilesPerCore) -> int64_t {
-      int64_t cap = reductionTilesPerCore / outputReductionTiles;
-      return (k > kTileWidth) ? cap / kLargeKMergeDivisor : cap;
-    };
-
-    if (twoDim) {
-      loadWorkerGrid();
-      // Bands occupy the reduction dim's grid axis and non-target slices the
-      // other, placed directly so every core index is a real coordinate.
-      // dim==0 transposes the index grid, so its band count must fit both axes.
-      int64_t bandGridLimit =
-          (dim == 1) ? workerGridShape[1]
-                     : std::min(workerGridShape[0], workerGridShape[1]);
-      int64_t ntGridLimit =
-          (dim == 1) ? workerGridShape[0] : workerGridShape[1];
-
-      // Fewest bands first: non-target slices are independent, while every
-      // extra band level costs a merge round. Powers of two close the
-      // shallowest chains, so try those before any other count.
-      for (int pass = 0; pass < 2 && !multiCore; ++pass) {
-        bool powerOfTwoOnly = (pass == 0);
-        for (int64_t bands = 2; bands <= bandGridLimit; ++bands) {
-          if (powerOfTwoOnly && (bands & (bands - 1)) != 0) {
-            continue;
-          }
-          int64_t candBandTiles = (fullReductionTiles + bands - 1) / bands;
-          // topk_block merges reduction tiles pairwise, so a band needs two.
-          if (candBandTiles < 2) {
-            continue;
-          }
-          int64_t maxNtPerCore = kMaxTilesPerCore / candBandTiles;
-          if (maxNtPerCore < 1) {
-            continue;
-          }
-          int64_t minNtShards =
-              (nonTargetTiles + maxNtPerCore - 1) / maxNtPerCore;
-          if (minNtShards > ntGridLimit) {
-            continue;
-          }
-          // More non-target slices shrink each core's slice, which frees tile
-          // budget for the merge rounds, so walk up until the chain closes.
-          for (int64_t ntSh = minNtShards; ntSh <= ntGridLimit; ++ntSh) {
-            int64_t candNtTiles = (nonTargetTiles + ntSh - 1) / ntSh;
-            int64_t candMergeCap = mergeCapFor(kMaxTilesPerCore / candNtTiles);
-            if (candMergeCap < 2 ||
-                !mergeChainCloses(bands, candMergeCap, workerGridShape)) {
-              continue;
-            }
-            numShards = bands;
-            bandTiles = candBandTiles;
-            ntShards = ntSh;
-            ntTilesPerCore = candNtTiles;
-            mergeCap = candMergeCap;
-            dataParallel = true;
-            multiCore = true;
-            break;
-          }
-          if (multiCore) {
-            break;
-          }
-        }
-      }
-      if (!multiCore) {
-        return rewriter.notifyMatchFailure(
-            op, "D2M topk: no 2D split fits both dimensions within the "
-                "per-core tile budget with a merge tree this worker grid can "
-                "hold");
-      }
-      paddedReductionTiles = numShards * bandTiles;
-      paddedNonTargetTiles = ntShards * ntTilesPerCore;
-    } else {
-      dataParallel = nonTargetTiles > kMaxTilesPerCore;
-      if (dataParallel) {
-        loadWorkerGrid();
-        int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
-        int64_t minNtShards =
-            (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
-        std::optional<int64_t> legalNtShards;
-        for (int64_t cand = minNtShards; cand <= maxGridCores; ++cand) {
-          if (!d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-                   .empty()) {
-            legalNtShards = cand;
-            break;
-          }
-        }
-        if (!legalNtShards) {
-          return rewriter.notifyMatchFailure(
-              op, "D2M topk: no core count splits the non-target dimension "
-                  "within the per-core tile budget on this worker grid");
-        }
-        ntShards = *legalNtShards;
-        ntTilesPerCore = (nonTargetTiles + ntShards - 1) / ntShards;
-        paddedNonTargetTiles = ntShards * ntTilesPerCore;
-      }
-
-      int64_t maxReductionTilesPerCore =
-          dataParallel ? fullReductionTiles : kMaxTilesPerCore / nonTargetTiles;
-
-      mergeCap = mergeCapFor(maxReductionTilesPerCore);
-
-      int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
-                          maxReductionTilesPerCore;
-      multiCore = !dataParallel && minShards > 1;
-
-      if (fullReductionTiles == 1) {
-        assert(k <= kTileWidth &&
-               "single-tile topk input only supports k <= 32");
-      }
-      // Bands are distributed one per core and folded onto the 2D worker grid
-      // by a virtual-grid map attached in emitShardTopk.
-      if (multiCore) {
-        loadWorkerGrid();
-        // Two passes: powers of two first (always close, shallowest tree)
-        // then any count whose chain closes, which
-        // is what reaches past 64 bands on larger grids.
-        for (int pass = 0; pass < 2 && numShards == 1; ++pass) {
-          bool powerOfTwoOnly = (pass == 0);
-          for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
-            if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
-              continue;
-            }
-            if (d2m::utils::findLegalPhysicalGridForVolume(cand,
-                                                           workerGridShape)
-                    .empty()) {
-              continue;
-            }
-            int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
-            if (candBandTiles > maxReductionTilesPerCore) {
-              continue;
-            }
-            if (!mergeChainCloses(cand, mergeCap, workerGridShape)) {
-              continue;
-            }
-            numShards = cand;
-            bandTiles = candBandTiles;
-            break;
-          }
-        }
-        if (numShards == 1) {
-          return rewriter.notifyMatchFailure(
-              op, "D2M topk: no band count fits the reduction dim within the "
-                  "per-core tile budget with a merge tree this worker grid can "
-                  "split evenly");
-        }
-        paddedReductionTiles = numShards * bandTiles;
-      }
-      if (dataParallel) {
-        paddedReductionTiles = localReductionTiles;
-      }
-    }
-
-    AffineMapAttr dataParallelFoldForwardAttr, dataParallelFoldInverseAttr;
-
+    // Buffers below carry logical grid shapes only; GridSelection folds them
+    // onto physical cores.
+    //
     // Emits a topk over a raw input, returning (values, indices) still in
     // device layout. gridCols > 1 bands the topk across that many cores for the
     // caller's merge tree; ntCores > 1 slices the non-target dim instead.
     auto emitShardTopk = [&](Value rawInput, int64_t gridCols = 1,
                              int64_t ntCores = 1) -> std::pair<Value, Value> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
-      int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
       bool isDataParallel = ntCores > 1;
       bool isBanded = gridCols > 1;
-      bool directGrid = isBanded && isDataParallel;
-
-      SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
-                                            inputType.getShape().end());
 
       Value layoutedInput;
-      AffineMapAttr foldForwardMapAttr, foldInverseMapAttr;
-      auto attachFold = [&](d2m::EmptyOp emptyOp) {
-        if (foldForwardMapAttr) {
-          emptyOp.setVirtualGridForwardMappingAttr(foldForwardMapAttr);
-          emptyOp.setVirtualGridInverseMappingAttr(foldInverseMapAttr);
-        }
-      };
-      // dim==0 index buffers live shape-swapped and so need bands across grid
-      // COLUMNS, not down the value input's ROWS.
-      AffineMapAttr arangeFoldForwardMapAttr, arangeFoldInverseMapAttr;
-      auto attachArangeFold = [&](d2m::EmptyOp emptyOp) {
-        if (arangeFoldForwardMapAttr) {
-          emptyOp.setVirtualGridForwardMappingAttr(arangeFoldForwardMapAttr);
-          emptyOp.setVirtualGridInverseMappingAttr(arangeFoldInverseMapAttr);
-        }
-      };
-      auto attachChainFold = [&](d2m::EmptyOp emptyOp, bool arangeFold) {
-        if (arangeFold) {
-          attachArangeFold(emptyOp);
-        } else {
-          attachFold(emptyOp);
-        }
-      };
+
+      constexpr std::array<int64_t, 2> defaultTileShape =
+          ttcore::TileType::getDefaultShape();
+      SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
+                                        defaultTileShape.end());
+      auto tileElemType =
+          ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
+      std::size_t logicalRank = inputType.getShape().size();
+
       if (isBanded || isDataParallel) {
-        constexpr std::array<int64_t, 2> defaultTileShape =
-            ttcore::TileType::getDefaultShape();
-        SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
-                                          defaultTileShape.end());
-        auto tileElemType =
-            ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-        SmallVector<int64_t> shardDimAlignments(inputType.getShape().size(),
-                                                kTileWidth);
-        shardDimAlignments[dim] = paddedReductionTiles * kTileWidth;
-        shardDimAlignments[1 - dim] = paddedNonTargetTiles * kTileWidth;
-        auto shardedLayout = ttcore::MetalLayoutAttr::get(
-            ctx, inputType.getShape(), memorySpaces[0],
-            ttcore::TensorMemoryLayout::Sharded,
-            ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
-                ctx, inputType.getShape().size()),
-            shardDimAlignments);
+        SmallVector<int64_t> shardTiles(logicalRank, 1);
+        shardTiles[dim] = paddedReductionTiles;
+        shardTiles[1 - dim] = paddedNonTargetTiles;
+        auto shardedLayout = d2m::utils::buildShardedTileLayout(
+            ctx, inputType.getShape(), shardTiles, memorySpaces[0]);
         SmallVector<int64_t> shardedGrid =
             (dim == 1) ? SmallVector<int64_t>{ntCores, gridCols}
                        : SmallVector<int64_t>{gridCols, ntCores};
         SmallVector<int64_t> shardedDeviceShape =
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
-
-        std::size_t shardRank = inputType.getShape().size();
-        bool needsPad = false;
-        for (std::size_t i = 0; i < shardRank; ++i) {
-          int64_t allocatedElems = shardedDeviceShape[i] *
-                                   shardedDeviceShape[shardRank + i] *
-                                   kTileWidth;
-          if (allocatedElems > inputType.getShape()[i]) {
-            needsPad = true;
-            break;
-          }
-        }
+        bool needsPad = d2m::utils::deviceShapeNeedsPadding(
+            shardedDeviceShape, inputType.getShape());
 
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
 
-        // A 2D split's virtual grid already IS a physical one, so leave the
-        // fold maps null: the broadcast index read, the in-place narrowings and
-        // the merge gathers all assume d2m.core_index is a real coordinate.
-        if (!directGrid) {
-          SmallVector<int64_t> physicalGrid =
-              d2m::utils::findLegalPhysicalGridForVolume(ntCores * gridCols,
-                                                         workerGridShape);
-          assert(!physicalGrid.empty() &&
-                 "shard count has no legal worker-grid factorization");
-          auto [forwardMap, inverseMap] =
-              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
-                                                            physicalGrid);
-          foldForwardMapAttr = AffineMapAttr::get(forwardMap);
-          foldInverseMapAttr = AffineMapAttr::get(inverseMap);
-          if (isBanded) {
-            // Swapped for dim==0, matching the arange buffer's orientation.
-            SmallVector<int64_t> arangeGrid =
-                (dim == 1)
-                    ? shardedGrid
-                    : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
-            auto [arangeForwardMap, arangeInverseMap] =
-                ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
-                                                              physicalGrid);
-            arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
-            arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
-          }
-        }
-        if (isDataParallel) {
-          dataParallelFoldForwardAttr = foldForwardMapAttr;
-          dataParallelFoldInverseAttr = foldInverseMapAttr;
-        }
-        attachFold(shardedEmpty);
         Value tilized =
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
         if (needsPad) {
           auto maskOutput = rewriter.create<d2m::EmptyOp>(
               loc, shardedDeviceShape, tileElemType, shardedLayout);
-          attachFold(maskOutput);
           layoutedInput =
               rewriter
                   .create<d2m::MaskOp>(loc, tilized, maskOutput,
@@ -4206,30 +3916,15 @@ public:
         } else {
           layoutedInput = tilized;
         }
-        if (isDataParallel && paddedReductionTiles > fullReductionTiles) {
-          // Keeps the arange buffer covering the padded reduction extent.
-          topkLogicalShape[dim] = paddedReductionTiles * kTileWidth;
-        }
       } else if (reductionDimSize <= kTileWidth) {
         // topk_block merges reduction tiles pairwise and so needs >=2, so pad
         // the buffer out via dimAlignments and let the mask below fill the
         // extra tile with -inf.
-        constexpr std::array<int64_t, 2> defaultTileShape =
-            ttcore::TileType::getDefaultShape();
-        SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
-                                          defaultTileShape.end());
-        auto tileElemType =
-            ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-        SmallVector<int64_t> paddedDimAlignments(inputType.getShape().size(),
-                                                 kTileWidth);
-        paddedDimAlignments[dim] = 2 * kTileWidth;
-        auto paddedLayout = ttcore::MetalLayoutAttr::get(
-            ctx, inputType.getShape(), memorySpaces[0],
-            ttcore::TensorMemoryLayout::Sharded,
-            ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
-                ctx, inputType.getShape().size()),
-            paddedDimAlignments);
-        SmallVector<int64_t> unitGrid(inputType.getShape().size(), 1);
+        SmallVector<int64_t> paddedTiles(logicalRank, 1);
+        paddedTiles[dim] = 2;
+        auto paddedLayout = d2m::utils::buildShardedTileLayout(
+            ctx, inputType.getShape(), paddedTiles, memorySpaces[0]);
+        SmallVector<int64_t> unitGrid(logicalRank, 1);
         SmallVector<int64_t> paddedDeviceShape =
             paddedLayout.getDeviceShape(unitGrid, tileShapeVec);
         auto paddedEmpty = rewriter.create<d2m::EmptyOp>(
@@ -4244,7 +3939,6 @@ public:
                                                  paddedLayout.getLogicalShape(),
                                                  ttcore::OOBVal::NegInf)
                             .getResult();
-        topkLogicalShape[dim] = 2 * kTileWidth;
       } else {
         layoutedInput =
             createOptimalLayoutOp(rawInput, memorySpaces[0], /*tiled=*/true,
@@ -4257,39 +3951,11 @@ public:
       ArrayRef<int64_t> deviceShape = layoutedType.getShape();
       std::size_t physicalRank = deviceShape.size() / 2;
 
-      // Grid dim the non-target slices spread over; bands take the other one.
-      std::size_t ntGridDim =
-          (dim == 1) ? (physicalRank - 2) : (physicalRank - 1);
-
-      SmallVector<int64_t> idxDeviceShape(deviceShape.begin(),
-                                          deviceShape.end());
-      ttcore::MetalLayoutAttr idxMetalLayout = metalLayout;
-      if (isDataParallel) {
-        // Slices of a band share an index range, so collapse only the slice
-        // grid dim. Keeping the band dim is what lets the arange derive its
-        // global indices from the core position.
-        idxDeviceShape[ntGridDim] = 1;
-        SmallVector<int64_t> idxLogicalShape;
-        for (std::size_t i = 0; i < physicalRank; ++i) {
-          idxLogicalShape.push_back(idxDeviceShape[i] *
-                                    deviceShape[physicalRank + i] * kTileWidth);
-        }
-        idxMetalLayout = ttcore::MetalLayoutAttr::get(
-            ctx, idxLogicalShape, metalLayout.getMemorySpace(),
-            ttcore::TensorMemoryLayout::Sharded);
-      }
-      bool idxChainFold = (dim == 0) || isDataParallel;
-
-      // useArangeFold selects the swapped (1xgridCols) fold placement for the
-      // dim==0 arange/bcast buffers, which are shape-swapped until
-      // fullTranspose.
-      auto wrapInToLayout = [&](Value genericResult,
-                                bool useArangeFold = false) -> Value {
+      auto wrapInToLayout = [&](Value genericResult) -> Value {
         auto resultType = cast<RankedTensorType>(genericResult.getType());
         auto emptyOp = rewriter.create<d2m::EmptyOp>(
             loc, resultType.getShape(), resultType.getElementType(),
             resultType.getEncoding());
-        attachChainFold(emptyOp, useArangeFold);
         return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
             .getResult(0);
       };
@@ -4299,90 +3965,28 @@ public:
       SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
       AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
-      // One-in/one-out generic mapping every tile through `makeTile`. A null
-      // `shardMap` means identity at the region's shard rank.
-      auto emitUnaryGeneric =
+      auto emitUnary =
           [&](Value src, Value out, AffineMap gridMap,
               llvm::function_ref<AffineMap(std::size_t)> shardMap,
               llvm::function_ref<Value(OpBuilder &, Location, ValueRange)>
                   makeTile) -> Value {
-        SmallVector<Value> ins = {src};
-        SmallVector<Value> outs = {out};
-        auto generic = rewriter.create<d2m::GenericOp>(
-            loc, ins, outs, /*additionalArgs=*/ValueRange(),
-            rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{gridMap, identityMap}),
-            rewriter.getArrayAttr(iteratorTypes));
-        generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-        withD2MGenericRegion(
-            rewriter, loc, generic, ins, outs,
-            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-              Value input = blockArgs[0];
-              Value output = blockArgs[1];
-              std::size_t shardRank =
-                  cast<RankedTensorType>(output.getType()).getRank();
-              AffineMap shardIdentity =
-                  rewriter.getMultiDimIdentityMap(shardRank);
-              AffineMap shardIn =
-                  shardMap ? shardMap(shardRank) : shardIdentity;
-              SmallVector<mlir::utils::IteratorType> linalgIters(
-                  shardRank, mlir::utils::IteratorType::parallel);
-              auto linalgOp = rewriter.create<linalg::GenericOp>(
-                  loc, output.getType(), input, output,
-                  SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
-                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                    b.create<linalg::YieldOp>(bodyLoc,
-                                              makeTile(b, bodyLoc, args));
-                  });
-              return {linalgOp->getResult(0)};
-            });
-        return generic->getResult(0);
+        return emitUnaryGeneric(rewriter, loc, src, out, gridMap, iteratorTypes,
+                                shardMap, makeTile);
       };
 
       auto tileTranspose = [&](OpBuilder &b, Location l, ValueRange args) {
         return b.create<d2m::TileTransposeOp>(l, args[1].getType(), args[0])
             .getResult();
       };
-      auto permuteLast2 = [&](std::size_t rank) {
-        SmallVector<AffineExpr> exprs;
-        for (std::size_t i = 0; i < rank; ++i) {
-          exprs.push_back(rewriter.getAffineDimExpr(i));
-        }
-        std::swap(exprs[rank - 2], exprs[rank - 1]);
-        return AffineMap::get(rank, 0, exprs, ctx);
-      };
 
-      auto transposeTiles = [&](Value src, bool arangeFold = false) -> Value {
+      auto transposeTiles = [&](Value src) -> Value {
         auto srcType = cast<RankedTensorType>(src.getType());
         auto empty = rewriter.create<d2m::EmptyOp>(
             loc, srcType.getShape(),
             cast<ttcore::TileType>(srcType.getElementType()),
             cast<ttcore::MetalLayoutAttr>(srcType.getEncoding()));
-        attachChainFold(empty, arangeFold);
-        return wrapInToLayout(
-            emitUnaryGeneric(src, empty.getResult(), identityMap,
-                             /*shardMap=*/nullptr, tileTranspose),
-            arangeFold);
-      };
-
-      // Grid + tile transpose: undoes the shape-swapped arange orientation,
-      // moving index data onto the reduction-row axis.
-      auto fullTranspose = [&](Value src) -> Value {
-        auto srcType = cast<RankedTensorType>(src.getType());
-        // Device shape is [grid..., shard...]; swap the last two of each half.
-        SmallVector<int64_t> dstDevShape(srcType.getShape().begin(),
-                                         srcType.getShape().end());
-        std::swap(dstDevShape[physicalRank - 2], dstDevShape[physicalRank - 1]);
-        std::swap(dstDevShape[2 * physicalRank - 2],
-                  dstDevShape[2 * physicalRank - 1]);
-        auto empty = rewriter.create<d2m::EmptyOp>(
-            loc, dstDevShape, cast<ttcore::TileType>(srcType.getElementType()),
-            isDataParallel ? idxMetalLayout : metalLayout);
-        attachChainFold(empty, isDataParallel);
-        return wrapInToLayout(emitUnaryGeneric(src, empty.getResult(),
-                                               permuteLast2(physicalRank),
-                                               permuteLast2, tileTranspose),
-                              isDataParallel);
+        return wrapInToLayout(emitUnary(src, empty.getResult(), identityMap,
+                                        /*shardMap=*/nullptr, tileTranspose));
       };
 
       // TopkBlockOp sorts along tile columns, but dim=1 puts the sort
@@ -4392,191 +3996,54 @@ public:
         topkInput = transposeTiles(layoutedInput);
       }
 
-      bool isShardedInput = isBanded || isDataParallel;
-
       auto idxTileType = ttcore::TileType::get(idxElemType);
-      // dim==0 builds the arange shape-swapped so the reduction lands on the
-      // column axis; fullTranspose reorients it below.
-      SmallVector<int64_t> arangeLogicalShape(topkLogicalShape.begin(),
-                                              topkLogicalShape.end());
-      if (dim == 0) {
-        std::swap(arangeLogicalShape[rank - 2], arangeLogicalShape[rank - 1]);
-      }
-      auto idxInputType = RankedTensorType::get(arangeLogicalShape, idxElemType,
-                                                inputType.getEncoding());
-      SmallVector<int64_t> arangeDeviceShape(idxDeviceShape.begin(),
-                                             idxDeviceShape.end());
-      ttcore::MetalLayoutAttr arangeMetalLayout = idxMetalLayout;
-      if (dim == 0) {
-        std::swap(arangeDeviceShape[physicalRank - 2],
-                  arangeDeviceShape[physicalRank - 1]);
-        std::swap(arangeDeviceShape[2 * physicalRank - 2],
-                  arangeDeviceShape[2 * physicalRank - 1]);
-        SmallVector<int64_t> swappedLogical(
-            idxMetalLayout.getLogicalShape().begin(),
-            idxMetalLayout.getLogicalShape().end());
-        std::swap(swappedLogical[swappedLogical.size() - 2],
-                  swappedLogical[swappedLogical.size() - 1]);
-        arangeMetalLayout = ttcore::MetalLayoutAttr::get(
-            ctx, swappedLogical, idxMetalLayout.getDimAlignments(),
-            idxMetalLayout.getCollapsedIntervals(),
-            idxMetalLayout.getMemorySpace(), idxMetalLayout.getMemoryLayout());
-      }
 
-      SmallVector<Value> arangeOutputs;
-      if (isShardedInput) {
-        auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
-        attachArangeFold(arangeEmpty);
-        arangeOutputs.push_back(arangeEmpty.getResult());
-      } else {
-        auto arangeOrigOutputs =
-            createDpsOutputs(loc, rewriter, {idxInputType});
-        auto [arangeins, laidOut] = toLayoutOperandsAndResults(
-            rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
-            /*noCollapse=*/false);
-        arangeOutputs = std::move(laidOut);
-      }
-      auto arangeOutput = arangeOutputs[0];
-      auto arangeTensorType =
-          mlir::cast<RankedTensorType>(arangeOutput.getType());
-      auto arangeLayout =
-          mlir::cast<ttcore::MetalLayoutAttr>(arangeTensorType.getEncoding());
-      auto arangeTileType =
-          mlir::cast<ttcore::TileType>(arangeTensorType.getElementType());
-      Type arangeElemType = arangeTileType.getElementType();
-      ArrayRef<int64_t> arangeGridShape =
-          arangeLayout.getGridShape(arangeTensorType);
-      SmallVector<int64_t> arangeScratchShape(arangeGridShape.begin(),
-                                              arangeGridShape.end());
-      arangeScratchShape.append({1, 1});
-      auto arangeScratchTileType = ttcore::TileType::get(arangeElemType);
-      auto arangeScratchLayout = ttcore::MetalLayoutAttr::get(
+      // The kernel builds its own index tiles from this core's grid
+      // coordinate (see d2m-decompose-topk), so all that has to be handed in
+      // is one scratch tile per core for the lane pattern. A leaf topk's
+      // indices are just the reduction coordinate, so nothing upstream has to
+      // materialize, broadcast or transpose a full arange -- and a banded or
+      // data-parallel shard needs no cross-core index traffic at all.
+      ArrayRef<int64_t> idxGridShape = metalLayout.getGridShape(layoutedType);
+      SmallVector<int64_t> idxScratchShape(idxGridShape.begin(),
+                                           idxGridShape.end());
+      idxScratchShape.append({1, 1});
+      auto idxScratchLayout = ttcore::MetalLayoutAttr::get(
           ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
           ttcore::TensorMemoryLayout::Sharded);
-      Value indexTileTensor =
-          rewriter
-              .create<d2m::EmptyOp>(loc, arangeScratchShape,
-                                    arangeScratchTileType, arangeScratchLayout)
-              .getResult();
-
-      // DecomposeArange derives the global index from tile grid position and
-      // ignores numElements.
-      int64_t numElements = topkLogicalShape[dim];
-
-      AffineExpr zero = rewriter.getAffineConstantExpr(0);
-      AffineMap arangeConstMap =
-          AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
-      AffineMap arangeIdentMap = rewriter.getMultiDimIdentityMap(physicalRank);
-      SmallVector<AffineMap> arangeMaps = {arangeConstMap, arangeIdentMap};
-
-      SmallVector<Attribute> arangeIters(
-          physicalRank,
-          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-      SmallVector<Value> arangeGenericInputs = {indexTileTensor};
-      auto arange = rewriter.create<d2m::GenericOp>(
-          loc, arangeGenericInputs, arangeOutputs,
-          /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(arangeMaps),
-          rewriter.getArrayAttr(arangeIters));
-      arange->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-
-      withD2MGenericRegion(
-          rewriter, loc, arange, arangeGenericInputs, arangeOutputs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            Value idxTile = blockArgs[0];
-            Value outTile = blockArgs[1];
-            Value result = rewriter
-                               .create<d2m::ArangeBlockOp>(loc, idxTile,
-                                                           outTile, numElements,
-                                                           /*start=*/0,
-                                                           /*step=*/1)
-                               .getResult();
-            return {result};
-          });
-
-      // The row-major arange sequences indices along COLUMNS, so broadcast row
-      // 0 down the rows. For dim==0 the buffer is shape-swapped, so this fills
-      // each row with the reduction sequence and fullTranspose reorients it.
-      d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
-          d2m::TileBcastTypeAttr::get(ctx, d2m::TileBcastType::Row);
-      SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
-                                               arange.getResults().end());
-      SmallVector<Value> postArangeBcastOutputs;
-      // Allocate at the sharded arange device shape so the L1 buffer splits
-      // across cores and the operand grid matches the sharded arange input.
-      if (isShardedInput) {
-        auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
-        attachArangeFold(bcastEmpty);
-        postArangeBcastOutputs.push_back(bcastEmpty.getResult());
-      } else {
-        auto postArangeBcastOrigOutputs =
-            createDpsOutputs(loc, rewriter, {idxInputType});
-        auto [postArangeBcastins, laidOut] = toLayoutOperandsAndResults(
-            rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
-            /*noCollapse=*/false);
-        postArangeBcastOutputs = std::move(laidOut);
-      }
-
-      // Zeroing the broadcast axis is required: an identity map would make
-      // linalg infer that axis's extent from the iteration domain, mismatching
-      // the collapsed input shard when the non-target dim spans >1 tile.
-      auto zeroLast2 = [&](std::size_t rank) {
-        mlir::MutableAffineMap m(rewriter.getMultiDimIdentityMap(rank));
-        m.setResult(rank - 2, rewriter.getAffineConstantExpr(0));
-        return m.getAffineMap();
-      };
-      Value postArangeBcast = emitUnaryGeneric(
-          postArangeBcastInputs[0], postArangeBcastOutputs[0],
-          zeroLast2(physicalRank), zeroLast2,
-          [&](OpBuilder &b, Location l, ValueRange args) {
-            return b
-                .create<d2m::TileBcastOp>(l, args[1].getType(), args[0],
-                                          postArangeBcastTypeAttr)
-                .getResult();
-          });
-
-      Value idxBuf = wrapInToLayout(postArangeBcast, idxChainFold);
-      if (dim == 1) {
-        idxBuf = transposeTiles(idxBuf, /*arangeFold=*/idxChainFold);
-      } else {
-        idxBuf = fullTranspose(idxBuf);
-      }
+      auto idxScratchEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, idxScratchShape, idxTileType, idxScratchLayout);
+      Value idxBuf = idxScratchEmpty.getResult();
 
       auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
           loc, deviceShape, f32TileType, metalLayout);
       auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
           loc, deviceShape, idxTileType, metalLayout);
-      attachFold(topkValsEmpty);
-      attachFold(topkIdxEmpty);
-
-      // Drops the dim the slices spread over, so every slice of a band reads
-      // that band's one index buffer.
-      AffineMap idxGridMap = identityMap;
-      if (isDataParallel) {
-        mlir::MutableAffineMap broadcastMap(identityMap);
-        broadcastMap.setResult(ntGridDim, rewriter.getAffineConstantExpr(0));
-        idxGridMap = broadcastMap.getAffineMap();
-      }
 
       SmallVector<Value> topkInputs = {topkInput, idxBuf};
       SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
                                         topkIdxEmpty.getResult()};
+      // The scratch tile carries no per-core data (the kernel overwrites it
+      // before reading), and a constant map is what lets its 1x1 shard sit
+      // alongside the full-shard operands: an identity map would put it in the
+      // generic's shard-extent comparison and fail verification.
+      SmallVector<AffineExpr> idxConstExprs(physicalRank,
+                                            rewriter.getAffineConstantExpr(0));
+      AffineMap idxConstMap =
+          AffineMap::get(physicalRank, 0, idxConstExprs, ctx);
       auto topkGeneric = rewriter.create<d2m::GenericOp>(
           loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
           rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-              identityMap, idxGridMap, identityMap, identityMap}),
+              identityMap, idxConstMap, identityMap, identityMap}),
           rewriter.getArrayAttr(iteratorTypes));
-      topkGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
       withD2MGenericRegion(
           rewriter, loc, topkGeneric, topkInputs, topkOutputs,
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
             auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
                 loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-                reductionDimSize, /*stableSort=*/false, dim);
+                reductionDimSize, /*stableSort=*/false, dim,
+                /*generateIndices=*/true);
             return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
           });
 
@@ -4585,41 +4052,27 @@ public:
                 wrapInToLayout(topkGeneric->getResult(1))};
       }
 
-      std::size_t redPhys =
+      std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       std::size_t deviceRedDimLocal =
-          deviceShape.size() - (physicalRank - redPhys);
-      constexpr int64_t kTileDimLocal = 32;
+          deviceShape.size() - (physicalRank - genRedDim);
 
       // Narrow each band in place before the cross-core gather, or the wide
       // leaf result stays live on every core and overflows L1.
       auto compactBands = [&](Value wideResult) -> Value {
         auto wideType = cast<RankedTensorType>(wideResult.getType());
         auto tileType = cast<ttcore::TileType>(wideType.getElementType());
-        auto wideMetalLayout =
-            cast<ttcore::MetalLayoutAttr>(wideType.getEncoding());
         SmallVector<int64_t> narrowShape(wideType.getShape().begin(),
                                          wideType.getShape().end());
         narrowShape[deviceRedDimLocal] = outputReductionTiles;
-        SmallVector<int64_t> narrowLogical;
-        for (std::size_t i = 0; i < physicalRank; ++i) {
-          narrowLogical.push_back(
-              narrowShape[i] * narrowShape[i + physicalRank] * kTileDimLocal);
-        }
-        auto narrowLayout = ttcore::MetalLayoutAttr::get(
-            ctx, narrowLogical, wideMetalLayout.getDimAlignments(),
-            wideMetalLayout.getCollapsedIntervals(),
-            wideMetalLayout.getMemorySpace(),
-            wideMetalLayout.getMemoryLayout());
+        auto narrowLayout = d2m::utils::rebuildLayoutForDeviceShape(
+            cast<ttcore::MetalLayoutAttr>(wideType.getEncoding()), narrowShape);
         auto narrowEmpty = rewriter.create<d2m::EmptyOp>(
             loc, narrowShape, tileType, narrowLayout);
-        attachFold(narrowEmpty);
 
-        std::size_t genRedDim =
-            (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
         auto generic = emitInPlaceNarrowing(
-            rewriter, loc, ctx, wideResult, narrowEmpty, physicalRank,
-            genRedDim, identityMap, iteratorTypes);
+            rewriter, loc, wideResult, narrowEmpty, physicalRank, genRedDim,
+            identityMap, iteratorTypes);
         return wrapInToLayout(generic->getResult(0));
       };
 
@@ -4629,20 +4082,11 @@ public:
 
     std::size_t physicalRank = static_cast<std::size_t>(rank);
 
-    AffineMapAttr mergeFoldForwardAttr, mergeFoldInverseAttr;
-    auto attachMergeFold = [&](d2m::EmptyOp emptyOp) {
-      if (mergeFoldForwardAttr) {
-        emptyOp.setVirtualGridForwardMappingAttr(mergeFoldForwardAttr);
-        emptyOp.setVirtualGridInverseMappingAttr(mergeFoldInverseAttr);
-      }
-    };
-
     auto relayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
       auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
                                                    resultType.getElementType(),
                                                    resultType.getEncoding());
-      attachMergeFold(emptyOp);
       return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
           .getResult(0);
     };
@@ -4655,40 +4099,22 @@ public:
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // Rebuilds the logical shape as grid x shard so a re-split device shape
-    // keeps the same total extent, which the composite view checks.
-    auto layoutForDeviceShape =
-        [&](ttcore::MetalLayoutAttr layout,
-            ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
-      constexpr int64_t kTileDim = 32;
-      SmallVector<int64_t> newLogical;
-      for (std::size_t i = 0; i < physicalRank; ++i) {
-        newLogical.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
-                             kTileDim);
-      }
-      return ttcore::MetalLayoutAttr::get(
-          ctx, newLogical, layout.getDimAlignments(),
-          layout.getCollapsedIntervals(), layout.getMemorySpace(),
-          layout.getMemoryLayout());
-    };
-
     // Narrows a merge result back to its leading outputReductionTiles on every
     // core, restoring the one-band-per-core shape the next round consumes.
     auto compactToTile = [&](Value fullPartial) -> Value {
       auto fullType = cast<RankedTensorType>(fullPartial.getType());
       auto tileType = cast<ttcore::TileType>(fullType.getElementType());
-      auto layout = cast<ttcore::MetalLayoutAttr>(fullType.getEncoding());
       SmallVector<int64_t> compactShape(fullType.getShape().begin(),
                                         fullType.getShape().end());
       compactShape[deviceRedDim] = outputReductionTiles;
-      auto compactLayout = layoutForDeviceShape(layout, compactShape);
+      auto compactLayout = d2m::utils::rebuildLayoutForDeviceShape(
+          cast<ttcore::MetalLayoutAttr>(fullType.getEncoding()), compactShape);
       auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, compactShape, tileType,
                                                     compactLayout);
-      attachMergeFold(outEmpty);
       std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      auto generic = emitInPlaceNarrowing(rewriter, loc, ctx, fullPartial,
-                                          outEmpty, physicalRank, genRedDim,
+      auto generic = emitInPlaceNarrowing(rewriter, loc, fullPartial, outEmpty,
+                                          physicalRank, genRedDim,
                                           mergeIdentity, mergeIters);
       return relayout(generic->getResult(0));
     };
@@ -4735,37 +4161,14 @@ public:
 
         // Re-splitting preserves the grid x shard product, so the wide layout
         // carries the same logical extent as the input's.
-        auto valWideLayout = layoutForDeviceShape(
+        auto valWideLayout = d2m::utils::rebuildLayoutForDeviceShape(
             cast<ttcore::MetalLayoutAttr>(valsInType.getEncoding()), wideShape);
-        auto idxWideLayout = layoutForDeviceShape(
+        auto idxWideLayout = d2m::utils::rebuildLayoutForDeviceShape(
             cast<ttcore::MetalLayoutAttr>(idxInType.getEncoding()), wideShape);
         auto valWideType =
             RankedTensorType::get(wideShape, valTileType, valWideLayout);
         auto idxWideType =
             RankedTensorType::get(wideShape, idxTileType, idxWideLayout);
-
-        // A 2D split already occupies a real ntShards x numGroups grid, so it
-        // stays unfolded like the leaf buffers it re-splits.
-        mergeFoldForwardAttr = nullptr;
-        mergeFoldInverseAttr = nullptr;
-        if (!twoDim && numGroups > 1) {
-          SmallVector<int64_t> roundGrid(physicalRank, 1);
-          roundGrid[deviceGridDim] = numGroups;
-          SmallVector<int64_t> physicalGrid =
-              d2m::utils::findLegalPhysicalGridForVolume(numGroups,
-                                                         workerGridShape);
-          assert(!physicalGrid.empty() &&
-                 "merge group count has no legal worker-grid factorization");
-          auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
-              ctx, roundGrid, physicalGrid);
-          mergeFoldForwardAttr = AffineMapAttr::get(fwd);
-          mergeFoldInverseAttr = AffineMapAttr::get(inv);
-        }
-        // Cleared on return so later buffers carry no fold.
-        auto clearFold = llvm::make_scope_exit([&] {
-          mergeFoldForwardAttr = nullptr;
-          mergeFoldInverseAttr = nullptr;
-        });
 
         // Values and indices gather through separate generics, since the
         // DMA-expansion pass supports only one composite view per GenericOp
@@ -4778,7 +4181,6 @@ public:
           auto copyOut = rewriter.create<d2m::EmptyOp>(
               loc, wideType.getShape(), wideType.getElementType(),
               wideType.getEncoding());
-          attachMergeFold(copyOut);
           SmallVector<Value> ins = {composite.getResult()};
           SmallVector<Value> outs = {copyOut.getResult()};
           auto copyGeneric = rewriter.create<d2m::GenericOp>(
@@ -4786,13 +4188,11 @@ public:
               rewriter.getAffineMapArrayAttr(
                   SmallVector<AffineMap>{mergeIdentity, mergeIdentity}),
               rewriter.getArrayAttr(mergeIters));
-          copyGeneric->setAttr("d2m.skip_grid_selection",
-                               rewriter.getUnitAttr());
           withD2MGenericRegion(
               rewriter, loc, copyGeneric, ins, outs,
               [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-                auto linalgOp = emitLeadingTileCopy(
-                    rewriter, loc, ctx, blockArgs[0], blockArgs[1],
+                auto linalgOp = d2m::utils::emitLeadingTileCopy(
+                    rewriter, loc, blockArgs[0], blockArgs[1],
                     /*shardRedDim=*/std::nullopt);
                 return {linalgOp->getResult(0)};
               });
@@ -4807,8 +4207,6 @@ public:
             loc, wideShape, valTileType, valWideType.getEncoding());
         auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
             loc, wideShape, idxTileType, idxWideType.getEncoding());
-        attachMergeFold(mergeValsOut);
-        attachMergeFold(mergeIdxOut);
         SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
         SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
                                            mergeIdxOut.getResult()};
@@ -4817,8 +4215,6 @@ public:
             rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
                 mergeIdentity, mergeIdentity, mergeIdentity, mergeIdentity}),
             rewriter.getArrayAttr(mergeIters));
-        mergeGeneric->setAttr("d2m.skip_grid_selection",
-                              rewriter.getUnitAttr());
         withD2MGenericRegion(
             rewriter, loc, mergeGeneric, mergeInputs, mergeOutputs,
             [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
@@ -4840,7 +4236,7 @@ public:
       int64_t bands = numShards;
       while (bands > 1) {
         int64_t numGroups =
-            pickMergeGroupCount(bands, mergeCap, workerGridShape);
+            d2m::pickMergeGroupCount(bands, mergeCap, workerGridShape);
         assert(numGroups > 0 &&
                "merge chain was validated during shard selection");
         level = mergeRound(level.first, level.second, bands, numGroups);
@@ -4855,8 +4251,8 @@ public:
     auto extractIdxIndicesType = RankedTensorType::get(
         indicesType.getShape(), fuseIdxCast ? idxOutElemType : idxElemType);
 
-    // Must be split like its input, on the same cores and with the same fold,
-    // or the extract gathers the whole result onto one core.
+    // Must be split like its input, on the same core count, or the extract
+    // gathers the whole result onto one core.
     auto createDataParallelExtractOutput =
         [&](RankedTensorType logicalType) -> Value {
       constexpr std::array<int64_t, 2> defaultTileShape =
@@ -4865,23 +4261,15 @@ public:
                                         defaultTileShape.end());
       auto tileElemType =
           ttcore::TileType::get(logicalType.getElementType(), tileShapeVec);
-      SmallVector<int64_t> alignments(logicalType.getRank(), kTileWidth);
-      alignments[1 - dim] = paddedNonTargetTiles * kTileWidth;
-      auto layout = ttcore::MetalLayoutAttr::get(
-          ctx, logicalType.getShape(), memorySpaces[1],
-          ttcore::TensorMemoryLayout::Sharded,
-          ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
-              ctx, logicalType.getRank()),
-          alignments);
+      SmallVector<int64_t> shardTiles(logicalType.getRank(), 1);
+      shardTiles[1 - dim] = paddedNonTargetTiles;
+      auto layout = d2m::utils::buildShardedTileLayout(
+          ctx, logicalType.getShape(), shardTiles, memorySpaces[1]);
       SmallVector<int64_t> grid = (dim == 1)
                                       ? SmallVector<int64_t>{ntShards, 1}
                                       : SmallVector<int64_t>{1, ntShards};
       auto emptyOp = rewriter.create<d2m::EmptyOp>(
           loc, layout.getDeviceShape(grid, tileShapeVec), tileElemType, layout);
-      if (dataParallelFoldForwardAttr) {
-        emptyOp.setVirtualGridForwardMappingAttr(dataParallelFoldForwardAttr);
-        emptyOp.setVirtualGridInverseMappingAttr(dataParallelFoldInverseAttr);
-      }
       return emptyOp.getResult();
     };
 
@@ -4922,35 +4310,18 @@ public:
       auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
           loc, extractedIdxType.getShape(), idxCastTileType,
           extractedIdxType.getEncoding());
-      if (dataParallel && dataParallelFoldForwardAttr) {
-        idxCastEmpty.setVirtualGridForwardMappingAttr(
-            dataParallelFoldForwardAttr);
-        idxCastEmpty.setVirtualGridInverseMappingAttr(
-            dataParallelFoldInverseAttr);
-      }
-      SmallVector<Value> castInputs = {idxFinal};
-      SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
       std::size_t castRank = extractedIdxType.getShape().size() / 2;
       AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
       SmallVector<Attribute> castIters(
           castRank,
           ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-      auto idxCastGeneric = rewriter.create<d2m::GenericOp>(
-          loc, castInputs, castOutputs, /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(
-              SmallVector<AffineMap>{castIdentity, castIdentity}),
-          rewriter.getArrayAttr(castIters));
-      idxCastGeneric->setAttr("d2m.skip_grid_selection",
-                              rewriter.getUnitAttr());
-      withD2MGenericRegion(
-          rewriter, loc, idxCastGeneric, castInputs, castOutputs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx,
-                                                blockArgs[0], blockArgs[1],
-                                                /*shardRedDim=*/std::nullopt);
-            return {linalgOp->getResult(0)};
+      idxFinal = emitUnaryGeneric(
+          rewriter, loc, idxFinal, idxCastEmpty.getResult(), castIdentity,
+          castIters, /*shardMap=*/nullptr,
+          [&](OpBuilder &b, Location l, ValueRange args) {
+            return b.create<d2m::TileTypecastOp>(l, args[1].getType(), args[0])
+                .getResult();
           });
-      idxFinal = idxCastGeneric->getResult(0);
     }
 
     Operation *valResult =

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3597,13 +3597,9 @@ public:
   }
 };
 
-// Picks the group count for one round of the topk merge tree over `bands`
-// partials. A round is a single grid-wide generic, so its one output memref
-// type forces one shard shape and therefore one group size: the count must
-// divide `bands`, leave at most `mergeCap` bands per group, and be a legal core
-// count in its own right. Ascending order takes the fewest groups, i.e. the
-// largest the cap allows, which keeps the tree shallow. Returns 0 when the
-// round has no legal move.
+// Picks the smallest legal group count for one merge round (divides `bands`,
+// <= mergeCap bands/group, valid core count); smallest groups keeps the tree
+// shallow
 static int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
                                    ArrayRef<int64_t> workerGridShape) {
   for (int64_t groups = 1; groups < bands; ++groups) {
@@ -3622,12 +3618,8 @@ static int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
   return 0;
 }
 
-// True when repeated pickMergeGroupCount walks `bands` all the way down to a
-// single partial. Each step strictly decreases, so this terminates. It fails
-// only where some level admits no divisor in [2, mergeCap] that is also
-// grid-legal — a band count that is prime and larger than the cap is the
-// canonical case, which is why the shard search must check the whole chain and
-// not just the first round.
+// True when repeatedly applying pickMergeGroupCount reduces `bands` to 1.
+// Fails if any level has no divisor in [2, mergeCap] that is also grid-legal.
 static bool mergeChainCloses(int64_t bands, int64_t mergeCap,
                              ArrayRef<int64_t> workerGridShape) {
   while (bands > 1) {
@@ -3651,6 +3643,26 @@ public:
         D2MNamedRewriterCommon(defaultInputMemSpace, defaultOutputMemSpace,
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
+
+  SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
+                                      std::size_t gridRank) const {
+    SmallVector<Value> indices;
+    for (std::size_t i = 0; i < gridRank; ++i) {
+      indices.push_back(builder.create<d2m::CoreIndexOp>(
+          loc, builder.getIndexType(), builder.getI64IntegerAttr(i),
+          /*virtual_grid_map=*/nullptr));
+    }
+    return indices;
+  }
+
+  // Opts a generic out of reblocking, which would otherwise read the narrowing
+  // generics' constant input map as a broadcast and rebuild their regions.
+  void makeExplicitDatamovementForm(ConversionPatternRewriter &rewriter,
+                                    d2m::GenericOp generic) const {
+    generic.setBlockFactorsAttr(rewriter.getI64ArrayAttr({}));
+    generic.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr({}));
+    generic.setIteratorTypesAttr(rewriter.getArrayAttr({}));
+  }
 
   // Emits a linalg.generic copying `input` into `output` tile-by-tile via
   // TileTypecastOp. With `shardRedDim` set, a non-invertible `dim mod extent`
@@ -3680,6 +3692,80 @@ public:
               bodyLoc, args[1].getType(), args[0]);
           b.create<linalg::YieldOp>(bodyLoc, copied);
         });
+  }
+
+  // Narrows `wide` in place to `narrowEmpty`'s shape, every core keeping its
+  // own shard
+  d2m::GenericOp emitInPlaceNarrowing(ConversionPatternRewriter &rewriter,
+                                      Location loc, MLIRContext *ctx,
+                                      Value wide, d2m::EmptyOp narrowEmpty,
+                                      std::size_t physicalRank,
+                                      std::size_t genRedDim,
+                                      AffineMap identityMap,
+                                      ArrayRef<Attribute> iteratorTypes) const {
+    auto wideType = cast<RankedTensorType>(wide.getType());
+    auto narrowType = cast<RankedTensorType>(narrowEmpty.getType());
+    auto tileType = cast<ttcore::TileType>(wideType.getElementType());
+
+    AffineMap constInMap =
+        AffineMap::get(physicalRank, 0,
+                       SmallVector<AffineExpr>(
+                           physicalRank, rewriter.getAffineConstantExpr(0)),
+                       ctx);
+    SmallVector<Value> ins = {wide};
+    SmallVector<Value> outs = {narrowEmpty.getResult()};
+    auto generic = rewriter.create<d2m::GenericOp>(
+        loc, ins, outs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(
+            SmallVector<AffineMap>{constInMap, identityMap}),
+        rewriter.getArrayAttr(iteratorTypes));
+    generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+
+    auto insertPoint = rewriter.saveInsertionPoint();
+    rewriter.startOpModification(generic);
+    mlir::Region &region = generic->getRegions().front();
+    mlir::Block *block = rewriter.createBlock(&region);
+    rewriter.setInsertionPointToStart(block);
+
+    auto inShardType = RankedTensorType::get(
+        wideType.getShape().take_back(physicalRank), tileType);
+    auto outShardType = RankedTensorType::get(
+        narrowType.getShape().take_back(physicalRank), tileType);
+    std::size_t shardRank = outShardType.getRank();
+    std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
+
+    Value loadBuf = rewriter
+                        .create<tensor::EmptyOp>(loc, inShardType.getShape(),
+                                                 inShardType.getElementType())
+                        .getResult();
+    SmallVector<Value> srcIndices =
+        buildCoreIndices(rewriter, loc, physicalRank);
+    Value loaded = rewriter
+                       .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
+                                                  wide, srcIndices)
+                       .getResult();
+
+    Value outBuf = rewriter
+                       .create<tensor::EmptyOp>(loc, outShardType.getShape(),
+                                                outShardType.getElementType())
+                       .getResult();
+    auto linalgOp =
+        emitLeadingTileCopy(rewriter, loc, ctx, loaded, outBuf, shardRedDim);
+
+    SmallVector<Value> outIndices =
+        buildCoreIndices(rewriter, loc, physicalRank);
+    Value storeResult =
+        rewriter
+            .create<d2m::RemoteStoreOp>(loc, narrowEmpty.getType(),
+                                        narrowEmpty.getResult(), outIndices,
+                                        linalgOp->getResult(0))
+            .getResult();
+    rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
+    rewriter.finalizeOpModification(generic);
+    rewriter.restoreInsertionPoint(insertPoint);
+
+    makeExplicitDatamovementForm(rewriter, generic);
+    return generic;
   }
 
   // Extracts top-k results from topkResult into extractOutput, collapsing
@@ -3729,8 +3815,7 @@ public:
 
           // The input map must stay non-invertible, or linalg infers the loop
           // bound from the full input extent and rejects the smaller output
-          // shard. `mod inReductionExtent` keeps it non-invertible without
-          // changing in-range read indices.
+          // shard; `mod inReductionExtent` keeps in-range reads unchanged.
           AffineExpr projExpr =
               outputReductionTiles == 1
                   ? rewriter.getAffineConstantExpr(0)
@@ -3791,9 +3876,9 @@ public:
           op, "D2M topk only supports 2D reduction on dim 0 or dim 1");
     }
 
-    // Multi-core sharding: a very wide reduction dim does not fit in one core's
-    // L1, so split it into bands, run a local topk per band, and merge the
-    // partials in a cross-core tree.
+    // Multi-core sharding splits whichever dim overflows one core's L1: the
+    // reduction dim into bands merged back by a tree, or the non-target dim
+    // into independent slices needing no merge.
     constexpr int64_t kTileWidth = 32;
     int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
     // L1-safe tile budget per core; values and indices share it.
@@ -3801,65 +3886,86 @@ public:
     int64_t fullReductionElems = inputType.getShape()[dim];
     int64_t nonTargetElems = inputType.getShape()[1 - dim];
     int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
-    if (nonTargetTiles > kMaxTilesPerCore) {
-      return rewriter.notifyMatchFailure(
-          op, "D2M topk: non-target dimension alone exceeds the per-core "
-              "tile budget");
-    }
-    // NOT scaled by outputReductionTiles: a band core's L1 is dominated by its
-    // bandTiles-wide input, so k>32 pressure is bounded separately by mergeCap.
-    int64_t maxReductionTilesPerCore = kMaxTilesPerCore / nonTargetTiles;
+    int64_t fullReductionTiles =
+        (fullReductionElems + kTileWidth - 1) / kTileWidth;
 
-    // Bands one merge core can absorb in a round. Hoisted above the shard
-    // search because a band count is usable only if its whole merge tree closes
-    // at this cap.
+    int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
+    Type idxElemType = rewriter.getI32Type();
+
+    SmallVector<int64_t> workerGridShape;
+    int64_t maxGridCores = 1;
+    auto loadWorkerGrid = [&]() {
+      if (!workerGridShape.empty()) {
+        return;
+      }
+      auto device = ttcore::lookupDevice(op);
+      workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
+      assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
+      maxGridCores = workerGridShape[0] * workerGridShape[1];
+    };
+
+    bool dataParallel = nonTargetTiles > kMaxTilesPerCore;
+    int64_t ntShards = 1;
+    int64_t paddedNonTargetTiles = nonTargetTiles;
+    if (dataParallel) {
+      loadWorkerGrid();
+      // Every core keeps the whole reduction dim, so it must fit alongside at
+      // least one non-target tile.
+      if (localReductionTiles >= kMaxTilesPerCore) {
+        return rewriter.notifyMatchFailure(
+            op, "D2M topk: both dimensions exceed the per-core tile budget; "
+                "splitting them jointly is unsupported");
+      }
+      int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
+      int64_t minNtShards =
+          (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
+      std::optional<int64_t> legalNtShards;
+      for (int64_t cand = minNtShards; cand <= maxGridCores; ++cand) {
+        if (!d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+                 .empty()) {
+          legalNtShards = cand;
+          break;
+        }
+      }
+      if (!legalNtShards) {
+        return rewriter.notifyMatchFailure(
+            op, "D2M topk: no core count splits the non-target dimension "
+                "within the per-core tile budget on this worker grid");
+      }
+      ntShards = *legalNtShards;
+      paddedNonTargetTiles =
+          ntShards * ((nonTargetTiles + ntShards - 1) / ntShards);
+    }
+
+    int64_t maxReductionTilesPerCore =
+        dataParallel ? fullReductionTiles : kMaxTilesPerCore / nonTargetTiles;
+
+    // Bands one merge core can absorb in a round
     int64_t mergeCap = maxReductionTilesPerCore / outputReductionTiles;
     if (k > 32) {
       // Greater per-partial footprint, so put fewer tiles on each merge core.
       mergeCap /= 4;
     }
 
-    // The topk SFPU LLK reads the index lane only as INT32 (with fp32_dest_acc
-    // on) or LO16 otherwise, never as a float. Int32 forces fp32_dest_acc and
-    // selects the INT32 path, so indices round-trip losslessly at any size.
-    Type idxElemType = rewriter.getI32Type();
-    int64_t fullReductionTiles =
-        (fullReductionElems + kTileWidth - 1) / kTileWidth;
-    // A lower bound only; the count chosen below must also be grid-legal.
     int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
                         maxReductionTilesPerCore;
-    bool multiCore = minShards > 1;
+    bool multiCore = !dataParallel && minShards > 1;
 
     if (fullReductionTiles == 1) {
-      // A single tile holds at most kTileWidth elements; k>32 would need a
-      // 2-tile output with no second input tile to source it from.
       assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
-    // Bands are distributed one per core and folded onto the 2D worker grid by
-    // a virtual-grid map attached in emitShardTopk. They need not divide
-    // fullReductionTiles evenly; all carry bandTiles tiles, and the padding
-    // tail out to paddedReductionTiles is masked to -inf.
-    SmallVector<int64_t> workerGridShape;
+    // Bands are distributed one per core and folded onto the 2D worker grid
+    // by a virtual-grid map attached in emitShardTopk. They need not divide
+    // fullReductionTiles evenly; the padding tail out to paddedReductionTiles
+    // is masked to -inf.
     int64_t numShards = 1;
     int64_t bandTiles = fullReductionTiles;
     int64_t paddedReductionTiles = fullReductionTiles;
     if (multiCore) {
-      auto device = ttcore::lookupDevice(op);
-      workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
-      assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
-
-      int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
-      // A band count must be grid-legal (the fold invariant), fit the per-core
-      // tile budget, and have a merge tree that closes -- every round splits
-      // one grid-wide generic evenly, so each level needs a grid-legal divisor
-      // leaving at most mergeCap bands per group.
-      //
-      // Two passes. The first takes only powers of two, which always close
-      // (halving is available at every level) and give the shallowest balanced
-      // tree; on an 8x8 grid they already reach all 64 cores, so that pass
-      // decides every Wormhole shape. The second pass admits any count whose
-      // chain closes, which is what reaches past 64 bands on larger grids --
-      // e.g. 66, 70, 72, 80, 90, 100 on Blackhole's 10x11.
+      loadWorkerGrid();
+      // Two passes: powers of two first (always close, shallowest tree)
+      // then any count whose chain closes, which
+      // is what reaches past 64 bands on larger grids.
       for (int pass = 0; pass < 2 && numShards == 1; ++pass) {
         bool powerOfTwoOnly = (pass == 0);
         for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
@@ -3890,29 +3996,31 @@ public:
       }
       paddedReductionTiles = numShards * bandTiles;
     }
+    if (dataParallel) {
+      paddedReductionTiles = localReductionTiles;
+    }
+
+    AffineMapAttr dataParallelFoldForwardAttr, dataParallelFoldInverseAttr;
 
     // Emits a topk over a raw input, returning (values, indices) still in
-    // device layout. arangeStart offsets indices so band g yields GLOBAL
-    // indices; gridCols > 1 splits the topk across that many cores and returns
-    // the result still distributed one band per core, each band narrowed to its
-    // leading outputReductionTiles, for the caller's merge tree to gather.
+    // device layout. arangeStart offsets indices so band g yields global
+    // indices; gridCols > 1 splits the topk across that many cores, each band
+    // narrowed to its leading outputReductionTiles for the caller's merge
+    // tree to gather. ntCores > 1 splits the non-target dim instead, leaving
+    // every core's slice already final with nothing to merge.
     auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols = 1) -> std::pair<Value, Value> {
+                             int64_t gridCols = 1,
+                             int64_t ntCores = 1) -> std::pair<Value, Value> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
+      bool isDataParallel = ntCores > 1;
+      bool isBanded = gridCols > 1;
 
-      // Grows to match the arange/index buffer when the reduction dim is
-      // padded, since the topk d2m.generic requires both operands to share a
-      // shard shape.
       SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                             inputType.getShape().end());
 
       Value layoutedInput;
-      // Attached to every EmptyOp at the 1xgridCols device grid so its buffer
-      // lands on the same folded cores as the input. Without the map such a
-      // buffer requests physical core columns 0..gridCols-1 and crashes for
-      // gridCols>8.
       AffineMapAttr foldForwardMapAttr, foldInverseMapAttr;
       auto attachFold = [&](d2m::EmptyOp emptyOp) {
         if (foldForwardMapAttr) {
@@ -3922,8 +4030,7 @@ public:
       };
       // Fold maps for the dim==0 arange/index buffers, which live shape-swapped
       // on a 1xgridCols grid and so need bands across grid COLUMNS rather than
-      // down the value input's ROWS. A 1xN and an Nx1 grid collapse to the same
-      // cores in the same order, so the later fullTranspose moves no data.
+      // down the value input's ROWS
       AffineMapAttr arangeFoldForwardMapAttr, arangeFoldInverseMapAttr;
       auto attachArangeFold = [&](d2m::EmptyOp emptyOp) {
         if (arangeFoldForwardMapAttr) {
@@ -3931,23 +4038,26 @@ public:
           emptyOp.setVirtualGridInverseMappingAttr(arangeFoldInverseMapAttr);
         }
       };
-      if (gridCols > 1) {
-        // One band per core, since topk is per-slice and each core needs the
-        // full non-target dim over its own band. A literal 1xgridCols placement
-        // is untranslatable past the worker width, hence the virtual-grid map.
+      auto attachChainFold = [&](d2m::EmptyOp emptyOp, bool arangeFold) {
+        if (arangeFold) {
+          attachArangeFold(emptyOp);
+        } else {
+          attachFold(emptyOp);
+        }
+      };
+      if (isBanded || isDataParallel) {
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
                                           defaultTileShape.end());
         auto tileElemType =
             ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-        // Pad via a dimAlignment, which keeps logical_shape truthful.
-        bool needsReductionPad = paddedReductionTiles > fullReductionTiles;
+        bool needsPad = paddedReductionTiles > fullReductionTiles ||
+                        paddedNonTargetTiles > nonTargetTiles;
         SmallVector<int64_t> shardDimAlignments(inputType.getShape().size(),
                                                 kTileWidth);
-        if (needsReductionPad) {
-          shardDimAlignments[dim] = paddedReductionTiles * kTileWidth;
-        }
+        shardDimAlignments[dim] = paddedReductionTiles * kTileWidth;
+        shardDimAlignments[1 - dim] = paddedNonTargetTiles * kTileWidth;
         auto shardedLayout = ttcore::MetalLayoutAttr::get(
             ctx, inputType.getShape(), memorySpaces[0],
             ttcore::TensorMemoryLayout::Sharded,
@@ -3955,38 +4065,43 @@ public:
                 ctx, inputType.getShape().size()),
             shardDimAlignments);
         SmallVector<int64_t> shardedGrid =
-            (dim == 1) ? SmallVector<int64_t>{1, gridCols}
-                       : SmallVector<int64_t>{gridCols, 1};
+            (dim == 1) ? SmallVector<int64_t>{ntCores, gridCols}
+                       : SmallVector<int64_t>{gridCols, ntCores};
         SmallVector<int64_t> shardedDeviceShape =
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
 
-        // Swapped for dim==0, matching the arange buffer's own orientation.
-        SmallVector<int64_t> arangeGrid =
-            (dim == 1) ? shardedGrid
-                       : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
         SmallVector<int64_t> physicalGrid =
-            d2m::utils::findLegalPhysicalGridForVolume(gridCols,
+            d2m::utils::findLegalPhysicalGridForVolume(ntCores * gridCols,
                                                        workerGridShape);
         assert(!physicalGrid.empty() &&
-               "band count has no legal worker-grid factorization");
+               "shard count has no legal worker-grid factorization");
         auto [forwardMap, inverseMap] =
             ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
                                                           physicalGrid);
-        auto [arangeForwardMap, arangeInverseMap] =
-            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
-                                                          physicalGrid);
         foldForwardMapAttr = AffineMapAttr::get(forwardMap);
         foldInverseMapAttr = AffineMapAttr::get(inverseMap);
-        arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
-        arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
+        if (isBanded) {
+          // Swapped for dim==0, matching the arange buffer's orientation.
+          SmallVector<int64_t> arangeGrid =
+              (dim == 1) ? shardedGrid
+                         : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
+          auto [arangeForwardMap, arangeInverseMap] =
+              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
+                                                            physicalGrid);
+          arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
+          arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
+        } else {
+          dataParallelFoldForwardAttr = foldForwardMapAttr;
+          dataParallelFoldInverseAttr = foldInverseMapAttr;
+        }
         attachFold(shardedEmpty);
         Value tilized =
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
-        if (needsReductionPad) {
-          // -inf so the padding lanes never win top-k.
+        if (needsPad) {
+          // -inf so the padding lanes never win top-k, and are never NaN.
           auto maskOutput = rewriter.create<d2m::EmptyOp>(
               loc, shardedDeviceShape, tileElemType, shardedLayout);
           attachFold(maskOutput);
@@ -3999,11 +4114,14 @@ public:
         } else {
           layoutedInput = tilized;
         }
+        if (isDataParallel && paddedReductionTiles > fullReductionTiles) {
+          // Keeps the arange buffer covering the padded reduction extent.
+          topkLogicalShape[dim] = paddedReductionTiles * kTileWidth;
+        }
       } else if (reductionDimSize <= kTileWidth) {
         // A single-tile reduction dim leaves no room for the merge tree, which
         // needs >=2 tiles, so force the buffer to 2 tiles via dimAlignments and
-        // let the mask op below fill the extra tile with -inf. Built manually
-        // because createOptimalLayoutOp cannot express physical > logical.
+        // let the mask op below fill the extra tile with -inf
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
@@ -4047,6 +4165,23 @@ public:
       ArrayRef<int64_t> deviceShape = layoutedType.getShape();
       std::size_t physicalRank = deviceShape.size() / 2;
 
+      SmallVector<int64_t> idxDeviceShape(deviceShape.begin(),
+                                          deviceShape.end());
+      ttcore::MetalLayoutAttr idxMetalLayout = metalLayout;
+      if (isDataParallel) {
+        // In data-parallel path, each core gets the same index buffer
+        SmallVector<int64_t> shardLogicalShape;
+        for (std::size_t i = 0; i < physicalRank; ++i) {
+          idxDeviceShape[i] = 1;
+          shardLogicalShape.push_back(deviceShape[physicalRank + i] *
+                                      kTileWidth);
+        }
+        idxMetalLayout = ttcore::MetalLayoutAttr::get(
+            ctx, shardLogicalShape, metalLayout.getMemorySpace(),
+            ttcore::TensorMemoryLayout::Sharded);
+      }
+      bool idxChainFold = (dim == 0) || isDataParallel;
+
       // useArangeFold selects the swapped (1xgridCols) fold placement for the
       // dim==0 arange/bcast buffers, which are shape-swapped until
       // fullTranspose.
@@ -4056,11 +4191,7 @@ public:
         auto emptyOp = rewriter.create<d2m::EmptyOp>(
             loc, resultType.getShape(), resultType.getElementType(),
             resultType.getEncoding());
-        if (useArangeFold) {
-          attachArangeFold(emptyOp);
-        } else {
-          attachFold(emptyOp);
-        }
+        attachChainFold(emptyOp, useArangeFold);
         return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
             .getResult(0);
       };
@@ -4071,13 +4202,13 @@ public:
       AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
       // Applies TileTransposeOp to every tile in the shard.
-      auto transposeTiles = [&](Value src) -> Value {
+      auto transposeTiles = [&](Value src, bool arangeFold = false) -> Value {
         auto srcType = cast<RankedTensorType>(src.getType());
         auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
         auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
         auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
             loc, srcType.getShape(), srcTileType, srcLayout);
-        attachFold(transposeEmpty);
+        attachChainFold(transposeEmpty, arangeFold);
         SmallVector<Value> transposeInputs = {src};
         SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
         auto transposeGeneric = rewriter.create<d2m::GenericOp>(
@@ -4112,13 +4243,11 @@ public:
               return {linalgOp->getResult(0)};
             });
 
-        return wrapInToLayout(transposeGeneric->getResult(0));
+        return wrapInToLayout(transposeGeneric->getResult(0), arangeFold);
       };
 
-      // Full transpose (grid + tile): reorients an index buffer from the
-      // shape-swapped arange orientation back to the value input's natural
-      // one, swapping the grid and shard dims so index data moves onto the
-      // reduction-row axis.
+      // Full transpose (grid + tile): undoes the shape-swapped arange
+      // orientation, moving index data onto the reduction-row axis.
       auto fullTranspose = [&](Value src) -> Value {
         auto srcType = cast<RankedTensorType>(src.getType());
         auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
@@ -4130,11 +4259,10 @@ public:
         std::swap(dstDevShape[physicalRank - 2], dstDevShape[physicalRank - 1]);
         std::swap(dstDevShape[2 * physicalRank - 2],
                   dstDevShape[2 * physicalRank - 1]);
-        // Output carries the value input's fold and layout, so the transposed
-        // buffer lands co-located with topkInput.
         auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, dstDevShape, srcTileType, metalLayout);
-        attachFold(transposeEmpty);
+            loc, dstDevShape, srcTileType,
+            isDataParallel ? idxMetalLayout : metalLayout);
+        attachChainFold(transposeEmpty, isDataParallel);
         SmallVector<AffineExpr> permExprs;
         for (std::size_t i = 0; i < physicalRank; ++i) {
           permExprs.push_back(rewriter.getAffineDimExpr(i));
@@ -4185,7 +4313,7 @@ public:
               return {linalgOp->getResult(0)};
             });
 
-        return wrapInToLayout(transposeGeneric->getResult(0));
+        return wrapInToLayout(transposeGeneric->getResult(0), isDataParallel);
       };
 
       // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
@@ -4195,13 +4323,11 @@ public:
         topkInput = transposeTiles(layoutedInput);
       }
 
-      // The multi-core case direct-allocates its buffers at a folded physical
-      // placement rather than the default unit-grid [0,0].
-      bool isFoldedShard = gridCols > 1;
+      bool isFoldedShard = isBanded || isDataParallel;
 
       auto idxTileType = ttcore::TileType::get(idxElemType);
       // dim==0 swaps the last two dims so the reduction lands on the column
-      // axis, which fullTranspose undoes afterwards; dim==1 is already natural.
+      // axis, which fullTranspose undoes afterwards
       SmallVector<int64_t> arangeLogicalShape(topkLogicalShape.begin(),
                                               topkLogicalShape.end());
       if (dim == 0) {
@@ -4209,28 +4335,25 @@ public:
       }
       auto idxInputType = RankedTensorType::get(arangeLogicalShape, idxElemType,
                                                 inputType.getEncoding());
-      SmallVector<int64_t> arangeDeviceShape(deviceShape.begin(),
-                                             deviceShape.end());
-      ttcore::MetalLayoutAttr arangeMetalLayout = metalLayout;
+      SmallVector<int64_t> arangeDeviceShape(idxDeviceShape.begin(),
+                                             idxDeviceShape.end());
+      ttcore::MetalLayoutAttr arangeMetalLayout = idxMetalLayout;
       if (dim == 0) {
         std::swap(arangeDeviceShape[physicalRank - 2],
                   arangeDeviceShape[physicalRank - 1]);
         std::swap(arangeDeviceShape[2 * physicalRank - 2],
                   arangeDeviceShape[2 * physicalRank - 1]);
         SmallVector<int64_t> swappedLogical(
-            metalLayout.getLogicalShape().begin(),
-            metalLayout.getLogicalShape().end());
+            idxMetalLayout.getLogicalShape().begin(),
+            idxMetalLayout.getLogicalShape().end());
         std::swap(swappedLogical[swappedLogical.size() - 2],
                   swappedLogical[swappedLogical.size() - 1]);
         arangeMetalLayout = ttcore::MetalLayoutAttr::get(
-            ctx, swappedLogical, metalLayout.getDimAlignments(),
-            metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
-            metalLayout.getMemoryLayout());
+            ctx, swappedLogical, idxMetalLayout.getDimAlignments(),
+            idxMetalLayout.getCollapsedIntervals(),
+            idxMetalLayout.getMemorySpace(), idxMetalLayout.getMemoryLayout());
       }
 
-      // A folded placement must not route through toLayoutOperandsAndResults,
-      // which leaves a dead full-width unit-grid buffer L1-allocated; allocate
-      // directly at the sharded device shape instead.
       SmallVector<Value> arangeOutputs;
       if (isFoldedShard) {
         auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
@@ -4300,13 +4423,7 @@ public:
                                .create<d2m::ArangeBlockOp>(
                                    loc, idxTile, outTile, numElements,
                                    /*start=*/arangeStart,
-                                   /*step=*/1,
-                                   // Both dims build the arange row-major:
-                                   // ArangeBlockOp sequences the global index
-                                   // along tile COLUMNS, which is natural for
-                                   // dim==1 and shape-swapped (then
-                                   // fullTransposed back) for dim==0.
-                                   /*colMajor=*/false)
+                                   /*step=*/1)
                                .getResult();
             return {result};
           });
@@ -4389,17 +4506,10 @@ public:
             return {linalgOp->getResult(0)};
           });
 
-      // The bcast result is in the swapped arange orientation for dim==0 and
-      // natural for dim==1, so wrap it with the matching fold placement.
       Value idxBuf = wrapInToLayout(postArangeBcast->getResult(0),
-                                    /*useArangeFold=*/dim == 0);
-
-      // TopkBlockOp reads value and index tiles in lockstep, so bring the index
-      // buffer into the value input's orientation. dim==1 needs only a per-tile
-      // transpose; dim==0 needs a full grid+tile transpose to turn the column
-      // sequence into the down-the-rows sequence the value input expects.
+                                    /*useArangeFold=*/idxChainFold);
       if (dim == 1) {
-        idxBuf = transposeTiles(idxBuf);
+        idxBuf = transposeTiles(idxBuf, /*arangeFold=*/idxChainFold);
       } else {
         idxBuf = fullTranspose(idxBuf);
       }
@@ -4411,13 +4521,24 @@ public:
       attachFold(topkValsEmpty);
       attachFold(topkIdxEmpty);
 
+      // The operand map drops the dim the slices spread over, so every core
+      // reads the one unit-grid index buffer.
+      AffineMap idxGridMap = identityMap;
+      if (isDataParallel) {
+        std::size_t ntGridDim =
+            (dim == 1) ? (physicalRank - 2) : (physicalRank - 1);
+        mlir::MutableAffineMap broadcastMap(identityMap);
+        broadcastMap.setResult(ntGridDim, rewriter.getAffineConstantExpr(0));
+        idxGridMap = broadcastMap.getAffineMap();
+      }
+
       SmallVector<Value> topkInputs = {topkInput, idxBuf};
       SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
                                         topkIdxEmpty.getResult()};
       auto topkGeneric = rewriter.create<d2m::GenericOp>(
           loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
           rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-              identityMap, identityMap, identityMap, identityMap}),
+              identityMap, idxGridMap, identityMap, identityMap}),
           rewriter.getArrayAttr(iteratorTypes));
       topkGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
@@ -4430,16 +4551,11 @@ public:
             return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
           });
 
-      // The whole result as one grid-1x1 partial; the extract reads its
-      // leading tiles.
-      if (gridCols == 1) {
+      if (!isBanded) {
         return {wrapInToLayout(topkGeneric->getResult(0)),
                 wrapInToLayout(topkGeneric->getResult(1))};
       }
 
-      // The bands stay put: narrowing is in place and the cross-core gather is
-      // the caller's, driven by one composite view over this whole grid-wide
-      // result rather than by a collector generic per band.
       std::size_t redPhys =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       std::size_t deviceRedDimLocal =
@@ -4448,9 +4564,7 @@ public:
 
       // Per-band pre-compaction: narrow each band in place, before the
       // cross-core gather, or the wide leaf result stays live on every core
-      // and overflows L1. No affine input map can express "band g reads band
-      // g and stays put," so a constant grid map bypasses the verifier and an
-      // explicit remote_load at this cell's own position drives the real read.
+      // and overflows L1
       auto compactBands = [&](Value wideResult) -> Value {
         auto wideType = cast<RankedTensorType>(wideResult.getType());
         auto tileType = cast<ttcore::TileType>(wideType.getElementType());
@@ -4479,87 +4593,18 @@ public:
 
         std::size_t genRedDim =
             (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-        // A constant grid map on the input makes hasOperandBroadcasting true,
-        // so the verifier skips both the grid-equality and shard-shape checks
-        // for it. The real read is the remote_load below.
-        AffineMap constInMap =
-            AffineMap::get(physicalRank, 0,
-                           SmallVector<AffineExpr>(
-                               physicalRank, rewriter.getAffineConstantExpr(0)),
-                           ctx);
-        SmallVector<Value> ins = {wideResult};
-        SmallVector<Value> outs = {narrowEmpty.getResult()};
-        auto generic = rewriter.create<d2m::GenericOp>(
-            loc, ins, outs, /*additionalArgs=*/ValueRange(),
-            rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{constInMap, identityMap}),
-            rewriter.getArrayAttr(iteratorTypes));
-        generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-
-        // Build the region manually, since the auto-generated one would
-        // remote_load at the constant input map's grid index, i.e. band 0. Load
-        // from this cell's own grid position instead, then narrow and store.
-        {
-          auto insertPoint = rewriter.saveInsertionPoint();
-          rewriter.startOpModification(generic);
-          mlir::Region &region = generic->getRegions().front();
-          mlir::Block *block = rewriter.createBlock(&region);
-          rewriter.setInsertionPointToStart(block);
-
-          auto inShardType = RankedTensorType::get(
-              wideType.getShape().take_back(physicalRank), tileType);
-          auto outShardType = RankedTensorType::get(
-              ArrayRef<int64_t>(narrowShape).take_back(physicalRank), tileType);
-          std::size_t shardRank = outShardType.getRank();
-          std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-
-          // remote_load at this cell's own grid position, so band g reads band
-          // g. The source buffer's virtual-grid fold is composed by the DMA
-          // address path onto the physical core, so the index stays logical.
-          Value loadBuf =
-              rewriter
-                  .create<tensor::EmptyOp>(loc, inShardType.getShape(),
-                                           inShardType.getElementType())
-                  .getResult();
-          SmallVector<Value> srcIndices =
-              d2m::utils::buildGridIndices(rewriter, loc, identityMap);
-          Value loaded =
-              rewriter
-                  .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
-                                             wideResult, srcIndices)
-                  .getResult();
-
-          Value outBuf =
-              rewriter
-                  .create<tensor::EmptyOp>(loc, outShardType.getShape(),
-                                           outShardType.getElementType())
-                  .getResult();
-          auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded,
-                                              outBuf, shardRedDim);
-
-          SmallVector<Value> outIndices =
-              d2m::utils::buildGridIndices(rewriter, loc, identityMap);
-          Value storeResult =
-              rewriter
-                  .create<d2m::RemoteStoreOp>(
-                      loc, narrowEmpty.getType(), narrowEmpty.getResult(),
-                      outIndices, linalgOp->getResult(0))
-                  .getResult();
-          rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
-          rewriter.finalizeOpModification(generic);
-          rewriter.restoreInsertionPoint(insertPoint);
-        }
+        auto generic = emitInPlaceNarrowing(
+            rewriter, loc, ctx, wideResult, narrowEmpty, physicalRank,
+            genRedDim, identityMap, iteratorTypes);
         return wrapInToLayout(generic->getResult(0));
       };
 
       return {compactBands(topkGeneric->getResult(0)),
               compactBands(topkGeneric->getResult(1))};
-    }; // emitShardTopk
+    };
 
     std::size_t physicalRank = static_cast<std::size_t>(rank);
 
-    // Set for the currently-emitting merge round so its buffers fold onto that
-    // round's numGroups cores; null outside one, leaving EmptyOps unit-grid.
     AffineMapAttr mergeFoldForwardAttr, mergeFoldInverseAttr;
     auto attachMergeFold = [&](d2m::EmptyOp emptyOp) {
       if (mergeFoldForwardAttr) {
@@ -4588,10 +4633,8 @@ public:
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // Rebuilds `layout` with a logical shape spanning all of `deviceShape`,
-    // i.e. grid x shard rather than one core's share. A merge round re-splits
-    // that product without changing it, so its composite view sees the same
-    // logical extent on both sides.
+    // A merge round re-splits that product without changing it, so its
+    // composite view sees the same logical extent on both sides.
     auto layoutForDeviceShape =
         [&](ttcore::MetalLayoutAttr layout,
             ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
@@ -4622,81 +4665,17 @@ public:
       attachMergeFold(outEmpty);
       std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      // A constant grid map on the input makes hasOperandBroadcasting true, so
-      // the verifier skips the shard-shape check that the narrowing would
-      // otherwise fail. It must NOT drive the read: on a grid wider than one
-      // core it resolves to grid cell 0, so every core would narrow band 0.
-      // The explicit remote_load at this cell's own position below is the real
-      // read, exactly as in compactBands.
-      AffineMap constInMap =
-          AffineMap::get(physicalRank, 0,
-                         SmallVector<AffineExpr>(
-                             physicalRank, rewriter.getAffineConstantExpr(0)),
-                         ctx);
-      SmallVector<Value> ins = {fullPartial};
-      SmallVector<Value> outs = {outEmpty.getResult()};
-      auto generic = rewriter.create<d2m::GenericOp>(
-          loc, ins, outs, /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(
-              SmallVector<AffineMap>{constInMap, mergeIdentity}),
-          rewriter.getArrayAttr(mergeIters));
-      generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-
-      // Built by hand, since withD2MGenericRegion would derive the read from
-      // the constant map above and pull every core's data from grid cell 0.
-      {
-        auto insertPoint = rewriter.saveInsertionPoint();
-        rewriter.startOpModification(generic);
-        mlir::Region &region = generic->getRegions().front();
-        mlir::Block *block = rewriter.createBlock(&region);
-        rewriter.setInsertionPointToStart(block);
-
-        auto inShardType = RankedTensorType::get(
-            fullType.getShape().take_back(physicalRank), tileType);
-        auto outShardType = RankedTensorType::get(
-            ArrayRef<int64_t>(compactShape).take_back(physicalRank), tileType);
-        std::size_t shardRank = outShardType.getRank();
-        std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-
-        Value loadBuf =
-            rewriter
-                .create<tensor::EmptyOp>(loc, inShardType.getShape(),
-                                         inShardType.getElementType())
-                .getResult();
-        SmallVector<Value> srcIndices =
-            d2m::utils::buildGridIndices(rewriter, loc, mergeIdentity);
-        Value loaded = rewriter
-                           .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
-                                                      fullPartial, srcIndices)
-                           .getResult();
-
-        Value outBuf =
-            rewriter
-                .create<tensor::EmptyOp>(loc, outShardType.getShape(),
-                                         outShardType.getElementType())
-                .getResult();
-        auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded, outBuf,
-                                            shardRedDim);
-
-        SmallVector<Value> outIndices =
-            d2m::utils::buildGridIndices(rewriter, loc, mergeIdentity);
-        Value storeResult =
-            rewriter
-                .create<d2m::RemoteStoreOp>(loc, outEmpty.getType(),
-                                            outEmpty.getResult(), outIndices,
-                                            linalgOp->getResult(0))
-                .getResult();
-        rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
-        rewriter.finalizeOpModification(generic);
-        rewriter.restoreInsertionPoint(insertPoint);
-      }
+      auto generic = emitInPlaceNarrowing(rewriter, loc, ctx, fullPartial,
+                                          outEmpty, physicalRank, genRedDim,
+                                          mergeIdentity, mergeIters);
       return relayout(generic->getResult(0));
     };
 
     Value topkValsRelayouted, topkIdxRelayouted;
     if (!multiCore) {
       std::pair<Value, Value> single =
-          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0);
+          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
+                        /*gridCols=*/1, /*ntCores=*/ntShards);
       topkValsRelayouted = single.first;
       topkIdxRelayouted = single.second;
     } else {
@@ -4711,16 +4690,9 @@ public:
       std::size_t deviceGridDim = static_cast<std::size_t>(dim);
 
       // Collapses `bands` partials, one per core, down to `numGroups`: core g
-      // merges the groupTiles bands starting at g * groupTiles. Every group of
-      // the round runs in the same generics, so a round costs a fixed five
-      // regardless of how many groups it has.
-      //
-      // The gather is a lone composite view over the still-distributed input.
-      // Its result re-splits that same grid x shard extent onto the merge grid,
-      // so D2MExpandDMAReadCompositeView resolves each destination tile back to
-      // its (band, tile-in-band) by div/rem and issues the DMA read pulling it
-      // off whichever core holds it. One view replaces what used to be a
-      // collector generic per band plus a CompositeView per group.
+      // merges the groupTiles bands starting at g * groupTiles, via one
+      // composite view that D2MExpandDMAReadCompositeView resolves per tile
+      // into a DMA read off the source core.
       auto mergeRound = [&](Value valsIn, Value idxIn, int64_t bands,
                             int64_t numGroups) -> std::pair<Value, Value> {
         int64_t groupTiles = bands / numGroups;
@@ -4740,10 +4712,7 @@ public:
         wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
 
         // Re-splitting leaves grid x shard alone, so the wide layout carries
-        // the same logical extent as the input's. That is exactly what the
-        // composite verifier wants: it sums the inputs' logical extents along
-        // the composite dim against the output's, and here the lone input
-        // already accounts for all of it.
+        // the same logical extent as the input's
         auto valWideLayout = layoutForDeviceShape(
             cast<ttcore::MetalLayoutAttr>(valsInType.getEncoding()), wideShape);
         auto idxWideLayout = layoutForDeviceShape(
@@ -4858,25 +4827,55 @@ public:
       topkIdxRelayouted = level.second;
     }
 
-    // Index extract uses the index-element-type topk tiles. For dim==0 the
-    // extract's inner tile op is already a TileTypecastOp, so targeting its
-    // output at the user index type folds the narrowing cast in. dim==1 uses
-    // TileTransposeOp, unverified for dtype changes, so it casts separately.
     Type idxOutElemType = indicesType.getElementType();
     bool fuseIdxCast = (dim == 0);
     auto extractIdxIndicesType = RankedTensorType::get(
         indicesType.getShape(), fuseIdxCast ? idxOutElemType : idxElemType);
 
-    SmallVector<Value> origValOutputs =
-        createDpsOutputs(loc, rewriter, {valuesType});
-    SmallVector<Value> origIdxOutputs =
-        createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
-    Value extractValsLayout = createOptimalLayoutOp(
-        origValOutputs[0], memorySpaces[1], /*tiled=*/true,
-        /*noCollapse=*/false, rewriter);
-    Value extractIdxLayout = createOptimalLayoutOp(
-        origIdxOutputs[0], memorySpaces[1], /*tiled=*/true,
-        /*noCollapse=*/false, rewriter);
+    // The extract output must be split like its input on the same folded
+    // cores, or the extract gathers the whole result onto one core.
+    auto createDataParallelExtractOutput =
+        [&](RankedTensorType logicalType) -> Value {
+      constexpr std::array<int64_t, 2> defaultTileShape =
+          ttcore::TileType::getDefaultShape();
+      SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
+                                        defaultTileShape.end());
+      auto tileElemType =
+          ttcore::TileType::get(logicalType.getElementType(), tileShapeVec);
+      SmallVector<int64_t> alignments(logicalType.getRank(), kTileWidth);
+      alignments[1 - dim] = paddedNonTargetTiles * kTileWidth;
+      auto layout = ttcore::MetalLayoutAttr::get(
+          ctx, logicalType.getShape(), memorySpaces[1],
+          ttcore::TensorMemoryLayout::Sharded,
+          ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+              ctx, logicalType.getRank()),
+          alignments);
+      SmallVector<int64_t> grid = (dim == 1)
+                                      ? SmallVector<int64_t>{ntShards, 1}
+                                      : SmallVector<int64_t>{1, ntShards};
+      auto emptyOp = rewriter.create<d2m::EmptyOp>(
+          loc, layout.getDeviceShape(grid, tileShapeVec), tileElemType, layout);
+      emptyOp.setVirtualGridForwardMappingAttr(dataParallelFoldForwardAttr);
+      emptyOp.setVirtualGridInverseMappingAttr(dataParallelFoldInverseAttr);
+      return emptyOp.getResult();
+    };
+
+    Value extractValsLayout, extractIdxLayout;
+    if (dataParallel) {
+      extractValsLayout = createDataParallelExtractOutput(valuesType);
+      extractIdxLayout = createDataParallelExtractOutput(extractIdxIndicesType);
+    } else {
+      SmallVector<Value> origValOutputs =
+          createDpsOutputs(loc, rewriter, {valuesType});
+      SmallVector<Value> origIdxOutputs =
+          createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
+      extractValsLayout = createOptimalLayoutOp(origValOutputs[0],
+                                                memorySpaces[1], /*tiled=*/true,
+                                                /*noCollapse=*/false, rewriter);
+      extractIdxLayout = createOptimalLayoutOp(origIdxOutputs[0],
+                                               memorySpaces[1], /*tiled=*/true,
+                                               /*noCollapse=*/false, rewriter);
+    }
 
     std::size_t extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
 
@@ -4898,6 +4897,12 @@ public:
       auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
           loc, extractedIdxType.getShape(), idxCastTileType,
           extractedIdxType.getEncoding());
+      if (dataParallel) {
+        idxCastEmpty.setVirtualGridForwardMappingAttr(
+            dataParallelFoldForwardAttr);
+        idxCastEmpty.setVirtualGridInverseMappingAttr(
+            dataParallelFoldInverseAttr);
+      }
       SmallVector<Value> castInputs = {idxFinal};
       SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
       std::size_t castRank = extractedIdxType.getShape().size() / 2;

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -6,10 +6,10 @@
 
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
-#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
 #include "ttmlir/Dialect/D2M/IR/D2M.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -3635,82 +3635,25 @@ public:
     const int32_t k = op.getK();
     assert(k <= 64 && "D2M topk only supports k <= 64");
     const int64_t reductionDimSize = inputType.getShape()[dim];
+
+    // guard against k > 32 for the single tile case
     if ((reductionDimSize + kTileWidth - 1) / kTileWidth == 1) {
       assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
 
-    // Reduction tiles one output partial occupies.
-    const int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
-    const d2m::TopKGeometry geometry =
-        d2m::getTopKGeometry(dim, static_cast<std::size_t>(rank));
-
-    Value layoutedInput;
-    if (reductionDimSize <= kTileWidth) {
-      // topk_block merges reduction tiles pairwise, so it needs at least two.
-      SmallVector<int64_t> paddedTiles(rank, 1);
-      paddedTiles[dim] = 2;
-      layoutedInput = d2m::utils::layoutAndMask(
-          rewriter, loc, adaptor.getInputTensor(), paddedTiles,
-          SmallVector<int64_t>(rank, 1), memorySpaces[0]);
-    } else {
-      layoutedInput = createOptimalLayoutOp(
-          adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
-          /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);
-    }
+    // Placeholder leaf: d2m-grid-selection plans padding/transpose/extract,
+    // and d2m-lower-topk replaces this leaf with the planned chain.
+    Value layoutedInput = createOptimalLayoutOp(
+        adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
+        /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);
 
     auto [topkVals, topkIdx] = d2m::utils::emitLeafTopk(
         rewriter, loc, layoutedInput, k, dim, reductionDimSize);
+    d2m::utils::setTopkIndexType(topkVals.getDefiningOp(),
+                                 indicesType.getElementType());
 
-    Type idxOutElemType = indicesType.getElementType();
-    bool fuseIdxCast = (dim == 0);
-    // Must match the index element type emitLeafTopk picks.
-    Type leafIdxElemType = rewriter.getI32Type();
-    auto extractIdxIndicesType = RankedTensorType::get(
-        indicesType.getShape(), fuseIdxCast ? idxOutElemType : leafIdxElemType);
-
-    SmallVector<Value> origValOutputs =
-        createDpsOutputs(loc, rewriter, {valuesType});
-    SmallVector<Value> origIdxOutputs =
-        createDpsOutputs(loc, rewriter, {extractIdxIndicesType});
-    Value extractValsLayout =
-        createOptimalLayoutOp(origValOutputs[0], memorySpaces[1],
-                              /*tiled=*/true, /*noCollapse=*/false, rewriter);
-    Value extractIdxLayout =
-        createOptimalLayoutOp(origIdxOutputs[0], memorySpaces[1],
-                              /*tiled=*/true, /*noCollapse=*/false, rewriter);
-
-    auto extractValsGeneric = d2m::utils::emitTopKExtract(
-        rewriter, loc, d2m::utils::materializeToLayout(rewriter, loc, topkVals),
-        extractValsLayout, geometry.extractProjectDim, outputReductionTiles,
-        dim);
-    auto extractIdxGeneric = d2m::utils::emitTopKExtract(
-        rewriter, loc, d2m::utils::materializeToLayout(rewriter, loc, topkIdx),
-        extractIdxLayout, geometry.extractProjectDim, outputReductionTiles,
-        dim);
-
-    Value idxFinal = extractIdxGeneric->getResult(0);
-    if (!fuseIdxCast) {
-      // Its own region, so the D2M->TTKernel store/DST-index lookup still finds
-      // a single terminal compute op.
-      auto extractedIdxType = cast<RankedTensorType>(idxFinal.getType());
-      auto idxCastTileType = ttcore::TileType::get(
-          idxOutElemType,
-          cast<ttcore::TileType>(extractedIdxType.getElementType()).getShape());
-      auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, extractedIdxType.getShape(), idxCastTileType,
-          extractedIdxType.getEncoding());
-      idxFinal = d2m::utils::emitUnaryGeneric(
-          rewriter, loc, idxFinal, idxCastEmpty.getResult(),
-          [&](OpBuilder &b, Location l, ValueRange args) {
-            return b.create<d2m::TileTypecastOp>(l, args[1].getType(), args[0])
-                .getResult();
-          });
-      d2m::utils::markPinnedGrid(idxFinal.getDefiningOp());
-    }
-
-    Operation *valResult =
-        unLayoutResult(rewriter, extractValsGeneric->getResult(0), valuesType);
-    Operation *idxResult = unLayoutResult(rewriter, idxFinal, indicesType);
+    Operation *valResult = unLayoutResult(rewriter, topkVals, valuesType);
+    Operation *idxResult = unLayoutResult(rewriter, topkIdx, indicesType);
 
     rewriter.replaceOp(op, {valResult->getResult(0), idxResult->getResult(0)});
     return success();

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3597,19 +3597,16 @@ public:
   }
 };
 
-// Builds a virtual-grid fold pair like ttmlir::d2m::utils::grids::
-// createCoreVirtMaps, but for a LOCAL virtual grid that occupies a
-// contiguous slice [colBase, colBase + volume(localVirtualGrid)) of a larger
-// logical column space folded onto physicalGrid. Used to place topk's
-// uneven-band remainder shard (a 1x1 local grid) at physical linear index
-// colBase within physicalGrid's row-major layout -- passed the full worker
-// grid so the remainder lands on the first core of the next free row after
-// the full-band group's rows. A constant colBase offset leaves the fold SPAN
-// (evalShape end-minus-start extent) equal to volume(localVirtualGrid), so the
-// stored-map volume invariant (getGridMapsFromVirtualGridMapping) still holds.
+// Like ttmlir::d2m::utils::grids::createCoreVirtMaps, but for a local virtual
+// grid occupying the slice [colBase, colBase + volume(localVirtualGrid)) of
+// physicalGrid's row-major layout.
 static std::pair<AffineMap, AffineMap>
 createOffsetCoreVirtMaps(MLIRContext *ctx, ArrayRef<int64_t> localVirtualGrid,
                          ArrayRef<int64_t> physicalGrid, int64_t colBase) {
+  assert(colBase >= 0 && "core offset must be non-negative");
+  assert(colBase + ttmlir::utils::volume<int64_t>(localVirtualGrid) <=
+             ttmlir::utils::volume<int64_t>(physicalGrid) &&
+         "offset core placement runs past the end of the physical grid");
   AffineMap collapseMap =
       ttmlir::d2m::utils::grids::createCollapseMap(ctx, localVirtualGrid);
   AffineExpr shiftedIdx =
@@ -3622,9 +3619,6 @@ createOffsetCoreVirtMaps(MLIRContext *ctx, ArrayRef<int64_t> localVirtualGrid,
       ttmlir::d2m::utils::grids::extendWithIdentityDimsAndResults(
           expandMap.compose(shiftedCollapseMap), localVirtualGrid.size());
 
-  // Inverse: physical (y, x) -> local linear index - colBase. Same collapse
-  // idiom as the forward physical lookup, over physicalGrid, then subtract
-  // colBase and re-expand to the local virtual grid's own coordinates.
   AffineMap physCollapseMap =
       ttmlir::d2m::utils::grids::createCollapseMap(ctx, physicalGrid);
   AffineExpr localLinearIdx =
@@ -3650,9 +3644,36 @@ public:
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
 
-  // Extracts top-k results from topkResult into extractOutput, collapsing
-  // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
-  // each tile to handle row/column orientation.
+  // Emits a linalg.generic copying `input` into `output` tile-by-tile via
+  // TileTypecastOp. With `shardRedDim` set, a non-invertible `dim mod extent`
+  // map on it takes the loop bound from the narrow output, copying only the
+  // leading tiles; without it the map is an identity over the whole shard.
+  linalg::GenericOp
+  emitLeadingTileCopy(OpBuilder &builder, Location loc, MLIRContext *ctx,
+                      Value input, Value output,
+                      std::optional<std::size_t> shardRedDim) const {
+    auto inShardType = cast<RankedTensorType>(input.getType());
+    std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
+    SmallVector<AffineExpr> inExprs;
+    for (std::size_t i = 0; i < shardRank; ++i) {
+      AffineExpr idx = builder.getAffineDimExpr(i);
+      inExprs.push_back(i == shardRedDim ? idx % inShardType.getShape()[i]
+                                         : idx);
+    }
+    AffineMap shardInMap = AffineMap::get(shardRank, 0, inExprs, ctx);
+    AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
+    SmallVector<mlir::utils::IteratorType> linalgIters(
+        shardRank, mlir::utils::IteratorType::parallel);
+    return builder.create<linalg::GenericOp>(
+        loc, output.getType(), input, output,
+        SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
+        [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+          Value copied = b.create<d2m::TileTypecastOp>(
+              bodyLoc, args[1].getType(), args[0]);
+          b.create<linalg::YieldOp>(bodyLoc, copied);
+        });
+  }
+
   // Extracts top-k results from topkResult into extractOutput, collapsing
   // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
   // each tile to handle row/column orientation.
@@ -3661,7 +3682,7 @@ public:
                                       Value topkResult, Value extractOutput,
                                       std::size_t extractProjectDim,
                                       int64_t outputReductionTiles,
-                                      int64_t lastStride, int32_t dim) const {
+                                      int32_t dim) const {
     std::size_t extractRank =
         ttcore::getDeviceLayout(extractOutput).getRank() / 2;
     AffineMap extractIdentity = rewriter.getMultiDimIdentityMap(extractRank);
@@ -3700,14 +3721,12 @@ public:
 
           // The input map must stay non-invertible, or linalg infers the loop
           // bound from the full input extent and rejects the smaller output
-          // shard. With lastStride=1, `dim * lastStride` folds to an identity
-          // map, so we wrap it in `mod inReductionExtent` to stay
-          // non-invertible without changing the in-range read indices
+          // shard. `mod inReductionExtent` keeps it non-invertible without
+          // changing in-range read indices.
           AffineExpr projExpr =
               outputReductionTiles == 1
                   ? rewriter.getAffineConstantExpr(0)
-                  : (rewriter.getAffineDimExpr(extractProjectDim) *
-                     lastStride) %
+                  : rewriter.getAffineDimExpr(extractProjectDim) %
                         inReductionExtent;
           SmallVector<AffineExpr> mapFirstExprs;
           for (std::size_t i = 0; i < outShardRank; ++i) {
@@ -3730,7 +3749,6 @@ public:
                   result = b.create<d2m::TileTransposeOp>(
                       bodyLoc, args[1].getType(), args[0]);
                 } else {
-                  // dim=0: copy tile via typecast
                   result = b.create<d2m::TileTypecastOp>(
                       bodyLoc, args[1].getType(), args[0]);
                 }
@@ -3765,32 +3783,13 @@ public:
           op, "D2M topk only supports 2D reduction on dim 0 or dim 1");
     }
 
-    // Multi-core sharding: a very wide reduction dim does not fit in a single
-    // core's L1. Split it into G column bands ("slices"), run a local topk per
-    // slice, then merge the sorted partials in a cross-core reduction tree.
-    // Supports k<=64: dim==0 or dim==1 with an arbitrary non-target dim,
-    // capped by the per-core L1 tile budget below. Each partial (local topk
-    // result, gathered partial, and merge-tree node) carries
-    // outputReductionTiles reduction tiles -- 1 for k<=32, 2 for k<=64 (the
-    // canonical winner=tile0/loser=tile1 layout D2MDecomposeTopk's large-k
-    // left-fold produces). Computed here (rather than where it's used lower
-    // down) since the multi-core gather/merge lambdas below capture it.
+    // Multi-core sharding: a very wide reduction dim does not fit in one core's
+    // L1, so split it into bands, run a local topk per band, and merge the
+    // partials in a cross-core tree.
     constexpr int64_t kTileWidth = 32;
     int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
-    // Total L1-safe tile budget per core (values + indices share this). Every
-    // core must hold its full non-target-dim footprint over its reduction
-    // band, so the reduction-tile cap is this budget divided by how many
-    // tiles the non-target dim occupies.
-    //
-    // Empirically a single core holds 43 tiles of a single-band topk (it
-    // reuses buffers sequentially), but a multi-core band core carries
-    // additional simultaneously-live buffers (per-core gather/merge
-    // infrastructure) that don't fit that same budget. kMaxTilesPerCore is the
-    // single-core ceiling (also the multiCore-vs-single-core threshold below);
-    // kMaxMultiCoreTilesPerCore is the smaller, measured-safe cap used only for
-    // sizing multi-core bands.
+    // L1-safe tile budget per core; values and indices share it.
     constexpr int64_t kMaxTilesPerCore = 43;
-    constexpr int64_t kMaxMultiCoreTilesPerCore = 43;
     int64_t fullReductionElems = inputType.getShape()[dim];
     int64_t nonTargetElems = inputType.getShape()[1 - dim];
     int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
@@ -3799,132 +3798,51 @@ public:
           op, "D2M topk: non-target dimension alone exceeds the per-core "
               "tile budget");
     }
-    // Per-core cap on reduction-dim tiles, accounting for the non-target
-    // dim's footprint on every core (nonTargetTiles * reductionTiles <=
-    // kMaxTilesPerCore). Used for the single-core-vs-multi-core decision
-    // below; multi-core band sizing uses the smaller
-    // maxMultiCoreReductionTilesPerCore instead (a multi-core core carries
-    // extra simultaneously-live gather/merge buffers a single-core run reuses
-    // sequentially, so it needs a tighter budget). This band cap is NOT scaled
-    // by outputReductionTiles: a band core's L1 is dominated by its
-    // bandTiles-wide input, and the k>32 doubling only adds
-    // outputReductionTiles small output tiles. The k>32 pressure lands on the
-    // merge tree, where each partial carries outputReductionTiles reduction
-    // tiles; that is bounded separately via mergeCap (see the merge-tree loop
-    // below).
+    // NOT scaled by outputReductionTiles: a band core's L1 is dominated by its
+    // bandTiles-wide input, so k>32 pressure is bounded separately by mergeCap.
     int64_t maxReductionTilesPerCore = kMaxTilesPerCore / nonTargetTiles;
-    int64_t maxMultiCoreReductionTilesPerCore =
-        kMaxMultiCoreTilesPerCore / nonTargetTiles;
 
-    // Index element type for the arange / topk index buffers. The topk SFPU
-    // LLK reads the index lane only as INT32 (when fp32_dest_acc is on) or as a
-    // 16-bit integer (LO16, otherwise) -- never as a float. Int32 makes any
-    // 32-bit operand force fp32_dest_acc on the compute kernel, selecting the
-    // INT32 index path, so indices round-trip losslessly for any reduction
-    // size.
+    // The topk SFPU LLK reads the index lane only as INT32 (with fp32_dest_acc
+    // on) or LO16 otherwise, never as a float. Int32 forces fp32_dest_acc and
+    // selects the INT32 path, so indices round-trip losslessly at any size.
     Type idxElemType = rewriter.getI32Type();
     int64_t fullReductionTiles =
         (fullReductionElems + kTileWidth - 1) / kTileWidth;
-    // Minimum cores needed so each band is <= maxReductionTilesPerCore tiles.
-    // This is a lower bound; the actual band count is the physical grid area
-    // chosen below (which must divide fullReductionTiles evenly and fit the
-    // worker grid), so it may exceed this minimum.
+    // A lower bound only; the count chosen below must also be grid-legal.
     int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
                         maxReductionTilesPerCore;
     bool multiCore = minShards > 1;
 
-    if (fullReductionTiles < 1) {
-      return rewriter.notifyMatchFailure(
-          op,
-          "D2M topk requires at least 1 tile along the reduction dimension");
-    }
     if (fullReductionTiles == 1) {
       // A single tile holds at most kTileWidth elements; k>32 would need a
       // 2-tile output with no second input tile to source it from.
       assert(k <= kTileWidth && "single-tile topk input only supports k <= 32");
     }
-    // The reduction bands are distributed one per core: numShards bands, each a
-    // logical shard at grid position [0, g]. The tensor keeps a 1xnumShards
-    // device grid; a virtual-grid map (attached in emitShardTopk) folds those
-    // numShards logical positions onto the 2D physical worker grid. numShards
-    // is 1 for single-core, chosen below for multi-core.
-    //
-    // Bands need not divide fullReductionTiles evenly: all numShards bands
-    // carry the same bandTiles = ceil(fullReductionTiles / numShards) tiles,
-    // with any padding tail masked to -inf. This lets ANY fullReductionTiles
-    // pick a grid-legal numShards -- exact-divisor band counts don't exist for
-    // many tile counts (e.g. 1377 = 3^3*17 has no divisor that is both
-    // <= maxMultiCoreReductionTilesPerCore-sized bands and <=8x8
-    // grid-factorable).
+    // Bands are distributed one per core and folded onto the 2D worker grid by
+    // a virtual-grid map attached in emitShardTopk. They need not divide
+    // fullReductionTiles evenly; all carry bandTiles tiles, and the padding
+    // tail out to paddedReductionTiles is masked to -inf.
     SmallVector<int64_t> workerGridShape;
     int64_t numShards = 1;
     int64_t bandTiles = fullReductionTiles;
-    // Padded reduction-tile extent of the multi-core sharded tensor
-    // (numShards * bandTiles). Equals fullReductionTiles for a clean even
-    // split; larger when numShards does not divide evenly, with the tail
-    // [fullReductionElems, paddedReductionTiles*32) masked with -inf.
     int64_t paddedReductionTiles = fullReductionTiles;
     if (multiCore) {
-      // Hard-fail (no TTNN fallback) for configs outside supported scope.
-      // outputReductionTiles (2 for k>32) is folded into
-      // maxMultiCoreReductionTilesPerCore above, so k<=64 is otherwise handled
-      // like k<=32 throughout the gather/merge tree below.
-      assert(k <= 64 && "multi-core topk only supports k <= 64");
-
       auto device = ttcore::lookupDevice(op);
       workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
       assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
 
-      int64_t workerHeight = workerGridShape[0];
-      int64_t workerWidth = workerGridShape[1];
-
-      // Placement is constrained by the virtual-grid fold invariant
-      // (getGridMapsFromVirtualGridMapping, Utils.cpp): a tensor whose logical
-      // grid has volume V may only carry a stored fold whose physical *span*
-      // (evalShape extent, NOT bounding box) has volume V. Folding V logical
-      // positions onto a near-square grid whose area exceeds V therefore fails
-      // -- so numShards must EXACTLY tile its physical grid, i.e. numShards
-      // itself must be grid-legal (findLegalPhysicalGridForVolume non-empty).
-      //
-      // Selection: pick the SMALLEST grid-legal numShards >= minShards (the
-      // tile-budget lower bound). Every band then carries the SAME
-      // bandTiles = ceil(fullReductionTiles / numShards) reduction tiles -- one
-      // uniform sharded tensor, folded as a single grid-legal rectangle. When
-      // numShards does not divide fullReductionTiles evenly, the padded device
-      // shape (numShards * bandTiles tiles) exceeds the real data
-      // (fullReductionTiles tiles); the layout masks the [fullReductionElems,
-      // padded) tail with -inf so those padding lanes never win top-k (same
-      // masking idiom as the single-tile-reduction path below). This mirrors
-      // GridSelection's virtual-grid trick (pick a grid-legal count, let the
-      // layout absorb the ragged tail) but with a per-core tile budget: we take
-      // the smallest legal count rather than the largest legal factor.
-      //
-      // A prime or awkward fullReductionTiles whose budget-minimum core count
-      // exceeds the largest grid-legal count (<= workerHeight * workerWidth)
-      // has NO solution -- the reduction genuinely needs more cores than the
-      // worker grid provides. That is a hard capacity limit, so fail the match
-      // cleanly (no assert / no TTNN fallback) rather than crash.
-      //
-      // Multi-core bands use their OWN (smaller, measured-safe) per-core tile
-      // budget -- maxMultiCoreReductionTilesPerCore rather than the
-      // single-core maxReductionTilesPerCore -- since a band core carries
-      // extra simultaneously-live gather/merge buffers a single-core run
-      // reuses sequentially. Recompute the search's lower bound against that
-      // cap (may exceed minShards, which was only the single-core-vs-
-      // multi-core threshold) and skip any grid-legal cand whose resulting
-      // bandTiles still exceeds it.
-      int64_t multiCoreMinShards =
-          std::max(minShards, (fullReductionTiles +
-                               maxMultiCoreReductionTilesPerCore - 1) /
-                                  maxMultiCoreReductionTilesPerCore);
-      int64_t maxGridCores = workerHeight * workerWidth;
-      for (int64_t cand = multiCoreMinShards; cand <= maxGridCores; ++cand) {
+      int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
+      // The fold invariant requires numShards to be grid-legal, so pick the
+      // smallest such count >= minShards whose bands also fit the tile budget.
+      // Since every skipped candidate is illegal or busts that budget, running
+      // off maxGridCores means this grid needs more cores (reported below).
+      for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
         if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
                 .empty()) {
           continue;
         }
         int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
-        if (candBandTiles > maxMultiCoreReductionTilesPerCore) {
+        if (candBandTiles > maxReductionTilesPerCore) {
           continue;
         }
         numShards = cand;
@@ -3936,74 +3854,31 @@ public:
             op, "D2M topk: reduction dim needs more cores than the worker grid "
                 "provides at the per-core tile budget");
       }
-      // Uniform bands: the sharded tensor is padded to numShards * bandTiles
-      // tiles and the tail masked (no separate short remainder band);
-      // paddedReductionTiles records the padded extent.
       paddedReductionTiles = numShards * bandTiles;
-      assert(bandTiles <= maxMultiCoreReductionTilesPerCore &&
-             "chosen bandTiles exceeds the multi-core per-core reduction-tile "
-             "budget");
-      assert(paddedReductionTiles >= fullReductionTiles &&
-             "padded reduction extent must cover the real data");
     }
 
-    // Emits the full single-shard topk (layout -> transpose -> arange/index ->
-    // TopkBlockOp -> relayout) over a raw [ht, shardWidth] input, returning the
-    // (values, indices) partials still in device layout (pre-extract).
-    // arangeStart offsets the index buffer so slice g yields GLOBAL indices.
-    // gridCols > 1 distributes the local topk compute across that many cores by
-    // reblocking the reduction-dim tiles into grid columns (one band per core).
-    // Returns one (values, indices) partial per source core: a single grid-1x1
-    // partial for the single-core path (gridCols==1), or gridCols grid-1x1
-    // partials for the multi-core path (one per band). Each partial is a
-    // grid-1x1 buffer holding that band's local top-k (pre-extract, global
-    // indices). The caller CompositeViews the multi-core partials and runs a
-    // final merge topk_block to pick the global top-k.
-    // foldTotalShards / foldColBase mark an uneven-band split (see band
-    // selection). The two calls DO NOT share one physical grid -- the fold
-    // invariant forbids folding a group onto a grid whose area exceeds the
-    // group's band count. Instead each half folds self-consistently:
-    //   - Full-band group: gridCols == foldTotalShards - 1 (grid-legal by band
-    //     selection, but NOT necessarily a multiple of the worker width),
-    //     foldColBase == 0. Folds onto its OWN
-    //     findLegalPhysicalGridForVolume(gridCols) = fh x fw rectangle at the
-    //     worker origin.
-    //   - Remainder band: gridCols == 1, foldColBase == fh * workerWidth
-    //   (worker
-    //     cell (fh, 0)). Placed at that physical linear index in the worker
-    //     grid's row-major layout -- the first core of the row just past the
-    //     full group's fh x fw rectangle, hence disjoint from the full group.
-    //     foldTotalShards is only a "this is a split half"
-    //     signal (it drives isFoldedShard for the gridCols==1 remainder).
-    // Defaults (both 0) select the plain gridCols-sized fold with no offset,
-    // i.e. the existing equal-band / single-core path.
+    // Emits a single-shard topk over a raw input, returning (values, indices)
+    // partials still in device layout. arangeStart offsets indices so band g
+    // yields GLOBAL indices; gridCols > 1 splits the topk across that many
+    // cores and returns one grid-1x1 partial per band for the caller to merge.
     auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols = 1, int64_t foldTotalShards = 0,
-                             int64_t foldColBase =
-                                 0) -> SmallVector<std::pair<Value, Value>> {
+                             int64_t gridCols =
+                                 1) -> SmallVector<std::pair<Value, Value>> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
 
-      // The value input's logical shape. When large-k pads the reduction dim to
-      // a power-of-2 tile count, this grows to match the arange/index buffer,
-      // since topk d2m.generic requires both operands to share a shard shape.
+      // Grows to match the arange/index buffer when the reduction dim is
+      // padded, since the topk d2m.generic requires both operands to share a
+      // shard shape.
       SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
                                             inputType.getShape().end());
 
-      // Lay out the input in L1 tiled form. For gridCols>1 the reduction dim is
-      // split into gridCols bands, one per core: the input is tilized DIRECTLY
-      // into a [1,gridCols,ht,wt/gridCols] buffer so the to_layout/tilize
-      // itself is sharded per-core. Reblocking a unit-grid
-      // createOptimalLayoutOp result instead would only add a view over a
-      // buffer already tilized whole-on-one -core, so that staging buffer would
-      // overflow L1 for wide reduction dims.
       Value layoutedInput;
-      // Virtual-grid fold maps for the multi-core path. Set when gridCols>1 and
-      // attached (via attachFold below) to EVERY EmptyOp allocated at the
-      // 1xgridCols device grid, so their buffers place on the same folded
-      // physical cores as the input. Without the map a 1xgridCols buffer would
-      // request physical core columns 0..gridCols-1 and crash for gridCols>8.
+      // Attached to every EmptyOp at the 1xgridCols device grid so its buffer
+      // lands on the same folded cores as the input. Without the map such a
+      // buffer requests physical core columns 0..gridCols-1 and crashes for
+      // gridCols>8.
       AffineMapAttr foldForwardMapAttr, foldInverseMapAttr;
       auto attachFold = [&](d2m::EmptyOp emptyOp) {
         if (foldForwardMapAttr) {
@@ -4011,53 +3886,28 @@ public:
           emptyOp.setVirtualGridInverseMappingAttr(foldInverseMapAttr);
         }
       };
-      if (gridCols > 1 || foldTotalShards > 0) {
-        // Distribute the gridCols reduction bands (one band <=
-        // maxMultiCoreReductionTilesPerCore reduction tiles) across the worker
-        // grid, one band per core. The
-        // tensor keeps a 1xgridCols (dim==1) or gridColsx1 (dim==0) device
-        // grid -- band g == reduction tiles [g*shardTiles, (g+1)*shardTiles),
-        // so each core holds the full non-target dim over a distinct band
-        // along the reduction dim. This is the tile-correct sharding: topk is
-        // per-slice, so every core must see the full non-target dim over its
-        // band. (Reshaping the logical shape to a 2D tensor grid is WRONG: it
-        // would tile-group different elements and split each slice across
-        // cores.)
-        //
-        // A literal 1xgridCols (or gridColsx1) placement asks for physical
-        // core columns (or rows) 0..gridCols-1, which exceeds the worker
-        // width/height once gridCols exceeds it (e.g. 1x32 on 8x8 asks for
-        // col 31 -> the coordinate manager cannot translate it). So attach a
-        // virtual-grid mapping that folds the gridCols logical shard
-        // positions onto the 2D physical grid (the same createCoreVirtMaps
-        // machinery GridSelection uses). Logical shard [0, g] (or [g, 0])
-        // lands on physical core findLegalPhysicalGridForVolume-folded from
-        // g, while the tensor grid, generic maps, and gather indices all stay
-        // at the logical shardedGrid shape. The buffer placement (flatbuffer)
-        // and the DMA address path both read this same forward map, so they
-        // agree; the physical grid MUST be the one
-        // findLegalPhysicalGridForVolume picks (that is what both consumers
-        // recompute deterministically).
-        //
-        // foldTotalShards>0 means this call is one half of an uneven-band
-        // split (see emitShardTopk's doc comment); the placement below folds
-        // each half self-consistently (full group on its own grid, remainder
-        // at an offset worker core) rather than sharing one physical grid.
+      // Fold maps for the dim==0 arange/index buffers, which live shape-swapped
+      // on a 1xgridCols grid and so need bands across grid COLUMNS rather than
+      // down the value input's ROWS. A 1xN and an Nx1 grid collapse to the same
+      // cores in the same order, so the later fullTranspose moves no data.
+      AffineMapAttr arangeFoldForwardMapAttr, arangeFoldInverseMapAttr;
+      auto attachArangeFold = [&](d2m::EmptyOp emptyOp) {
+        if (arangeFoldForwardMapAttr) {
+          emptyOp.setVirtualGridForwardMappingAttr(arangeFoldForwardMapAttr);
+          emptyOp.setVirtualGridInverseMappingAttr(arangeFoldInverseMapAttr);
+        }
+      };
+      if (gridCols > 1) {
+        // One band per core, since topk is per-slice and each core needs the
+        // full non-target dim over its own band. A literal 1xgridCols placement
+        // is untranslatable past the worker width, hence the virtual-grid map.
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
                                           defaultTileShape.end());
         auto tileElemType =
             ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
-        // When numShards does not divide the reduction tiles evenly, the
-        // sharded buffer is padded along the reduction dim to
-        // paddedReductionTiles (== numShards * bandTiles) tiles so every band
-        // is bandTiles wide. Force that padded extent via a dimAlignment on the
-        // reduction dim while keeping the layout's logical_shape truthful
-        // (still inputType's shape); a MaskOp below fills the padded tail with
-        // -inf so it never wins top-k. For a clean even split
-        // paddedReductionTiles == fullReductionTiles and the alignment is the
-        // default tile width (no padding, no mask -- byte-identical old path).
+        // Pad via a dimAlignment, which keeps logical_shape truthful.
         bool needsReductionPad = paddedReductionTiles > fullReductionTiles;
         SmallVector<int64_t> shardDimAlignments(inputType.getShape().size(),
                                                 kTileWidth);
@@ -4077,47 +3927,32 @@ public:
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
-        // Placement respects the fold invariant (each tensor's logical grid
-        // volume must equal its physical fold *span*):
-        //   - Full group / plain call (foldColBase == 0): fold this call's own
-        //     gridCols-wide grid onto findLegalPhysicalGridForVolume(gridCols).
-        //     gridCols is guaranteed grid-legal by band selection, so the span
-        //     equals gridCols exactly. This holds for the equal-band path
-        //     (foldTotalShards == 0) and for the full-band half of an uneven
-        //     split (foldTotalShards > 0, foldColBase == 0), occupying the
-        //     fh x fw rectangle at the worker origin.
-        //   - Remainder half (foldColBase > 0, always gridCols == 1): place the
-        //     single band at physical linear index foldColBase within the
-        //     WORKER grid's row-major layout -- worker cell (fh, 0), the first
-        //     core of the row just past the full group's fh x fw rectangle. A
-        //     constant offset leaves the span at 1 (evalShape subtracts start
-        //     from end), so the 1x1 grid's volume matches. Disjoint from the
-        //     full group because that rectangle spans only rows [0, fh).
-        AffineMap forwardMap, inverseMap;
-        if (foldColBase > 0) {
-          std::tie(forwardMap, inverseMap) = createOffsetCoreVirtMaps(
-              ctx, shardedGrid, workerGridShape, foldColBase);
-        } else {
-          SmallVector<int64_t> physicalGrid =
-              d2m::utils::findLegalPhysicalGridForVolume(gridCols,
-                                                         workerGridShape);
-          assert(!physicalGrid.empty() &&
-                 "band count has no legal worker-grid factorization");
-          std::tie(forwardMap, inverseMap) =
-              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
-                                                            physicalGrid);
-        }
+
+        // Swapped for dim==0, matching the arange buffer's own orientation.
+        SmallVector<int64_t> arangeGrid =
+            (dim == 1) ? shardedGrid
+                       : SmallVector<int64_t>{shardedGrid[1], shardedGrid[0]};
+        SmallVector<int64_t> physicalGrid =
+            d2m::utils::findLegalPhysicalGridForVolume(gridCols,
+                                                       workerGridShape);
+        assert(!physicalGrid.empty() &&
+               "band count has no legal worker-grid factorization");
+        auto [forwardMap, inverseMap] =
+            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
+                                                          physicalGrid);
+        auto [arangeForwardMap, arangeInverseMap] =
+            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, arangeGrid,
+                                                          physicalGrid);
         foldForwardMapAttr = AffineMapAttr::get(forwardMap);
         foldInverseMapAttr = AffineMapAttr::get(inverseMap);
+        arangeFoldForwardMapAttr = AffineMapAttr::get(arangeForwardMap);
+        arangeFoldInverseMapAttr = AffineMapAttr::get(arangeInverseMap);
         attachFold(shardedEmpty);
         Value tilized =
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
         if (needsReductionPad) {
-          // Fill the padded reduction tail [fullReductionElems, padded) with
-          // -inf so those lanes never win top-k. The mask derives the real
-          // extent from the layout's (truthful) logical_shape; the padded
-          // physical tail beyond it is the region set to -inf.
+          // -inf so the padding lanes never win top-k.
           auto maskOutput = rewriter.create<d2m::EmptyOp>(
               loc, shardedDeviceShape, tileElemType, shardedLayout);
           attachFold(maskOutput);
@@ -4131,14 +3966,10 @@ public:
           layoutedInput = tilized;
         }
       } else if (reductionDimSize <= kTileWidth) {
-        // A single-tile reduction dim has no room for the merge tree (it
-        // needs >=2 tiles). Force the physical buffer to 2 tiles along dim
-        // via dimAlignments while keeping the layout's logical_shape truthful
-        // (still reductionDimSize), so the mask op below fills exactly the
-        // extra tile with -inf (it never wins topk). Built manually rather
-        // than through createOptimalLayoutOp, whose oobVal masking derives
-        // the physical size from the same logical shape it masks against, so
-        // it cannot express "physical > logical-rounded-to-tile" on its own.
+        // A single-tile reduction dim leaves no room for the merge tree, which
+        // needs >=2 tiles, so force the buffer to 2 tiles via dimAlignments and
+        // let the mask op below fill the extra tile with -inf. Built manually
+        // because createOptimalLayoutOp cannot express physical > logical.
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
@@ -4169,8 +4000,6 @@ public:
                                                  paddedLayout.getLogicalShape(),
                                                  ttcore::OOBVal::NegInf)
                             .getResult();
-        // The arange/index buffer built below must share this padded shard
-        // shape, since the topk d2m.generic requires both operands to match.
         topkLogicalShape[dim] = 2 * kTileWidth;
       } else {
         layoutedInput =
@@ -4184,26 +4013,20 @@ public:
       ArrayRef<int64_t> deviceShape = layoutedType.getShape();
       std::size_t physicalRank = deviceShape.size() / 2;
 
-      int64_t ht = deviceShape[deviceShape.size() - 2];
-      int64_t wt = deviceShape[deviceShape.size() - 1];
-      int64_t numReductionTiles = (dim == 1) ? wt : ht;
-      // The >=1 reduction-tile requirement is enforced on the full input before
-      // this lambda runs (single-core) / guaranteed by 32-tile shards
-      // (multi-core), so it is an invariant here.
-      assert(numReductionTiles >= 1 &&
-             "shard must have at least 1 tile along the reduction dimension");
-      // D2MDecomposeTopk's large-k left-fold keeps the accumulator at canonical
-      // tiles (winner=0, loser=1) for any tile count, so no power-of-2 padding
-      // (and no -inf mask) is needed on the reduction dim.
-
-      auto topkIdxTileType = ttcore::TileType::get(idxElemType);
-
-      auto wrapInToLayout = [&](Value genericResult) -> Value {
+      // useArangeFold selects the swapped (1xgridCols) fold placement for the
+      // dim==0 arange/bcast buffers, which are shape-swapped until
+      // fullTranspose.
+      auto wrapInToLayout = [&](Value genericResult,
+                                bool useArangeFold = false) -> Value {
         auto resultType = cast<RankedTensorType>(genericResult.getType());
         auto emptyOp = rewriter.create<d2m::EmptyOp>(
             loc, resultType.getShape(), resultType.getElementType(),
             resultType.getEncoding());
-        attachFold(emptyOp);
+        if (useArangeFold) {
+          attachArangeFold(emptyOp);
+        } else {
+          attachFold(emptyOp);
+        }
         return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
             .getResult(0);
       };
@@ -4213,9 +4036,7 @@ public:
       SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
       AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
 
-      // Emits a generic that applies TileTransposeOp to every tile in the
-      // shard. Used for both value and index when dim==1 to keep them in the
-      // same orientation.
+      // Applies TileTransposeOp to every tile in the shard.
       auto transposeTiles = [&](Value src) -> Value {
         auto srcType = cast<RankedTensorType>(src.getType());
         auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
@@ -4231,10 +4052,6 @@ public:
             rewriter.getAffineMapArrayAttr(
                 SmallVector<AffineMap>{identityMap, identityMap}),
             rewriter.getArrayAttr(iteratorTypes));
-        // topk generics keep the whole reduction dim on one core: the block
-        // ops (transpose/arange/bcast/topk) assume the full shard is local, and
-        // GridSelection derives grids from operand shape (not iterator types),
-        // so it would otherwise shard the reduction dim and corrupt the result.
         transposeGeneric->setAttr("d2m.skip_grid_selection",
                                   rewriter.getUnitAttr());
 
@@ -4249,8 +4066,6 @@ public:
                   rewriter.getMultiDimIdentityMap(shardRank);
               SmallVector<mlir::utils::IteratorType> linalgIters(
                   shardRank, mlir::utils::IteratorType::parallel);
-              // TileTransposeOp operates on a single tile. linalg::GenericOp
-              // iterates over all tiles in the shard to apply it to each.
               auto linalgOp = rewriter.create<linalg::GenericOp>(
                   loc, output.getType(), input, output,
                   SmallVector<AffineMap>{shardIdentity, shardIdentity},
@@ -4266,54 +4081,39 @@ public:
         return wrapInToLayout(transposeGeneric->getResult(0));
       };
 
-      // Full (grid-level) transpose: swaps the shard's last two tile-grid dims
-      // AND transposes within each tile, so an R-row x C-col buffer becomes a
-      // genuine C x R buffer (unlike transposeTiles, which keeps the grid shape
-      // and only transposes within each tile). Used to build the dim==0 index
-      // buffer: fill the arange into a [C, R] buffer (so the [0..R-1] sequence
-      // runs along the R-long axis, spanning all tiles), then transpose here to
-      // [R, C] so idxBuf[r][c] == r == the global dim-0 index.
-      auto transposeTilesGrid = [&](Value src) -> Value {
+      // Full transpose (grid + tile): reorients an index buffer from the
+      // shape-swapped arange orientation back to the value input's natural
+      // one, swapping the grid and shard dims so index data moves onto the
+      // reduction-row axis.
+      auto fullTranspose = [&](Value src) -> Value {
         auto srcType = cast<RankedTensorType>(src.getType());
         auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
-        auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
-        ArrayRef<int64_t> srcDeviceShape = srcType.getShape();
-        std::size_t deviceRank = srcDeviceShape.size();
-        // Output device shape swaps the last two (shard) tile dims.
-        SmallVector<int64_t> dstDeviceShape(srcDeviceShape.begin(),
-                                            srcDeviceShape.end());
-        std::swap(dstDeviceShape[deviceRank - 1],
-                  dstDeviceShape[deviceRank - 2]);
-        // Output logical shape (the layout carries a logical shape whose tile
-        // extents must track the swapped physical tile counts).
-        constexpr int64_t kTileDim = 32;
-        SmallVector<int64_t> dstLogical = {
-            dstDeviceShape[deviceRank - 2] * kTileDim,
-            dstDeviceShape[deviceRank - 1] * kTileDim};
-        auto dstLayout = ttcore::MetalLayoutAttr::get(
-            ctx, dstLogical, srcLayout.getDimAlignments(),
-            srcLayout.getCollapsedIntervals(), srcLayout.getMemorySpace(),
-            srcLayout.getMemoryLayout());
-        auto dstType =
-            RankedTensorType::get(dstDeviceShape, srcTileType, dstLayout);
+        // Device rank is 2*physicalRank, laid out [grid..., shard...]; swap the
+        // last two of each.
+        ArrayRef<int64_t> srcDevShape = srcType.getShape();
+        SmallVector<int64_t> dstDevShape(srcDevShape.begin(),
+                                         srcDevShape.end());
+        std::swap(dstDevShape[physicalRank - 2], dstDevShape[physicalRank - 1]);
+        std::swap(dstDevShape[2 * physicalRank - 2],
+                  dstDevShape[2 * physicalRank - 1]);
+        // Output carries the value input's fold and layout, so the transposed
+        // buffer lands co-located with topkInput.
         auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, dstType.getShape(), srcTileType, dstLayout);
+            loc, dstDevShape, srcTileType, metalLayout);
         attachFold(transposeEmpty);
+        SmallVector<AffineExpr> permExprs;
+        for (std::size_t i = 0; i < physicalRank; ++i) {
+          permExprs.push_back(rewriter.getAffineDimExpr(i));
+        }
+        std::swap(permExprs[physicalRank - 2], permExprs[physicalRank - 1]);
+        AffineMap gridPermMap = AffineMap::get(physicalRank, 0, permExprs, ctx);
         SmallVector<Value> transposeInputs = {src};
         SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
-        // Input map permutes the last two shard dims so tile [.., i, j] reads
-        // from source tile [.., j, i]; output map is identity.
-        SmallVector<AffineExpr> inExprs;
-        for (std::size_t i = 0; i < physicalRank; ++i) {
-          inExprs.push_back(rewriter.getAffineDimExpr(i));
-        }
-        std::swap(inExprs[physicalRank - 1], inExprs[physicalRank - 2]);
-        AffineMap permInMap = AffineMap::get(physicalRank, 0, inExprs, ctx);
         auto transposeGeneric = rewriter.create<d2m::GenericOp>(
             loc, transposeInputs, transposeOutputs,
             /*additionalArgs=*/ValueRange(),
             rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{permInMap, identityMap}),
+                SmallVector<AffineMap>{gridPermMap, identityMap}),
             rewriter.getArrayAttr(iteratorTypes));
         transposeGeneric->setAttr("d2m.skip_grid_selection",
                                   rewriter.getUnitAttr());
@@ -4325,29 +4125,23 @@ public:
               Value output = blockArgs[1];
               std::size_t shardRank =
                   cast<RankedTensorType>(output.getType()).getRank();
-              // The input and output shards have TRANSPOSED grid shapes here
-              // ([1,8] vs [8,1]): withD2MGenericRegion hands each block arg its
-              // own operand's shard shape, so the maps must reconcile them. The
-              // iteration domain follows the OUTPUT (identity map); the INPUT
-              // map permutes the last two shard dims so output tile [d0,d1]
-              // reads input tile [d1,d0]. A single identity on both (as for a
-              // shape-preserving per-tile transpose) would make linalg infer
-              // conflicting extents for the swapped dim and fail verification.
+              // Permute the last two shard dims so output tile (r, c) reads
+              // input tile (c, r).
+              SmallVector<AffineExpr> shardPermExprs;
+              for (std::size_t i = 0; i < shardRank; ++i) {
+                shardPermExprs.push_back(rewriter.getAffineDimExpr(i));
+              }
+              std::swap(shardPermExprs[shardRank - 2],
+                        shardPermExprs[shardRank - 1]);
+              AffineMap shardInputMap =
+                  AffineMap::get(shardRank, 0, shardPermExprs, ctx);
               AffineMap shardIdentity =
                   rewriter.getMultiDimIdentityMap(shardRank);
-              SmallVector<AffineExpr> shardInExprs;
-              for (std::size_t i = 0; i < shardRank; ++i) {
-                shardInExprs.push_back(rewriter.getAffineDimExpr(i));
-              }
-              std::swap(shardInExprs[shardRank - 1],
-                        shardInExprs[shardRank - 2]);
-              AffineMap shardPermMap =
-                  AffineMap::get(shardRank, 0, shardInExprs, ctx);
               SmallVector<mlir::utils::IteratorType> linalgIters(
                   shardRank, mlir::utils::IteratorType::parallel);
               auto linalgOp = rewriter.create<linalg::GenericOp>(
                   loc, output.getType(), input, output,
-                  SmallVector<AffineMap>{shardPermMap, shardIdentity},
+                  SmallVector<AffineMap>{shardInputMap, shardIdentity},
                   linalgIters,
                   [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
                     Value transposed = b.create<d2m::TileTransposeOp>(
@@ -4367,94 +4161,47 @@ public:
         topkInput = transposeTiles(layoutedInput);
       }
 
-      // Setting up the arange op.
-      //
-      // dim==0 index construction has two strategies:
-      //
-      // (a) single-core (swapArange): the reduction runs along tile ROWS, but
-      //     the arange primitive naturally sequences indices along tile
-      //     COLUMNS. So build the ENTIRE arange+broadcast on a shape-SWAPPED
-      //     [wt, ht] buffer -- reusing the same column-sequencing/Row-
-      //     broadcast the dim==1 path uses -- then grid-transpose the result
-      //     back to [ht, wt] via transposeTilesGrid. After the transpose
-      //     idxBuf[r][c] == r == the global dim-0 index across all tiles.
-      //
-      // (b) multi-core banded along dim==0 (colMajorArange): a grid transpose
-      //     under a non-trivial (gridColsx1) grid is impossible -- the outer
-      //     d2m.generic's single grid-rank indexing map must simultaneously
-      //     describe an IDENTITY grid permutation (both operands share the
-      //     gridColsx1 grid) and a SWAPPING shard permutation (shard goes
-      //     [1,wt]->[wt,1]), which no single map can express. So instead build
-      //     the arange DIRECTLY in the natural [ht, wt] orientation and set
-      //     colMajor=true so ArangeBlockOp sequences indices DOWN the rows
-      //     (row-major global index), then Col-broadcast. This yields
-      //     idxBuf[r][c] == r with no transpose at all.
-      // isFoldedShard covers both the equal-band multi-core case (gridCols>1)
-      // and an uneven-split remainder band (gridCols==1, foldTotalShards>0):
-      // both are direct-allocated at a folded physical placement rather than
-      // the default unit-grid [0,0], so both need the colMajor arange
-      // construction (see the swapArange comment below for why the swapped
-      // construction is incompatible with a folded placement).
-      bool isFoldedShard = gridCols > 1 || foldTotalShards > 0;
-      bool colMajorArange = (dim == 0 && isFoldedShard);
-      bool swapArange = (dim == 0 && !colMajorArange);
+      // The multi-core case direct-allocates its buffers at a folded physical
+      // placement rather than the default unit-grid [0,0].
+      bool isFoldedShard = gridCols > 1;
 
-      // Arange emits integer indices; allocate its buffers with the index
-      // element type (bf16 for small reduction dims, Int32 otherwise) rather
-      // than f32.
       auto idxTileType = ttcore::TileType::get(idxElemType);
-      // Logical shape for the arange/bcast buffers: swapped for dim==0 so the
-      // sequence axis lands on columns, matching the dim==1-style construction.
+      // dim==0 swaps the last two dims so the reduction lands on the column
+      // axis, which fullTranspose undoes afterwards; dim==1 is already natural.
       SmallVector<int64_t> arangeLogicalShape(topkLogicalShape.begin(),
                                               topkLogicalShape.end());
-      if (swapArange) {
-        std::swap(arangeLogicalShape[rank - 1], arangeLogicalShape[rank - 2]);
+      if (dim == 0) {
+        std::swap(arangeLogicalShape[rank - 2], arangeLogicalShape[rank - 1]);
       }
       auto idxInputType = RankedTensorType::get(arangeLogicalShape, idxElemType,
                                                 inputType.getEncoding());
+      SmallVector<int64_t> arangeDeviceShape(deviceShape.begin(),
+                                             deviceShape.end());
+      ttcore::MetalLayoutAttr arangeMetalLayout = metalLayout;
+      if (dim == 0) {
+        std::swap(arangeDeviceShape[physicalRank - 2],
+                  arangeDeviceShape[physicalRank - 1]);
+        std::swap(arangeDeviceShape[2 * physicalRank - 2],
+                  arangeDeviceShape[2 * physicalRank - 1]);
+        SmallVector<int64_t> swappedLogical(
+            metalLayout.getLogicalShape().begin(),
+            metalLayout.getLogicalShape().end());
+        std::swap(swappedLogical[swappedLogical.size() - 2],
+                  swappedLogical[swappedLogical.size() - 1]);
+        arangeMetalLayout = ttcore::MetalLayoutAttr::get(
+            ctx, swappedLogical, metalLayout.getDimAlignments(),
+            metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
+            metalLayout.getMemoryLayout());
+      }
 
-      // For the swapped dim==0 buffer we must allocate the arange/bcast tensors
-      // DIRECTLY at the swapped physical [wt, ht] device shape. Routing through
-      // createOptimalLayoutOp instead re-derives the tile grid from the
-      // encoding collapse intervals and hands back the UN-swapped [ht, wt]
-      // shard, which makes the broadcast's linalg maps mismatch (expects [1,8],
-      // gets [8,1]). Build a swapped device shape + matching MetalLayoutAttr
-      // (mirrors the dst-side construction in transposeTilesGrid).
-      SmallVector<int64_t> swappedDeviceShape(deviceShape.begin(),
-                                              deviceShape.end());
-      std::swap(swappedDeviceShape[deviceShape.size() - 1],
-                swappedDeviceShape[deviceShape.size() - 2]);
-      constexpr int64_t kArangeTileDim = 32;
-      SmallVector<int64_t> swappedLogical = {
-          swappedDeviceShape[deviceShape.size() - 2] * kArangeTileDim,
-          swappedDeviceShape[deviceShape.size() - 1] * kArangeTileDim};
-      auto swappedMetalLayout = ttcore::MetalLayoutAttr::get(
-          ctx, swappedLogical, metalLayout.getDimAlignments(),
-          metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
-          metalLayout.getMemoryLayout());
-      // Shard the index buffer across the same gridCols cores as the input.
-      // For gridCols==1, toLayoutOperandsAndResults builds the unit-grid
-      // EmptyOp + to_layout as usual. For gridCols>1 we must NOT call it: it
-      // would materialize a full-width unit-grid buffer (e.g. 1x1x1x256 tiles =
-      // 1MB) on a single core, and overwriting the returned handle leaves that
-      // dead buffer in the IR where it still gets L1-allocated and overflows.
-      // Instead allocate the arange output directly at the sharded
-      // (1xgridCols or gridColsx1) device shape so each core owns only its
-      // band. Multi-core is either dim==1 (natural orientation) or dim==0 with
-      // colMajorArange (also natural [ht, wt] orientation, sequenced down rows
-      // in-block), so both use the un-swapped deviceShape here.
+      // A folded placement must not route through toLayoutOperandsAndResults,
+      // which leaves a dead full-width unit-grid buffer L1-allocated; allocate
+      // directly at the sharded device shape instead.
       SmallVector<Value> arangeOutputs;
       if (isFoldedShard) {
         auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, deviceShape, idxTileType, metalLayout);
-        attachFold(arangeEmpty);
-        arangeOutputs.push_back(arangeEmpty.getResult());
-      } else if (swapArange) {
-        // Direct-allocate at the swapped [wt, ht] device shape (see above);
-        // going through the layout infra would collapse it back to [ht, wt].
-        auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, swappedDeviceShape, idxTileType, swappedMetalLayout);
-        attachFold(arangeEmpty);
+            loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
+        attachArangeFold(arangeEmpty);
         arangeOutputs.push_back(arangeEmpty.getResult());
       } else {
         auto arangeOrigOutputs =
@@ -4487,17 +4234,17 @@ public:
                                     arangeScratchTileType, arangeScratchLayout)
               .getResult();
 
-      int64_t numElements =
-          (dim == 0) ? topkLogicalShape[rank - 2] : topkLogicalShape[rank - 1];
+      // DecomposeArange derives the global index purely from tile grid position
+      // and ignores numElements, so this is cosmetic, but keep it truthful.
+      int64_t numElements = topkLogicalShape[dim];
 
-      // Build affine maps: scratch input always at (0,0), output is identity.
+      // Scratch input always at (0,0), output is identity.
       AffineExpr zero = rewriter.getAffineConstantExpr(0);
       AffineMap arangeConstMap =
           AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
       AffineMap arangeIdentMap = rewriter.getMultiDimIdentityMap(physicalRank);
       SmallVector<AffineMap> arangeMaps = {arangeConstMap, arangeIdentMap};
 
-      // All iterators are parallel for arange.
       SmallVector<Attribute> arangeIters(
           physicalRank,
           ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
@@ -4520,47 +4267,32 @@ public:
                                    loc, idxTile, outTile, numElements,
                                    /*start=*/arangeStart,
                                    /*step=*/1,
-                                   /*colMajor=*/colMajorArange)
+                                   // Both dims build the arange row-major:
+                                   // ArangeBlockOp sequences the global index
+                                   // along tile COLUMNS, which is natural for
+                                   // dim==1 and shape-swapped (then
+                                   // fullTransposed back) for dim==0.
+                                   /*colMajor=*/false)
                                .getResult();
             return {result};
           });
 
-      // Setting up the broadcast after arange.
-
-      // Broadcast first row or column to full shape.
-      //   dim==1 and swapped dim==0 (single-core): arange sequences indices
-      //     along COLUMNS, so value at (r,c) == c (same for all rows) ->
-      //     broadcast row 0 DOWN the rows (Row broadcast). Swapped dim==0 is
-      //     handled on its [wt, ht] buffer here and grid-transposed to [ht, wt]
-      //     afterwards.
-      //   colMajorArange (multi-core dim==0): arange sequences indices DOWN
-      //     the ROWS, so value at (r,c) == r (same for all cols) -> broadcast
-      //     col 0 ACROSS the columns (Col broadcast). No transpose afterwards.
-      d2m::TileBcastType postArangeBcastType =
-          colMajorArange ? d2m::TileBcastType::Col : d2m::TileBcastType::Row;
+      // The row-major arange sequences indices along COLUMNS, so broadcast row
+      // 0 down the rows. For dim==0 the buffer is shape-swapped, so this fills
+      // each row with the reduction sequence and fullTranspose reorients it.
       d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
-          d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
+          d2m::TileBcastTypeAttr::get(ctx, d2m::TileBcastType::Row);
       SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
                                                arange.getResults().end());
       SmallVector<Value> postArangeBcastOutputs;
-      // For multicore, allocate the broadcast output at the sharded device
-      // shape (1xgridCols or gridColsx1, natural orientation for both dim==1
-      // and colMajorArange dim==0) so its L1 buffer is split across cores and
-      // its operand grid matches the sharded arange input (and topkInput).
+      // Allocate at the sharded arange device shape so the L1 buffer splits
+      // across cores and the operand grid matches the sharded arange input.
       if (isFoldedShard) {
         auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, deviceShape, idxTileType, metalLayout);
-        attachFold(bcastEmpty);
-        postArangeBcastOutputs.push_back(bcastEmpty.getResult());
-      } else if (swapArange) {
-        // Match the swapped [wt, ht] arange input so the broadcast's linalg
-        // maps line up (see the swappedDeviceShape rationale above).
-        auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
-            loc, swappedDeviceShape, idxTileType, swappedMetalLayout);
-        attachFold(bcastEmpty);
+            loc, arangeDeviceShape, idxTileType, arangeMetalLayout);
+        attachArangeFold(bcastEmpty);
         postArangeBcastOutputs.push_back(bcastEmpty.getResult());
       } else {
-        // For single-core, use the standard layout wrapping.
         auto postArangeBcastOrigOutputs =
             createDpsOutputs(loc, rewriter, {idxInputType});
         auto [postArangeBcastins, laidOut] = toLayoutOperandsAndResults(
@@ -4569,19 +4301,9 @@ public:
         postArangeBcastOutputs = std::move(laidOut);
       }
 
-      // Build affine maps: input is reduced, output is identity.
       mlir::MutableAffineMap postArangeInMap(
           rewriter.getMultiDimIdentityMap(physicalRank));
-      switch (postArangeBcastType) {
-      case d2m::TileBcastType::Row:
-        postArangeInMap.setResult(physicalRank - 2, zero);
-        break;
-      case d2m::TileBcastType::Col:
-        postArangeInMap.setResult(physicalRank - 1, zero);
-        break;
-      default:
-        break;
-      }
+      postArangeInMap.setResult(physicalRank - 2, zero);
       AffineMap postArangeBcastInputMap = postArangeInMap.getAffineMap();
       AffineMap postArangeBcastOutputMap =
           rewriter.getMultiDimIdentityMap(physicalRank);
@@ -4608,25 +4330,13 @@ public:
             Value output = blockArgs[1];
             std::size_t shardRank =
                 cast<RankedTensorType>(output.getType()).getRank();
-            // Reuse the outer d2m.generic's projecting maps (input map zeroes
-            // the broadcast axis). An identity map would make linalg infer the
-            // broadcast-axis extent from the iteration domain, mismatching the
-            // collapsed input shard when the non-target dim spans >1 tile (e.g.
-            // ht=2 for dim=1).
+            // Must zero the broadcast axis: an identity map would make linalg
+            // infer that axis's extent from the iteration domain, mismatching
+            // the collapsed input shard when the non-target dim spans >1 tile.
             mlir::MutableAffineMap shardInMap(
                 rewriter.getMultiDimIdentityMap(shardRank));
-            switch (postArangeBcastType) {
-            case d2m::TileBcastType::Row:
-              shardInMap.setResult(shardRank - 2,
-                                   rewriter.getAffineConstantExpr(0));
-              break;
-            case d2m::TileBcastType::Col:
-              shardInMap.setResult(shardRank - 1,
-                                   rewriter.getAffineConstantExpr(0));
-              break;
-            default:
-              break;
-            }
+            shardInMap.setResult(shardRank - 2,
+                                 rewriter.getAffineConstantExpr(0));
             AffineMap shardInputMap = shardInMap.getAffineMap();
             AffineMap shardIdentity =
                 rewriter.getMultiDimIdentityMap(shardRank);
@@ -4645,34 +4355,25 @@ public:
             return {linalgOp->getResult(0)};
           });
 
-      Value indexOperand = postArangeBcast->getResult(0);
-      Value idxBuf = wrapInToLayout(indexOperand);
+      // The bcast result is in the swapped arange orientation for dim==0 and
+      // natural for dim==1, so wrap it with the matching fold placement.
+      Value idxBuf = wrapInToLayout(postArangeBcast->getResult(0),
+                                    /*useArangeFold=*/dim == 0);
 
       // TopkBlockOp reads value and index tiles in lockstep, so bring the index
-      // buffer into the same orientation as the value input.
-      //   dim==1: arange+bcast yields idxBuf[row][col] = col; a per-tile
-      //     transpose makes the column index vary along the tile's row axis,
-      //     matching the transposed value tile.
-      //   dim==0 single-core (swapArange): idxBuf was built on the swapped
-      //     [wt, ht] buffer with the [0..R-1] sequence running along its
-      //     columns; a GRID transpose swaps the tile-grid dims AND transposes
-      //     within each tile, producing the genuine [ht, wt] buffer where
-      //     idxBuf[r][c] == r (the global dim-0 index) across all tiles. A
-      //     per-tile transpose alone would be wrong for ht>1 because it cannot
-      //     move the sequence across tile rows.
-      //   dim==0 multi-core (colMajorArange): idxBuf was built DIRECTLY in the
-      //     [ht, wt] orientation with colMajor sequencing (idxBuf[r][c] == r
-      //     already), matching the un-transposed value input, so NO transpose.
+      // buffer into the value input's orientation. dim==1 needs only a per-tile
+      // transpose; dim==0 needs a full grid+tile transpose to turn the column
+      // sequence into the down-the-rows sequence the value input expects.
       if (dim == 1) {
         idxBuf = transposeTiles(idxBuf);
-      } else if (!colMajorArange) {
-        idxBuf = transposeTilesGrid(idxBuf);
+      } else {
+        idxBuf = fullTranspose(idxBuf);
       }
 
       auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
           loc, deviceShape, f32TileType, metalLayout);
       auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, deviceShape, topkIdxTileType, metalLayout);
+          loc, deviceShape, idxTileType, metalLayout);
       attachFold(topkValsEmpty);
       attachFold(topkIdxEmpty);
 
@@ -4695,46 +4396,22 @@ public:
             return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
           });
 
-      // Single-core: return the whole topk result as one grid-1x1 partial; the
-      // driver's extract reads its tile 0 (k<=32) / leading tiles (k>32).
+      // The whole result as one grid-1x1 partial; the extract reads its
+      // leading tiles.
       if (gridCols == 1) {
         return {{wrapInToLayout(topkGeneric->getResult(0)),
                  wrapInToLayout(topkGeneric->getResult(1))}};
       }
 
-      // Multi-core gather (mirrors the reference D2MLowerGatherCore pattern:
-      // one collector core DMA-reads one payload per source core). Each source
-      // core's local top-k lives in the leading outputReductionTiles
-      // reduction tiles of its band shard (canonical winner=tile0/loser=tile1
-      // for k>32), across the FULL non-target extent (nonTargetTiles tiles).
-      // We produce gridCols separate grid-1x1 partials of shape
-      // [nonTargetTiles, outputReductionTiles] -- one per source core -- so
-      // the driver can CompositeView them and run a final merge topk_block.
-      // Building them as separate SSAs (rather than one wide buffer) is what
-      // lets ExpandDMAReadCompositeView later expand the merge's DMA read into
-      // gridCols per-source reads (a plain multi-tile ViewLayoutOp does NOT
-      // gather across cores; only a CompositeView does).
-      //
-      // The collector is a single grid-1x1 generic. Its region loops over the
-      // gridCols source grid bands issuing a remote_load from the band's
-      // logical grid position (which lowers to a shard-level DMA read from
-      // source core g), copies that band's leading outputReductionTiles
-      // reduction tiles (all nonTargetTiles non-target rows) into a fresh
-      // [nonTargetTiles, outputReductionTiles] buffer, and stores it.
-      // remote_load's grid index is loop-varying, so each iteration pulls a
-      // distinct core.
+      // Multi-core gather: one collector core DMA-reads one payload per source
+      // core, producing a grid-1x1 partial per source to CompositeView.
       SmallVector<std::pair<Value, Value>> partials;
-      // A grid-1x1 device layout for each gathered partial, of shape
-      // [nonTargetTiles, outputReductionTiles] tiles: derive it from the topk
-      // output's shard by shrinking the reduction dim to outputReductionTiles
-      // tiles while keeping the non-target dim's full tile extent.
       std::size_t redPhys =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       std::size_t deviceRedDimLocal =
           deviceShape.size() - (physicalRank - redPhys);
-      // Shard portion is the trailing physicalRank dims of deviceShape, laid
-      // out as [nonTarget, reduction] for dim==1 or [reduction, nonTarget] for
-      // dim==0; the non-target shard dim is deviceRedDimLocal's sibling.
+      // The shard portion is [nonTarget, reduction] for dim==1 and the reverse
+      // for dim==0, so the non-target dim is deviceRedDimLocal's sibling.
       std::size_t deviceNonTargetDimLocal =
           (dim == 1) ? deviceRedDimLocal - 1 : deviceRedDimLocal + 1;
       SmallVector<int64_t> perCorePartialShape(deviceShape.begin(),
@@ -4744,17 +4421,9 @@ public:
       perCorePartialShape[deviceRedDimLocal] = outputReductionTiles;
       perCorePartialShape[deviceNonTargetDimLocal] = nonTargetTiles;
 
-      // Each partial is a grid-1x1 [nonTargetTiles, outputReductionTiles]-tile
-      // buffer, so its layout's logical shape must be the
-      // nonTargetTiles*32 x outputReductionTiles*32 (or the transpose)
-      // extent, NOT the original input's full logical shape. The downstream
-      // CompositeViewOp verifier sums the partials' logical reduction extents
-      // and requires the total to equal the composite output's logical
-      // reduction extent (numShards*outputReductionTiles*32), and requires
-      // the non-composite (non-target) logical extent to match exactly
-      // across all partials and the output; with the original logical shape
-      // each partial would report the full reduction extent and the sum
-      // would blow up.
+      // Must report its own narrow tile extent, not the input's full logical
+      // shape: the CompositeViewOp verifier sums the partials' logical
+      // reduction extents against the composite output's.
       constexpr int64_t kTileDimLocal = 32;
       ttcore::MetalLayoutAttr perCorePartialLayout =
           ttcore::MetalLayoutAttr::get(
@@ -4768,10 +4437,8 @@ public:
               metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
               metalLayout.getMemoryLayout());
 
-      // Emits the collector generic for one topk result (values or index),
-      // returning gridCols grid-1x1 partials (partial g == source core g's
-      // leading outputReductionTiles reduction tiles, across the full
-      // nonTargetTiles extent).
+      // Returns gridCols grid-1x1 partials, where partial g holds source core
+      // g's leading reduction tiles across the full non-target extent.
       auto gatherPerCore = [&](Value gridResult) -> SmallVector<Value> {
         auto gridType = cast<RankedTensorType>(gridResult.getType());
         auto tileType = cast<ttcore::TileType>(gridType.getElementType());
@@ -4779,13 +4446,9 @@ public:
         for (int64_t g = 0; g < gridCols; ++g) {
           auto outEmpty = rewriter.create<d2m::EmptyOp>(
               loc, perCorePartialShape, tileType, perCorePartialLayout);
-          // Place partial g's collector output at physical linear index g
-          // (same offset-core fold idiom as the remainder band and the merge
-          // tree) so the gridCols collected partials live on gridCols distinct
-          // cores instead of all piling onto core (0,0): without this, every
-          // one of the gridCols collector generics below defaults to an
-          // unfolded unit grid, so all their live buffers colocate on one core
-          // and blow the L1 budget for wide numShards.
+          // Place partial g at physical linear index g so the partials live on
+          // distinct cores. Otherwise every collector defaults to an unfolded
+          // unit grid and they all blow one core's L1 budget.
           {
             SmallVector<int64_t> unitGrid = {1, 1};
             auto [gatherFwd, gatherInv] =
@@ -4797,13 +4460,10 @@ public:
           }
           SmallVector<Value> ins = {gridResult};
           SmallVector<Value> outs = {outEmpty.getResult()};
-          // Grid-1x1 collector generic. The input is the whole [1,gridCols]
-          // grid result but this generic runs on a single core and gathers
-          // across cores via an explicit remote_load in its region (below), so
-          // the input's grid must NOT be required to match the [1,1] output.
-          // Give the input a constant (0,0) map so the grid verifier exempts it
-          // from the identity-map grid-equality check (same idiom as arange's
-          // scratch operand); the output keeps the identity map.
+          // Grid-1x1 collector generic. Its input is the whole grid result, but
+          // it runs on one core and gathers via the explicit remote_load below,
+          // so a constant (0,0) input map exempts it from the verifier's
+          // grid-equality check while the output keeps the identity map.
           AffineMap collectorInputMap = AffineMap::get(
               physicalRank, 0,
               SmallVector<AffineExpr>(physicalRank,
@@ -4816,9 +4476,9 @@ public:
               rewriter.getArrayAttr(iteratorTypes));
           generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
-          // Build the region manually: the auto-generated region would emit a
-          // single remote_load at the block index; we instead want an explicit
-          // load from source grid column g.
+          // Build the region manually, since the auto-generated one would emit
+          // a single remote_load at the block index rather than the explicit
+          // load from source grid column g that we want.
           {
             auto insertPoint = rewriter.saveInsertionPoint();
             rewriter.startOpModification(generic);
@@ -4826,8 +4486,6 @@ public:
             mlir::Block *block = rewriter.createBlock(&region);
             rewriter.setInsertionPointToStart(block);
 
-            // Local buffers: shard buffer to load a source band into, and the
-            // output shard buffer.
             auto srcShardType = RankedTensorType::get(
                 cast<RankedTensorType>(gridResult.getType())
                     .getShape()
@@ -4843,13 +4501,10 @@ public:
                     .create<tensor::EmptyOp>(loc, srcShardType.getShape(),
                                              srcShardType.getElementType())
                     .getResult();
-            // remote_load source band g: LOGICAL grid index [0, g] for dim==1
-            // (1xgridCols banding) or [g, 0] for dim==0 (gridColsx1 banding).
-            // The source buffer carries a virtual-grid forward map (attached
-            // where its sharded layout is built), and the DMA address path
-            // composes that map to fold the logical position onto the
-            // physical core band g actually lives on. So we address the
-            // logical position, not the folded physical core.
+            // remote_load source band g at its LOGICAL grid index, [0, g] for
+            // dim==1 and [g, 0] for dim==0. The source buffer carries a
+            // virtual-grid forward map that the DMA address path composes to
+            // reach the physical core band g lives on.
             Value zeroGrid = rewriter.create<arith::ConstantIndexOp>(loc, 0);
             Value bandGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
             SmallVector<Value> srcIndices =
@@ -4861,9 +4516,6 @@ public:
                                                gridResult, srcIndices)
                     .getResult();
 
-            // Copy the loaded band's leading outputReductionTiles reduction
-            // tiles (all nonTargetTiles non-target rows) into the
-            // [nonTargetTiles, outputReductionTiles] output shard.
             Value outBuf =
                 rewriter
                     .create<tensor::EmptyOp>(loc, outShardType.getShape(),
@@ -4871,40 +4523,9 @@ public:
                     .getResult();
             std::size_t shardRank = outShardType.getShape().size();
             std::size_t shardRedDim = shardRank - (physicalRank - redPhys);
-            int64_t inReductionExtent = srcShardType.getShape()[shardRedDim];
-            // Non-invertible input map on the reduction dim
-            // (`dim mod inReductionExtent`) so linalg takes the loop bound from
-            // the outputReductionTiles-wide output, NOT the full band: without
-            // it, linalg would infer the input operand's reduction extent from
-            // the loop bound and mismatch the loaded band's full extent. Since
-            // the loop index ranges [0, outputReductionTiles) and
-            // outputReductionTiles <= inReductionExtent, `idx mod extent ==
-            // idx` reads exactly the leading outputReductionTiles tiles -- tile
-            // 0 (and tile 1 for k>32), the canonical winner/loser layout. Same
-            // idiom as the extract generic.
-            SmallVector<AffineExpr> shardInExprs;
-            for (std::size_t i = 0; i < shardRank; ++i) {
-              shardInExprs.push_back(i == shardRedDim
-                                         ? rewriter.getAffineDimExpr(i) %
-                                               inReductionExtent
-                                         : rewriter.getAffineDimExpr(i));
-            }
-            AffineMap shardInMap =
-                AffineMap::get(shardRank, 0, shardInExprs, ctx);
-            AffineMap shardIdentity =
-                rewriter.getMultiDimIdentityMap(shardRank);
-            SmallVector<mlir::utils::IteratorType> linalgIters(
-                shardRank, mlir::utils::IteratorType::parallel);
-            auto linalgOp = rewriter.create<linalg::GenericOp>(
-                loc, outBuf.getType(), loaded, outBuf,
-                SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
-                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                  Value copied = b.create<d2m::TileTypecastOp>(
-                      bodyLoc, args[1].getType(), args[0]);
-                  b.create<linalg::YieldOp>(bodyLoc, copied);
-                });
+            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded,
+                                                outBuf, shardRedDim);
 
-            // Store into grid [0,0] of the grid-1x1 output.
             SmallVector<Value> outIndices =
                 d2m::utils::buildGridIndices(rewriter, loc, identityMap);
             Value storeResult =
@@ -4917,10 +4538,9 @@ public:
             rewriter.finalizeOpModification(generic);
             rewriter.restoreInsertionPoint(insertPoint);
           }
-          // Relayout to a fresh buffer at partial g's OWN per-g fold (built
-          // above for outEmpty), NOT emitShardTopk's input-band fold (which
-          // wrapInToLayout would apply and is a gridCols-wide fold, wrong for
-          // this single-core partial).
+          // Relayout to a fresh buffer at partial g's own per-g fold, not
+          // emitShardTopk's gridCols-wide input-band fold, which is what
+          // wrapInToLayout would apply and is wrong for a single-core partial.
           auto relayoutEmpty = rewriter.create<d2m::EmptyOp>(
               loc, perCorePartialShape, tileType, perCorePartialLayout);
           relayoutEmpty.setVirtualGridForwardMappingAttr(
@@ -4935,36 +4555,11 @@ public:
         return gathered;
       };
 
-      // Per-band pre-compaction (multi-core only): copy each band's leading
-      // outputReductionTiles reduction tiles into a narrow fresh buffer,
-      // grid-preserving ([1,gridCols] / gridColsx1), BEFORE the cross-core
-      // gather. Without this the wide leaf topk result (bandTiles reduction
-      // tiles per core, for BOTH values and indices) stays live across all
-      // gridCols collector reads -- every band core holds ~2*bandTiles tiles
-      // for the whole gather phase, which overflows L1 for wide reductions
-      // (e.g. 32x65536 -> 64 bands of 32 tiles). Compacting first drops that
-      // sustained-across-gather footprint to ~2*outputReductionTiles
-      // tiles/core; the wide leaf result dies at this generic's read.
-      //
-      // Grid-preserving: input and output both live on the [1,gridCols] (or
-      // gridColsx1) band grid, so output band g must read INPUT band g (its own
-      // core's wide leaf result), narrow it to outputReductionTiles tiles, and
-      // keep it resident on that same core. Correctness hinges on band-g-reads-
-      // band-g: we canNOT express that with an affine input map, because the
-      // reduction dim is simultaneously the grid-partition dim (gridCols) and
-      // the shard tile dim (bandTiles). An identity map on that dim would read
-      // band g correctly at the grid level, but re-enables the shard-shape
-      // verifier check (which then fails: input shard bandTiles !=
-      // outputReductionTiles). A constant-0 map exempts the shard check
-      // (hasOperandBroadcasting), but then reads band 0 for every cell.
-      //
-      // Resolution (same idiom as gatherPerCore): give the input a constant
-      // grid map so BOTH verifier checks (grid + shard) are bypassed, then
-      // drive the real per-cell read with an EXPLICIT remote_load whose grid
-      // index is this cell's own position (buildGridIndices over the identity
-      // map -> BlockIndexOp per dim). Cell g thus loads band g, narrows the
-      // leading outputReductionTiles tiles via the inner linalg's
-      // `dim mod extent`, and stores back to its own cell.
+      // Per-band pre-compaction: narrow each band in place, before the
+      // cross-core gather, or the wide leaf result stays live on every core
+      // and overflows L1. No affine input map can express "band g reads band
+      // g and stays put," so a constant grid map bypasses the verifier and an
+      // explicit remote_load at this cell's own position drives the real read.
       auto compactBands = [&](Value wideResult) -> Value {
         auto wideType = cast<RankedTensorType>(wideResult.getType());
         auto tileType = cast<ttcore::TileType>(wideType.getElementType());
@@ -4988,10 +4583,9 @@ public:
 
         std::size_t genRedDim =
             (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-        // Constant grid map on the input: makes hasOperandBroadcasting true so
-        // the verifier skips BOTH the grid-equality and the shard-shape checks
-        // for this operand. The real read is the explicit remote_load below;
-        // the output keeps the identity map.
+        // A constant grid map on the input makes hasOperandBroadcasting true,
+        // so the verifier skips both the grid-equality and shard-shape checks
+        // for it. The real read is the remote_load below.
         AffineMap constInMap =
             AffineMap::get(physicalRank, 0,
                            SmallVector<AffineExpr>(
@@ -5006,10 +4600,9 @@ public:
             rewriter.getArrayAttr(iteratorTypes));
         generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
-        // Build the region manually: the auto-generated region would
-        // remote_load at the constant input map's grid index (band 0) -- the
-        // bug. We instead load from THIS cell's own grid position (identity),
-        // narrow, and store.
+        // Build the region manually, since the auto-generated one would
+        // remote_load at the constant input map's grid index, i.e. band 0. Load
+        // from this cell's own grid position instead, then narrow and store.
         {
           auto insertPoint = rewriter.saveInsertionPoint();
           rewriter.startOpModification(generic);
@@ -5023,13 +4616,10 @@ public:
               ArrayRef<int64_t>(narrowShape).take_back(physicalRank), tileType);
           std::size_t shardRank = outShardType.getRank();
           std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-          int64_t inShardReductionExtent = inShardType.getShape()[shardRedDim];
 
-          // remote_load band g: grid index = this cell's own position (identity
-          // map -> BlockIndexOp per dim), so band g reads band g. The source
-          // buffer carries a virtual-grid fold, composed by the DMA address
-          // path onto the physical core band g lives on -- addressed via the
-          // logical position, same as gatherPerCore.
+          // remote_load at this cell's own grid position, so band g reads band
+          // g. The source buffer's virtual-grid fold is composed by the DMA
+          // address path onto the physical core, so the index stays logical.
           Value loadBuf =
               rewriter
                   .create<tensor::EmptyOp>(loc, inShardType.getShape(),
@@ -5043,36 +4633,14 @@ public:
                                              wideResult, srcIndices)
                   .getResult();
 
-          // Copy the loaded band's leading outputReductionTiles reduction tiles
-          // into the narrow output shard. `dim mod extent` clamps the loop
-          // bound to the output while reading the leading tiles of the input.
           Value outBuf =
               rewriter
                   .create<tensor::EmptyOp>(loc, outShardType.getShape(),
                                            outShardType.getElementType())
                   .getResult();
-          SmallVector<AffineExpr> shardInExprs;
-          for (std::size_t i = 0; i < shardRank; ++i) {
-            shardInExprs.push_back(i == shardRedDim
-                                       ? rewriter.getAffineDimExpr(i) %
-                                             inShardReductionExtent
-                                       : rewriter.getAffineDimExpr(i));
-          }
-          AffineMap shardInMap =
-              AffineMap::get(shardRank, 0, shardInExprs, ctx);
-          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
-          SmallVector<mlir::utils::IteratorType> linalgIters(
-              shardRank, mlir::utils::IteratorType::parallel);
-          auto linalgOp = rewriter.create<linalg::GenericOp>(
-              loc, outBuf.getType(), loaded, outBuf,
-              SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
-              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                Value copied = b.create<d2m::TileTypecastOp>(
-                    bodyLoc, args[1].getType(), args[0]);
-                b.create<linalg::YieldOp>(bodyLoc, copied);
-              });
+          auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded,
+                                              outBuf, shardRedDim);
 
-          // Store into this cell's own grid position (identity output map).
           SmallVector<Value> outIndices =
               d2m::utils::buildGridIndices(rewriter, loc, identityMap);
           Value storeResult =
@@ -5099,30 +4667,10 @@ public:
       return partials;
     }; // emitShardTopk
 
-    // ----- Drive the shard topk(s): single-core or the multi-core tree. -----
-
-    // physicalRank / lastStride are needed by the shared extract tail below
-    // and do not depend on which shard produced the result. physicalRank
-    // equals the input rank (device layout is grid + shard, each of input
-    // rank). outputReductionTiles is computed once, above, before the
-    // multi-core gather/merge lambdas that capture it. For k>32 the result
-    // spans 2 tiles; D2MDecomposeTopk's left-fold keeps the accumulator at
-    // canonical tiles (winner=0, loser=1), so the extract reads tile j from
-    // input tile j (lastStride=1) for any tile count, with no power-of-2
-    // padding. For k<=32 lastStride is unused. Extract/merge index buffers
-    // carry the same index element type chosen above (bf16 for small
-    // reduction dims, else Int32).
-    Type extractIdxElemType = idxElemType;
     std::size_t physicalRank = static_cast<std::size_t>(rank);
-    int64_t lastStride = 1;
 
-    // Fold maps for the CURRENTLY-EMITTING merge group, so every buffer a
-    // mergePartials call allocates lands on that group's assigned physical
-    // core (see the merge-tree loop, which assigns one core per group per
-    // round). Null outside a mergePartials call (single-core path, or between
-    // groups) -- then EmptyOps stay unit-grid on core (0,0), the original
-    // behavior. Set/cleared by mergePartials; the outer relayout/compactToTile
-    // helpers read them so their EmptyOps co-locate with the merge.
+    // Set for the currently-emitting merge group so its buffers land on that
+    // group's core; null outside one, leaving EmptyOps unit-grid on (0,0).
     AffineMapAttr mergeFoldForwardAttr, mergeFoldInverseAttr;
     auto attachMergeFold = [&](d2m::EmptyOp emptyOp) {
       if (mergeFoldForwardAttr) {
@@ -5131,7 +4679,6 @@ public:
       }
     };
 
-    // to_layout wrapper usable at this (outer) scope for the merge tree.
     auto relayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
       auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
@@ -5145,19 +4692,14 @@ public:
         ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
     SmallVector<Attribute> mergeIters(physicalRank, parallelAttr);
     AffineMap mergeIdentity = rewriter.getMultiDimIdentityMap(physicalRank);
-    // Device-tensor index of the reduction dim. The device layout is rank
-    // 2*physicalRank ([grid..., shard...]); the reduction tiles live in the
-    // shard portion, i.e. the last shard dim for dim==1 and the first shard dim
-    // for dim==0. compactToTile reshapes the device tensor, so it must index
-    // here, not in shard space.
+    // Reduction tiles live in the shard portion of the [grid..., shard...]
+    // layout: the last shard dim for dim==1 and the first for dim==0.
+    // compactToTile reshapes the device tensor, so it indexes here, not in
+    // shard space.
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // Rebuilds a MetalLayoutAttr from `layout` but with a logical shape that
-    // matches `deviceShape`'s tile counts (tileRows*32 x tileCols*32). The
-    // CompositeViewOp verifier checks logical shapes, so the layout's logical
-    // shape must track the physical tile count as the merge tree grows/shrinks
-    // the reduction dim.
+    // Rebuilds `layout` with a logical shape matching `deviceShape`'s tiles.
     auto layoutForDeviceShape =
         [&](ttcore::MetalLayoutAttr layout,
             ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
@@ -5171,27 +4713,8 @@ public:
           layout.getMemoryLayout());
     };
 
-    // Compacts the leading outputReductionTiles reduction tiles of a
-    // full-width partial (across its full non-target extent) into a fresh
-    // outputReductionTiles-reduction-tile device-layout buffer, giving a
-    // distinct SSA value the merge tree can CompositeView.
-    //
-    // The D2M generic-level input map MUST be a projected permutation (D2MOps
-    // inverts it for grid/DMA index generation; `dim mod extent` is not one
-    // and trips inverseAndBroadcastProjectedPermutation). It projects the
-    // reduction dim to constant 0 (a valid projected-permutation broadcast),
-    // identity elsewhere -- same map as the original k<=32 path. It only
-    // drives grid index generation, NOT the region's input shard shape: the
-    // input block arg always gets the operand's FULL shard shape (see
-    // createBlockArguments' getShardType, which reads the layout, not the
-    // indexing map), so it spans all groupTiles*outputReductionTiles reduction
-    // tiles. The real leading-tiles selection happens on the INNER
-    // linalg.generic, which is ordinary linalg and admits a non-invertible
-    // `dim mod extent` reduction map: since the reduction index ranges
-    // [0, outputReductionTiles) and outputReductionTiles <= the input's
-    // reduction extent, `idx mod extent == idx` copies exactly the leading
-    // tiles -- tile 0 (and tile 1 for k>32), the canonical winner/loser
-    // layout.
+    // Compacts a partial into a fresh narrow buffer, giving the merge tree a
+    // distinct SSA value to CompositeView.
     auto compactToTile = [&](Value fullPartial) -> Value {
       auto fullType = cast<RankedTensorType>(fullPartial.getType());
       auto tileType = cast<ttcore::TileType>(fullType.getElementType());
@@ -5199,16 +4722,14 @@ public:
       SmallVector<int64_t> compactShape(fullType.getShape().begin(),
                                         fullType.getShape().end());
       compactShape[deviceRedDim] = outputReductionTiles;
-      // Fresh layout whose logical shape matches the compacted physical
-      // shape (the CompositeViewOp verifier reads logical shapes).
       auto compactLayout = layoutForDeviceShape(layout, compactShape);
       auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, compactShape, tileType,
                                                     compactLayout);
       attachMergeFold(outEmpty);
       std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      // Generic-level input map: constant-0 on the reduction dim, identity
-      // elsewhere (projected permutation; drives grid indices only).
+      // Must stay a projected permutation, so leading-tile selection happens on
+      // the inner linalg instead.
       SmallVector<AffineExpr> inExprs;
       for (std::size_t i = 0; i < physicalRank; ++i) {
         inExprs.push_back(i == genRedDim ? rewriter.getAffineConstantExpr(0)
@@ -5228,35 +4749,11 @@ public:
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
             Value input = blockArgs[0];
             Value output = blockArgs[1];
-            auto inShardType = cast<RankedTensorType>(input.getType());
             std::size_t shardRank =
                 cast<RankedTensorType>(output.getType()).getRank();
             std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-            int64_t inShardReductionExtent =
-                inShardType.getShape()[shardRedDim];
-            // Copy of the leading tiles of the input into the compacted
-            // output; `dim mod extent` clamps the loop bound to the output.
-            SmallVector<AffineExpr> shardInExprs;
-            for (std::size_t i = 0; i < shardRank; ++i) {
-              shardInExprs.push_back(i == shardRedDim
-                                         ? rewriter.getAffineDimExpr(i) %
-                                               inShardReductionExtent
-                                         : rewriter.getAffineDimExpr(i));
-            }
-            AffineMap shardInMap =
-                AffineMap::get(shardRank, 0, shardInExprs, ctx);
-            AffineMap shardIdentity =
-                rewriter.getMultiDimIdentityMap(shardRank);
-            SmallVector<mlir::utils::IteratorType> linalgIters(
-                shardRank, mlir::utils::IteratorType::parallel);
-            auto linalgOp = rewriter.create<linalg::GenericOp>(
-                loc, output.getType(), input, output,
-                SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
-                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                  Value copied = b.create<d2m::TileTypecastOp>(
-                      bodyLoc, args[1].getType(), args[0]);
-                  b.create<linalg::YieldOp>(bodyLoc, copied);
-                });
+            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, input,
+                                                output, shardRedDim);
             return {linalgOp->getResult(0)};
           });
       return relayout(generic->getResult(0));
@@ -5269,50 +4766,19 @@ public:
       topkValsRelayouted = partials[0].first;
       topkIdxRelayouted = partials[0].second;
     } else {
-      // Distributed local topk: each of numShards cores runs topk_block on its
-      // own reduction-dim band. emitShardTopk gathers the per-core results into
-      // numShards separate grid-1x1 [nonTargetTiles, outputReductionTiles]-tile
-      // partials (one per source core, values + global indices), using an
-      // explicit per-source DMA collector (see emitShardTopk). CompositeView
-      // all numShards value partials (and, separately, index partials) into
-      // one [nonTargetTiles, numShards * outputReductionTiles]-tile buffer
-      // along the reduction dim, materialize, then run ONE final topk_block
-      // over those tiles to select the global top-k. The composite view is
-      // what makes ExpandDMAReadCompositeView pull each partial from its
-      // source core. One uniform sharded tensor: numShards bands of bandTiles
-      // reduction tiles each. When numShards does not divide
-      // fullReductionTiles evenly, the sharded buffer is padded to numShards
-      // * bandTiles tiles and the tail masked with -inf inside emitShardTopk
-      // (paddedReductionTiles), so every band is the same width and the
-      // padding lanes never win top-k.
+      // Each of numShards cores runs topk_block on its own band.
       SmallVector<std::pair<Value, Value>> partials =
           emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
                         /*gridCols=*/numShards);
 
-      // Merge a group of [nonTargetTiles, outputReductionTiles]-tile partials
-      // into a single top-k [nonTargetTiles, outputReductionTiles]-tile
-      // (values, indices) pair on one core: CompositeView the group along the
-      // reduction dim, materialize, run ONE topk_block, and compact back to
-      // outputReductionTiles reduction tiles.
-      // A single topk_block can only reduce tiles co-located on its core, so a
-      // group is capped at maxMultiCoreReductionTilesPerCore partials (L1-safe;
-      // that cap is already divided by outputReductionTiles at its definition
-      // above). For numShards > maxMultiCoreReductionTilesPerCore the driver
-      // below feeds this into a multi-level merge tree so no core ever holds
-      // more than the budget in tiles.
-      // foldColBase >= 0 places this whole merge (all its buffers and the
-      // topk_block) on the worker core at physical linear index foldColBase,
-      // via the same offset-core virtual-grid fold the remainder band uses.
-      // The group's input partials already carry their own fold maps (pointing
-      // at whatever cores they were produced on), so the CompositeView's
-      // DMA-read expansion gathers them onto this merge's core. foldColBase < 0
-      // leaves the merge unit-grid on core (0,0) (the original behavior).
+      // Merges a group into one (values, indices) pair on one core:
+      // CompositeView, materialize, run one topk_block, compact back down.
+      // foldColBase >= 0 places the merge at that worker linear index;
+      // negative leaves it on (0,0).
       auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group,
                                int64_t foldColBase =
                                    -1) -> std::pair<Value, Value> {
-        // Set the group's fold maps (read by relayout/compactToTile and the
-        // local EmptyOps below); clear them on return so buffers emitted
-        // between groups stay unit-grid.
+        // Cleared on return so buffers emitted between groups stay unit-grid.
         mergeFoldForwardAttr = nullptr;
         mergeFoldInverseAttr = nullptr;
         if (foldColBase >= 0) {
@@ -5329,11 +4795,6 @@ public:
 
         int64_t groupTiles = static_cast<int64_t>(group.size());
 
-        // Build a (groupTiles * outputReductionTiles)-tile buffer type along
-        // the reduction dim from a partial's layout (each partial carries
-        // outputReductionTiles reduction tiles). Values and indices carry
-        // different element types (f32 vs Int32), so build a wide type per
-        // side.
         auto partialType = cast<RankedTensorType>(group[0].first.getType());
         auto tileType = cast<ttcore::TileType>(partialType.getElementType());
         auto idxPartialType = cast<RankedTensorType>(group[0].second.getType());
@@ -5349,9 +4810,9 @@ public:
         auto wideIdxType =
             RankedTensorType::get(wideShape, idxTileType, wideLayout);
 
-        // Separate CompositeViews for values and indices (the DMA-expansion
-        // pass supports only one composite view per GenericOp, #7600), each
-        // materialized before the merge.
+        // Separate CompositeViews for values and indices, each materialized
+        // before the merge, since the DMA-expansion pass supports only one
+        // composite view per GenericOp (#7600).
         SmallVector<Value> valComposites, idxComposites;
         for (auto &p : group) {
           valComposites.push_back(p.first);
@@ -5364,16 +4825,6 @@ public:
             loc, wideIdxType, idxComposites, static_cast<int32_t>(dim),
             /*logicalSizes=*/nullptr);
 
-        // Materialize each composite into a genuinely-allocated L1 buffer via
-        // its OWN copy generic. ExpandDMAReadCompositeView allows only one
-        // composite view per generic (#7600); a plain to_layout on the
-        // composite bufferizes to a view_layout chain that
-        // getCompositeViewSource walks straight back to the composite, so
-        // feeding both composites into the merge generic would leave it with
-        // two composite-backed DMA reads and trip that assert. A dedicated copy
-        // generic per composite reads exactly one composite (so it DMA-expands
-        // cleanly) and yields a real buffer; the merge then reads two plain
-        // allocs.
         auto materializeComposite = [&](Value composite) -> Value {
           auto compType = cast<RankedTensorType>(composite.getType());
           auto copyOut = rewriter.create<d2m::EmptyOp>(
@@ -5392,23 +4843,9 @@ public:
           withD2MGenericRegion(
               rewriter, loc, copyGeneric, ins, outs,
               [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-                Value input = blockArgs[0];
-                Value output = blockArgs[1];
-                std::size_t shardRank =
-                    cast<RankedTensorType>(output.getType()).getRank();
-                AffineMap shardIdentity =
-                    rewriter.getMultiDimIdentityMap(shardRank);
-                SmallVector<mlir::utils::IteratorType> linalgIters(
-                    shardRank, mlir::utils::IteratorType::parallel);
-                auto linalgOp = rewriter.create<linalg::GenericOp>(
-                    loc, output.getType(), input, output,
-                    SmallVector<AffineMap>{shardIdentity, shardIdentity},
-                    linalgIters,
-                    [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                      Value copied = b.create<d2m::TileTypecastOp>(
-                          bodyLoc, args[1].getType(), args[0]);
-                      b.create<linalg::YieldOp>(bodyLoc, copied);
-                    });
+                auto linalgOp = emitLeadingTileCopy(
+                    rewriter, loc, ctx, blockArgs[0], blockArgs[1],
+                    /*shardRedDim=*/std::nullopt);
                 return {linalgOp->getResult(0)};
               });
           return relayout(copyGeneric->getResult(0));
@@ -5450,47 +4887,25 @@ public:
                 compactToTile(relayout(mergeGeneric->getResult(1)))};
       };
 
-      // Multi-level merge tree. A single mergePartials call runs one
-      // topk_block over a group of partials co-located on one core. Each
-      // partial carries the full nonTargetTiles footprint times
-      // outputReductionTiles reduction tiles, so a group of G partials
-      // materializes G * outputReductionTiles reduction tiles; that product
-      // (not G alone) must stay within the L1 band budget. So the cap on
-      // partials per group is maxMultiCoreReductionTilesPerCore /
-      // outputReductionTiles. When numShards exceeds that cap, reduce in
-      // rounds: each round partitions the current partials into balanced
-      // groups of <= cap, merges each group to one
-      // [nonTargetTiles, outputReductionTiles] partial, and feeds the round's
-      // outputs into the next round. Because each round divides the count by
-      // up to the cap, this converges in ceil(log_cap(numShards)) rounds -- a
-      // general k-ary merge tree, not the fixed two-group split. Groups are
-      // balanced (ceil-sized) so no core holds more than necessary; a
-      // trailing group of size 1 is carried forward unmerged rather than run
-      // through a degenerate single-input topk_block.
-      int64_t mergeCap =
-          (maxMultiCoreReductionTilesPerCore / outputReductionTiles);
+      // A group of G partials uses G * outputReductionTiles tiles. When
+      // numShards exceeds the cap, merge in rounds of balanced <= cap groups
+      // until one partial remains.
+      int64_t mergeCap = maxReductionTilesPerCore / outputReductionTiles;
       if (k > 32) {
-        // k > 32 has a greater footprint so we put less tiles on each merge
-        // core
+        // Greater per-partial footprint, so put fewer tiles on each merge core.
         mergeCap /= 4;
       }
       assert(mergeCap >= 2 &&
              "merge tree needs a cap of at least 2 partials per group");
-      // Distribute a round's groups across worker cores: group g's merge runs
-      // on the worker core at physical linear index g (row-major), so the
-      // numGroups merges in a round execute in parallel rather than serializing
-      // on core (0,0). Each merge's input partials carry their own fold maps
-      // (from the previous round's per-group placement, or the leaf gather), so
-      // the CompositeView DMA-read expansion gathers them onto group g's core.
-      // A round's numGroups is bounded by mergeCap <= the worker-grid area
-      // (mergeCap derives from the per-core tile budget, which is < grid area),
-      // so linear index g always maps to a real worker core.
+      // Group g goes at linear index g so merges run in parallel instead of
+      // serializing on (0,0). numGroups can't exceed the grid area:
+      // ceil(count/mergeCap) <= count/2, and the first round's count
+      // (numShards) is already grid-capped.
       int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
       SmallVector<std::pair<Value, Value>> level = std::move(partials);
       while (level.size() > 1) {
         int64_t count = static_cast<int64_t>(level.size());
-        // Balanced fan-in: spread partials over ceil(count / cap) groups so
-        // each group is <= cap and groups differ in size by at most one.
+        // Balanced fan-in: groups differ in size by at most one.
         int64_t numGroups = (count + mergeCap - 1) / mergeCap;
         assert(numGroups <= maxGridCores &&
                "merge round has more groups than worker cores");
@@ -5503,8 +4918,7 @@ public:
           int64_t groupSize = baseSize + (g < extra ? 1 : 0);
           assert(groupSize <= mergeCap && "merge group exceeds the L1 cap");
           if (groupSize == 1) {
-            // Nothing to merge; carry this partial into the next round (it
-            // keeps its existing core placement).
+            // Nothing to merge; carry forward, keeping its core placement.
             next.push_back(level[pos]);
           } else {
             next.push_back(mergePartials(
@@ -5520,18 +4934,13 @@ public:
     }
 
     // Index extract uses the index-element-type topk tiles. For dim==0 the
-    // extract generic's inner tile op is already a same-shape TileTypecastOp
-    // (see createExtractGeneric's `dim == 0` branch), so targeting its output
-    // directly at the user index element type (uint16) folds the narrowing
-    // cast into that same op and avoids a second generic. dim==1 uses
-    // TileTransposeOp instead, which is not verified to support a dtype
-    // change at the CB/pack level, so it keeps the separate typecast generic
-    // below.
+    // extract's inner tile op is already a TileTypecastOp, so targeting its
+    // output at the user index type folds the narrowing cast in. dim==1 uses
+    // TileTransposeOp, unverified for dtype changes, so it casts separately.
     Type idxOutElemType = indicesType.getElementType();
     bool fuseIdxCast = (dim == 0);
     auto extractIdxIndicesType = RankedTensorType::get(
-        indicesType.getShape(),
-        fuseIdxCast ? idxOutElemType : extractIdxElemType);
+        indicesType.getShape(), fuseIdxCast ? idxOutElemType : idxElemType);
 
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
@@ -5544,33 +4953,27 @@ public:
         origIdxOutputs[0], memorySpaces[1], /*tiled=*/true,
         /*noCollapse=*/false, rewriter);
 
-    // Need 1 output tile for k <= 32 and 2 tiles for k > 32
-    // outputReductionTiles and lastStride are computed once in the drive
-    // section above (they do not depend on the shard).
     std::size_t extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
 
     auto extractValsGeneric = createExtractGeneric(
         rewriter, loc, ctx, topkValsRelayouted, extractValsLayout,
-        extractProjectDim, outputReductionTiles, lastStride, dim);
+        extractProjectDim, outputReductionTiles, dim);
     auto extractIdxGeneric = createExtractGeneric(
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
-        extractProjectDim, outputReductionTiles, lastStride, dim);
+        extractProjectDim, outputReductionTiles, dim);
 
     Value idxFinal = extractIdxGeneric->getResult(0);
     if (!fuseIdxCast) {
-      // Typecast extracted indices to the output element type (uint16)
-      // before untilize. One tile op per region so D2M->TTKernel
-      // store/DST-index lookup finds a single terminal compute op.
-      Value extractedIdx = idxFinal;
-      auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
-      auto extractIdxTileType =
-          cast<ttcore::TileType>(extractedIdxType.getElementType());
-      auto idxCastTileType =
-          ttcore::TileType::get(idxOutElemType, extractIdxTileType.getShape());
+      // Its own region, so the D2M->TTKernel store/DST-index lookup still finds
+      // a single terminal compute op.
+      auto extractedIdxType = cast<RankedTensorType>(idxFinal.getType());
+      auto idxCastTileType = ttcore::TileType::get(
+          idxOutElemType,
+          cast<ttcore::TileType>(extractedIdxType.getElementType()).getShape());
       auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
           loc, extractedIdxType.getShape(), idxCastTileType,
           extractedIdxType.getEncoding());
-      SmallVector<Value> castInputs = {extractedIdx};
+      SmallVector<Value> castInputs = {idxFinal};
       SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
       std::size_t castRank = extractedIdxType.getShape().size() / 2;
       AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
@@ -5587,23 +4990,9 @@ public:
       withD2MGenericRegion(
           rewriter, loc, idxCastGeneric, castInputs, castOutputs,
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            Value input = blockArgs[0];
-            Value output = blockArgs[1];
-            std::size_t shardRank =
-                cast<RankedTensorType>(input.getType()).getRank();
-            AffineMap shardIdentity =
-                rewriter.getMultiDimIdentityMap(shardRank);
-            SmallVector<mlir::utils::IteratorType> linalgIters(
-                shardRank, mlir::utils::IteratorType::parallel);
-            auto linalgOp = rewriter.create<linalg::GenericOp>(
-                loc, output.getType(), input, output,
-                SmallVector<AffineMap>{shardIdentity, shardIdentity},
-                linalgIters,
-                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                  Value casted = b.create<d2m::TileTypecastOp>(
-                      bodyLoc, args[1].getType(), args[0]);
-                  b.create<linalg::YieldOp>(bodyLoc, casted);
-                });
+            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx,
+                                                blockArgs[0], blockArgs[1],
+                                                /*shardRedDim=*/std::nullopt);
             return {linalgOp->getResult(0)};
           });
       idxFinal = idxCastGeneric->getResult(0);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3597,39 +3597,47 @@ public:
   }
 };
 
-// Like ttmlir::d2m::utils::grids::createCoreVirtMaps, but for a local virtual
-// grid occupying the slice [colBase, colBase + volume(localVirtualGrid)) of
-// physicalGrid's row-major layout.
-static std::pair<AffineMap, AffineMap>
-createOffsetCoreVirtMaps(MLIRContext *ctx, ArrayRef<int64_t> localVirtualGrid,
-                         ArrayRef<int64_t> physicalGrid, int64_t colBase) {
-  assert(colBase >= 0 && "core offset must be non-negative");
-  assert(colBase + ttmlir::utils::volume<int64_t>(localVirtualGrid) <=
-             ttmlir::utils::volume<int64_t>(physicalGrid) &&
-         "offset core placement runs past the end of the physical grid");
-  AffineMap collapseMap =
-      ttmlir::d2m::utils::grids::createCollapseMap(ctx, localVirtualGrid);
-  AffineExpr shiftedIdx =
-      collapseMap.getResult(0) + getAffineConstantExpr(colBase, ctx);
-  AffineMap shiftedCollapseMap =
-      AffineMap::get(collapseMap.getNumDims(), 0, {shiftedIdx}, ctx);
-  AffineMap expandMap =
-      ttmlir::d2m::utils::grids::create1DtoNDMap(ctx, physicalGrid);
-  AffineMap forwardMap =
-      ttmlir::d2m::utils::grids::extendWithIdentityDimsAndResults(
-          expandMap.compose(shiftedCollapseMap), localVirtualGrid.size());
+// Picks the group count for one round of the topk merge tree over `bands`
+// partials. A round is a single grid-wide generic, so its one output memref
+// type forces one shard shape and therefore one group size: the count must
+// divide `bands`, leave at most `mergeCap` bands per group, and be a legal core
+// count in its own right. Ascending order takes the fewest groups, i.e. the
+// largest the cap allows, which keeps the tree shallow. Returns 0 when the
+// round has no legal move.
+static int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
+                                   ArrayRef<int64_t> workerGridShape) {
+  for (int64_t groups = 1; groups < bands; ++groups) {
+    if (bands % groups != 0) {
+      continue;
+    }
+    if (bands / groups > mergeCap) {
+      continue;
+    }
+    if (d2m::utils::findLegalPhysicalGridForVolume(groups, workerGridShape)
+            .empty()) {
+      continue;
+    }
+    return groups;
+  }
+  return 0;
+}
 
-  AffineMap physCollapseMap =
-      ttmlir::d2m::utils::grids::createCollapseMap(ctx, physicalGrid);
-  AffineExpr localLinearIdx =
-      physCollapseMap.getResult(0) - getAffineConstantExpr(colBase, ctx);
-  AffineMap toLocalLinear =
-      AffineMap::get(physCollapseMap.getNumDims(), 0, {localLinearIdx}, ctx);
-  AffineMap localExpandMap =
-      ttmlir::d2m::utils::grids::create1DtoNDMap(ctx, localVirtualGrid);
-  AffineMap inverseMap = ttmlir::d2m::utils::grids::prependResult(
-      localExpandMap.compose(toLocalLinear), getAffineConstantExpr(0, ctx));
-  return {forwardMap, inverseMap};
+// True when repeated pickMergeGroupCount walks `bands` all the way down to a
+// single partial. Each step strictly decreases, so this terminates. It fails
+// only where some level admits no divisor in [2, mergeCap] that is also
+// grid-legal — a band count that is prime and larger than the cap is the
+// canonical case, which is why the shard search must check the whole chain and
+// not just the first round.
+static bool mergeChainCloses(int64_t bands, int64_t mergeCap,
+                             ArrayRef<int64_t> workerGridShape) {
+  while (bands > 1) {
+    int64_t groups = pickMergeGroupCount(bands, mergeCap, workerGridShape);
+    if (groups == 0) {
+      return false;
+    }
+    bands = groups;
+  }
+  return true;
 }
 
 class D2MTopKRewriter : public OpConversionPattern<ttir::TopKOp>,
@@ -3802,6 +3810,15 @@ public:
     // bandTiles-wide input, so k>32 pressure is bounded separately by mergeCap.
     int64_t maxReductionTilesPerCore = kMaxTilesPerCore / nonTargetTiles;
 
+    // Bands one merge core can absorb in a round. Hoisted above the shard
+    // search because a band count is usable only if its whole merge tree closes
+    // at this cap.
+    int64_t mergeCap = maxReductionTilesPerCore / outputReductionTiles;
+    if (k > 32) {
+      // Greater per-partial footprint, so put fewer tiles on each merge core.
+      mergeCap /= 4;
+    }
+
     // The topk SFPU LLK reads the index lane only as INT32 (with fp32_dest_acc
     // on) or LO16 otherwise, never as a float. Int32 forces fp32_dest_acc and
     // selects the INT32 path, so indices round-trip losslessly at any size.
@@ -3832,38 +3849,55 @@ public:
       assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
 
       int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
-      // The fold invariant requires numShards to be grid-legal, so pick the
-      // smallest such count >= minShards whose bands also fit the tile budget.
-      // Since every skipped candidate is illegal or busts that budget, running
-      // off maxGridCores means this grid needs more cores (reported below).
-      for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
-        if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-                .empty()) {
-          continue;
+      // A band count must be grid-legal (the fold invariant), fit the per-core
+      // tile budget, and have a merge tree that closes -- every round splits
+      // one grid-wide generic evenly, so each level needs a grid-legal divisor
+      // leaving at most mergeCap bands per group.
+      //
+      // Two passes. The first takes only powers of two, which always close
+      // (halving is available at every level) and give the shallowest balanced
+      // tree; on an 8x8 grid they already reach all 64 cores, so that pass
+      // decides every Wormhole shape. The second pass admits any count whose
+      // chain closes, which is what reaches past 64 bands on larger grids --
+      // e.g. 66, 70, 72, 80, 90, 100 on Blackhole's 10x11.
+      for (int pass = 0; pass < 2 && numShards == 1; ++pass) {
+        bool powerOfTwoOnly = (pass == 0);
+        for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
+          if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
+            continue;
+          }
+          if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+                  .empty()) {
+            continue;
+          }
+          int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
+          if (candBandTiles > maxReductionTilesPerCore) {
+            continue;
+          }
+          if (!mergeChainCloses(cand, mergeCap, workerGridShape)) {
+            continue;
+          }
+          numShards = cand;
+          bandTiles = candBandTiles;
+          break;
         }
-        int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
-        if (candBandTiles > maxReductionTilesPerCore) {
-          continue;
-        }
-        numShards = cand;
-        bandTiles = candBandTiles;
-        break;
       }
       if (numShards == 1) {
         return rewriter.notifyMatchFailure(
-            op, "D2M topk: reduction dim needs more cores than the worker grid "
-                "provides at the per-core tile budget");
+            op, "D2M topk: no band count fits the reduction dim within the "
+                "per-core tile budget with a merge tree this worker grid can "
+                "split evenly");
       }
       paddedReductionTiles = numShards * bandTiles;
     }
 
-    // Emits a single-shard topk over a raw input, returning (values, indices)
-    // partials still in device layout. arangeStart offsets indices so band g
-    // yields GLOBAL indices; gridCols > 1 splits the topk across that many
-    // cores and returns one grid-1x1 partial per band for the caller to merge.
+    // Emits a topk over a raw input, returning (values, indices) still in
+    // device layout. arangeStart offsets indices so band g yields GLOBAL
+    // indices; gridCols > 1 splits the topk across that many cores and returns
+    // the result still distributed one band per core, each band narrowed to its
+    // leading outputReductionTiles, for the caller's merge tree to gather.
     auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols =
-                                 1) -> SmallVector<std::pair<Value, Value>> {
+                             int64_t gridCols = 1) -> std::pair<Value, Value> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
@@ -4399,161 +4433,18 @@ public:
       // The whole result as one grid-1x1 partial; the extract reads its
       // leading tiles.
       if (gridCols == 1) {
-        return {{wrapInToLayout(topkGeneric->getResult(0)),
-                 wrapInToLayout(topkGeneric->getResult(1))}};
+        return {wrapInToLayout(topkGeneric->getResult(0)),
+                wrapInToLayout(topkGeneric->getResult(1))};
       }
 
-      // Multi-core gather: one collector core DMA-reads one payload per source
-      // core, producing a grid-1x1 partial per source to CompositeView.
-      SmallVector<std::pair<Value, Value>> partials;
+      // The bands stay put: narrowing is in place and the cross-core gather is
+      // the caller's, driven by one composite view over this whole grid-wide
+      // result rather than by a collector generic per band.
       std::size_t redPhys =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       std::size_t deviceRedDimLocal =
           deviceShape.size() - (physicalRank - redPhys);
-      // The shard portion is [nonTarget, reduction] for dim==1 and the reverse
-      // for dim==0, so the non-target dim is deviceRedDimLocal's sibling.
-      std::size_t deviceNonTargetDimLocal =
-          (dim == 1) ? deviceRedDimLocal - 1 : deviceRedDimLocal + 1;
-      SmallVector<int64_t> perCorePartialShape(deviceShape.begin(),
-                                               deviceShape.end());
-      perCorePartialShape[0] = 1;
-      perCorePartialShape[1] = 1;
-      perCorePartialShape[deviceRedDimLocal] = outputReductionTiles;
-      perCorePartialShape[deviceNonTargetDimLocal] = nonTargetTiles;
-
-      // Must report its own narrow tile extent, not the input's full logical
-      // shape: the CompositeViewOp verifier sums the partials' logical
-      // reduction extents against the composite output's.
       constexpr int64_t kTileDimLocal = 32;
-      ttcore::MetalLayoutAttr perCorePartialLayout =
-          ttcore::MetalLayoutAttr::get(
-              ctx,
-              SmallVector<int64_t>{
-                  perCorePartialShape[perCorePartialShape.size() - 2] *
-                      kTileDimLocal,
-                  perCorePartialShape[perCorePartialShape.size() - 1] *
-                      kTileDimLocal},
-              metalLayout.getDimAlignments(),
-              metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
-              metalLayout.getMemoryLayout());
-
-      // Returns gridCols grid-1x1 partials, where partial g holds source core
-      // g's leading reduction tiles across the full non-target extent.
-      auto gatherPerCore = [&](Value gridResult) -> SmallVector<Value> {
-        auto gridType = cast<RankedTensorType>(gridResult.getType());
-        auto tileType = cast<ttcore::TileType>(gridType.getElementType());
-        SmallVector<Value> gathered;
-        for (int64_t g = 0; g < gridCols; ++g) {
-          auto outEmpty = rewriter.create<d2m::EmptyOp>(
-              loc, perCorePartialShape, tileType, perCorePartialLayout);
-          // Place partial g at physical linear index g so the partials live on
-          // distinct cores. Otherwise every collector defaults to an unfolded
-          // unit grid and they all blow one core's L1 budget.
-          {
-            SmallVector<int64_t> unitGrid = {1, 1};
-            auto [gatherFwd, gatherInv] =
-                createOffsetCoreVirtMaps(ctx, unitGrid, workerGridShape, g);
-            outEmpty.setVirtualGridForwardMappingAttr(
-                AffineMapAttr::get(gatherFwd));
-            outEmpty.setVirtualGridInverseMappingAttr(
-                AffineMapAttr::get(gatherInv));
-          }
-          SmallVector<Value> ins = {gridResult};
-          SmallVector<Value> outs = {outEmpty.getResult()};
-          // Grid-1x1 collector generic. Its input is the whole grid result, but
-          // it runs on one core and gathers via the explicit remote_load below,
-          // so a constant (0,0) input map exempts it from the verifier's
-          // grid-equality check while the output keeps the identity map.
-          AffineMap collectorInputMap = AffineMap::get(
-              physicalRank, 0,
-              SmallVector<AffineExpr>(physicalRank,
-                                      rewriter.getAffineConstantExpr(0)),
-              ctx);
-          auto generic = rewriter.create<d2m::GenericOp>(
-              loc, ins, outs, /*additionalArgs=*/ValueRange(),
-              rewriter.getAffineMapArrayAttr(
-                  SmallVector<AffineMap>{collectorInputMap, identityMap}),
-              rewriter.getArrayAttr(iteratorTypes));
-          generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-
-          // Build the region manually, since the auto-generated one would emit
-          // a single remote_load at the block index rather than the explicit
-          // load from source grid column g that we want.
-          {
-            auto insertPoint = rewriter.saveInsertionPoint();
-            rewriter.startOpModification(generic);
-            mlir::Region &region = generic->getRegions().front();
-            mlir::Block *block = rewriter.createBlock(&region);
-            rewriter.setInsertionPointToStart(block);
-
-            auto srcShardType = RankedTensorType::get(
-                cast<RankedTensorType>(gridResult.getType())
-                    .getShape()
-                    .take_back(physicalRank),
-                tileType);
-            auto outShardType =
-                RankedTensorType::get(cast<RankedTensorType>(outEmpty.getType())
-                                          .getShape()
-                                          .take_back(physicalRank),
-                                      tileType);
-            Value loadBuf =
-                rewriter
-                    .create<tensor::EmptyOp>(loc, srcShardType.getShape(),
-                                             srcShardType.getElementType())
-                    .getResult();
-            // remote_load source band g at its LOGICAL grid index, [0, g] for
-            // dim==1 and [g, 0] for dim==0. The source buffer carries a
-            // virtual-grid forward map that the DMA address path composes to
-            // reach the physical core band g lives on.
-            Value zeroGrid = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-            Value bandGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
-            SmallVector<Value> srcIndices =
-                (dim == 1) ? SmallVector<Value>{zeroGrid, bandGrid}
-                           : SmallVector<Value>{bandGrid, zeroGrid};
-            Value loaded =
-                rewriter
-                    .create<d2m::RemoteLoadOp>(loc, srcShardType, loadBuf,
-                                               gridResult, srcIndices)
-                    .getResult();
-
-            Value outBuf =
-                rewriter
-                    .create<tensor::EmptyOp>(loc, outShardType.getShape(),
-                                             outShardType.getElementType())
-                    .getResult();
-            std::size_t shardRank = outShardType.getShape().size();
-            std::size_t shardRedDim = shardRank - (physicalRank - redPhys);
-            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded,
-                                                outBuf, shardRedDim);
-
-            SmallVector<Value> outIndices =
-                d2m::utils::buildGridIndices(rewriter, loc, identityMap);
-            Value storeResult =
-                rewriter
-                    .create<d2m::RemoteStoreOp>(
-                        loc, outEmpty.getType(), outEmpty.getResult(),
-                        outIndices, linalgOp->getResult(0))
-                    .getResult();
-            rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
-            rewriter.finalizeOpModification(generic);
-            rewriter.restoreInsertionPoint(insertPoint);
-          }
-          // Relayout to a fresh buffer at partial g's own per-g fold, not
-          // emitShardTopk's gridCols-wide input-band fold, which is what
-          // wrapInToLayout would apply and is wrong for a single-core partial.
-          auto relayoutEmpty = rewriter.create<d2m::EmptyOp>(
-              loc, perCorePartialShape, tileType, perCorePartialLayout);
-          relayoutEmpty.setVirtualGridForwardMappingAttr(
-              outEmpty.getVirtualGridForwardMappingAttr());
-          relayoutEmpty.setVirtualGridInverseMappingAttr(
-              outEmpty.getVirtualGridInverseMappingAttr());
-          gathered.push_back(rewriter
-                                 .create<d2m::ToLayoutOp>(
-                                     loc, generic->getResult(0), relayoutEmpty)
-                                 .getResult(0));
-        }
-        return gathered;
-      };
 
       // Per-band pre-compaction: narrow each band in place, before the
       // cross-core gather, or the wide leaf result stays live on every core
@@ -4568,12 +4459,17 @@ public:
         SmallVector<int64_t> narrowShape(wideType.getShape().begin(),
                                          wideType.getShape().end());
         narrowShape[deviceRedDimLocal] = outputReductionTiles;
+        // Logical shape spans the whole distributed result, grid x shard, not
+        // one core's share. The merge rounds hold that product invariant while
+        // re-splitting it, which is what lets a single composite view over this
+        // value verify against its own re-split output.
+        SmallVector<int64_t> narrowLogical;
+        for (std::size_t i = 0; i < physicalRank; ++i) {
+          narrowLogical.push_back(
+              narrowShape[i] * narrowShape[i + physicalRank] * kTileDimLocal);
+        }
         auto narrowLayout = ttcore::MetalLayoutAttr::get(
-            ctx,
-            SmallVector<int64_t>{
-                narrowShape[narrowShape.size() - 2] * kTileDimLocal,
-                narrowShape[narrowShape.size() - 1] * kTileDimLocal},
-            wideMetalLayout.getDimAlignments(),
+            ctx, narrowLogical, wideMetalLayout.getDimAlignments(),
             wideMetalLayout.getCollapsedIntervals(),
             wideMetalLayout.getMemorySpace(),
             wideMetalLayout.getMemoryLayout());
@@ -4656,21 +4552,14 @@ public:
         return wrapInToLayout(generic->getResult(0));
       };
 
-      Value valCompacted = compactBands(topkGeneric->getResult(0));
-      Value idxCompacted = compactBands(topkGeneric->getResult(1));
-
-      SmallVector<Value> valPartials = gatherPerCore(valCompacted);
-      SmallVector<Value> idxPartials = gatherPerCore(idxCompacted);
-      for (int64_t g = 0; g < gridCols; ++g) {
-        partials.push_back({valPartials[g], idxPartials[g]});
-      }
-      return partials;
+      return {compactBands(topkGeneric->getResult(0)),
+              compactBands(topkGeneric->getResult(1))};
     }; // emitShardTopk
 
     std::size_t physicalRank = static_cast<std::size_t>(rank);
 
-    // Set for the currently-emitting merge group so its buffers land on that
-    // group's core; null outside one, leaving EmptyOps unit-grid on (0,0).
+    // Set for the currently-emitting merge round so its buffers fold onto that
+    // round's numGroups cores; null outside one, leaving EmptyOps unit-grid.
     AffineMapAttr mergeFoldForwardAttr, mergeFoldInverseAttr;
     auto attachMergeFold = [&](d2m::EmptyOp emptyOp) {
       if (mergeFoldForwardAttr) {
@@ -4699,22 +4588,27 @@ public:
     std::size_t deviceRedDim =
         (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // Rebuilds `layout` with a logical shape matching `deviceShape`'s tiles.
+    // Rebuilds `layout` with a logical shape spanning all of `deviceShape`,
+    // i.e. grid x shard rather than one core's share. A merge round re-splits
+    // that product without changing it, so its composite view sees the same
+    // logical extent on both sides.
     auto layoutForDeviceShape =
         [&](ttcore::MetalLayoutAttr layout,
             ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
       constexpr int64_t kTileDim = 32;
-      int64_t shardH = deviceShape[deviceShape.size() - 2];
-      int64_t shardW = deviceShape[deviceShape.size() - 1];
-      SmallVector<int64_t> newLogical = {shardH * kTileDim, shardW * kTileDim};
+      SmallVector<int64_t> newLogical;
+      for (std::size_t i = 0; i < physicalRank; ++i) {
+        newLogical.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
+                             kTileDim);
+      }
       return ttcore::MetalLayoutAttr::get(
           ctx, newLogical, layout.getDimAlignments(),
           layout.getCollapsedIntervals(), layout.getMemorySpace(),
           layout.getMemoryLayout());
     };
 
-    // Compacts a partial into a fresh narrow buffer, giving the merge tree a
-    // distinct SSA value to CompositeView.
+    // Narrows a merge result back to its leading outputReductionTiles on every
+    // core, restoring the one-band-per-core shape the next round consumes.
     auto compactToTile = [&](Value fullPartial) -> Value {
       auto fullType = cast<RankedTensorType>(fullPartial.getType());
       auto tileType = cast<ttcore::TileType>(fullType.getElementType());
@@ -4728,110 +4622,172 @@ public:
       attachMergeFold(outEmpty);
       std::size_t genRedDim =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-      // Must stay a projected permutation, so leading-tile selection happens on
-      // the inner linalg instead.
-      SmallVector<AffineExpr> inExprs;
-      for (std::size_t i = 0; i < physicalRank; ++i) {
-        inExprs.push_back(i == genRedDim ? rewriter.getAffineConstantExpr(0)
-                                         : rewriter.getAffineDimExpr(i));
-      }
-      AffineMap inProj = AffineMap::get(physicalRank, 0, inExprs, ctx);
+      // A constant grid map on the input makes hasOperandBroadcasting true, so
+      // the verifier skips the shard-shape check that the narrowing would
+      // otherwise fail. It must NOT drive the read: on a grid wider than one
+      // core it resolves to grid cell 0, so every core would narrow band 0.
+      // The explicit remote_load at this cell's own position below is the real
+      // read, exactly as in compactBands.
+      AffineMap constInMap =
+          AffineMap::get(physicalRank, 0,
+                         SmallVector<AffineExpr>(
+                             physicalRank, rewriter.getAffineConstantExpr(0)),
+                         ctx);
       SmallVector<Value> ins = {fullPartial};
       SmallVector<Value> outs = {outEmpty.getResult()};
       auto generic = rewriter.create<d2m::GenericOp>(
           loc, ins, outs, /*additionalArgs=*/ValueRange(),
           rewriter.getAffineMapArrayAttr(
-              SmallVector<AffineMap>{inProj, mergeIdentity}),
+              SmallVector<AffineMap>{constInMap, mergeIdentity}),
           rewriter.getArrayAttr(mergeIters));
       generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-      withD2MGenericRegion(
-          rewriter, loc, generic, ins, outs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            Value input = blockArgs[0];
-            Value output = blockArgs[1];
-            std::size_t shardRank =
-                cast<RankedTensorType>(output.getType()).getRank();
-            std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
-            auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, input,
-                                                output, shardRedDim);
-            return {linalgOp->getResult(0)};
-          });
+
+      // Built by hand, since withD2MGenericRegion would derive the read from
+      // the constant map above and pull every core's data from grid cell 0.
+      {
+        auto insertPoint = rewriter.saveInsertionPoint();
+        rewriter.startOpModification(generic);
+        mlir::Region &region = generic->getRegions().front();
+        mlir::Block *block = rewriter.createBlock(&region);
+        rewriter.setInsertionPointToStart(block);
+
+        auto inShardType = RankedTensorType::get(
+            fullType.getShape().take_back(physicalRank), tileType);
+        auto outShardType = RankedTensorType::get(
+            ArrayRef<int64_t>(compactShape).take_back(physicalRank), tileType);
+        std::size_t shardRank = outShardType.getRank();
+        std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
+
+        Value loadBuf =
+            rewriter
+                .create<tensor::EmptyOp>(loc, inShardType.getShape(),
+                                         inShardType.getElementType())
+                .getResult();
+        SmallVector<Value> srcIndices =
+            d2m::utils::buildGridIndices(rewriter, loc, mergeIdentity);
+        Value loaded = rewriter
+                           .create<d2m::RemoteLoadOp>(loc, inShardType, loadBuf,
+                                                      fullPartial, srcIndices)
+                           .getResult();
+
+        Value outBuf =
+            rewriter
+                .create<tensor::EmptyOp>(loc, outShardType.getShape(),
+                                         outShardType.getElementType())
+                .getResult();
+        auto linalgOp = emitLeadingTileCopy(rewriter, loc, ctx, loaded, outBuf,
+                                            shardRedDim);
+
+        SmallVector<Value> outIndices =
+            d2m::utils::buildGridIndices(rewriter, loc, mergeIdentity);
+        Value storeResult =
+            rewriter
+                .create<d2m::RemoteStoreOp>(loc, outEmpty.getType(),
+                                            outEmpty.getResult(), outIndices,
+                                            linalgOp->getResult(0))
+                .getResult();
+        rewriter.create<d2m::YieldOp>(loc, ValueRange{storeResult});
+        rewriter.finalizeOpModification(generic);
+        rewriter.restoreInsertionPoint(insertPoint);
+      }
       return relayout(generic->getResult(0));
     };
 
     Value topkValsRelayouted, topkIdxRelayouted;
     if (!multiCore) {
-      auto partials =
+      std::pair<Value, Value> single =
           emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0);
-      topkValsRelayouted = partials[0].first;
-      topkIdxRelayouted = partials[0].second;
+      topkValsRelayouted = single.first;
+      topkIdxRelayouted = single.second;
     } else {
-      // Each of numShards cores runs topk_block on its own band.
-      SmallVector<std::pair<Value, Value>> partials =
+      // Each of numShards cores runs topk_block on its own band, leaving the
+      // partials distributed one band per core.
+      std::pair<Value, Value> level =
           emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
                         /*gridCols=*/numShards);
 
-      // Merges a group into one (values, indices) pair on one core:
-      // CompositeView, materialize, run one topk_block, compact back down.
-      // foldColBase >= 0 places the merge at that worker linear index;
-      // negative leaves it on (0,0).
-      auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group,
-                               int64_t foldColBase =
-                                   -1) -> std::pair<Value, Value> {
-        // Cleared on return so buffers emitted between groups stay unit-grid.
+      // Grid dim the bands spread across: columns for dim==1, rows for dim==0,
+      // matching emitShardTopk's shardedGrid.
+      std::size_t deviceGridDim = static_cast<std::size_t>(dim);
+
+      // Collapses `bands` partials, one per core, down to `numGroups`: core g
+      // merges the groupTiles bands starting at g * groupTiles. Every group of
+      // the round runs in the same generics, so a round costs a fixed five
+      // regardless of how many groups it has.
+      //
+      // The gather is a lone composite view over the still-distributed input.
+      // Its result re-splits that same grid x shard extent onto the merge grid,
+      // so D2MExpandDMAReadCompositeView resolves each destination tile back to
+      // its (band, tile-in-band) by div/rem and issues the DMA read pulling it
+      // off whichever core holds it. One view replaces what used to be a
+      // collector generic per band plus a CompositeView per group.
+      auto mergeRound = [&](Value valsIn, Value idxIn, int64_t bands,
+                            int64_t numGroups) -> std::pair<Value, Value> {
+        int64_t groupTiles = bands / numGroups;
+        assert(groupTiles * numGroups == bands &&
+               "merge round must divide the band count evenly");
+
+        auto valsInType = cast<RankedTensorType>(valsIn.getType());
+        auto idxInType = cast<RankedTensorType>(idxIn.getType());
+        auto valTileType = cast<ttcore::TileType>(valsInType.getElementType());
+        auto idxTileType = cast<ttcore::TileType>(idxInType.getElementType());
+
+        // Same total extent as the input, re-split: numGroups cores each
+        // holding groupTiles bands' worth of reduction tiles.
+        SmallVector<int64_t> wideShape(valsInType.getShape().begin(),
+                                       valsInType.getShape().end());
+        wideShape[deviceGridDim] = numGroups;
+        wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
+
+        // Re-splitting leaves grid x shard alone, so the wide layout carries
+        // the same logical extent as the input's. That is exactly what the
+        // composite verifier wants: it sums the inputs' logical extents along
+        // the composite dim against the output's, and here the lone input
+        // already accounts for all of it.
+        auto valWideLayout = layoutForDeviceShape(
+            cast<ttcore::MetalLayoutAttr>(valsInType.getEncoding()), wideShape);
+        auto idxWideLayout = layoutForDeviceShape(
+            cast<ttcore::MetalLayoutAttr>(idxInType.getEncoding()), wideShape);
+        auto valWideType =
+            RankedTensorType::get(wideShape, valTileType, valWideLayout);
+        auto idxWideType =
+            RankedTensorType::get(wideShape, idxTileType, idxWideLayout);
+
+        // Spread the round's buffers over numGroups distinct cores.
         mergeFoldForwardAttr = nullptr;
         mergeFoldInverseAttr = nullptr;
-        if (foldColBase >= 0) {
-          SmallVector<int64_t> unitGrid = {1, 1};
-          auto [fwd, inv] = createOffsetCoreVirtMaps(
-              ctx, unitGrid, workerGridShape, foldColBase);
+        if (numGroups > 1) {
+          SmallVector<int64_t> roundGrid(physicalRank, 1);
+          roundGrid[deviceGridDim] = numGroups;
+          SmallVector<int64_t> physicalGrid =
+              d2m::utils::findLegalPhysicalGridForVolume(numGroups,
+                                                         workerGridShape);
+          assert(!physicalGrid.empty() &&
+                 "merge group count has no legal worker-grid factorization");
+          auto [fwd, inv] = ttmlir::d2m::utils::grids::createCoreVirtMaps(
+              ctx, roundGrid, physicalGrid);
           mergeFoldForwardAttr = AffineMapAttr::get(fwd);
           mergeFoldInverseAttr = AffineMapAttr::get(inv);
         }
+        // Cleared on return so later buffers stay unit-grid.
         auto clearFold = llvm::make_scope_exit([&] {
           mergeFoldForwardAttr = nullptr;
           mergeFoldInverseAttr = nullptr;
         });
 
-        int64_t groupTiles = static_cast<int64_t>(group.size());
-
-        auto partialType = cast<RankedTensorType>(group[0].first.getType());
-        auto tileType = cast<ttcore::TileType>(partialType.getElementType());
-        auto idxPartialType = cast<RankedTensorType>(group[0].second.getType());
-        auto idxTileType =
-            cast<ttcore::TileType>(idxPartialType.getElementType());
-        auto partialLayout =
-            cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
-        SmallVector<int64_t> wideShape(partialType.getShape().begin(),
-                                       partialType.getShape().end());
-        wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
-        auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
-        auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
-        auto wideIdxType =
-            RankedTensorType::get(wideShape, idxTileType, wideLayout);
-
-        // Separate CompositeViews for values and indices, each materialized
-        // before the merge, since the DMA-expansion pass supports only one
-        // composite view per GenericOp (#7600).
-        SmallVector<Value> valComposites, idxComposites;
-        for (auto &p : group) {
-          valComposites.push_back(p.first);
-          idxComposites.push_back(p.second);
-        }
-        auto valsComposite = rewriter.create<d2m::CompositeViewOp>(
-            loc, wideType, valComposites, static_cast<int32_t>(dim),
-            /*logicalSizes=*/nullptr);
-        auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
-            loc, wideIdxType, idxComposites, static_cast<int32_t>(dim),
-            /*logicalSizes=*/nullptr);
-
-        auto materializeComposite = [&](Value composite) -> Value {
-          auto compType = cast<RankedTensorType>(composite.getType());
+        // Values and indices gather through separate generics, since the
+        // DMA-expansion pass supports only one composite view per GenericOp
+        // (#7600).
+        auto gatherComposite = [&](Value in,
+                                   RankedTensorType wideType) -> Value {
+          auto composite = rewriter.create<d2m::CompositeViewOp>(
+              loc, wideType, ValueRange{in}, static_cast<int32_t>(dim),
+              /*logicalSizes=*/nullptr);
           auto copyOut = rewriter.create<d2m::EmptyOp>(
-              loc, compType.getShape(), compType.getElementType(),
-              compType.getEncoding());
+              loc, wideType.getShape(), wideType.getElementType(),
+              wideType.getEncoding());
           attachMergeFold(copyOut);
-          SmallVector<Value> ins = {composite};
+          SmallVector<Value> ins = {composite.getResult()};
           SmallVector<Value> outs = {copyOut.getResult()};
           auto copyGeneric = rewriter.create<d2m::GenericOp>(
               loc, ins, outs, /*additionalArgs=*/ValueRange(),
@@ -4850,16 +4806,15 @@ public:
               });
           return relayout(copyGeneric->getResult(0));
         };
-        Value valsMaterialized =
-            materializeComposite(valsComposite.getResult());
-        Value idxMaterialized = materializeComposite(idxComposite.getResult());
+        Value valsMaterialized = gatherComposite(valsIn, valWideType);
+        Value idxMaterialized = gatherComposite(idxIn, idxWideType);
 
         int64_t mergeReductionElems =
             groupTiles * outputReductionTiles * kTileWidth;
-        auto mergeValsOut =
-            rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
+        auto mergeValsOut = rewriter.create<d2m::EmptyOp>(
+            loc, wideShape, valTileType, valWideType.getEncoding());
         auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
-            loc, wideShape, idxTileType, wideLayout);
+            loc, wideShape, idxTileType, idxWideType.getEncoding());
         attachMergeFold(mergeValsOut);
         attachMergeFold(mergeIdxOut);
         SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
@@ -4887,50 +4842,20 @@ public:
                 compactToTile(relayout(mergeGeneric->getResult(1)))};
       };
 
-      // A group of G partials uses G * outputReductionTiles tiles. When
-      // numShards exceeds the cap, merge in rounds of balanced <= cap groups
-      // until one partial remains.
-      int64_t mergeCap = maxReductionTilesPerCore / outputReductionTiles;
-      if (k > 32) {
-        // Greater per-partial footprint, so put fewer tiles on each merge core.
-        mergeCap /= 4;
+      // Merge in rounds until one band remains. The shard search already proved
+      // this chain closes for numShards, so every round has a legal move, and
+      // pickMergeGroupCount only ever returns a count below the current one.
+      int64_t bands = numShards;
+      while (bands > 1) {
+        int64_t numGroups =
+            pickMergeGroupCount(bands, mergeCap, workerGridShape);
+        assert(numGroups > 0 &&
+               "merge chain was validated during shard selection");
+        level = mergeRound(level.first, level.second, bands, numGroups);
+        bands = numGroups;
       }
-      assert(mergeCap >= 2 &&
-             "merge tree needs a cap of at least 2 partials per group");
-      // Group g goes at linear index g so merges run in parallel instead of
-      // serializing on (0,0). numGroups can't exceed the grid area:
-      // ceil(count/mergeCap) <= count/2, and the first round's count
-      // (numShards) is already grid-capped.
-      int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
-      SmallVector<std::pair<Value, Value>> level = std::move(partials);
-      while (level.size() > 1) {
-        int64_t count = static_cast<int64_t>(level.size());
-        // Balanced fan-in: groups differ in size by at most one.
-        int64_t numGroups = (count + mergeCap - 1) / mergeCap;
-        assert(numGroups <= maxGridCores &&
-               "merge round has more groups than worker cores");
-        int64_t baseSize = count / numGroups;
-        int64_t extra = count % numGroups; // first `extra` groups get +1.
-        SmallVector<std::pair<Value, Value>> next;
-        next.reserve(numGroups);
-        int64_t pos = 0;
-        for (int64_t g = 0; g < numGroups; ++g) {
-          int64_t groupSize = baseSize + (g < extra ? 1 : 0);
-          assert(groupSize <= mergeCap && "merge group exceeds the L1 cap");
-          if (groupSize == 1) {
-            // Nothing to merge; carry forward, keeping its core placement.
-            next.push_back(level[pos]);
-          } else {
-            next.push_back(mergePartials(
-                ArrayRef<std::pair<Value, Value>>(level).slice(pos, groupSize),
-                /*foldColBase=*/g));
-          }
-          pos += groupSize;
-        }
-        level = std::move(next);
-      }
-      topkValsRelayouted = level.front().first;
-      topkIdxRelayouted = level.front().second;
+      topkValsRelayouted = level.first;
+      topkIdxRelayouted = level.second;
     }
 
     // Index extract uses the index-element-type topk tiles. For dim==0 the

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -4317,7 +4317,7 @@ public:
           metalLayout.getDimAlignments(), metalLayout.getCollapsedIntervals(),
           metalLayout.getMemorySpace(), metalLayout.getMemoryLayout());
 
-      // Emits the collector generic for one topk result (values or indices),
+      // Emits the collector generic for one topk result (values or index),
       // returning gridCols grid-1x1 partials (partial g == source core g's
       // tile 0).
       auto gatherPerCore = [&](Value gridResult) -> SmallVector<Value> {
@@ -4591,107 +4591,145 @@ public:
       SmallVector<std::pair<Value, Value>> partials = emitShardTopk(
           adaptor.getInputTensor(), /*arangeStart=*/0, /*gridCols=*/numShards);
 
-      // Build a numShards-tile buffer type along the reduction dim from a
-      // 1-tile partial's layout.
-      auto partialType = cast<RankedTensorType>(partials[0].first.getType());
-      auto tileType = cast<ttcore::TileType>(partialType.getElementType());
-      auto partialLayout =
-          cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
-      SmallVector<int64_t> wideShape(partialType.getShape().begin(),
-                                     partialType.getShape().end());
-      wideShape[deviceRedDim] = numShards;
-      auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
-      auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
+      // Merge a group of 1-tile partials into a single top-k 1-tile
+      // (values, indices) pair on one core: CompositeView the group along the
+      // reduction dim, materialize, run ONE topk_block, and compact to tile 0.
+      // A single topk_block can only reduce tiles co-located on its core, so a
+      // group is capped at kMaxShardTiles (L1-safe). For numShards > 32 the
+      // driver below splits into two groups so no core ever holds > 32 tiles.
+      auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group)
+          -> std::pair<Value, Value> {
+        int64_t groupTiles = static_cast<int64_t>(group.size());
 
-      // Separate CompositeViews for values and indices (the DMA-expansion pass
-      // supports only one composite view per GenericOp, #7600), each
-      // materialized before the merge.
-      SmallVector<Value> valComposites, idxComposites;
-      for (auto &p : partials) {
-        valComposites.push_back(p.first);
-        idxComposites.push_back(p.second);
-      }
-      auto valsComposite = rewriter.create<d2m::CompositeViewOp>(
-          loc, wideType, valComposites, static_cast<int32_t>(dim),
-          /*logicalSizes=*/nullptr);
-      auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
-          loc, wideType, idxComposites, static_cast<int32_t>(dim),
-          /*logicalSizes=*/nullptr);
+        // Build a groupTiles-tile buffer type along the reduction dim from a
+        // 1-tile partial's layout.
+        auto partialType = cast<RankedTensorType>(group[0].first.getType());
+        auto tileType = cast<ttcore::TileType>(partialType.getElementType());
+        auto partialLayout =
+            cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
+        SmallVector<int64_t> wideShape(partialType.getShape().begin(),
+                                       partialType.getShape().end());
+        wideShape[deviceRedDim] = groupTiles;
+        auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
+        auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
 
-      // Materialize each composite into a genuinely-allocated L1 buffer via its
-      // OWN copy generic. ExpandDMAReadCompositeView allows only one composite
-      // view per generic (#7600); a plain to_layout on the composite bufferizes
-      // to a view_layout chain that getCompositeViewSource walks straight back
-      // to the composite, so feeding both composites into the merge generic
-      // would leave it with two composite-backed DMA reads and trip that
-      // assert. A dedicated copy generic per composite reads exactly one
-      // composite (so it DMA-expands cleanly) and yields a real buffer; the
-      // merge then reads two plain allocs.
-      auto materializeComposite = [&](Value composite) -> Value {
-        auto compType = cast<RankedTensorType>(composite.getType());
-        auto copyOut = rewriter.create<d2m::EmptyOp>(loc, compType.getShape(),
-                                                     compType.getElementType(),
-                                                     compType.getEncoding());
-        SmallVector<Value> ins = {composite};
-        SmallVector<Value> outs = {copyOut.getResult()};
-        auto copyGeneric = rewriter.create<d2m::GenericOp>(
-            loc, ins, outs, /*additionalArgs=*/ValueRange(),
-            rewriter.getAffineMapArrayAttr(
-                SmallVector<AffineMap>{mergeIdentity, mergeIdentity}),
+        // Separate CompositeViews for values and indices (the DMA-expansion
+        // pass supports only one composite view per GenericOp, #7600), each
+        // materialized before the merge.
+        SmallVector<Value> valComposites, idxComposites;
+        for (auto &p : group) {
+          valComposites.push_back(p.first);
+          idxComposites.push_back(p.second);
+        }
+        auto valsComposite = rewriter.create<d2m::CompositeViewOp>(
+            loc, wideType, valComposites, static_cast<int32_t>(dim),
+            /*logicalSizes=*/nullptr);
+        auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
+            loc, wideType, idxComposites, static_cast<int32_t>(dim),
+            /*logicalSizes=*/nullptr);
+
+        // Materialize each composite into a genuinely-allocated L1 buffer via
+        // its OWN copy generic. ExpandDMAReadCompositeView allows only one
+        // composite view per generic (#7600); a plain to_layout on the
+        // composite bufferizes to a view_layout chain that
+        // getCompositeViewSource walks straight back to the composite, so
+        // feeding both composites into the merge generic would leave it with
+        // two composite-backed DMA reads and trip that assert. A dedicated copy
+        // generic per composite reads exactly one composite (so it DMA-expands
+        // cleanly) and yields a real buffer; the merge then reads two plain
+        // allocs.
+        auto materializeComposite = [&](Value composite) -> Value {
+          auto compType = cast<RankedTensorType>(composite.getType());
+          auto copyOut = rewriter.create<d2m::EmptyOp>(
+              loc, compType.getShape(), compType.getElementType(),
+              compType.getEncoding());
+          SmallVector<Value> ins = {composite};
+          SmallVector<Value> outs = {copyOut.getResult()};
+          auto copyGeneric = rewriter.create<d2m::GenericOp>(
+              loc, ins, outs, /*additionalArgs=*/ValueRange(),
+              rewriter.getAffineMapArrayAttr(
+                  SmallVector<AffineMap>{mergeIdentity, mergeIdentity}),
+              rewriter.getArrayAttr(mergeIters));
+          copyGeneric->setAttr("d2m.skip_grid_selection",
+                               rewriter.getUnitAttr());
+          withD2MGenericRegion(
+              rewriter, loc, copyGeneric, ins, outs,
+              [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+                Value input = blockArgs[0];
+                Value output = blockArgs[1];
+                std::size_t shardRank =
+                    cast<RankedTensorType>(output.getType()).getRank();
+                AffineMap shardIdentity =
+                    rewriter.getMultiDimIdentityMap(shardRank);
+                SmallVector<mlir::utils::IteratorType> linalgIters(
+                    shardRank, mlir::utils::IteratorType::parallel);
+                auto linalgOp = rewriter.create<linalg::GenericOp>(
+                    loc, output.getType(), input, output,
+                    SmallVector<AffineMap>{shardIdentity, shardIdentity},
+                    linalgIters,
+                    [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                      Value copied = b.create<d2m::TileTypecastOp>(
+                          bodyLoc, args[1].getType(), args[0]);
+                      b.create<linalg::YieldOp>(bodyLoc, copied);
+                    });
+                return {linalgOp->getResult(0)};
+              });
+          return relayout(copyGeneric->getResult(0));
+        };
+        Value valsMaterialized =
+            materializeComposite(valsComposite.getResult());
+        Value idxMaterialized = materializeComposite(idxComposite.getResult());
+
+        int64_t mergeReductionElems = groupTiles * 32;
+        auto mergeValsOut =
+            rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
+        auto mergeIdxOut =
+            rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
+        SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
+        SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
+                                           mergeIdxOut.getResult()};
+        auto mergeGeneric = rewriter.create<d2m::GenericOp>(
+            loc, mergeInputs, mergeOutputs, /*additionalArgs=*/ValueRange(),
+            rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
+                mergeIdentity, mergeIdentity, mergeIdentity, mergeIdentity}),
             rewriter.getArrayAttr(mergeIters));
-        copyGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+        mergeGeneric->setAttr("d2m.skip_grid_selection",
+                              rewriter.getUnitAttr());
         withD2MGenericRegion(
-            rewriter, loc, copyGeneric, ins, outs,
+            rewriter, loc, mergeGeneric, mergeInputs, mergeOutputs,
             [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-              Value input = blockArgs[0];
-              Value output = blockArgs[1];
-              std::size_t shardRank =
-                  cast<RankedTensorType>(output.getType()).getRank();
-              AffineMap shardIdentity =
-                  rewriter.getMultiDimIdentityMap(shardRank);
-              SmallVector<mlir::utils::IteratorType> linalgIters(
-                  shardRank, mlir::utils::IteratorType::parallel);
-              auto linalgOp = rewriter.create<linalg::GenericOp>(
-                  loc, output.getType(), input, output,
-                  SmallVector<AffineMap>{shardIdentity, shardIdentity},
-                  linalgIters,
-                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                    Value copied = b.create<d2m::TileTypecastOp>(
-                        bodyLoc, args[1].getType(), args[0]);
-                    b.create<linalg::YieldOp>(bodyLoc, copied);
-                  });
-              return {linalgOp->getResult(0)};
+              auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
+                  loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3],
+                  k,
+                  /*reductionDimSize=*/mergeReductionElems,
+                  /*stableSort=*/false, dim);
+              return {topkBlock.getResultValues(),
+                      topkBlock.getResultIndices()};
             });
-        return relayout(copyGeneric->getResult(0));
+        return {compactToTile(relayout(mergeGeneric->getResult(0))),
+                compactToTile(relayout(mergeGeneric->getResult(1)))};
       };
-      Value valsMaterialized = materializeComposite(valsComposite.getResult());
-      Value idxMaterialized = materializeComposite(idxComposite.getResult());
 
-      int64_t mergeReductionElems = numShards * 32;
-      auto mergeValsOut =
-          rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
-      auto mergeIdxOut =
-          rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
-      SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
-      SmallVector<Value> mergeOutputs = {mergeValsOut.getResult(),
-                                         mergeIdxOut.getResult()};
-      auto mergeGeneric = rewriter.create<d2m::GenericOp>(
-          loc, mergeInputs, mergeOutputs, /*additionalArgs=*/ValueRange(),
-          rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-              mergeIdentity, mergeIdentity, mergeIdentity, mergeIdentity}),
-          rewriter.getArrayAttr(mergeIters));
-      mergeGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-      withD2MGenericRegion(
-          rewriter, loc, mergeGeneric, mergeInputs, mergeOutputs,
-          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-            auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
-                loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-                /*reductionDimSize=*/mergeReductionElems, /*stableSort=*/false,
-                dim);
-            return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
-          });
-      topkValsRelayouted = compactToTile(relayout(mergeGeneric->getResult(0)));
-      topkIdxRelayouted = compactToTile(relayout(mergeGeneric->getResult(1)));
+      std::pair<Value, Value> merged;
+      if (numShards <= kMaxShardTiles) {
+        // All partials fit one core: a single topk_block reduces them.
+        merged = mergePartials(partials);
+      } else {
+        // > 32 partials would put > 32 tiles on the merge core. Split into two
+        // groups of <= 32, merge each on its own core to a 1-tile top-k
+        // partial, then merge those two partials with one final topk_block.
+        int64_t half = (numShards + 1) / 2;
+        assert(half <= kMaxShardTiles &&
+               "numShards > 2 * kMaxShardTiles is unsupported (needs a "
+               "multi-level merge tree)");
+        std::pair<Value, Value> g0 = mergePartials(
+            ArrayRef<std::pair<Value, Value>>(partials).take_front(half));
+        std::pair<Value, Value> g1 = mergePartials(
+            ArrayRef<std::pair<Value, Value>>(partials).drop_front(half));
+        merged = mergePartials(SmallVector<std::pair<Value, Value>>{g0, g1});
+      }
+      topkValsRelayouted = merged.first;
+      topkIdxRelayouted = merged.second;
     }
 
     // Index extract uses fp32 topk tiles; a typecast generic below converts

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3640,6 +3640,8 @@ public:
         rewriter.getAffineMapArrayAttr(
             SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
         rewriter.getArrayAttr(extractIters));
+    // Keep the extract on one core: it reads the full topk partial shard.
+    generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
 
     withD2MGenericRegion(
         rewriter, loc, generic, extractInputs, extractOutputs,
@@ -3718,43 +3720,419 @@ public:
           op, "D2M topk only supports 2D reduction on dim 0 or dim 1");
     }
 
-    int64_t reductionDimSize = inputType.getShape()[dim];
+    // Multi-core sharding: a very wide reduction dim does not fit in a single
+    // core's L1. Split it into G column bands ("slices"), run a local topk per
+    // slice, then merge the sorted partials in a cross-core reduction tree.
+    // First cut: k<=32 (small-k, 1-tile partials), dim==1, ht==1, and each
+    // slice is capped to kMaxShardTiles tiles wide.
+    constexpr int64_t kTileWidth = 32;
+    constexpr int64_t kMaxShardTiles = 32; // L1-safe shard width.
+    int64_t fullReductionElems = inputType.getShape()[dim];
+    int64_t fullReductionTiles = fullReductionElems / kTileWidth;
+    // G = number of slices needed so each slice is <= kMaxShardTiles tiles.
+    int64_t numShards =
+        (fullReductionTiles + kMaxShardTiles - 1) / kMaxShardTiles;
+    bool multiCore = numShards > 1;
 
-    // Logical shape for the value input, used to type the arange/index
-    // buffer since topk d2m.generic requires compatible operand shapes.
-    SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
-                                          inputType.getShape().end());
-
-    Value layoutedInput = createOptimalLayoutOp(
-        adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
-        /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);
-    auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
-    auto metalLayout =
-        cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
-    auto f32TileType = cast<ttcore::TileType>(layoutedType.getElementType());
-    ArrayRef<int64_t> deviceShape = layoutedType.getShape();
-    std::size_t physicalRank = deviceShape.size() / 2;
-
-    int64_t ht = deviceShape[deviceShape.size() - 2];
-    int64_t wt = deviceShape[deviceShape.size() - 1];
-    int64_t numReductionTiles = (dim == 1) ? wt : ht;
-    if (numReductionTiles < 2) {
+    if (fullReductionTiles < 2) {
       return rewriter.notifyMatchFailure(
           op,
           "D2M topk requires at least 2 tiles along the reduction dimension");
     }
-    // D2MDecomposeTopk's left-fold keeps the accumulator at canonical tiles
-    // (winner=0, loser=1), so extract always reads tile j from input tile j
-    // (lastStride=1)
+    if (multiCore) {
+      // Hard-fail (no TTNN fallback) for configs outside the first-cut scope.
+      assert(k <= 32 && "multi-core topk first cut only supports k <= 32");
+      assert(dim == 1 && "multi-core topk first cut only supports dim == 1");
+      assert(inputType.getShape()[0] == kTileWidth &&
+             "multi-core topk first cut only supports a single tile row "
+             "(ht == 1)");
+      assert(fullReductionElems % (kTileWidth * numShards) == 0 &&
+             "multi-core topk first cut requires the reduction dim to divide "
+             "evenly across shards");
+    }
+
+    // Reblocks a unit-grid ([1,1,ht,wt]) device tensor to grid 1xG
+    // ([1,G,ht,wt/G]) via a ViewLayoutOp so the G reduction-dim bands land on G
+    // distinct cores. createOptimalLayoutOp always builds a unit grid; this
+    // splits the shard's reduction-dim tiles across grid columns without moving
+    // data. GenericOp::build then auto-derives grid 1xG from the operand's grid
+    // shape, distributing the local topk compute across cores. Same idiom as
+    // the TTNN unit-grid reblock in createOptimalLayoutOp.
+    auto reblockToGrid = [&](Value value, int64_t gridCols) -> Value {
+      auto type = cast<RankedTensorType>(value.getType());
+      // No-op if already at the requested grid (also covers the single-core
+      // gridCols==1 path where the tensor is already unit grid).
+      ArrayRef<int64_t> curShape = type.getShape();
+      int64_t curGridCols = curShape[curShape.size() / 2 - 1];
+      if (curGridCols == gridCols) {
+        return value;
+      }
+      SmallVector<int64_t> newGrid = {1, gridCols};
+      auto [newShape, reblockMap] = ttmlir::utils::calculateReblockMapForGrid(
+          type.getShape(), newGrid, ctx);
+      auto newType = RankedTensorType::get(newShape, type.getElementType(),
+                                           type.getEncoding());
+      return rewriter
+          .create<d2m::ViewLayoutOp>(loc, newType, value, reblockMap,
+                                     /*reinterpretLayout=*/false)
+          .getResult();
+    };
+
+    // Emits the full single-shard topk (layout -> transpose -> arange/index ->
+    // TopkBlockOp -> relayout) over a raw [ht, shardWidth] input, returning the
+    // (values, indices) partials still in device layout (pre-extract).
+    // arangeStart offsets the index buffer so slice g yields GLOBAL indices.
+    // gridCols > 1 distributes the local topk compute across that many cores by
+    // reblocking the reduction-dim tiles into grid columns (one band per core).
+    auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
+                             int64_t gridCols = 1) -> std::pair<Value, Value> {
+      auto inputType = cast<RankedTensorType>(rawInput.getType());
+      int64_t rank = inputType.getRank();
+      int64_t reductionDimSize = inputType.getShape()[dim];
+
+      // The value input's logical shape. When large-k pads the reduction dim to
+      // a power-of-2 tile count, this grows to match the arange/index buffer,
+      // since topk d2m.generic requires both operands to share a shard shape.
+      SmallVector<int64_t> topkLogicalShape(inputType.getShape().begin(),
+                                            inputType.getShape().end());
+
+      Value layoutedInput =
+          createOptimalLayoutOp(rawInput, memorySpaces[0], /*tiled=*/true,
+                                /*noCollapse=*/false, rewriter);
+      // Shard the input across gridCols cores up front: reblock the unit-grid
+      // [1,1,ht,wt] layout to [1,gridCols,ht,wt/gridCols] so each core owns a
+      // wt/gridCols-tile band. Deriving deviceShape/metalLayout from this
+      // reblocked type makes the whole local-topk chain (transpose, arange,
+      // bcast, topk_block) allocate and compute per-core on its band.
+      layoutedInput = reblockToGrid(layoutedInput, gridCols);
+      auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
+      auto metalLayout =
+          cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
+      auto f32TileType = cast<ttcore::TileType>(layoutedType.getElementType());
+      ArrayRef<int64_t> deviceShape = layoutedType.getShape();
+      std::size_t physicalRank = deviceShape.size() / 2;
+
+      int64_t ht = deviceShape[deviceShape.size() - 2];
+      int64_t wt = deviceShape[deviceShape.size() - 1];
+      int64_t numReductionTiles = (dim == 1) ? wt : ht;
+      // The >=2 reduction-tile requirement is enforced on the full input before
+      // this lambda runs (single-core) / guaranteed by 32-tile shards
+      // (multi-core), so it is an invariant here.
+      assert(numReductionTiles >= 2 &&
+             "shard must have at least 2 tiles along the reduction dimension");
+      // D2MDecomposeTopk's large-k left-fold keeps the accumulator at canonical
+      // tiles (winner=0, loser=1) for any tile count, so no power-of-2 padding
+      // (and no -inf mask) is needed on the reduction dim.
+
+      Type f32Type = f32TileType.getElementType();
+      auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, deviceShape, f32TileType, metalLayout);
+      auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, deviceShape, f32TileType, metalLayout);
+
+      auto wrapInToLayout = [&](Value genericResult) -> Value {
+        auto resultType = cast<RankedTensorType>(genericResult.getType());
+        auto emptyOp = rewriter.create<d2m::EmptyOp>(
+            loc, resultType.getShape(), resultType.getElementType(),
+            resultType.getEncoding());
+        return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
+            .getResult(0);
+      };
+
+      auto parallel =
+          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
+      SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+      AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+
+      // Emits a generic that applies TileTransposeOp to every tile in the
+      // shard. Used for both value and index when dim==1 to keep them in the
+      // same orientation.
+      auto transposeTiles = [&](Value src) -> Value {
+        auto srcType = cast<RankedTensorType>(src.getType());
+        auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
+        auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
+        auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
+            loc, srcType.getShape(), srcTileType, srcLayout);
+        SmallVector<Value> transposeInputs = {src};
+        SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
+        auto transposeGeneric = rewriter.create<d2m::GenericOp>(
+            loc, transposeInputs, transposeOutputs,
+            /*additionalArgs=*/ValueRange(),
+            rewriter.getAffineMapArrayAttr(
+                SmallVector<AffineMap>{identityMap, identityMap}),
+            rewriter.getArrayAttr(iteratorTypes));
+        // topk generics keep the whole reduction dim on one core: the block
+        // ops (transpose/arange/bcast/topk) assume the full shard is local, and
+        // GridSelection derives grids from operand shape (not iterator types),
+        // so it would otherwise shard the reduction dim and corrupt the result.
+        transposeGeneric->setAttr("d2m.skip_grid_selection",
+                                  rewriter.getUnitAttr());
+
+        withD2MGenericRegion(
+            rewriter, loc, transposeGeneric, transposeInputs, transposeOutputs,
+            [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+              Value input = blockArgs[0];
+              Value output = blockArgs[1];
+              std::size_t shardRank =
+                  cast<RankedTensorType>(input.getType()).getRank();
+              AffineMap shardIdentity =
+                  rewriter.getMultiDimIdentityMap(shardRank);
+              SmallVector<mlir::utils::IteratorType> linalgIters(
+                  shardRank, mlir::utils::IteratorType::parallel);
+              // TileTransposeOp operates on a single tile. linalg::GenericOp
+              // iterates over all tiles in the shard to apply it to each.
+              auto linalgOp = rewriter.create<linalg::GenericOp>(
+                  loc, output.getType(), input, output,
+                  SmallVector<AffineMap>{shardIdentity, shardIdentity},
+                  linalgIters,
+                  [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                    Value transposed = b.create<d2m::TileTransposeOp>(
+                        bodyLoc, args[1].getType(), args[0]);
+                    b.create<linalg::YieldOp>(bodyLoc, transposed);
+                  });
+              return {linalgOp->getResult(0)};
+            });
+
+        return wrapInToLayout(transposeGeneric->getResult(0));
+      };
+
+      // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
+      // operates on tile columns, so we transpose the tiles first.
+      Value topkInput = layoutedInput;
+      if (dim == 1) {
+        topkInput = transposeTiles(layoutedInput);
+      }
+
+      // Setting up the arange op.
+
+      auto f32InputType = RankedTensorType::get(topkLogicalShape, f32Type,
+                                                inputType.getEncoding());
+      auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {f32InputType});
+      auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
+          rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
+          /*noCollapse=*/false);
+
+      // Shard the index buffer across the same gridCols cores as the input so
+      // arange/bcast allocate and run per-core. toLayoutOperandsAndResults
+      // always builds a unit grid, so reblock to 1xgridCols here; the scratch
+      // and downstream empties derive their grid from this output.
+      arangeOutputs[0] = reblockToGrid(arangeOutputs[0], gridCols);
+      auto arangeOutput = arangeOutputs[0];
+      auto arangeTensorType =
+          mlir::cast<RankedTensorType>(arangeOutput.getType());
+      auto arangeLayout =
+          mlir::cast<ttcore::MetalLayoutAttr>(arangeTensorType.getEncoding());
+      auto arangeTileType =
+          mlir::cast<ttcore::TileType>(arangeTensorType.getElementType());
+      Type arangeElemType = arangeTileType.getElementType();
+      ArrayRef<int64_t> arangeGridShape =
+          arangeLayout.getGridShape(arangeTensorType);
+      SmallVector<int64_t> arangeScratchShape(arangeGridShape.begin(),
+                                              arangeGridShape.end());
+      arangeScratchShape.append({1, 1});
+      auto arangeScratchTileType = ttcore::TileType::get(arangeElemType);
+      auto arangeScratchLayout = ttcore::MetalLayoutAttr::get(
+          ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
+          ttcore::TensorMemoryLayout::Sharded);
+      Value indexTileTensor =
+          rewriter
+              .create<d2m::EmptyOp>(loc, arangeScratchShape,
+                                    arangeScratchTileType, arangeScratchLayout)
+              .getResult();
+
+      int64_t numElements =
+          (dim == 0) ? topkLogicalShape[rank - 2] : topkLogicalShape[rank - 1];
+
+      // Build affine maps: scratch input always at (0,0), output is identity.
+      AffineExpr zero = rewriter.getAffineConstantExpr(0);
+      AffineMap arangeConstMap =
+          AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
+      AffineMap arangeIdentMap = rewriter.getMultiDimIdentityMap(physicalRank);
+      SmallVector<AffineMap> arangeMaps = {arangeConstMap, arangeIdentMap};
+
+      // All iterators are parallel for arange.
+      SmallVector<Attribute> arangeIters(
+          physicalRank,
+          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+      SmallVector<Value> arangeGenericInputs = {indexTileTensor};
+      auto arange = rewriter.create<d2m::GenericOp>(
+          loc, arangeGenericInputs, arangeOutputs,
+          /*additionalArgs=*/ValueRange(),
+          rewriter.getAffineMapArrayAttr(arangeMaps),
+          rewriter.getArrayAttr(arangeIters));
+      arange->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+
+      withD2MGenericRegion(
+          rewriter, loc, arange, arangeGenericInputs, arangeOutputs,
+          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+            Value idxTile = blockArgs[0];
+            Value outTile = blockArgs[1];
+            Value result = rewriter
+                               .create<d2m::ArangeBlockOp>(
+                                   loc, idxTile, outTile, numElements,
+                                   /*start=*/arangeStart,
+                                   /*step=*/1,
+                                   /*colMajor=*/(dim == 0))
+                               .getResult();
+            return {result};
+          });
+
+      // Setting up the broadcast after arange.
+
+      // Broadcast first row or column to full shape.
+      d2m::TileBcastType postArangeBcastType =
+          (dim == 1) ? d2m::TileBcastType::Row : d2m::TileBcastType::Col;
+      d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
+          d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
+      SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
+                                               arange.getResults().end());
+      auto postArangeBcastOrigOutputs =
+          createDpsOutputs(loc, rewriter, {f32InputType});
+      auto [postArangeBcastins, postArangeBcastOutputs] =
+          toLayoutOperandsAndResults(
+              rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs},
+              true,
+              /*noCollapse=*/false);
+      // Match the sharded (1xgridCols) arange input grid so the bcast generic's
+      // operand grids agree and it too runs per-core.
+      postArangeBcastOutputs[0] =
+          reblockToGrid(postArangeBcastOutputs[0], gridCols);
+
+      // Build affine maps: input is reduced, output is identity.
+      mlir::MutableAffineMap postArangeInMap(
+          rewriter.getMultiDimIdentityMap(physicalRank));
+      switch (postArangeBcastType) {
+      case d2m::TileBcastType::Row:
+        postArangeInMap.setResult(physicalRank - 2, zero);
+        break;
+      case d2m::TileBcastType::Col:
+        postArangeInMap.setResult(physicalRank - 1, zero);
+        break;
+      default:
+        break;
+      }
+      AffineMap postArangeBcastInputMap = postArangeInMap.getAffineMap();
+      AffineMap postArangeBcastOutputMap =
+          rewriter.getMultiDimIdentityMap(physicalRank);
+      SmallVector<AffineMap> postArangeBcastMaps = {postArangeBcastInputMap,
+                                                    postArangeBcastOutputMap};
+
+      SmallVector<Attribute> postArangeBcastIters(
+          physicalRank,
+          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+      d2m::GenericOp postArangeBcast = rewriter.create<d2m::GenericOp>(
+          loc, postArangeBcastInputs, postArangeBcastOutputs,
+          /*additionalArgs=*/ValueRange(),
+          rewriter.getAffineMapArrayAttr(postArangeBcastMaps),
+          rewriter.getArrayAttr(postArangeBcastIters));
+      postArangeBcast->setAttr("d2m.skip_grid_selection",
+                               rewriter.getUnitAttr());
+
+      withD2MGenericRegion(
+          rewriter, loc, postArangeBcast, postArangeBcastInputs,
+          postArangeBcastOutputs,
+          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+            Value input = blockArgs[0];
+            Value output = blockArgs[1];
+            std::size_t shardRank =
+                cast<RankedTensorType>(output.getType()).getRank();
+            // Reuse the outer d2m.generic's projecting maps (input map zeroes
+            // the broadcast axis). An identity map would make linalg infer the
+            // broadcast-axis extent from the iteration domain, mismatching the
+            // collapsed input shard when the non-target dim spans >1 tile (e.g.
+            // ht=2 for dim=1).
+            mlir::MutableAffineMap shardInMap(
+                rewriter.getMultiDimIdentityMap(shardRank));
+            switch (postArangeBcastType) {
+            case d2m::TileBcastType::Row:
+              shardInMap.setResult(shardRank - 2,
+                                   rewriter.getAffineConstantExpr(0));
+              break;
+            case d2m::TileBcastType::Col:
+              shardInMap.setResult(shardRank - 1,
+                                   rewriter.getAffineConstantExpr(0));
+              break;
+            default:
+              break;
+            }
+            AffineMap shardInputMap = shardInMap.getAffineMap();
+            AffineMap shardIdentity =
+                rewriter.getMultiDimIdentityMap(shardRank);
+            SmallVector<mlir::utils::IteratorType> linalgIters(
+                shardRank, mlir::utils::IteratorType::parallel);
+            auto linalgOp = rewriter.create<linalg::GenericOp>(
+                loc, output.getType(), input, output,
+                SmallVector<AffineMap>{shardInputMap, shardIdentity},
+                linalgIters,
+                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                  Value bcast = b.create<d2m::TileBcastOp>(
+                      bodyLoc, args[1].getType(), args[0],
+                      postArangeBcastTypeAttr);
+                  b.create<linalg::YieldOp>(bodyLoc, bcast);
+                });
+            return {linalgOp->getResult(0)};
+          });
+
+      Value indexOperand = postArangeBcast->getResult(0);
+      Value idxBuf = wrapInToLayout(indexOperand);
+
+      // TopkBlockOp reads value and index tiles in lockstep, so transpose the
+      // index buffer the same way as the value input for dim==1. For dim==1,
+      // arange+bcast yields idxBuf[row][col] = col, so after transpose the
+      // column index varies along the tile's row axis, matching the value tile.
+      if (dim == 1) {
+        idxBuf = transposeTiles(idxBuf);
+      }
+
+      SmallVector<Value> topkInputs = {topkInput, idxBuf};
+      SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
+                                        topkIdxEmpty.getResult()};
+      auto topkGeneric = rewriter.create<d2m::GenericOp>(
+          loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
+          rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
+              identityMap, identityMap, identityMap, identityMap}),
+          rewriter.getArrayAttr(iteratorTypes));
+      topkGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+
+      withD2MGenericRegion(
+          rewriter, loc, topkGeneric, topkInputs, topkOutputs,
+          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+            auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
+                loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
+                reductionDimSize, /*stableSort=*/false, dim);
+            return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
+          });
+
+      // Gather the per-core (1xgridCols) topk results back to a unit grid so
+      // the downstream extract/merge path (which assumes 1x1) is unchanged.
+      // This is the single cross-core boundary; distributing the merge is
+      // future work.
+      Value topkValsRelayouted =
+          reblockToGrid(wrapInToLayout(topkGeneric->getResult(0)), 1);
+      Value topkIdxRelayouted =
+          reblockToGrid(wrapInToLayout(topkGeneric->getResult(1)), 1);
+
+      return {topkValsRelayouted, topkIdxRelayouted};
+    }; // emitShardTopk
+
+    // ----- Drive the shard topk(s): single-core or the multi-core tree. -----
+
+    // physicalRank / lastStride / outputReductionTiles are needed by the shared
+    // extract tail below and do not depend on which shard produced the result.
+    // physicalRank equals the input rank (device layout is grid + shard, each
+    // of input rank). For k>32 the result spans 2 tiles; D2MDecomposeTopk's
+    // left-fold keeps the accumulator at canonical tiles (winner=0, loser=1),
+    // so the extract reads tile j from input tile j (lastStride=1) for any tile
+    // count, with no power-of-2 padding. For k<=32 lastStride is unused.
+    Type elemF32Type = rewriter.getF32Type();
+    std::size_t physicalRank = static_cast<std::size_t>(rank);
+    int64_t outputReductionTiles = (k + 31) / 32;
     int64_t lastStride = 1;
 
-    Type f32Type = f32TileType.getElementType();
-    auto topkValsEmpty = rewriter.create<d2m::EmptyOp>(
-        loc, deviceShape, f32TileType, metalLayout);
-    auto topkIdxEmpty = rewriter.create<d2m::EmptyOp>(loc, deviceShape,
-                                                      f32TileType, metalLayout);
-
-    auto wrapInToLayout = [&](Value genericResult) -> Value {
+    // to_layout wrapper usable at this (outer) scope for the merge tree.
+    auto relayout = [&](Value genericResult) -> Value {
       auto resultType = cast<RankedTensorType>(genericResult.getType());
       auto emptyOp = rewriter.create<d2m::EmptyOp>(loc, resultType.getShape(),
                                                    resultType.getElementType(),
@@ -3762,260 +4140,208 @@ public:
       return rewriter.create<d2m::ToLayoutOp>(loc, genericResult, emptyOp)
           .getResult(0);
     };
-
-    auto parallel =
+    auto parallelAttr =
         ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
-    SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
-    AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+    SmallVector<Attribute> mergeIters(physicalRank, parallelAttr);
+    AffineMap mergeIdentity = rewriter.getMultiDimIdentityMap(physicalRank);
+    // Shard-space index of the reduction dim (used for generic-level affine
+    // maps, which operate on the [sh, sw] shard portion of rank physicalRank).
+    std::size_t redPhysDim =
+        (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+    // Device-tensor index of the reduction dim. The device layout is rank
+    // 2*physicalRank ([grid..., shard...]); the reduction tiles live in the
+    // shard portion, i.e. the last shard dim for dim==1 and the first shard dim
+    // for dim==0. compactToTile/mergePair reshape the device tensor, so they
+    // must index here, not in shard space.
+    std::size_t deviceRedDim =
+        (dim == 1) ? (2 * physicalRank - 1) : (2 * physicalRank - 2);
 
-    // Emits a generic that applies TileTransposeOp to every tile in the shard.
-    // Used for both value and index when dim==1 to keep them in the same
-    // orientation.
-    auto transposeTiles = [&](Value src) -> Value {
-      auto srcType = cast<RankedTensorType>(src.getType());
-      auto srcTileType = cast<ttcore::TileType>(srcType.getElementType());
-      auto srcLayout = cast<ttcore::MetalLayoutAttr>(srcType.getEncoding());
-      auto transposeEmpty = rewriter.create<d2m::EmptyOp>(
-          loc, srcType.getShape(), srcTileType, srcLayout);
-      SmallVector<Value> transposeInputs = {src};
-      SmallVector<Value> transposeOutputs = {transposeEmpty.getResult()};
-      auto transposeGeneric = rewriter.create<d2m::GenericOp>(
-          loc, transposeInputs, transposeOutputs,
-          /*additionalArgs=*/ValueRange(),
+    // Rebuilds a MetalLayoutAttr from `layout` but with a logical shape that
+    // matches `deviceShape`'s tile counts (tileRows*32 x tileCols*32). The
+    // CompositeViewOp verifier checks logical shapes, so the layout's logical
+    // shape must track the physical tile count as the merge tree grows/shrinks
+    // the reduction dim.
+    auto layoutForDeviceShape =
+        [&](ttcore::MetalLayoutAttr layout,
+            ArrayRef<int64_t> deviceShape) -> ttcore::MetalLayoutAttr {
+      constexpr int64_t kTileDim = 32;
+      int64_t shardH = deviceShape[deviceShape.size() - 2];
+      int64_t shardW = deviceShape[deviceShape.size() - 1];
+      SmallVector<int64_t> newLogical = {shardH * kTileDim, shardW * kTileDim};
+      return ttcore::MetalLayoutAttr::get(
+          ctx, newLogical, layout.getDimAlignments(),
+          layout.getCollapsedIntervals(), layout.getMemorySpace(),
+          layout.getMemoryLayout());
+    };
+
+    // Compacts tile 0 of a full-width partial into a fresh 1-tile f32
+    // device-layout buffer, giving a distinct SSA value the merge tree can
+    // CompositeView. Projects the reduction physical dim to constant 0 (copy of
+    // tile 0), identity elsewhere.
+    auto compactToTile = [&](Value fullPartial) -> Value {
+      auto fullType = cast<RankedTensorType>(fullPartial.getType());
+      auto tileType = cast<ttcore::TileType>(fullType.getElementType());
+      auto layout = cast<ttcore::MetalLayoutAttr>(fullType.getEncoding());
+      SmallVector<int64_t> oneTileShape(fullType.getShape().begin(),
+                                        fullType.getShape().end());
+      oneTileShape[deviceRedDim] = 1;
+      // Fresh layout whose logical shape matches the compacted 1-tile physical
+      // shape (the CompositeViewOp verifier reads logical shapes).
+      auto oneTileLayout = layoutForDeviceShape(layout, oneTileShape);
+      auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, oneTileShape, tileType,
+                                                    oneTileLayout);
+      // Input map projects the reduction dim to 0; output identity.
+      SmallVector<AffineExpr> inExprs;
+      for (std::size_t i = 0; i < physicalRank; ++i) {
+        inExprs.push_back(i == redPhysDim ? rewriter.getAffineConstantExpr(0)
+                                          : rewriter.getAffineDimExpr(i));
+      }
+      AffineMap inProj = AffineMap::get(physicalRank, 0, inExprs, ctx);
+      SmallVector<Value> ins = {fullPartial};
+      SmallVector<Value> outs = {outEmpty.getResult()};
+      auto generic = rewriter.create<d2m::GenericOp>(
+          loc, ins, outs, /*additionalArgs=*/ValueRange(),
           rewriter.getAffineMapArrayAttr(
-              SmallVector<AffineMap>{identityMap, identityMap}),
-          rewriter.getArrayAttr(iteratorTypes));
-
+              SmallVector<AffineMap>{inProj, mergeIdentity}),
+          rewriter.getArrayAttr(mergeIters));
+      generic->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
       withD2MGenericRegion(
-          rewriter, loc, transposeGeneric, transposeInputs, transposeOutputs,
+          rewriter, loc, generic, ins, outs,
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
             Value input = blockArgs[0];
             Value output = blockArgs[1];
             std::size_t shardRank =
-                cast<RankedTensorType>(input.getType()).getRank();
+                cast<RankedTensorType>(output.getType()).getRank();
+            // Copy of the (projected) input tile into the 1-tile output.
+            SmallVector<AffineExpr> shardInExprs;
+            for (std::size_t i = 0; i < shardRank; ++i) {
+              shardInExprs.push_back(
+                  i == (shardRank - (physicalRank - redPhysDim))
+                      ? rewriter.getAffineConstantExpr(0)
+                      : rewriter.getAffineDimExpr(i));
+            }
+            AffineMap shardInMap =
+                AffineMap::get(shardRank, 0, shardInExprs, ctx);
             AffineMap shardIdentity =
                 rewriter.getMultiDimIdentityMap(shardRank);
             SmallVector<mlir::utils::IteratorType> linalgIters(
                 shardRank, mlir::utils::IteratorType::parallel);
-            // TileTransposeOp operates on a single tile. linalg::GenericOp
-            // iterates over all tiles in the shard to apply it to each.
             auto linalgOp = rewriter.create<linalg::GenericOp>(
                 loc, output.getType(), input, output,
-                SmallVector<AffineMap>{shardIdentity, shardIdentity},
-                linalgIters,
+                SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
                 [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                  Value transposed = b.create<d2m::TileTransposeOp>(
+                  Value copied = b.create<d2m::TileTypecastOp>(
                       bodyLoc, args[1].getType(), args[0]);
-                  b.create<linalg::YieldOp>(bodyLoc, transposed);
+                  b.create<linalg::YieldOp>(bodyLoc, copied);
                 });
             return {linalgOp->getResult(0)};
           });
-
-      return wrapInToLayout(transposeGeneric->getResult(0));
+      return relayout(generic->getResult(0));
     };
 
-    // When dim=1, the sort dimension falls along tile rows, but TopkBlockOp
-    // operates on tile columns, so we transpose the tiles first.
-    Value topkInput = layoutedInput;
-    if (dim == 1) {
-      topkInput = transposeTiles(layoutedInput);
+    // Merges two 1-tile (vals, idx) partials into one 1-tile partial by
+    // CompositeView-ing them into a 2-tile buffer and running a TopkBlockOp
+    // generic over it (result lands in tile 0), then compacting back to 1 tile.
+    // Indices are CARRIED (not regenerated) so global indices propagate.
+    auto mergePair = [&](std::pair<Value, Value> a,
+                         std::pair<Value, Value> b) -> std::pair<Value, Value> {
+      auto tileType = cast<ttcore::TileType>(
+          cast<RankedTensorType>(a.first.getType()).getElementType());
+      auto layout = cast<ttcore::MetalLayoutAttr>(
+          cast<RankedTensorType>(a.first.getType()).getEncoding());
+      SmallVector<int64_t> twoTileShape(
+          cast<RankedTensorType>(a.first.getType()).getShape().begin(),
+          cast<RankedTensorType>(a.first.getType()).getShape().end());
+      twoTileShape[deviceRedDim] = 2;
+      // Fresh layout whose logical shape matches the 2-tile physical shape so
+      // the CompositeViewOp logical-shape verifier is satisfied (inputs are
+      // 1 tile each along the composite dim; sum == 2 tiles == output).
+      auto twoTileLayout = layoutForDeviceShape(layout, twoTileShape);
+      auto twoTileType =
+          RankedTensorType::get(twoTileShape, tileType, twoTileLayout);
+
+      // CompositeViewOp's dim indexes the layout's logical shape (rank
+      // physicalRank), so the composite axis is the logical reduction dim.
+      auto valsComposite = rewriter.create<d2m::CompositeViewOp>(
+          loc, twoTileType, ValueRange{a.first, b.first},
+          static_cast<int32_t>(dim), /*logicalSizes=*/nullptr);
+      auto idxComposite = rewriter.create<d2m::CompositeViewOp>(
+          loc, twoTileType, ValueRange{a.second, b.second},
+          static_cast<int32_t>(dim), /*logicalSizes=*/nullptr);
+
+      // Materialize both composites into real 2-tile buffers before the merge
+      // generic. The DMA-expansion pass supports only one composite view per
+      // GenericOp (#7600); the merge needs both values and indices, so we copy
+      // each composite into a plain buffer here and feed those to the generic.
+      Value valsMaterialized = relayout(valsComposite.getResult());
+      Value idxMaterialized = relayout(idxComposite.getResult());
+
+      auto valsOut = rewriter.create<d2m::EmptyOp>(loc, twoTileShape, tileType,
+                                                   twoTileLayout);
+      auto idxOut = rewriter.create<d2m::EmptyOp>(loc, twoTileShape, tileType,
+                                                  twoTileLayout);
+      SmallVector<Value> mergeInputs = {valsMaterialized, idxMaterialized};
+      SmallVector<Value> mergeOutputs = {valsOut.getResult(),
+                                         idxOut.getResult()};
+      auto mergeGeneric = rewriter.create<d2m::GenericOp>(
+          loc, mergeInputs, mergeOutputs, /*additionalArgs=*/ValueRange(),
+          rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
+              mergeIdentity, mergeIdentity, mergeIdentity, mergeIdentity}),
+          rewriter.getArrayAttr(mergeIters));
+      mergeGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
+      withD2MGenericRegion(
+          rewriter, loc, mergeGeneric, mergeInputs, mergeOutputs,
+          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+            auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
+                loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
+                /*reductionDimSize=*/2 * 32, /*stableSort=*/false, dim);
+            return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
+          });
+      Value mergedVals = relayout(mergeGeneric->getResult(0));
+      Value mergedIdx = relayout(mergeGeneric->getResult(1));
+      return {compactToTile(mergedVals), compactToTile(mergedIdx)};
+    };
+
+    Value topkValsRelayouted, topkIdxRelayouted;
+    if (!multiCore) {
+      std::tie(topkValsRelayouted, topkIdxRelayouted) =
+          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0);
+    } else {
+      // Run one local topk over the full input, distributed across numShards
+      // cores: the reduction-dim tile bands are reblocked into grid columns so
+      // each core runs topk_block on its own band. The per-core partials are
+      // gathered back to a unit grid inside emitShardTopk; the merge across
+      // bands is handled by the existing reduction tree below.
+      SmallVector<std::pair<Value, Value>> partials;
+      {
+        auto [pv, pi] =
+            emitShardTopk(adaptor.getInputTensor(),
+                          /*arangeStart=*/0, /*gridCols=*/numShards);
+        partials.push_back({compactToTile(pv), compactToTile(pi)});
+      }
+
+      // Reduction tree: fold pairs level by level; a ragged (odd) tail element
+      // is carried unchanged to the next level (top-k merge is associative, so
+      // any pairing order yields the same global top-k).
+      while (partials.size() > 1) {
+        SmallVector<std::pair<Value, Value>> next;
+        for (std::size_t i = 0; i + 1 < partials.size(); i += 2) {
+          next.push_back(mergePair(partials[i], partials[i + 1]));
+        }
+        if (partials.size() % 2 == 1) {
+          next.push_back(partials.back());
+        }
+        partials = std::move(next);
+      }
+      topkValsRelayouted = partials[0].first;
+      topkIdxRelayouted = partials[0].second;
     }
-
-    // Setting up the arange op.
-
-    auto f32InputType = RankedTensorType::get(topkLogicalShape, f32Type,
-                                              inputType.getEncoding());
-    auto arangeOrigOutputs = createDpsOutputs(loc, rewriter, {f32InputType});
-    auto [arangeins, arangeOutputs] = toLayoutOperandsAndResults(
-        rewriter, {SmallVector<Value>{}, arangeOrigOutputs}, true,
-        /*noCollapse=*/false);
-
-    // Create a scratch tile (copied from D2MArangeOpRewriter).
-    auto arangeOutput = arangeOutputs[0];
-    auto arangeTensorType =
-        mlir::cast<RankedTensorType>(arangeOutput.getType());
-    auto arangeLayout =
-        mlir::cast<ttcore::MetalLayoutAttr>(arangeTensorType.getEncoding());
-    auto arangeTileType =
-        mlir::cast<ttcore::TileType>(arangeTensorType.getElementType());
-    Type arangeElemType = arangeTileType.getElementType();
-    ArrayRef<int64_t> arangeGridShape =
-        arangeLayout.getGridShape(arangeTensorType);
-    SmallVector<int64_t> arangeScratchShape(arangeGridShape.begin(),
-                                            arangeGridShape.end());
-    arangeScratchShape.append({1, 1});
-    auto arangeScratchTileType = ttcore::TileType::get(arangeElemType);
-    auto arangeScratchLayout = ttcore::MetalLayoutAttr::get(
-        ctx, SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
-        ttcore::TensorMemoryLayout::Sharded);
-    Value indexTileTensor =
-        rewriter
-            .create<d2m::EmptyOp>(loc, arangeScratchShape,
-                                  arangeScratchTileType, arangeScratchLayout)
-            .getResult();
-
-    int64_t numElements =
-        (dim == 0) ? topkLogicalShape[rank - 2] : topkLogicalShape[rank - 1];
-
-    // Build affine maps: scratch input always at (0,0), output is identity.
-    AffineExpr zero = rewriter.getAffineConstantExpr(0);
-    AffineMap arangeConstMap =
-        AffineMap::get(physicalRank, 0, {zero, zero}, ctx);
-    AffineMap arangeIdentMap = rewriter.getMultiDimIdentityMap(physicalRank);
-    SmallVector<AffineMap> arangeMaps = {arangeConstMap, arangeIdentMap};
-
-    // All iterators are parallel for arange.
-    SmallVector<Attribute> arangeIters(
-        physicalRank,
-        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-    SmallVector<Value> arangeGenericInputs = {indexTileTensor};
-    auto arange = rewriter.create<d2m::GenericOp>(
-        loc, arangeGenericInputs, arangeOutputs,
-        /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(arangeMaps),
-        rewriter.getArrayAttr(arangeIters));
-
-    withD2MGenericRegion(
-        rewriter, loc, arange, arangeGenericInputs, arangeOutputs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          Value idxTile = blockArgs[0];
-          Value outTile = blockArgs[1];
-          Value result = rewriter
-                             .create<d2m::ArangeBlockOp>(
-                                 loc, idxTile, outTile, numElements,
-                                 /*start=*/0,
-                                 /*step=*/1,
-                                 /*colMajor=*/(dim == 0))
-                             .getResult();
-          return {result};
-        });
-
-    // Setting up the broadcast after arange.
-
-    // Broadcast first row or column to full shape.
-    d2m::TileBcastType postArangeBcastType =
-        (dim == 1) ? d2m::TileBcastType::Row : d2m::TileBcastType::Col;
-    d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
-        d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
-    SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
-                                             arange.getResults().end());
-    auto postArangeBcastOrigOutputs =
-        createDpsOutputs(loc, rewriter, {f32InputType});
-    auto [postArangeBcastins, postArangeBcastOutputs] =
-        toLayoutOperandsAndResults(
-            rewriter, {SmallVector<Value>{}, postArangeBcastOrigOutputs}, true,
-            /*noCollapse=*/false);
-
-    // Build affine maps: input is reduced, output is identity.
-    mlir::MutableAffineMap postArangeInMap(
-        rewriter.getMultiDimIdentityMap(physicalRank));
-    switch (postArangeBcastType) {
-    case d2m::TileBcastType::Row:
-      postArangeInMap.setResult(physicalRank - 2, zero);
-      break;
-    case d2m::TileBcastType::Col:
-      postArangeInMap.setResult(physicalRank - 1, zero);
-      break;
-    default:
-      break;
-    }
-    AffineMap postArangeBcastInputMap = postArangeInMap.getAffineMap();
-    AffineMap postArangeBcastOutputMap =
-        rewriter.getMultiDimIdentityMap(physicalRank);
-    SmallVector<AffineMap> postArangeBcastMaps = {postArangeBcastInputMap,
-                                                  postArangeBcastOutputMap};
-
-    SmallVector<Attribute> postArangeBcastIters(
-        physicalRank,
-        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-    d2m::GenericOp postArangeBcast = rewriter.create<d2m::GenericOp>(
-        loc, postArangeBcastInputs, postArangeBcastOutputs,
-        /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(postArangeBcastMaps),
-        rewriter.getArrayAttr(postArangeBcastIters));
-
-    withD2MGenericRegion(
-        rewriter, loc, postArangeBcast, postArangeBcastInputs,
-        postArangeBcastOutputs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          Value input = blockArgs[0];
-          Value output = blockArgs[1];
-          std::size_t shardRank =
-              cast<RankedTensorType>(output.getType()).getRank();
-          // Reuse the outer d2m.generic's projecting maps (input map zeroes the
-          // broadcast axis). An identity map would make linalg infer the
-          // broadcast-axis extent from the iteration domain, mismatching the
-          // collapsed input shard when the non-target dim spans >1 tile (e.g.
-          // ht=2 for dim=1).
-          mlir::MutableAffineMap shardInMap(
-              rewriter.getMultiDimIdentityMap(shardRank));
-          switch (postArangeBcastType) {
-          case d2m::TileBcastType::Row:
-            shardInMap.setResult(shardRank - 2,
-                                 rewriter.getAffineConstantExpr(0));
-            break;
-          case d2m::TileBcastType::Col:
-            shardInMap.setResult(shardRank - 1,
-                                 rewriter.getAffineConstantExpr(0));
-            break;
-          default:
-            break;
-          }
-          AffineMap shardInputMap = shardInMap.getAffineMap();
-          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
-          SmallVector<mlir::utils::IteratorType> linalgIters(
-              shardRank, mlir::utils::IteratorType::parallel);
-          auto linalgOp = rewriter.create<linalg::GenericOp>(
-              loc, output.getType(), input, output,
-              SmallVector<AffineMap>{shardInputMap, shardIdentity}, linalgIters,
-              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                Value bcast = b.create<d2m::TileBcastOp>(
-                    bodyLoc, args[1].getType(), args[0],
-                    postArangeBcastTypeAttr);
-                b.create<linalg::YieldOp>(bodyLoc, bcast);
-              });
-          return {linalgOp->getResult(0)};
-        });
-
-    Value indexOperand = postArangeBcast->getResult(0);
-    Value idxBuf = wrapInToLayout(indexOperand);
-
-    // TopkBlockOp reads value and index tiles in lockstep, so transpose the
-    // index buffer the same way as the value input for dim==1. For dim==1,
-    // arange+bcast yields idxBuf[row][col] = col, so after transpose the
-    // column index varies along the tile's row axis, matching the value tile.
-    if (dim == 1) {
-      idxBuf = transposeTiles(idxBuf);
-    }
-
-    SmallVector<Value> topkInputs = {topkInput, idxBuf};
-    SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
-                                      topkIdxEmpty.getResult()};
-    auto topkGeneric = rewriter.create<d2m::GenericOp>(
-        loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(SmallVector<AffineMap>{
-            identityMap, identityMap, identityMap, identityMap}),
-        rewriter.getArrayAttr(iteratorTypes));
-
-    withD2MGenericRegion(
-        rewriter, loc, topkGeneric, topkInputs, topkOutputs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          auto topkBlock = rewriter.create<d2m::TopkBlockOp>(
-              loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-              reductionDimSize, /*stableSort=*/false, dim);
-          return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
-        });
-
-    Value topkValsRelayouted = wrapInToLayout(topkGeneric->getResult(0));
-    Value topkIdxRelayouted = wrapInToLayout(topkGeneric->getResult(1));
 
     // Index extract uses fp32 topk tiles; a typecast generic below converts
     // to the user index output element type (uint16) for width-preserving
     // untilize.
     auto f32IndicesType =
-        RankedTensorType::get(indicesType.getShape(), f32Type);
+        RankedTensorType::get(indicesType.getShape(), elemF32Type);
 
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
@@ -4029,7 +4355,8 @@ public:
         /*noCollapse=*/false, rewriter);
 
     // Need 1 output tile for k <= 32 and 2 tiles for k > 32
-    int64_t outputReductionTiles = (k + 31) / 32;
+    // outputReductionTiles and lastStride are computed once in the drive
+    // section above (they do not depend on the shard).
     std::size_t extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
 
     auto extractValsGeneric = createExtractGeneric(
@@ -4064,6 +4391,7 @@ public:
         rewriter.getAffineMapArrayAttr(
             SmallVector<AffineMap>{castIdentity, castIdentity}),
         rewriter.getArrayAttr(castIters));
+    idxCastGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
     withD2MGenericRegion(
         rewriter, loc, idxCastGeneric, castInputs, castOutputs,
         [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3597,9 +3597,10 @@ public:
   }
 };
 
-/// Lowers `ttir.topk` single-core: lay the input out, run one `d2m.topk_block`
-/// over the whole reduction, extract the surviving k elements. `d2m-lower-topk`
-/// rewrites this output across the grid when the shape calls for it.
+/// Lowers `ttir.topk`: lay the input out, run one `d2m.topk_block` over the
+/// whole reduction, extract the surviving k elements. What grid that runs on
+/// is decided later — `d2m-grid-selection` plans the split and
+/// `d2m-build-topk-chain` re-emits it as that chain.
 class D2MTopKRewriter : public OpConversionPattern<ttir::TopKOp>,
                         D2MNamedRewriterCommon {
 public:
@@ -3642,7 +3643,7 @@ public:
     }
 
     // Placeholder leaf: d2m-grid-selection plans padding/transpose/extract,
-    // and d2m-lower-topk replaces this leaf with the planned chain.
+    // and d2m-build-topk-chain replaces this leaf with the planned chain.
     Value layoutedInput = createOptimalLayoutOp(
         adaptor.getInputTensor(), memorySpaces[0], /*tiled=*/true,
         /*noCollapse=*/false, rewriter, ttcore::OOBVal::NegInf);

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -3596,6 +3596,47 @@ public:
   }
 };
 
+// Builds a virtual-grid fold pair like ttmlir::d2m::utils::grids::
+// createCoreVirtMaps, but for a LOCAL virtual grid that occupies a
+// contiguous slice [colBase, colBase + volume(localVirtualGrid)) of a larger
+// logical column space folded onto physicalGrid. Used to place topk's
+// uneven-band remainder shard (a 1x1 local grid) at physical linear index
+// colBase within physicalGrid's row-major layout -- passed the full worker
+// grid so the remainder lands on the first core of the next free row after
+// the full-band group's rows. A constant colBase offset leaves the fold SPAN
+// (evalShape end-minus-start extent) equal to volume(localVirtualGrid), so the
+// stored-map volume invariant (getGridMapsFromVirtualGridMapping) still holds.
+static std::pair<AffineMap, AffineMap>
+createOffsetCoreVirtMaps(MLIRContext *ctx, ArrayRef<int64_t> localVirtualGrid,
+                         ArrayRef<int64_t> physicalGrid, int64_t colBase) {
+  AffineMap collapseMap =
+      ttmlir::d2m::utils::grids::createCollapseMap(ctx, localVirtualGrid);
+  AffineExpr shiftedIdx =
+      collapseMap.getResult(0) + getAffineConstantExpr(colBase, ctx);
+  AffineMap shiftedCollapseMap =
+      AffineMap::get(collapseMap.getNumDims(), 0, {shiftedIdx}, ctx);
+  AffineMap expandMap =
+      ttmlir::d2m::utils::grids::create1DtoNDMap(ctx, physicalGrid);
+  AffineMap forwardMap =
+      ttmlir::d2m::utils::grids::extendWithIdentityDimsAndResults(
+          expandMap.compose(shiftedCollapseMap), localVirtualGrid.size());
+
+  // Inverse: physical (y, x) -> local linear index - colBase. Same collapse
+  // idiom as the forward physical lookup, over physicalGrid, then subtract
+  // colBase and re-expand to the local virtual grid's own coordinates.
+  AffineMap physCollapseMap =
+      ttmlir::d2m::utils::grids::createCollapseMap(ctx, physicalGrid);
+  AffineExpr localLinearIdx =
+      physCollapseMap.getResult(0) - getAffineConstantExpr(colBase, ctx);
+  AffineMap toLocalLinear =
+      AffineMap::get(physCollapseMap.getNumDims(), 0, {localLinearIdx}, ctx);
+  AffineMap localExpandMap =
+      ttmlir::d2m::utils::grids::create1DtoNDMap(ctx, localVirtualGrid);
+  AffineMap inverseMap = ttmlir::d2m::utils::grids::prependResult(
+      localExpandMap.compose(toLocalLinear), getAffineConstantExpr(0, ctx));
+  return {forwardMap, inverseMap};
+}
+
 class D2MTopKRewriter : public OpConversionPattern<ttir::TopKOp>,
                         D2MNamedRewriterCommon {
 public:
@@ -3608,6 +3649,9 @@ public:
                                ttnnMode, collapseTensors,
                                enableMulticastInference) {}
 
+  // Extracts top-k results from topkResult into extractOutput, collapsing
+  // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
+  // each tile to handle row/column orientation.
   // Extracts top-k results from topkResult into extractOutput, collapsing
   // extractProjectDim to tile 0. Transposes (dim=1) or typecasts (dim=0)
   // each tile to handle row/column orientation.
@@ -3723,11 +3767,53 @@ public:
     // Multi-core sharding: a very wide reduction dim does not fit in a single
     // core's L1. Split it into G column bands ("slices"), run a local topk per
     // slice, then merge the sorted partials in a cross-core reduction tree.
-    // First cut: k<=32 (small-k, 1-tile partials), dim==1, ht==1, and each
-    // slice is capped to kMaxShardTiles tiles wide.
+    // Supports k<=64: dim==0 or dim==1 with an arbitrary non-target dim,
+    // capped by the per-core L1 tile budget below. Each partial (local topk
+    // result, gathered partial, and merge-tree node) carries
+    // outputReductionTiles reduction tiles -- 1 for k<=32, 2 for k<=64 (the
+    // canonical winner=tile0/loser=tile1 layout D2MDecomposeTopk's large-k
+    // left-fold produces). Computed here (rather than where it's used lower
+    // down) since the multi-core gather/merge lambdas below capture it.
     constexpr int64_t kTileWidth = 32;
-    constexpr int64_t kMaxShardTiles = 32; // L1-safe shard width.
+    int64_t outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
+    // Total L1-safe tile budget per core (values + indices share this). Every
+    // core must hold its full non-target-dim footprint over its reduction
+    // band, so the reduction-tile cap is this budget divided by how many
+    // tiles the non-target dim occupies.
+    //
+    // Empirically a single core holds 43 tiles of a single-band topk (it
+    // reuses buffers sequentially), but a multi-core band core carries
+    // additional simultaneously-live buffers (per-core gather/merge
+    // infrastructure) that don't fit that same budget. kMaxTilesPerCore is the
+    // single-core ceiling (also the multiCore-vs-single-core threshold below);
+    // kMaxMultiCoreTilesPerCore is the smaller, measured-safe cap used only for
+    // sizing multi-core bands.
+    constexpr int64_t kMaxTilesPerCore = 43;
+    constexpr int64_t kMaxMultiCoreTilesPerCore = 32;
     int64_t fullReductionElems = inputType.getShape()[dim];
+    int64_t nonTargetElems = inputType.getShape()[1 - dim];
+    int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
+    if (nonTargetTiles > kMaxTilesPerCore) {
+      return rewriter.notifyMatchFailure(
+          op, "D2M topk: non-target dimension alone exceeds the per-core "
+              "tile budget");
+    }
+    // Per-core cap on reduction-dim tiles, accounting for the non-target
+    // dim's footprint on every core (nonTargetTiles * reductionTiles <=
+    // kMaxTilesPerCore). Used for the single-core-vs-multi-core decision
+    // below; multi-core band sizing uses the smaller
+    // maxMultiCoreReductionTilesPerCore instead (a multi-core core carries
+    // extra simultaneously-live gather/merge buffers a single-core run reuses
+    // sequentially, so it needs a tighter budget). This band cap is NOT scaled
+    // by outputReductionTiles: a band core's L1 is dominated by its
+    // bandTiles-wide input, and the k>32 doubling only adds
+    // outputReductionTiles small output tiles. The k>32 pressure lands on the
+    // merge tree, where each partial carries outputReductionTiles reduction
+    // tiles; that is bounded separately via mergeCap (see the merge-tree loop
+    // below).
+    int64_t maxReductionTilesPerCore = kMaxTilesPerCore / nonTargetTiles;
+    int64_t maxMultiCoreReductionTilesPerCore =
+        kMaxMultiCoreTilesPerCore / nonTargetTiles;
 
     // Index element type for the arange / topk index buffers. The topk SFPU
     // LLK reads the index lane only as INT32 (when fp32_dest_acc is on) or as a
@@ -3738,12 +3824,12 @@ public:
     Type idxElemType = rewriter.getI32Type();
     int64_t fullReductionTiles =
         (fullReductionElems + kTileWidth - 1) / kTileWidth;
-    // Minimum cores needed so each band is <= kMaxShardTiles tiles. This is a
-    // lower bound; the actual band count is the physical grid area chosen below
-    // (which must divide fullReductionTiles evenly and fit the worker grid), so
-    // it may exceed this minimum.
-    int64_t minShards =
-        (fullReductionTiles + kMaxShardTiles - 1) / kMaxShardTiles;
+    // Minimum cores needed so each band is <= maxReductionTilesPerCore tiles.
+    // This is a lower bound; the actual band count is the physical grid area
+    // chosen below (which must divide fullReductionTiles evenly and fit the
+    // worker grid), so it may exceed this minimum.
+    int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
+                        maxReductionTilesPerCore;
     bool multiCore = minShards > 1;
 
     if (fullReductionTiles < 1) {
@@ -3761,48 +3847,103 @@ public:
     // device grid; a virtual-grid map (attached in emitShardTopk) folds those
     // numShards logical positions onto the 2D physical worker grid. numShards
     // is 1 for single-core, chosen below for multi-core.
+    //
+    // Bands need not divide fullReductionTiles evenly: all numShards bands
+    // carry the same bandTiles = ceil(fullReductionTiles / numShards) tiles,
+    // with any padding tail masked to -inf. This lets ANY fullReductionTiles
+    // pick a grid-legal numShards -- exact-divisor band counts don't exist for
+    // many tile counts (e.g. 1377 = 3^3*17 has no divisor that is both
+    // <= maxMultiCoreReductionTilesPerCore-sized bands and <=8x8
+    // grid-factorable).
     SmallVector<int64_t> workerGridShape;
     int64_t numShards = 1;
+    int64_t bandTiles = fullReductionTiles;
+    // Padded reduction-tile extent of the multi-core sharded tensor
+    // (numShards * bandTiles). Equals fullReductionTiles for a clean even
+    // split; larger when numShards does not divide evenly, with the tail
+    // [fullReductionElems, paddedReductionTiles*32) masked with -inf.
+    int64_t paddedReductionTiles = fullReductionTiles;
     if (multiCore) {
-      // Hard-fail (no TTNN fallback) for configs outside the first-cut scope.
-      assert(k <= 32 && "multi-core topk first cut only supports k <= 32");
-      assert(dim == 1 && "multi-core topk first cut only supports dim == 1");
-      assert(inputType.getShape()[0] == kTileWidth &&
-             "multi-core topk first cut only supports a single tile row "
-             "(ht == 1)");
+      // Hard-fail (no TTNN fallback) for configs outside supported scope.
+      // outputReductionTiles (2 for k>32) is folded into
+      // maxMultiCoreReductionTilesPerCore above, so k<=64 is otherwise handled
+      // like k<=32 throughout the gather/merge tree below.
+      assert(k <= 64 && "multi-core topk only supports k <= 64");
 
       auto device = ttcore::lookupDevice(op);
       workerGridShape = llvm::to_vector(device.getWorkerGrid().getShape());
       assert(workerGridShape.size() == 2 && "expected a 2D worker grid");
 
-      // Pick the band count. It must (1) be >= minShards so each band holds
-      // <= kMaxShardTiles reduction tiles, (2) divide fullReductionTiles evenly
-      // so getDeviceShape can shard the tile plane cleanly, and (3) have a
-      // legal 2D factorization within the worker grid so the 1xnumShards
-      // logical grid can be folded onto physical cores
-      // (findLegalPhysicalGridForVolume). Pinning numShards to minShards (=
-      // ceil(tiles/32)) fails whenever that count is prime-ish (e.g. 23 or 27,
-      // which have no <=8x<=8 factor pair); searching upward for the first
-      // divisor that also factors legally always finds one when
-      // fullReductionTiles has a suitable divisor.
-      for (int64_t cand = minShards; cand <= fullReductionTiles; ++cand) {
-        if (fullReductionTiles % cand != 0) {
-          continue;
-        }
-        if (fullReductionTiles / cand > kMaxShardTiles) {
-          continue;
-        }
+      int64_t workerHeight = workerGridShape[0];
+      int64_t workerWidth = workerGridShape[1];
+
+      // Placement is constrained by the virtual-grid fold invariant
+      // (getGridMapsFromVirtualGridMapping, Utils.cpp): a tensor whose logical
+      // grid has volume V may only carry a stored fold whose physical *span*
+      // (evalShape extent, NOT bounding box) has volume V. Folding V logical
+      // positions onto a near-square grid whose area exceeds V therefore fails
+      // -- so numShards must EXACTLY tile its physical grid, i.e. numShards
+      // itself must be grid-legal (findLegalPhysicalGridForVolume non-empty).
+      //
+      // Selection: pick the SMALLEST grid-legal numShards >= minShards (the
+      // tile-budget lower bound). Every band then carries the SAME
+      // bandTiles = ceil(fullReductionTiles / numShards) reduction tiles -- one
+      // uniform sharded tensor, folded as a single grid-legal rectangle. When
+      // numShards does not divide fullReductionTiles evenly, the padded device
+      // shape (numShards * bandTiles tiles) exceeds the real data
+      // (fullReductionTiles tiles); the layout masks the [fullReductionElems,
+      // padded) tail with -inf so those padding lanes never win top-k (same
+      // masking idiom as the single-tile-reduction path below). This mirrors
+      // GridSelection's virtual-grid trick (pick a grid-legal count, let the
+      // layout absorb the ragged tail) but with a per-core tile budget: we take
+      // the smallest legal count rather than the largest legal factor.
+      //
+      // A prime or awkward fullReductionTiles whose budget-minimum core count
+      // exceeds the largest grid-legal count (<= workerHeight * workerWidth)
+      // has NO solution -- the reduction genuinely needs more cores than the
+      // worker grid provides. That is a hard capacity limit, so fail the match
+      // cleanly (no assert / no TTNN fallback) rather than crash.
+      //
+      // Multi-core bands use their OWN (smaller, measured-safe) per-core tile
+      // budget -- maxMultiCoreReductionTilesPerCore rather than the
+      // single-core maxReductionTilesPerCore -- since a band core carries
+      // extra simultaneously-live gather/merge buffers a single-core run
+      // reuses sequentially. Recompute the search's lower bound against that
+      // cap (may exceed minShards, which was only the single-core-vs-
+      // multi-core threshold) and skip any grid-legal cand whose resulting
+      // bandTiles still exceeds it.
+      int64_t multiCoreMinShards =
+          std::max(minShards, (fullReductionTiles +
+                               maxMultiCoreReductionTilesPerCore - 1) /
+                                  maxMultiCoreReductionTilesPerCore);
+      int64_t maxGridCores = workerHeight * workerWidth;
+      for (int64_t cand = multiCoreMinShards; cand <= maxGridCores; ++cand) {
         if (d2m::utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
                 .empty()) {
           continue;
         }
+        int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
+        if (candBandTiles > maxMultiCoreReductionTilesPerCore) {
+          continue;
+        }
         numShards = cand;
+        bandTiles = candBandTiles;
         break;
       }
-      assert(numShards > 1 &&
-             "multi-core topk: no band count divides the reduction tile count "
-             "with <= kMaxShardTiles tiles per core and a legal worker-grid "
-             "factorization");
+      if (numShards == 1) {
+        return rewriter.notifyMatchFailure(
+            op, "D2M topk: reduction dim needs more cores than the worker grid "
+                "provides at the per-core tile budget");
+      }
+      // Uniform bands: the sharded tensor is padded to numShards * bandTiles
+      // tiles and the tail masked (no separate short remainder band);
+      // paddedReductionTiles records the padded extent.
+      paddedReductionTiles = numShards * bandTiles;
+      assert(bandTiles <= maxMultiCoreReductionTilesPerCore &&
+             "chosen bandTiles exceeds the multi-core per-core reduction-tile "
+             "budget");
+      assert(paddedReductionTiles >= fullReductionTiles &&
+             "padded reduction extent must cover the real data");
     }
 
     // Emits the full single-shard topk (layout -> transpose -> arange/index ->
@@ -3817,9 +3958,28 @@ public:
     // grid-1x1 buffer holding that band's local top-k (pre-extract, global
     // indices). The caller CompositeViews the multi-core partials and runs a
     // final merge topk_block to pick the global top-k.
+    // foldTotalShards / foldColBase mark an uneven-band split (see band
+    // selection). The two calls DO NOT share one physical grid -- the fold
+    // invariant forbids folding a group onto a grid whose area exceeds the
+    // group's band count. Instead each half folds self-consistently:
+    //   - Full-band group: gridCols == foldTotalShards - 1 (grid-legal by band
+    //     selection, but NOT necessarily a multiple of the worker width),
+    //     foldColBase == 0. Folds onto its OWN
+    //     findLegalPhysicalGridForVolume(gridCols) = fh x fw rectangle at the
+    //     worker origin.
+    //   - Remainder band: gridCols == 1, foldColBase == fh * workerWidth
+    //   (worker
+    //     cell (fh, 0)). Placed at that physical linear index in the worker
+    //     grid's row-major layout -- the first core of the row just past the
+    //     full group's fh x fw rectangle, hence disjoint from the full group.
+    //     foldTotalShards is only a "this is a split half"
+    //     signal (it drives isFoldedShard for the gridCols==1 remainder).
+    // Defaults (both 0) select the plain gridCols-sized fold with no offset,
+    // i.e. the existing equal-band / single-core path.
     auto emitShardTopk = [&](Value rawInput, int64_t arangeStart,
-                             int64_t gridCols =
-                                 1) -> SmallVector<std::pair<Value, Value>> {
+                             int64_t gridCols = 1, int64_t foldTotalShards = 0,
+                             int64_t foldColBase =
+                                 0) -> SmallVector<std::pair<Value, Value>> {
       auto inputType = cast<RankedTensorType>(rawInput.getType());
       int64_t rank = inputType.getRank();
       int64_t reductionDimSize = inputType.getShape()[dim];
@@ -3850,57 +4010,125 @@ public:
           emptyOp.setVirtualGridInverseMappingAttr(foldInverseMapAttr);
         }
       };
-      if (gridCols > 1) {
-        // Distribute the gridCols reduction bands (one band = kMaxShardTiles
-        // reduction tiles) across the worker grid, one band per core. The
-        // tensor keeps a 1xgridCols device grid -- band g == reduction tiles
-        // [g*shardTiles, (g+1)*shardTiles), so each core holds all ht rows and
-        // a distinct COLUMN band. This is the tile-correct sharding: topk is
-        // per-row, so every core must see the full row (ht) over its column
+      if (gridCols > 1 || foldTotalShards > 0) {
+        // Distribute the gridCols reduction bands (one band <=
+        // maxMultiCoreReductionTilesPerCore reduction tiles) across the worker
+        // grid, one band per core. The
+        // tensor keeps a 1xgridCols (dim==1) or gridColsx1 (dim==0) device
+        // grid -- band g == reduction tiles [g*shardTiles, (g+1)*shardTiles),
+        // so each core holds the full non-target dim over a distinct band
+        // along the reduction dim. This is the tile-correct sharding: topk is
+        // per-slice, so every core must see the full non-target dim over its
         // band. (Reshaping the logical shape to a 2D tensor grid is WRONG: it
-        // would tile-group different elements and split each row across cores.)
+        // would tile-group different elements and split each slice across
+        // cores.)
         //
-        // A literal 1xgridCols placement asks for physical core columns
-        // 0..gridCols-1, which exceeds the worker width once gridCols > worker
-        // cols (e.g. 1x32 on 8x8 asks for col 31 -> the coordinate manager
-        // cannot translate it). So attach a virtual-grid mapping that folds the
-        // gridCols logical shard positions onto the 2D physical grid (the same
-        // createCoreVirtMaps machinery GridSelection uses). Logical shard [0,
-        // g] lands on physical core findLegalPhysicalGridForVolume-folded from
+        // A literal 1xgridCols (or gridColsx1) placement asks for physical
+        // core columns (or rows) 0..gridCols-1, which exceeds the worker
+        // width/height once gridCols exceeds it (e.g. 1x32 on 8x8 asks for
+        // col 31 -> the coordinate manager cannot translate it). So attach a
+        // virtual-grid mapping that folds the gridCols logical shard
+        // positions onto the 2D physical grid (the same createCoreVirtMaps
+        // machinery GridSelection uses). Logical shard [0, g] (or [g, 0])
+        // lands on physical core findLegalPhysicalGridForVolume-folded from
         // g, while the tensor grid, generic maps, and gather indices all stay
-        // 1xgridCols. The buffer placement (flatbuffer) and the DMA address
-        // path both read this same forward map, so they agree; the physical
-        // grid MUST be the one findLegalPhysicalGridForVolume picks (that is
-        // what both consumers recompute deterministically).
+        // at the logical shardedGrid shape. The buffer placement (flatbuffer)
+        // and the DMA address path both read this same forward map, so they
+        // agree; the physical grid MUST be the one
+        // findLegalPhysicalGridForVolume picks (that is what both consumers
+        // recompute deterministically).
+        //
+        // foldTotalShards>0 means this call is one half of an uneven-band
+        // split (see emitShardTopk's doc comment); the placement below folds
+        // each half self-consistently (full group on its own grid, remainder
+        // at an offset worker core) rather than sharing one physical grid.
         constexpr std::array<int64_t, 2> defaultTileShape =
             ttcore::TileType::getDefaultShape();
         SmallVector<int64_t> tileShapeVec(defaultTileShape.begin(),
                                           defaultTileShape.end());
         auto tileElemType =
             ttcore::TileType::get(inputType.getElementType(), tileShapeVec);
+        // When numShards does not divide the reduction tiles evenly, the
+        // sharded buffer is padded along the reduction dim to
+        // paddedReductionTiles (== numShards * bandTiles) tiles so every band
+        // is bandTiles wide. Force that padded extent via a dimAlignment on the
+        // reduction dim while keeping the layout's logical_shape truthful
+        // (still inputType's shape); a MaskOp below fills the padded tail with
+        // -inf so it never wins top-k. For a clean even split
+        // paddedReductionTiles == fullReductionTiles and the alignment is the
+        // default tile width (no padding, no mask -- byte-identical old path).
+        bool needsReductionPad = paddedReductionTiles > fullReductionTiles;
+        SmallVector<int64_t> shardDimAlignments(inputType.getShape().size(),
+                                                kTileWidth);
+        if (needsReductionPad) {
+          shardDimAlignments[dim] = paddedReductionTiles * kTileWidth;
+        }
         auto shardedLayout = ttcore::MetalLayoutAttr::get(
             ctx, inputType.getShape(), memorySpaces[0],
-            ttcore::TensorMemoryLayout::Sharded);
-        SmallVector<int64_t> shardedGrid = {1, gridCols};
+            ttcore::TensorMemoryLayout::Sharded,
+            ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+                ctx, inputType.getShape().size()),
+            shardDimAlignments);
+        SmallVector<int64_t> shardedGrid =
+            (dim == 1) ? SmallVector<int64_t>{1, gridCols}
+                       : SmallVector<int64_t>{gridCols, 1};
         SmallVector<int64_t> shardedDeviceShape =
             shardedLayout.getDeviceShape(shardedGrid, tileShapeVec);
         auto shardedEmpty = rewriter.create<d2m::EmptyOp>(
             loc, shardedDeviceShape, tileElemType, shardedLayout);
-        // Fold the 1xgridCols logical shard grid onto the 2D physical grid.
-        SmallVector<int64_t> physicalGrid =
-            d2m::utils::findLegalPhysicalGridForVolume(gridCols,
-                                                       workerGridShape);
-        assert(!physicalGrid.empty() &&
-               "band count has no legal worker-grid factorization");
-        auto [forwardMap, inverseMap] =
-            ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
-                                                          physicalGrid);
+        // Placement respects the fold invariant (each tensor's logical grid
+        // volume must equal its physical fold *span*):
+        //   - Full group / plain call (foldColBase == 0): fold this call's own
+        //     gridCols-wide grid onto findLegalPhysicalGridForVolume(gridCols).
+        //     gridCols is guaranteed grid-legal by band selection, so the span
+        //     equals gridCols exactly. This holds for the equal-band path
+        //     (foldTotalShards == 0) and for the full-band half of an uneven
+        //     split (foldTotalShards > 0, foldColBase == 0), occupying the
+        //     fh x fw rectangle at the worker origin.
+        //   - Remainder half (foldColBase > 0, always gridCols == 1): place the
+        //     single band at physical linear index foldColBase within the
+        //     WORKER grid's row-major layout -- worker cell (fh, 0), the first
+        //     core of the row just past the full group's fh x fw rectangle. A
+        //     constant offset leaves the span at 1 (evalShape subtracts start
+        //     from end), so the 1x1 grid's volume matches. Disjoint from the
+        //     full group because that rectangle spans only rows [0, fh).
+        AffineMap forwardMap, inverseMap;
+        if (foldColBase > 0) {
+          std::tie(forwardMap, inverseMap) = createOffsetCoreVirtMaps(
+              ctx, shardedGrid, workerGridShape, foldColBase);
+        } else {
+          SmallVector<int64_t> physicalGrid =
+              d2m::utils::findLegalPhysicalGridForVolume(gridCols,
+                                                         workerGridShape);
+          assert(!physicalGrid.empty() &&
+                 "band count has no legal worker-grid factorization");
+          std::tie(forwardMap, inverseMap) =
+              ttmlir::d2m::utils::grids::createCoreVirtMaps(ctx, shardedGrid,
+                                                            physicalGrid);
+        }
         foldForwardMapAttr = AffineMapAttr::get(forwardMap);
         foldInverseMapAttr = AffineMapAttr::get(inverseMap);
         attachFold(shardedEmpty);
-        layoutedInput =
+        Value tilized =
             rewriter.create<d2m::ToLayoutOp>(loc, rawInput, shardedEmpty)
                 .getResult(0);
+        if (needsReductionPad) {
+          // Fill the padded reduction tail [fullReductionElems, padded) with
+          // -inf so those lanes never win top-k. The mask derives the real
+          // extent from the layout's (truthful) logical_shape; the padded
+          // physical tail beyond it is the region set to -inf.
+          auto maskOutput = rewriter.create<d2m::EmptyOp>(
+              loc, shardedDeviceShape, tileElemType, shardedLayout);
+          attachFold(maskOutput);
+          layoutedInput =
+              rewriter
+                  .create<d2m::MaskOp>(loc, tilized, maskOutput,
+                                       shardedLayout.getLogicalShape(),
+                                       ttcore::OOBVal::NegInf)
+                  .getResult();
+        } else {
+          layoutedInput = tilized;
+        }
       } else if (reductionDimSize <= kTileWidth) {
         // A single-tile reduction dim has no room for the merge tree (it
         // needs >=2 tiles). Force the physical buffer to 2 tiles along dim
@@ -4146,16 +4374,35 @@ public:
 
       // Setting up the arange op.
       //
-      // dim==0 index construction: the reduction runs along tile ROWS, but the
-      // arange primitive naturally sequences indices along tile COLUMNS (and
-      // spanning multiple column tiles). So for dim==0 we build the ENTIRE
-      // arange+broadcast on a shape-SWAPPED [wt, ht] buffer -- reusing the same
-      // column-sequencing/Row-broadcast the dim==1 path uses -- then grid-
-      // transpose the result back to [ht, wt] via transposeTilesGrid. After the
-      // transpose idxBuf[r][c] == r == the global dim-0 index, across ALL
-      // tiles. (Multi-core is dim==1 only, so this swap only ever runs
-      // single-core.)
-      bool swapArange = (dim == 0);
+      // dim==0 index construction has two strategies:
+      //
+      // (a) single-core (swapArange): the reduction runs along tile ROWS, but
+      //     the arange primitive naturally sequences indices along tile
+      //     COLUMNS. So build the ENTIRE arange+broadcast on a shape-SWAPPED
+      //     [wt, ht] buffer -- reusing the same column-sequencing/Row-
+      //     broadcast the dim==1 path uses -- then grid-transpose the result
+      //     back to [ht, wt] via transposeTilesGrid. After the transpose
+      //     idxBuf[r][c] == r == the global dim-0 index across all tiles.
+      //
+      // (b) multi-core banded along dim==0 (colMajorArange): a grid transpose
+      //     under a non-trivial (gridColsx1) grid is impossible -- the outer
+      //     d2m.generic's single grid-rank indexing map must simultaneously
+      //     describe an IDENTITY grid permutation (both operands share the
+      //     gridColsx1 grid) and a SWAPPING shard permutation (shard goes
+      //     [1,wt]->[wt,1]), which no single map can express. So instead build
+      //     the arange DIRECTLY in the natural [ht, wt] orientation and set
+      //     colMajor=true so ArangeBlockOp sequences indices DOWN the rows
+      //     (row-major global index), then Col-broadcast. This yields
+      //     idxBuf[r][c] == r with no transpose at all.
+      // isFoldedShard covers both the equal-band multi-core case (gridCols>1)
+      // and an uneven-split remainder band (gridCols==1, foldTotalShards>0):
+      // both are direct-allocated at a folded physical placement rather than
+      // the default unit-grid [0,0], so both need the colMajor arange
+      // construction (see the swapArange comment below for why the swapped
+      // construction is incompatible with a folded placement).
+      bool isFoldedShard = gridCols > 1 || foldTotalShards > 0;
+      bool colMajorArange = (dim == 0 && isFoldedShard);
+      bool swapArange = (dim == 0 && !colMajorArange);
 
       // Arange emits integer indices; allocate its buffers with the index
       // element type (bf16 for small reduction dims, Int32 otherwise) rather
@@ -4196,11 +4443,13 @@ public:
       // would materialize a full-width unit-grid buffer (e.g. 1x1x1x256 tiles =
       // 1MB) on a single core, and overwriting the returned handle leaves that
       // dead buffer in the IR where it still gets L1-allocated and overflows.
-      // Instead allocate the arange output directly at the sharded 1xgridCols
-      // device shape (same deviceShape / metalLayout as the value buffers) so
-      // each core owns only its band.
+      // Instead allocate the arange output directly at the sharded
+      // (1xgridCols or gridColsx1) device shape so each core owns only its
+      // band. Multi-core is either dim==1 (natural orientation) or dim==0 with
+      // colMajorArange (also natural [ht, wt] orientation, sequenced down rows
+      // in-block), so both use the un-swapped deviceShape here.
       SmallVector<Value> arangeOutputs;
-      if (gridCols > 1) {
+      if (isFoldedShard) {
         auto arangeEmpty = rewriter.create<d2m::EmptyOp>(
             loc, deviceShape, idxTileType, metalLayout);
         attachFold(arangeEmpty);
@@ -4275,27 +4524,35 @@ public:
                                .create<d2m::ArangeBlockOp>(
                                    loc, idxTile, outTile, numElements,
                                    /*start=*/arangeStart,
-                                   /*step=*/1)
+                                   /*step=*/1,
+                                   /*colMajor=*/colMajorArange)
                                .getResult();
             return {result};
           });
 
       // Setting up the broadcast after arange.
 
-      // Broadcast first row or column to full shape. Both dim==1 and the
-      // swapped dim==0 buffer sequence indices along COLUMNS, so both broadcast
-      // row 0 DOWN the rows (Row broadcast). (dim==0 is handled on its swapped
-      // [wt, ht] buffer here and grid-transposed to [ht, wt] afterwards.)
-      d2m::TileBcastType postArangeBcastType = d2m::TileBcastType::Row;
+      // Broadcast first row or column to full shape.
+      //   dim==1 and swapped dim==0 (single-core): arange sequences indices
+      //     along COLUMNS, so value at (r,c) == c (same for all rows) ->
+      //     broadcast row 0 DOWN the rows (Row broadcast). Swapped dim==0 is
+      //     handled on its [wt, ht] buffer here and grid-transposed to [ht, wt]
+      //     afterwards.
+      //   colMajorArange (multi-core dim==0): arange sequences indices DOWN
+      //     the ROWS, so value at (r,c) == r (same for all cols) -> broadcast
+      //     col 0 ACROSS the columns (Col broadcast). No transpose afterwards.
+      d2m::TileBcastType postArangeBcastType =
+          colMajorArange ? d2m::TileBcastType::Col : d2m::TileBcastType::Row;
       d2m::TileBcastTypeAttr postArangeBcastTypeAttr =
           d2m::TileBcastTypeAttr::get(ctx, postArangeBcastType);
       SmallVector<Value> postArangeBcastInputs(arange.getResults().begin(),
                                                arange.getResults().end());
       SmallVector<Value> postArangeBcastOutputs;
-      // For multicore, allocate the broadcast output at the sharded 1xgridCols
-      // device shape so its L1 buffer is split across cores and its operand
-      // grid matches the sharded arange input (and topkInput).
-      if (gridCols > 1) {
+      // For multicore, allocate the broadcast output at the sharded device
+      // shape (1xgridCols or gridColsx1, natural orientation for both dim==1
+      // and colMajorArange dim==0) so its L1 buffer is split across cores and
+      // its operand grid matches the sharded arange input (and topkInput).
+      if (isFoldedShard) {
         auto bcastEmpty = rewriter.create<d2m::EmptyOp>(
             loc, deviceShape, idxTileType, metalLayout);
         attachFold(bcastEmpty);
@@ -4401,15 +4658,19 @@ public:
       //   dim==1: arange+bcast yields idxBuf[row][col] = col; a per-tile
       //     transpose makes the column index vary along the tile's row axis,
       //     matching the transposed value tile.
-      //   dim==0: idxBuf was built on the swapped [wt, ht] buffer with the
-      //     [0..R-1] sequence running along its columns; a GRID transpose swaps
-      //     the tile-grid dims AND transposes within each tile, producing the
-      //     genuine [ht, wt] buffer where idxBuf[r][c] == r (the global dim-0
-      //     index) across all tiles. A per-tile transpose alone would be wrong
-      //     for ht>1 because it cannot move the sequence across tile rows.
+      //   dim==0 single-core (swapArange): idxBuf was built on the swapped
+      //     [wt, ht] buffer with the [0..R-1] sequence running along its
+      //     columns; a GRID transpose swaps the tile-grid dims AND transposes
+      //     within each tile, producing the genuine [ht, wt] buffer where
+      //     idxBuf[r][c] == r (the global dim-0 index) across all tiles. A
+      //     per-tile transpose alone would be wrong for ht>1 because it cannot
+      //     move the sequence across tile rows.
+      //   dim==0 multi-core (colMajorArange): idxBuf was built DIRECTLY in the
+      //     [ht, wt] orientation with colMajor sequencing (idxBuf[r][c] == r
+      //     already), matching the un-transposed value input, so NO transpose.
       if (dim == 1) {
         idxBuf = transposeTiles(idxBuf);
-      } else {
+      } else if (!colMajorArange) {
         idxBuf = transposeTilesGrid(idxBuf);
       }
 
@@ -4441,60 +4702,81 @@ public:
 
       // Multi-core gather (mirrors the reference D2MLowerGatherCore pattern:
       // one collector core DMA-reads one payload per source core). Each source
-      // core's local top-k lives in tile 0 of its band shard. We produce
-      // gridCols separate grid-1x1 single-tile partials -- one per source core
-      // -- so the driver can CompositeView them and run a final merge
-      // topk_block. Building them as separate SSAs (rather than one wide
-      // buffer) is what lets ExpandDMAReadCompositeView later expand the
-      // merge's DMA read into gridCols per-source reads (a plain multi-tile
-      // ViewLayoutOp does NOT gather across cores; only a CompositeView does).
+      // core's local top-k lives in the leading outputReductionTiles
+      // reduction tiles of its band shard (canonical winner=tile0/loser=tile1
+      // for k>32), across the FULL non-target extent (nonTargetTiles tiles).
+      // We produce gridCols separate grid-1x1 partials of shape
+      // [nonTargetTiles, outputReductionTiles] -- one per source core -- so
+      // the driver can CompositeView them and run a final merge topk_block.
+      // Building them as separate SSAs (rather than one wide buffer) is what
+      // lets ExpandDMAReadCompositeView later expand the merge's DMA read into
+      // gridCols per-source reads (a plain multi-tile ViewLayoutOp does NOT
+      // gather across cores; only a CompositeView does).
       //
       // The collector is a single grid-1x1 generic. Its region loops over the
-      // gridCols source grid columns issuing a remote_load from grid [0, g]
-      // (which lowers to a shard-level DMA read from source core g), copies
-      // that band's tile 0 into a fresh 1-tile buffer, and stores it.
+      // gridCols source grid bands issuing a remote_load from the band's
+      // logical grid position (which lowers to a shard-level DMA read from
+      // source core g), copies that band's leading outputReductionTiles
+      // reduction tiles (all nonTargetTiles non-target rows) into a fresh
+      // [nonTargetTiles, outputReductionTiles] buffer, and stores it.
       // remote_load's grid index is loop-varying, so each iteration pulls a
       // distinct core.
       SmallVector<std::pair<Value, Value>> partials;
-      // A grid-1x1 single-tile device layout for each gathered partial. Derive
-      // it from the topk output's shard by shrinking the reduction dim to 1.
+      // A grid-1x1 device layout for each gathered partial, of shape
+      // [nonTargetTiles, outputReductionTiles] tiles: derive it from the topk
+      // output's shard by shrinking the reduction dim to outputReductionTiles
+      // tiles while keeping the non-target dim's full tile extent.
       std::size_t redPhys =
           (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
       std::size_t deviceRedDimLocal =
           deviceShape.size() - (physicalRank - redPhys);
-      SmallVector<int64_t> oneTilePerCoreShape(deviceShape.begin(),
+      // Shard portion is the trailing physicalRank dims of deviceShape, laid
+      // out as [nonTarget, reduction] for dim==1 or [reduction, nonTarget] for
+      // dim==0; the non-target shard dim is deviceRedDimLocal's sibling.
+      std::size_t deviceNonTargetDimLocal =
+          (dim == 1) ? deviceRedDimLocal - 1 : deviceRedDimLocal + 1;
+      SmallVector<int64_t> perCorePartialShape(deviceShape.begin(),
                                                deviceShape.end());
-      oneTilePerCoreShape[0] = 1;
-      oneTilePerCoreShape[1] = 1;
-      oneTilePerCoreShape[deviceRedDimLocal] = 1;
+      perCorePartialShape[0] = 1;
+      perCorePartialShape[1] = 1;
+      perCorePartialShape[deviceRedDimLocal] = outputReductionTiles;
+      perCorePartialShape[deviceNonTargetDimLocal] = nonTargetTiles;
 
-      // Each partial is a grid-1x1 single tile, so its layout's logical shape
-      // must be the 1-tile extent (32x32), NOT the original input's 32x8192.
-      // The downstream CompositeViewOp verifier sums the partials' logical
-      // reduction extents and requires the total to equal the composite
-      // output's logical reduction extent (numShards*32); with the original
-      // logical shape each partial would report 8192 and the sum would blow up.
+      // Each partial is a grid-1x1 [nonTargetTiles, outputReductionTiles]-tile
+      // buffer, so its layout's logical shape must be the
+      // nonTargetTiles*32 x outputReductionTiles*32 (or the transpose)
+      // extent, NOT the original input's full logical shape. The downstream
+      // CompositeViewOp verifier sums the partials' logical reduction extents
+      // and requires the total to equal the composite output's logical
+      // reduction extent (numShards*outputReductionTiles*32), and requires
+      // the non-composite (non-target) logical extent to match exactly
+      // across all partials and the output; with the original logical shape
+      // each partial would report the full reduction extent and the sum
+      // would blow up.
       constexpr int64_t kTileDimLocal = 32;
-      ttcore::MetalLayoutAttr oneTileLayout = ttcore::MetalLayoutAttr::get(
-          ctx,
-          SmallVector<int64_t>{
-              oneTilePerCoreShape[oneTilePerCoreShape.size() - 2] *
-                  kTileDimLocal,
-              oneTilePerCoreShape[oneTilePerCoreShape.size() - 1] *
-                  kTileDimLocal},
-          metalLayout.getDimAlignments(), metalLayout.getCollapsedIntervals(),
-          metalLayout.getMemorySpace(), metalLayout.getMemoryLayout());
+      ttcore::MetalLayoutAttr perCorePartialLayout =
+          ttcore::MetalLayoutAttr::get(
+              ctx,
+              SmallVector<int64_t>{
+                  perCorePartialShape[perCorePartialShape.size() - 2] *
+                      kTileDimLocal,
+                  perCorePartialShape[perCorePartialShape.size() - 1] *
+                      kTileDimLocal},
+              metalLayout.getDimAlignments(),
+              metalLayout.getCollapsedIntervals(), metalLayout.getMemorySpace(),
+              metalLayout.getMemoryLayout());
 
       // Emits the collector generic for one topk result (values or index),
       // returning gridCols grid-1x1 partials (partial g == source core g's
-      // tile 0).
+      // leading outputReductionTiles reduction tiles, across the full
+      // nonTargetTiles extent).
       auto gatherPerCore = [&](Value gridResult) -> SmallVector<Value> {
         auto gridType = cast<RankedTensorType>(gridResult.getType());
         auto tileType = cast<ttcore::TileType>(gridType.getElementType());
         SmallVector<Value> gathered;
         for (int64_t g = 0; g < gridCols; ++g) {
           auto outEmpty = rewriter.create<d2m::EmptyOp>(
-              loc, oneTilePerCoreShape, tileType, oneTileLayout);
+              loc, perCorePartialShape, tileType, perCorePartialLayout);
           SmallVector<Value> ins = {gridResult};
           SmallVector<Value> outs = {outEmpty.getResult()};
           // Grid-1x1 collector generic. The input is the whole [1,gridCols]
@@ -4543,22 +4825,27 @@ public:
                     .create<tensor::EmptyOp>(loc, srcShardType.getShape(),
                                              srcShardType.getElementType())
                     .getResult();
-            // remote_load source band g: LOGICAL grid index [0, g]. The source
-            // buffer carries a virtual-grid forward map (attached where its
-            // 1xgridCols layout is built), and the DMA address path composes
-            // that map to fold [0, g] onto the physical core band g actually
-            // lives on. So we address the logical position, not the folded
-            // physical core.
+            // remote_load source band g: LOGICAL grid index [0, g] for dim==1
+            // (1xgridCols banding) or [g, 0] for dim==0 (gridColsx1 banding).
+            // The source buffer carries a virtual-grid forward map (attached
+            // where its sharded layout is built), and the DMA address path
+            // composes that map to fold the logical position onto the
+            // physical core band g actually lives on. So we address the
+            // logical position, not the folded physical core.
             Value zeroGrid = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-            Value colGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
-            SmallVector<Value> srcIndices = {zeroGrid, colGrid};
+            Value bandGrid = rewriter.create<arith::ConstantIndexOp>(loc, g);
+            SmallVector<Value> srcIndices =
+                (dim == 1) ? SmallVector<Value>{zeroGrid, bandGrid}
+                           : SmallVector<Value>{bandGrid, zeroGrid};
             Value loaded =
                 rewriter
                     .create<d2m::RemoteLoadOp>(loc, srcShardType, loadBuf,
                                                gridResult, srcIndices)
                     .getResult();
 
-            // Copy tile 0 of the loaded band into the 1-tile output shard.
+            // Copy the loaded band's leading outputReductionTiles reduction
+            // tiles (all nonTargetTiles non-target rows) into the
+            // [nonTargetTiles, outputReductionTiles] output shard.
             Value outBuf =
                 rewriter
                     .create<tensor::EmptyOp>(loc, outShardType.getShape(),
@@ -4567,9 +4854,16 @@ public:
             std::size_t shardRank = outShardType.getShape().size();
             std::size_t shardRedDim = shardRank - (physicalRank - redPhys);
             int64_t inReductionExtent = srcShardType.getShape()[shardRedDim];
-            // Non-invertible input map on the reduction dim (`dim mod extent`)
-            // so linalg takes the loop bound from the 1-tile output, not the
-            // full band. Same idiom as the extract generic.
+            // Non-invertible input map on the reduction dim
+            // (`dim mod inReductionExtent`) so linalg takes the loop bound from
+            // the outputReductionTiles-wide output, NOT the full band: without
+            // it, linalg would infer the input operand's reduction extent from
+            // the loop bound and mismatch the loaded band's full extent. Since
+            // the loop index ranges [0, outputReductionTiles) and
+            // outputReductionTiles <= inReductionExtent, `idx mod extent ==
+            // idx` reads exactly the leading outputReductionTiles tiles -- tile
+            // 0 (and tile 1 for k>32), the canonical winner/loser layout. Same
+            // idiom as the extract generic.
             SmallVector<AffineExpr> shardInExprs;
             for (std::size_t i = 0; i < shardRank; ++i) {
               shardInExprs.push_back(i == shardRedDim
@@ -4620,18 +4914,19 @@ public:
 
     // ----- Drive the shard topk(s): single-core or the multi-core tree. -----
 
-    // physicalRank / lastStride / outputReductionTiles are needed by the shared
-    // extract tail below and do not depend on which shard produced the result.
-    // physicalRank equals the input rank (device layout is grid + shard, each
-    // of input rank). For k>32 the result spans 2 tiles; D2MDecomposeTopk's
-    // left-fold keeps the accumulator at canonical tiles (winner=0, loser=1),
-    // so the extract reads tile j from input tile j (lastStride=1) for any tile
-    // count, with no power-of-2 padding. For k<=32 lastStride is unused.
-    // Extract/merge index buffers carry the same index element type chosen
-    // above (bf16 for small reduction dims, else Int32).
+    // physicalRank / lastStride are needed by the shared extract tail below
+    // and do not depend on which shard produced the result. physicalRank
+    // equals the input rank (device layout is grid + shard, each of input
+    // rank). outputReductionTiles is computed once, above, before the
+    // multi-core gather/merge lambdas that capture it. For k>32 the result
+    // spans 2 tiles; D2MDecomposeTopk's left-fold keeps the accumulator at
+    // canonical tiles (winner=0, loser=1), so the extract reads tile j from
+    // input tile j (lastStride=1) for any tile count, with no power-of-2
+    // padding. For k<=32 lastStride is unused. Extract/merge index buffers
+    // carry the same index element type chosen above (bf16 for small
+    // reduction dims, else Int32).
     Type extractIdxElemType = idxElemType;
     std::size_t physicalRank = static_cast<std::size_t>(rank);
-    int64_t outputReductionTiles = (k + 31) / 32;
     int64_t lastStride = 1;
 
     // to_layout wrapper usable at this (outer) scope for the merge tree.
@@ -4647,10 +4942,6 @@ public:
         ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
     SmallVector<Attribute> mergeIters(physicalRank, parallelAttr);
     AffineMap mergeIdentity = rewriter.getMultiDimIdentityMap(physicalRank);
-    // Shard-space index of the reduction dim (used for generic-level affine
-    // maps, which operate on the [sh, sw] shard portion of rank physicalRank).
-    std::size_t redPhysDim =
-        (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
     // Device-tensor index of the reduction dim. The device layout is rank
     // 2*physicalRank ([grid..., shard...]); the reduction tiles live in the
     // shard portion, i.e. the last shard dim for dim==1 and the first shard dim
@@ -4677,27 +4968,47 @@ public:
           layout.getMemoryLayout());
     };
 
-    // Compacts tile 0 of a full-width partial into a fresh 1-tile f32
-    // device-layout buffer, giving a distinct SSA value the merge tree can
-    // CompositeView. Projects the reduction physical dim to constant 0 (copy of
-    // tile 0), identity elsewhere.
+    // Compacts the leading outputReductionTiles reduction tiles of a
+    // full-width partial (across its full non-target extent) into a fresh
+    // outputReductionTiles-reduction-tile device-layout buffer, giving a
+    // distinct SSA value the merge tree can CompositeView.
+    //
+    // The D2M generic-level input map MUST be a projected permutation (D2MOps
+    // inverts it for grid/DMA index generation; `dim mod extent` is not one
+    // and trips inverseAndBroadcastProjectedPermutation). It projects the
+    // reduction dim to constant 0 (a valid projected-permutation broadcast),
+    // identity elsewhere -- same map as the original k<=32 path. It only
+    // drives grid index generation, NOT the region's input shard shape: the
+    // input block arg always gets the operand's FULL shard shape (see
+    // createBlockArguments' getShardType, which reads the layout, not the
+    // indexing map), so it spans all groupTiles*outputReductionTiles reduction
+    // tiles. The real leading-tiles selection happens on the INNER
+    // linalg.generic, which is ordinary linalg and admits a non-invertible
+    // `dim mod extent` reduction map: since the reduction index ranges
+    // [0, outputReductionTiles) and outputReductionTiles <= the input's
+    // reduction extent, `idx mod extent == idx` copies exactly the leading
+    // tiles -- tile 0 (and tile 1 for k>32), the canonical winner/loser
+    // layout.
     auto compactToTile = [&](Value fullPartial) -> Value {
       auto fullType = cast<RankedTensorType>(fullPartial.getType());
       auto tileType = cast<ttcore::TileType>(fullType.getElementType());
       auto layout = cast<ttcore::MetalLayoutAttr>(fullType.getEncoding());
-      SmallVector<int64_t> oneTileShape(fullType.getShape().begin(),
+      SmallVector<int64_t> compactShape(fullType.getShape().begin(),
                                         fullType.getShape().end());
-      oneTileShape[deviceRedDim] = 1;
-      // Fresh layout whose logical shape matches the compacted 1-tile physical
+      compactShape[deviceRedDim] = outputReductionTiles;
+      // Fresh layout whose logical shape matches the compacted physical
       // shape (the CompositeViewOp verifier reads logical shapes).
-      auto oneTileLayout = layoutForDeviceShape(layout, oneTileShape);
-      auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, oneTileShape, tileType,
-                                                    oneTileLayout);
-      // Input map projects the reduction dim to 0; output identity.
+      auto compactLayout = layoutForDeviceShape(layout, compactShape);
+      auto outEmpty = rewriter.create<d2m::EmptyOp>(loc, compactShape, tileType,
+                                                    compactLayout);
+      std::size_t genRedDim =
+          (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+      // Generic-level input map: constant-0 on the reduction dim, identity
+      // elsewhere (projected permutation; drives grid indices only).
       SmallVector<AffineExpr> inExprs;
       for (std::size_t i = 0; i < physicalRank; ++i) {
-        inExprs.push_back(i == redPhysDim ? rewriter.getAffineConstantExpr(0)
-                                          : rewriter.getAffineDimExpr(i));
+        inExprs.push_back(i == genRedDim ? rewriter.getAffineConstantExpr(0)
+                                         : rewriter.getAffineDimExpr(i));
       }
       AffineMap inProj = AffineMap::get(physicalRank, 0, inExprs, ctx);
       SmallVector<Value> ins = {fullPartial};
@@ -4713,15 +5024,20 @@ public:
           [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
             Value input = blockArgs[0];
             Value output = blockArgs[1];
+            auto inShardType = cast<RankedTensorType>(input.getType());
             std::size_t shardRank =
                 cast<RankedTensorType>(output.getType()).getRank();
-            // Copy of the (projected) input tile into the 1-tile output.
+            std::size_t shardRedDim = shardRank - (physicalRank - genRedDim);
+            int64_t inShardReductionExtent =
+                inShardType.getShape()[shardRedDim];
+            // Copy of the leading tiles of the input into the compacted
+            // output; `dim mod extent` clamps the loop bound to the output.
             SmallVector<AffineExpr> shardInExprs;
             for (std::size_t i = 0; i < shardRank; ++i) {
-              shardInExprs.push_back(
-                  i == (shardRank - (physicalRank - redPhysDim))
-                      ? rewriter.getAffineConstantExpr(0)
-                      : rewriter.getAffineDimExpr(i));
+              shardInExprs.push_back(i == shardRedDim
+                                         ? rewriter.getAffineDimExpr(i) %
+                                               inShardReductionExtent
+                                         : rewriter.getAffineDimExpr(i));
             }
             AffineMap shardInMap =
                 AffineMap::get(shardRank, 0, shardInExprs, ctx);
@@ -4751,29 +5067,44 @@ public:
     } else {
       // Distributed local topk: each of numShards cores runs topk_block on its
       // own reduction-dim band. emitShardTopk gathers the per-core results into
-      // numShards separate grid-1x1 single-tile partials (one per source core,
-      // values + global indices), using an explicit per-source DMA collector
-      // (see emitShardTopk). CompositeView all numShards value partials (and,
-      // separately, index partials) into one numShards-tile buffer along the
-      // reduction dim, materialize, then run ONE final topk_block over those
-      // tiles to select the global top-k. The composite view is what makes
-      // ExpandDMAReadCompositeView pull each partial from its source core.
-      SmallVector<std::pair<Value, Value>> partials = emitShardTopk(
-          adaptor.getInputTensor(), /*arangeStart=*/0, /*gridCols=*/numShards);
+      // numShards separate grid-1x1 [nonTargetTiles, outputReductionTiles]-tile
+      // partials (one per source core, values + global indices), using an
+      // explicit per-source DMA collector (see emitShardTopk). CompositeView
+      // all numShards value partials (and, separately, index partials) into
+      // one [nonTargetTiles, numShards * outputReductionTiles]-tile buffer
+      // along the reduction dim, materialize, then run ONE final topk_block
+      // over those tiles to select the global top-k. The composite view is
+      // what makes ExpandDMAReadCompositeView pull each partial from its
+      // source core. One uniform sharded tensor: numShards bands of bandTiles
+      // reduction tiles each. When numShards does not divide
+      // fullReductionTiles evenly, the sharded buffer is padded to numShards
+      // * bandTiles tiles and the tail masked with -inf inside emitShardTopk
+      // (paddedReductionTiles), so every band is the same width and the
+      // padding lanes never win top-k.
+      SmallVector<std::pair<Value, Value>> partials =
+          emitShardTopk(adaptor.getInputTensor(), /*arangeStart=*/0,
+                        /*gridCols=*/numShards);
 
-      // Merge a group of 1-tile partials into a single top-k 1-tile
+      // Merge a group of [nonTargetTiles, outputReductionTiles]-tile partials
+      // into a single top-k [nonTargetTiles, outputReductionTiles]-tile
       // (values, indices) pair on one core: CompositeView the group along the
-      // reduction dim, materialize, run ONE topk_block, and compact to tile 0.
+      // reduction dim, materialize, run ONE topk_block, and compact back to
+      // outputReductionTiles reduction tiles.
       // A single topk_block can only reduce tiles co-located on its core, so a
-      // group is capped at kMaxShardTiles (L1-safe). For numShards > 32 the
-      // driver below splits into two groups so no core ever holds > 32 tiles.
+      // group is capped at maxMultiCoreReductionTilesPerCore partials (L1-safe;
+      // that cap is already divided by outputReductionTiles at its definition
+      // above). For numShards > maxMultiCoreReductionTilesPerCore the driver
+      // below feeds this into a multi-level merge tree so no core ever holds
+      // more than the budget in tiles.
       auto mergePartials = [&](ArrayRef<std::pair<Value, Value>> group)
           -> std::pair<Value, Value> {
         int64_t groupTiles = static_cast<int64_t>(group.size());
 
-        // Build a groupTiles-tile buffer type along the reduction dim from a
-        // 1-tile partial's layout. Values and indices carry different element
-        // types (f32 vs Int32), so build a wide type per side.
+        // Build a (groupTiles * outputReductionTiles)-tile buffer type along
+        // the reduction dim from a partial's layout (each partial carries
+        // outputReductionTiles reduction tiles). Values and indices carry
+        // different element types (f32 vs Int32), so build a wide type per
+        // side.
         auto partialType = cast<RankedTensorType>(group[0].first.getType());
         auto tileType = cast<ttcore::TileType>(partialType.getElementType());
         auto idxPartialType = cast<RankedTensorType>(group[0].second.getType());
@@ -4783,7 +5114,7 @@ public:
             cast<ttcore::MetalLayoutAttr>(partialType.getEncoding());
         SmallVector<int64_t> wideShape(partialType.getShape().begin(),
                                        partialType.getShape().end());
-        wideShape[deviceRedDim] = groupTiles;
+        wideShape[deviceRedDim] = groupTiles * outputReductionTiles;
         auto wideLayout = layoutForDeviceShape(partialLayout, wideShape);
         auto wideType = RankedTensorType::get(wideShape, tileType, wideLayout);
         auto wideIdxType =
@@ -4856,7 +5187,8 @@ public:
             materializeComposite(valsComposite.getResult());
         Value idxMaterialized = materializeComposite(idxComposite.getResult());
 
-        int64_t mergeReductionElems = groupTiles * 32;
+        int64_t mergeReductionElems =
+            groupTiles * outputReductionTiles * kTileWidth;
         auto mergeValsOut =
             rewriter.create<d2m::EmptyOp>(loc, wideShape, tileType, wideLayout);
         auto mergeIdxOut = rewriter.create<d2m::EmptyOp>(
@@ -4886,33 +5218,70 @@ public:
                 compactToTile(relayout(mergeGeneric->getResult(1)))};
       };
 
-      std::pair<Value, Value> merged;
-      if (numShards <= kMaxShardTiles) {
-        // All partials fit one core: a single topk_block reduces them.
-        merged = mergePartials(partials);
-      } else {
-        // > 32 partials would put > 32 tiles on the merge core. Split into two
-        // groups of <= 32, merge each on its own core to a 1-tile top-k
-        // partial, then merge those two partials with one final topk_block.
-        int64_t half = (numShards + 1) / 2;
-        assert(half <= kMaxShardTiles &&
-               "numShards > 2 * kMaxShardTiles is unsupported (needs a "
-               "multi-level merge tree)");
-        std::pair<Value, Value> g0 = mergePartials(
-            ArrayRef<std::pair<Value, Value>>(partials).take_front(half));
-        std::pair<Value, Value> g1 = mergePartials(
-            ArrayRef<std::pair<Value, Value>>(partials).drop_front(half));
-        merged = mergePartials(SmallVector<std::pair<Value, Value>>{g0, g1});
+      // Multi-level merge tree. A single mergePartials call runs one
+      // topk_block over a group of partials co-located on one core. Each
+      // partial carries the full nonTargetTiles footprint times
+      // outputReductionTiles reduction tiles, so a group of G partials
+      // materializes G * outputReductionTiles reduction tiles; that product
+      // (not G alone) must stay within the L1 band budget. So the cap on
+      // partials per group is maxMultiCoreReductionTilesPerCore /
+      // outputReductionTiles. When numShards exceeds that cap, reduce in
+      // rounds: each round partitions the current partials into balanced
+      // groups of <= cap, merges each group to one
+      // [nonTargetTiles, outputReductionTiles] partial, and feeds the round's
+      // outputs into the next round. Because each round divides the count by
+      // up to the cap, this converges in ceil(log_cap(numShards)) rounds -- a
+      // general k-ary merge tree, not the fixed two-group split. Groups are
+      // balanced (ceil-sized) so no core holds more than necessary; a
+      // trailing group of size 1 is carried forward unmerged rather than run
+      // through a degenerate single-input topk_block.
+      int64_t mergeCap =
+          maxMultiCoreReductionTilesPerCore / outputReductionTiles;
+      assert(mergeCap >= 2 &&
+             "merge tree needs a cap of at least 2 partials per group");
+      SmallVector<std::pair<Value, Value>> level = std::move(partials);
+      while (level.size() > 1) {
+        int64_t count = static_cast<int64_t>(level.size());
+        // Balanced fan-in: spread partials over ceil(count / cap) groups so
+        // each group is <= cap and groups differ in size by at most one.
+        int64_t numGroups = (count + mergeCap - 1) / mergeCap;
+        int64_t baseSize = count / numGroups;
+        int64_t extra = count % numGroups; // first `extra` groups get +1.
+        SmallVector<std::pair<Value, Value>> next;
+        next.reserve(numGroups);
+        int64_t pos = 0;
+        for (int64_t g = 0; g < numGroups; ++g) {
+          int64_t groupSize = baseSize + (g < extra ? 1 : 0);
+          assert(groupSize <= mergeCap && "merge group exceeds the L1 cap");
+          if (groupSize == 1) {
+            // Nothing to merge; carry this partial into the next round.
+            next.push_back(level[pos]);
+          } else {
+            next.push_back(
+                mergePartials(ArrayRef<std::pair<Value, Value>>(level).slice(
+                    pos, groupSize)));
+          }
+          pos += groupSize;
+        }
+        level = std::move(next);
       }
-      topkValsRelayouted = merged.first;
-      topkIdxRelayouted = merged.second;
+      topkValsRelayouted = level.front().first;
+      topkIdxRelayouted = level.front().second;
     }
 
-    // Index extract uses the index-element-type topk tiles; a typecast generic
-    // below converts to the user index output element type (uint16) for
-    // width-preserving untilize.
-    auto extractIdxIndicesType =
-        RankedTensorType::get(indicesType.getShape(), extractIdxElemType);
+    // Index extract uses the index-element-type topk tiles. For dim==0 the
+    // extract generic's inner tile op is already a same-shape TileTypecastOp
+    // (see createExtractGeneric's `dim == 0` branch), so targeting its output
+    // directly at the user index element type (uint16) folds the narrowing
+    // cast into that same op and avoids a second generic. dim==1 uses
+    // TileTransposeOp instead, which is not verified to support a dtype
+    // change at the CB/pack level, so it keeps the separate typecast generic
+    // below.
+    Type idxOutElemType = indicesType.getElementType();
+    bool fuseIdxCast = (dim == 0);
+    auto extractIdxIndicesType = RankedTensorType::get(
+        indicesType.getShape(),
+        fuseIdxCast ? idxOutElemType : extractIdxElemType);
 
     SmallVector<Value> origValOutputs =
         createDpsOutputs(loc, rewriter, {valuesType});
@@ -4937,57 +5306,62 @@ public:
         rewriter, loc, ctx, topkIdxRelayouted, extractIdxLayout,
         extractProjectDim, outputReductionTiles, lastStride, dim);
 
-    // Typecast extracted indices to the output element type (uint16)
-    // before untilize. One tile op per region so D2M->TTKernel store/DST-index
-    // lookup finds a single terminal compute op.
-    Value extractedIdx = extractIdxGeneric->getResult(0);
-    auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
-    Type idxOutElemType = indicesType.getElementType();
-    auto extractIdxTileType =
-        cast<ttcore::TileType>(extractedIdxType.getElementType());
-    auto idxCastTileType =
-        ttcore::TileType::get(idxOutElemType, extractIdxTileType.getShape());
-    auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
-        loc, extractedIdxType.getShape(), idxCastTileType,
-        extractedIdxType.getEncoding());
-    SmallVector<Value> castInputs = {extractedIdx};
-    SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
-    std::size_t castRank = extractedIdxType.getShape().size() / 2;
-    AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
-    SmallVector<Attribute> castIters(
-        castRank,
-        ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-    auto idxCastGeneric = rewriter.create<d2m::GenericOp>(
-        loc, castInputs, castOutputs, /*additionalArgs=*/ValueRange(),
-        rewriter.getAffineMapArrayAttr(
-            SmallVector<AffineMap>{castIdentity, castIdentity}),
-        rewriter.getArrayAttr(castIters));
-    idxCastGeneric->setAttr("d2m.skip_grid_selection", rewriter.getUnitAttr());
-    withD2MGenericRegion(
-        rewriter, loc, idxCastGeneric, castInputs, castOutputs,
-        [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
-          Value input = blockArgs[0];
-          Value output = blockArgs[1];
-          std::size_t shardRank =
-              cast<RankedTensorType>(input.getType()).getRank();
-          AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
-          SmallVector<mlir::utils::IteratorType> linalgIters(
-              shardRank, mlir::utils::IteratorType::parallel);
-          auto linalgOp = rewriter.create<linalg::GenericOp>(
-              loc, output.getType(), input, output,
-              SmallVector<AffineMap>{shardIdentity, shardIdentity}, linalgIters,
-              [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-                Value casted = b.create<d2m::TileTypecastOp>(
-                    bodyLoc, args[1].getType(), args[0]);
-                b.create<linalg::YieldOp>(bodyLoc, casted);
-              });
-          return {linalgOp->getResult(0)};
-        });
+    Value idxFinal = extractIdxGeneric->getResult(0);
+    if (!fuseIdxCast) {
+      // Typecast extracted indices to the output element type (uint16)
+      // before untilize. One tile op per region so D2M->TTKernel
+      // store/DST-index lookup finds a single terminal compute op.
+      Value extractedIdx = idxFinal;
+      auto extractedIdxType = cast<RankedTensorType>(extractedIdx.getType());
+      auto extractIdxTileType =
+          cast<ttcore::TileType>(extractedIdxType.getElementType());
+      auto idxCastTileType =
+          ttcore::TileType::get(idxOutElemType, extractIdxTileType.getShape());
+      auto idxCastEmpty = rewriter.create<d2m::EmptyOp>(
+          loc, extractedIdxType.getShape(), idxCastTileType,
+          extractedIdxType.getEncoding());
+      SmallVector<Value> castInputs = {extractedIdx};
+      SmallVector<Value> castOutputs = {idxCastEmpty.getResult()};
+      std::size_t castRank = extractedIdxType.getShape().size() / 2;
+      AffineMap castIdentity = rewriter.getMultiDimIdentityMap(castRank);
+      SmallVector<Attribute> castIters(
+          castRank,
+          ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+      auto idxCastGeneric = rewriter.create<d2m::GenericOp>(
+          loc, castInputs, castOutputs, /*additionalArgs=*/ValueRange(),
+          rewriter.getAffineMapArrayAttr(
+              SmallVector<AffineMap>{castIdentity, castIdentity}),
+          rewriter.getArrayAttr(castIters));
+      idxCastGeneric->setAttr("d2m.skip_grid_selection",
+                              rewriter.getUnitAttr());
+      withD2MGenericRegion(
+          rewriter, loc, idxCastGeneric, castInputs, castOutputs,
+          [&](ArrayRef<Value> blockArgs) -> SmallVector<Value> {
+            Value input = blockArgs[0];
+            Value output = blockArgs[1];
+            std::size_t shardRank =
+                cast<RankedTensorType>(input.getType()).getRank();
+            AffineMap shardIdentity =
+                rewriter.getMultiDimIdentityMap(shardRank);
+            SmallVector<mlir::utils::IteratorType> linalgIters(
+                shardRank, mlir::utils::IteratorType::parallel);
+            auto linalgOp = rewriter.create<linalg::GenericOp>(
+                loc, output.getType(), input, output,
+                SmallVector<AffineMap>{shardIdentity, shardIdentity},
+                linalgIters,
+                [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+                  Value casted = b.create<d2m::TileTypecastOp>(
+                      bodyLoc, args[1].getType(), args[0]);
+                  b.create<linalg::YieldOp>(bodyLoc, casted);
+                });
+            return {linalgOp->getResult(0)};
+          });
+      idxFinal = idxCastGeneric->getResult(0);
+    }
 
     Operation *valResult =
         unLayoutResult(rewriter, extractValsGeneric->getResult(0), valuesType);
-    Operation *idxResult =
-        unLayoutResult(rewriter, idxCastGeneric->getResult(0), indicesType);
+    Operation *idxResult = unLayoutResult(rewriter, idxFinal, indicesType);
 
     rewriter.replaceOp(op, {valResult->getResult(0), idxResult->getResult(0)});
     return success();

--- a/lib/Dialect/D2M/Analysis/CMakeLists.txt
+++ b/lib/Dialect/D2M/Analysis/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_dialect_library(MLIRD2MAnalysis
   CBProducerConsumer.cpp
   GenericInterchangeAnalysis.cpp
   GridAnalysis.cpp
+  TopKShardingStrategy.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${PROJECT_SOURCE_DIR}/include/ttmlir

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -25,13 +25,6 @@ bool GridAnalysis::isTTNNOperand(Value operand) {
   return operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>() != nullptr;
 }
 
-// The grid a value's layout already encodes.
-static llvm::SmallVector<int64_t> encodedGridShape(Value value) {
-  auto type = mlir::cast<RankedTensorType>(value.getType());
-  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(type.getEncoding());
-  return llvm::to_vector(layout.getGridShape(type));
-}
-
 // Find the largest value <= maxFactor that divides all the given physical
 // dimensions. Returns 1 if no better common factor exists.
 static int64_t findLargestCommonFactor(int64_t maxFactor,
@@ -378,32 +371,6 @@ computeCompositeInputGridInfos(d2m::CompositeViewOp compositeView,
   return inputInfos;
 }
 
-GenericGridAnalysisResult GridAnalysis::analyzePinnedGenericOp(
-    GenericOp genericOp,
-    const EffectiveTargetGridRange &effectiveTargetGridRange) {
-  GenericGridAnalysisResult result;
-  result.effectiveTargetGridRange = effectiveTargetGridRange;
-
-  for (auto [operandIndex, operand] :
-       llvm::enumerate(genericOp.getInputsAndOutputs())) {
-    OperandGridInfo info;
-    info.setOwner(genericOp);
-    info.setOperandIndex(operandIndex);
-    info.selectedGrid = encodedGridShape(operand);
-    info.pinned = true;
-    if (auto compositeView = operand.getDefiningOp<d2m::CompositeViewOp>()) {
-      for (Value input : compositeView.getInputs()) {
-        info.compositeInputInfos.push_back(
-            {input, encodedGridShape(input),
-             mlir::cast<RankedTensorType>(input.getType())});
-      }
-    }
-    result.normalizedOperandGrids.push_back(info.selectedGrid);
-    result.operandInfos.push_back(std::move(info));
-  }
-  return result;
-}
-
 GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     GenericOp genericOp,
     const EffectiveTargetGridRange &effectiveTargetGridRange) {
@@ -601,8 +568,8 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
   return result;
 }
 
-EffectiveTargetGridRange
-GridAnalysis::getTargetGridRange(GenericOp genericOp) const {
+EffectiveTargetGridRange getTargetGridRange(GenericOp genericOp,
+                                            ArrayRef<int64_t> deviceGridShape) {
   EffectiveTargetGridRange targetGridRange;
   mlir::Region *region = genericOp->getParentRegion();
   if (auto spatialOp = mlir::dyn_cast<d2m::SpatialOp>(region->getParentOp())) {
@@ -628,21 +595,18 @@ GridAnalysis::GridAnalysis(Operation *moduleOp,
                            ArrayRef<int64_t> deviceGridShape, bool ttnnMode)
     : deviceGridShape(deviceGridShape), ttnnMode(ttnnMode) {
   moduleOp->walk([&](GenericOp genericOp) {
+    // Skip explicit datamovement form — users manage grids manually.
+    if (genericOp.isExplicitDatamovementForm()) {
+      return;
+    }
     if (genericOp->hasAttr("d2m.skip_grid_selection")) {
       return;
     }
-    // A pinned generic still needs its grids folded onto physical cores, so it
-    // is analyzed even in explicit datamovement form.
-    bool pinned = utils::hasPinnedGrid(genericOp);
-    // Skip explicit datamovement form — users manage grids manually.
-    if (genericOp.isExplicitDatamovementForm() && !pinned) {
-      return;
-    }
 
-    EffectiveTargetGridRange targetGridRange = getTargetGridRange(genericOp);
+    EffectiveTargetGridRange targetGridRange =
+        d2m::getTargetGridRange(genericOp, deviceGridShape);
     GenericGridAnalysisResult result =
-        pinned ? analyzePinnedGenericOp(genericOp, targetGridRange)
-               : analyzeGenericOp(genericOp, targetGridRange);
+        analyzeGenericOp(genericOp, targetGridRange);
     results[genericOp.getOperation()] =
         std::make_unique<GenericGridAnalysisResult>(std::move(result));
   });

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -5,8 +5,6 @@
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
 
 #include "ttmlir/Asserts.h"
-#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
-#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -27,80 +25,11 @@ bool GridAnalysis::isTTNNOperand(Value operand) {
   return operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>() != nullptr;
 }
 
-static bool isTopKRelayoutOp(Operation *op) {
-  return mlir::isa<d2m::ToLayoutOp, d2m::ViewLayoutOp, d2m::MaskOp,
-                   d2m::CompositeViewOp>(op);
-}
-
-static bool hasLeftDeviceLayout(Value value) {
-  auto shapedType = mlir::dyn_cast<ShapedType>(value.getType());
-  return !shapedType || !ttcore::getDeviceLayout(shapedType);
-}
-
-llvm::DenseSet<Operation *>
-GridAnalysis::collectTopKPinnedGenerics(Operation *root) {
-  // Seed on the leaf and merge generics; the rest of the expansion is reachable
-  // from them.
-  llvm::SmallVector<Operation *> worklist;
-  llvm::DenseSet<Operation *> pinned;
-  root->walk([&](GenericOp genericOp) {
-    bool holdsTopk = false;
-    genericOp->walk([&](TopkBlockOp) {
-      holdsTopk = true;
-      return WalkResult::interrupt();
-    });
-    if (holdsTopk && pinned.insert(genericOp.getOperation()).second) {
-      worklist.push_back(genericOp.getOperation());
-    }
-  });
-
-  auto visitProducer = [&](Value value) {
-    while (Operation *def = value.getDefiningOp()) {
-      if (mlir::isa<GenericOp>(def)) {
-        if (pinned.insert(def).second) {
-          worklist.push_back(def);
-        }
-        return;
-      }
-      if (!isTopKRelayoutOp(def) || def->getNumOperands() == 0) {
-        return;
-      }
-      value = def->getOperand(0);
-    }
-  };
-
-  // Single-input only, so an unrelated consumer reading topk's result is not
-  // dragged in.
-  auto visitConsumers = [&](Value value, auto &&recurse) -> void {
-    if (hasLeftDeviceLayout(value)) {
-      return;
-    }
-    for (Operation *user : value.getUsers()) {
-      if (auto consumer = mlir::dyn_cast<GenericOp>(user)) {
-        if (consumer.getInputs().size() == 1 && pinned.insert(user).second) {
-          worklist.push_back(user);
-        }
-        continue;
-      }
-      if (!isTopKRelayoutOp(user)) {
-        continue;
-      }
-      for (Value result : user->getResults()) {
-        recurse(result, recurse);
-      }
-    }
-  };
-
-  while (!worklist.empty()) {
-    auto genericOp = mlir::cast<GenericOp>(worklist.pop_back_val());
-    for (Value input : genericOp.getInputs()) {
-      visitProducer(input);
-    }
-    for (Value result : genericOp->getResults()) {
-      visitConsumers(result, visitConsumers);
-    }
-  }
-  return pinned;
+// The grid a value's layout already encodes.
+static llvm::SmallVector<int64_t> encodedGridShape(Value value) {
+  auto type = mlir::cast<RankedTensorType>(value.getType());
+  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(type.getEncoding());
+  return llvm::to_vector(layout.getGridShape(type));
 }
 
 // Find the largest value <= maxFactor that divides all the given physical
@@ -449,9 +378,35 @@ computeCompositeInputGridInfos(d2m::CompositeViewOp compositeView,
   return inputInfos;
 }
 
+GenericGridAnalysisResult GridAnalysis::analyzePinnedGenericOp(
+    GenericOp genericOp,
+    const EffectiveTargetGridRange &effectiveTargetGridRange) {
+  GenericGridAnalysisResult result;
+  result.effectiveTargetGridRange = effectiveTargetGridRange;
+
+  for (auto [operandIndex, operand] :
+       llvm::enumerate(genericOp.getInputsAndOutputs())) {
+    OperandGridInfo info;
+    info.setOwner(genericOp);
+    info.setOperandIndex(operandIndex);
+    info.selectedGrid = encodedGridShape(operand);
+    info.pinned = true;
+    if (auto compositeView = operand.getDefiningOp<d2m::CompositeViewOp>()) {
+      for (Value input : compositeView.getInputs()) {
+        info.compositeInputInfos.push_back(
+            {input, encodedGridShape(input),
+             mlir::cast<RankedTensorType>(input.getType())});
+      }
+    }
+    result.normalizedOperandGrids.push_back(info.selectedGrid);
+    result.operandInfos.push_back(std::move(info));
+  }
+  return result;
+}
+
 GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     GenericOp genericOp,
-    const EffectiveTargetGridRange &effectiveTargetGridRange, bool pinned) {
+    const EffectiveTargetGridRange &effectiveTargetGridRange) {
   GenericGridAnalysisResult result;
   result.effectiveTargetGridRange = effectiveTargetGridRange;
   ArrayRef<int64_t> targetGridShape = result.effectiveTargetGridRange.shape;
@@ -462,9 +417,7 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
   // computeGridAwareDimAlignments produces consistent alignments.
   int64_t minGridDim = *llvm::min_element(targetGridShape);
   auto indexingMaps = genericOp.getIndexingMapsValue();
-  // Empty only for pinned generics in explicit datamovement form.
-  unsigned numLoopDims =
-      indexingMaps.empty() ? 0 : indexingMaps.front().getNumDims();
+  unsigned numLoopDims = indexingMaps.front().getNumDims();
 
   // For each loop dim, find which operand-dim positions it maps to. If it
   // appears at different positions across operands, mark those positions as
@@ -539,11 +492,8 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     llvm::SmallVector<int64_t> physShape =
         utils::computePhysicalShape(operand, targetGrid, ttnnMode);
     physicalShapes.push_back(physShape);
-    // A pinned split is dictated by the lowering; only the fold onto physical
-    // cores is left to compute.
     auto optimalGrid =
-        pinned ? llvm::to_vector(operandLayout.getGridShape(operandType))
-               : utils::computeOptimalGrid(operandType, physShape, targetGrid);
+        utils::computeOptimalGrid(operandType, physShape, targetGrid);
     optimalOperandGrids.push_back(optimalGrid);
 
     OperandGridInfo info;
@@ -551,7 +501,6 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     info.setOperandIndex(operandIndex);
     info.selectedGrid = optimalGrid; // Will be updated after normalization.
     info.targetGrid = perOperandTargetGrids[operandIndex];
-    info.forceRebuild = pinned;
 
     unsigned outputBegin = genericOp.getOutputs().getBeginOperandIndex();
     if (operandIndex >= outputBegin &&
@@ -565,11 +514,8 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
 
     // If the operand is a view over a ToLayoutOp (not fronting a TTNN cast),
     // pre-compute the ToLayoutOp's own optimal grid so it can be updated
-    // independently at apply time. A pinned producer is already at the right
-    // grid.
-    if (auto toLayoutOp =
-            pinned ? d2m::ToLayoutOp()
-                   : utils::getToLayoutProducerBehindViews(operand)) {
+    // independently at apply time.
+    if (auto toLayoutOp = utils::getToLayoutProducerBehindViews(operand)) {
       if (!toLayoutOp.getInput().getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
         Value toLayoutResult = toLayoutOp.getResult(0);
         auto inputType =
@@ -619,13 +565,9 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     }
   }
 
-  // Normalize the operand grids for the generic operation. Pinned operands are
-  // already consistent; normalizing would trade the required split for a
-  // common factor.
-  result.normalizedOperandGrids =
-      pinned ? llvm::to_vector(optimalOperandGrids)
-             : normalizeOperandGridsForGeneric(genericOp, optimalOperandGrids,
-                                               physicalShapes);
+  // Normalize the operand grids for the generic operation.
+  result.normalizedOperandGrids = normalizeOperandGridsForGeneric(
+      genericOp, optimalOperandGrids, physicalShapes);
 
   // Propagate normalized grids back to non-reinterpret ViewLayout operands
   // only. Other operand kinds use their independently computed optimal
@@ -649,17 +591,6 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     auto compositeView =
         info.getLiveOperand().getDefiningOp<d2m::CompositeViewOp>();
     if (!compositeView) {
-      continue;
-    }
-    if (pinned) {
-      for (Value input : compositeView.getInputs()) {
-        auto inputType = mlir::cast<RankedTensorType>(input.getType());
-        auto inputLayout =
-            mlir::cast<ttcore::MetalLayoutAttr>(inputType.getEncoding());
-        info.compositeInputInfos.push_back(
-            {input, llvm::to_vector(inputLayout.getGridShape(inputType)),
-             inputType});
-      }
       continue;
     }
     info.compositeInputInfos = computeCompositeInputGridInfos(
@@ -696,25 +627,22 @@ GridAnalysis::getTargetGridRange(GenericOp genericOp) const {
 GridAnalysis::GridAnalysis(Operation *moduleOp,
                            ArrayRef<int64_t> deviceGridShape, bool ttnnMode)
     : deviceGridShape(deviceGridShape), ttnnMode(ttnnMode) {
-  // Generics whose split is fixed by their lowering (see D2MTopKRewriter).
-  llvm::DenseSet<Operation *> pinnedGenerics =
-      collectTopKPinnedGenerics(moduleOp);
-
   moduleOp->walk([&](GenericOp genericOp) {
-    bool pinned = pinnedGenerics.contains(genericOp);
-    // Skip explicit datamovement form — users manage grids manually. Pinned
-    // generics are the exception: the topk narrowings use this form but still
-    // need their buffers folded onto physical cores.
-    if (genericOp.isExplicitDatamovementForm() && !pinned) {
+    if (genericOp->hasAttr("d2m.skip_grid_selection")) {
       return;
     }
-    if (genericOp->hasAttr("d2m.skip_grid_selection")) {
+    // A pinned generic still needs its grids folded onto physical cores, so it
+    // is analyzed even in explicit datamovement form.
+    bool pinned = utils::hasPinnedGrid(genericOp);
+    // Skip explicit datamovement form — users manage grids manually.
+    if (genericOp.isExplicitDatamovementForm() && !pinned) {
       return;
     }
 
     EffectiveTargetGridRange targetGridRange = getTargetGridRange(genericOp);
     GenericGridAnalysisResult result =
-        analyzeGenericOp(genericOp, targetGridRange, pinned);
+        pinned ? analyzePinnedGenericOp(genericOp, targetGridRange)
+               : analyzeGenericOp(genericOp, targetGridRange);
     results[genericOp.getOperation()] =
         std::make_unique<GenericGridAnalysisResult>(std::move(result));
   });

--- a/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
+++ b/lib/Dialect/D2M/Analysis/GridAnalysis.cpp
@@ -5,6 +5,8 @@
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
 
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -23,6 +25,82 @@ bool GridAnalysis::isTTNNOperand(Value operand) {
     operand = view.getInput();
   }
   return operand.getDefiningOp<ttir::TTNNMetalLayoutCastOp>() != nullptr;
+}
+
+static bool isTopKRelayoutOp(Operation *op) {
+  return mlir::isa<d2m::ToLayoutOp, d2m::ViewLayoutOp, d2m::MaskOp,
+                   d2m::CompositeViewOp>(op);
+}
+
+static bool hasLeftDeviceLayout(Value value) {
+  auto shapedType = mlir::dyn_cast<ShapedType>(value.getType());
+  return !shapedType || !ttcore::getDeviceLayout(shapedType);
+}
+
+llvm::DenseSet<Operation *>
+GridAnalysis::collectTopKPinnedGenerics(Operation *root) {
+  // Seed on the leaf and merge generics; the rest of the expansion is reachable
+  // from them.
+  llvm::SmallVector<Operation *> worklist;
+  llvm::DenseSet<Operation *> pinned;
+  root->walk([&](GenericOp genericOp) {
+    bool holdsTopk = false;
+    genericOp->walk([&](TopkBlockOp) {
+      holdsTopk = true;
+      return WalkResult::interrupt();
+    });
+    if (holdsTopk && pinned.insert(genericOp.getOperation()).second) {
+      worklist.push_back(genericOp.getOperation());
+    }
+  });
+
+  auto visitProducer = [&](Value value) {
+    while (Operation *def = value.getDefiningOp()) {
+      if (mlir::isa<GenericOp>(def)) {
+        if (pinned.insert(def).second) {
+          worklist.push_back(def);
+        }
+        return;
+      }
+      if (!isTopKRelayoutOp(def) || def->getNumOperands() == 0) {
+        return;
+      }
+      value = def->getOperand(0);
+    }
+  };
+
+  // Single-input only, so an unrelated consumer reading topk's result is not
+  // dragged in.
+  auto visitConsumers = [&](Value value, auto &&recurse) -> void {
+    if (hasLeftDeviceLayout(value)) {
+      return;
+    }
+    for (Operation *user : value.getUsers()) {
+      if (auto consumer = mlir::dyn_cast<GenericOp>(user)) {
+        if (consumer.getInputs().size() == 1 && pinned.insert(user).second) {
+          worklist.push_back(user);
+        }
+        continue;
+      }
+      if (!isTopKRelayoutOp(user)) {
+        continue;
+      }
+      for (Value result : user->getResults()) {
+        recurse(result, recurse);
+      }
+    }
+  };
+
+  while (!worklist.empty()) {
+    auto genericOp = mlir::cast<GenericOp>(worklist.pop_back_val());
+    for (Value input : genericOp.getInputs()) {
+      visitProducer(input);
+    }
+    for (Value result : genericOp->getResults()) {
+      visitConsumers(result, visitConsumers);
+    }
+  }
+  return pinned;
 }
 
 // Find the largest value <= maxFactor that divides all the given physical
@@ -373,7 +451,7 @@ computeCompositeInputGridInfos(d2m::CompositeViewOp compositeView,
 
 GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     GenericOp genericOp,
-    const EffectiveTargetGridRange &effectiveTargetGridRange) {
+    const EffectiveTargetGridRange &effectiveTargetGridRange, bool pinned) {
   GenericGridAnalysisResult result;
   result.effectiveTargetGridRange = effectiveTargetGridRange;
   ArrayRef<int64_t> targetGridShape = result.effectiveTargetGridRange.shape;
@@ -384,7 +462,9 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
   // computeGridAwareDimAlignments produces consistent alignments.
   int64_t minGridDim = *llvm::min_element(targetGridShape);
   auto indexingMaps = genericOp.getIndexingMapsValue();
-  unsigned numLoopDims = indexingMaps.front().getNumDims();
+  // Empty only for pinned generics in explicit datamovement form.
+  unsigned numLoopDims =
+      indexingMaps.empty() ? 0 : indexingMaps.front().getNumDims();
 
   // For each loop dim, find which operand-dim positions it maps to. If it
   // appears at different positions across operands, mark those positions as
@@ -459,8 +539,11 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     llvm::SmallVector<int64_t> physShape =
         utils::computePhysicalShape(operand, targetGrid, ttnnMode);
     physicalShapes.push_back(physShape);
+    // A pinned split is dictated by the lowering; only the fold onto physical
+    // cores is left to compute.
     auto optimalGrid =
-        utils::computeOptimalGrid(operandType, physShape, targetGrid);
+        pinned ? llvm::to_vector(operandLayout.getGridShape(operandType))
+               : utils::computeOptimalGrid(operandType, physShape, targetGrid);
     optimalOperandGrids.push_back(optimalGrid);
 
     OperandGridInfo info;
@@ -468,6 +551,7 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     info.setOperandIndex(operandIndex);
     info.selectedGrid = optimalGrid; // Will be updated after normalization.
     info.targetGrid = perOperandTargetGrids[operandIndex];
+    info.forceRebuild = pinned;
 
     unsigned outputBegin = genericOp.getOutputs().getBeginOperandIndex();
     if (operandIndex >= outputBegin &&
@@ -481,8 +565,11 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
 
     // If the operand is a view over a ToLayoutOp (not fronting a TTNN cast),
     // pre-compute the ToLayoutOp's own optimal grid so it can be updated
-    // independently at apply time.
-    if (auto toLayoutOp = utils::getToLayoutProducerBehindViews(operand)) {
+    // independently at apply time. A pinned producer is already at the right
+    // grid.
+    if (auto toLayoutOp =
+            pinned ? d2m::ToLayoutOp()
+                   : utils::getToLayoutProducerBehindViews(operand)) {
       if (!toLayoutOp.getInput().getDefiningOp<ttir::TTNNMetalLayoutCastOp>()) {
         Value toLayoutResult = toLayoutOp.getResult(0);
         auto inputType =
@@ -532,9 +619,13 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     }
   }
 
-  // Normalize the operand grids for the generic operation.
-  result.normalizedOperandGrids = normalizeOperandGridsForGeneric(
-      genericOp, optimalOperandGrids, physicalShapes);
+  // Normalize the operand grids for the generic operation. Pinned operands are
+  // already consistent; normalizing would trade the required split for a
+  // common factor.
+  result.normalizedOperandGrids =
+      pinned ? llvm::to_vector(optimalOperandGrids)
+             : normalizeOperandGridsForGeneric(genericOp, optimalOperandGrids,
+                                               physicalShapes);
 
   // Propagate normalized grids back to non-reinterpret ViewLayout operands
   // only. Other operand kinds use their independently computed optimal
@@ -558,6 +649,17 @@ GenericGridAnalysisResult GridAnalysis::analyzeGenericOp(
     auto compositeView =
         info.getLiveOperand().getDefiningOp<d2m::CompositeViewOp>();
     if (!compositeView) {
+      continue;
+    }
+    if (pinned) {
+      for (Value input : compositeView.getInputs()) {
+        auto inputType = mlir::cast<RankedTensorType>(input.getType());
+        auto inputLayout =
+            mlir::cast<ttcore::MetalLayoutAttr>(inputType.getEncoding());
+        info.compositeInputInfos.push_back(
+            {input, llvm::to_vector(inputLayout.getGridShape(inputType)),
+             inputType});
+      }
       continue;
     }
     info.compositeInputInfos = computeCompositeInputGridInfos(
@@ -594,9 +696,16 @@ GridAnalysis::getTargetGridRange(GenericOp genericOp) const {
 GridAnalysis::GridAnalysis(Operation *moduleOp,
                            ArrayRef<int64_t> deviceGridShape, bool ttnnMode)
     : deviceGridShape(deviceGridShape), ttnnMode(ttnnMode) {
+  // Generics whose split is fixed by their lowering (see D2MTopKRewriter).
+  llvm::DenseSet<Operation *> pinnedGenerics =
+      collectTopKPinnedGenerics(moduleOp);
+
   moduleOp->walk([&](GenericOp genericOp) {
-    // Skip explicit datamovement form — users manage grids manually.
-    if (genericOp.isExplicitDatamovementForm()) {
+    bool pinned = pinnedGenerics.contains(genericOp);
+    // Skip explicit datamovement form — users manage grids manually. Pinned
+    // generics are the exception: the topk narrowings use this form but still
+    // need their buffers folded onto physical cores.
+    if (genericOp.isExplicitDatamovementForm() && !pinned) {
       return;
     }
     if (genericOp->hasAttr("d2m.skip_grid_selection")) {
@@ -605,7 +714,7 @@ GridAnalysis::GridAnalysis(Operation *moduleOp,
 
     EffectiveTargetGridRange targetGridRange = getTargetGridRange(genericOp);
     GenericGridAnalysisResult result =
-        analyzeGenericOp(genericOp, targetGridRange);
+        analyzeGenericOp(genericOp, targetGridRange, pinned);
     results[genericOp.getOperation()] =
         std::make_unique<GenericGridAnalysisResult>(std::move(result));
   });

--- a/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
+++ b/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
@@ -5,10 +5,13 @@
 #include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
 
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Utils.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -123,21 +126,6 @@ TopKL1Budget topKL1Budget(GenericOp leaf, ttcore::ChipDescAttr chipDesc,
   return budget;
 }
 
-TopKGeometry getTopKGeometry(int32_t dim, std::size_t physicalRank) {
-  assert((dim == 0 || dim == 1) && "topk geometry expects a 2D reduction dim");
-  assert(physicalRank >= 2u &&
-         "topk geometry expects a rank >= 2 device shape");
-
-  const std::size_t redDim =
-      (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-
-  TopKGeometry geometry;
-  geometry.deviceRedDim = physicalRank + redDim;
-  geometry.deviceGridDim = static_cast<std::size_t>(dim);
-  geometry.extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
-  return geometry;
-}
-
 mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
     int64_t k, int32_t dim, llvm::ArrayRef<int64_t> inputShape,
     llvm::ArrayRef<int64_t> workerGridShape, const TopKL1Budget &budget,
@@ -240,10 +228,9 @@ mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
     }
   }
 
-  // Neither one-dimensional split works once the non-target dim overflows a
-  // core and the reduction dim cannot ride along whole on every core. Thinner
-  // non-target slices free tile budget for the merge rounds, so walk up until
-  // the chain closes.
+  // Neither one-dimensional split fits when both dims are larger than L1 can
+  // hold. More bands never shrinks what a merge core gathers; only a narrower
+  // non-target slice does.
   if (scanPowerOfTwoFirst(2, bandGridLimit, [&](int64_t bands) {
         for (int64_t ntShards = 2; ntShards <= ntGridLimit; ++ntShards) {
           if (accept(bands, ntShards)) {
@@ -259,6 +246,249 @@ mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
                   "dimensions fits the per-core tile budget with a merge tree "
                   "this worker grid can hold";
   return mlir::failure();
+}
+
+namespace {
+
+// Walks back through the to_layouts, view_layouts, masks, and transpose
+// generics of ttir-to-d2m's placeholder chain to the original logical value.
+Value findLogicalInput(Value value) {
+  auto isDevice = [](Value v) {
+    auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
+    return type &&
+           mlir::isa_and_nonnull<ttcore::MetalLayoutAttr>(type.getEncoding());
+  };
+  while (isDevice(value)) {
+    Operation *def = value.getDefiningOp();
+    if (auto toLayout = mlir::dyn_cast_if_present<ToLayoutOp>(def)) {
+      value = toLayout.getInput();
+    } else if (auto view = mlir::dyn_cast_if_present<ViewLayoutOp>(def)) {
+      value = view.getInput();
+    } else if (auto mask = mlir::dyn_cast_if_present<MaskOp>(def)) {
+      value = mask.getInput();
+    } else if (auto generic = mlir::dyn_cast_if_present<GenericOp>(def);
+               generic && generic.getInputs().size() == 1) {
+      value = generic.getInputs()[0];
+    } else {
+      return nullptr;
+    }
+  }
+  return value;
+}
+
+} // namespace
+
+SingleCoreTopK readSingleCoreTopK(GenericOp leaf) {
+  SingleCoreTopK chain;
+  chain.leaf = leaf;
+  chain.logicalInput = findLogicalInput(leaf.getInputs()[0]);
+  TT_assert(chain.logicalInput);
+  auto indexType = leaf->getAttrOfType<TypeAttr>(utils::kTopkIndexTypeAttr);
+  TT_assertv(indexType, "topk leaf carries no d2m.topk_index_type");
+  chain.indexElementType = indexType.getValue();
+  return chain;
+}
+
+namespace {
+
+// Build a sharded L1 MetalLayoutAttr for `logicalShape` where dim i is padded
+// out to `tilesPerDim[i]` tiles. Uses default collapsed intervals.
+ttcore::MetalLayoutAttr
+buildShardedTileLayout(MLIRContext *ctx, ArrayRef<int64_t> logicalShape,
+                       ArrayRef<int64_t> tilesPerDim,
+                       ttcore::MemorySpace memorySpace) {
+  TT_assert(tilesPerDim.size() == logicalShape.size());
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  SmallVector<int64_t> dimAlignments;
+  dimAlignments.reserve(tilesPerDim.size());
+  for (int64_t tiles : tilesPerDim) {
+    dimAlignments.push_back(tiles * tileDim);
+  }
+  return ttcore::MetalLayoutAttr::get(
+      ctx, logicalShape, memorySpace, ttcore::TensorMemoryLayout::Sharded,
+      ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+          ctx, logicalShape.size()),
+      dimAlignments);
+}
+
+// Rebuilds `layout`'s logical shape from a [grid..., shard...] `deviceShape`:
+// narrowing a partial's device extent shrinks what it logically stands for.
+ttcore::MetalLayoutAttr
+rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
+                            ArrayRef<int64_t> deviceShape) {
+  TT_assert(deviceShape.size() % 2 == 0u);
+  const std::size_t physicalRank = deviceShape.size() / 2;
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  llvm::SmallVector<int64_t> logicalShape;
+  logicalShape.reserve(physicalRank);
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    logicalShape.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
+                           tileDim);
+  }
+  return ttcore::MetalLayoutAttr::get(
+      layout.getContext(), logicalShape, layout.getDimAlignments(),
+      layout.getCollapsedIntervals(), layout.getMemorySpace(),
+      layout.getMemoryLayout());
+}
+
+} // namespace
+
+TopKBufferPlans planTopKBuffers(SingleCoreTopK chain,
+                                const TopKShardingStrategy &strategy, int64_t k,
+                                int32_t dim) {
+  MLIRContext *ctx = chain.leaf.getContext();
+  auto logicalInputType =
+      mlir::cast<RankedTensorType>(chain.logicalInput.getType());
+  const std::size_t rank = logicalInputType.getRank();
+  // The reduction axis in the shard half of a [grid..., shard...] device shape.
+  const std::size_t deviceRedDim = rank + dim;
+  llvm::SmallVector<int64_t> tileShape =
+      llvm::to_vector(ttcore::TileType::getDefaultShape());
+
+  auto leafInputLayout = mlir::cast<ttcore::MetalLayoutAttr>(
+      mlir::cast<RankedTensorType>(chain.leaf.getInputs()[0].getType())
+          .getEncoding());
+  const ttcore::MemorySpace memSpace = leafInputLayout.getMemorySpace();
+
+  auto valTileType =
+      ttcore::TileType::get(logicalInputType.getElementType(), tileShape);
+  auto idxTileType =
+      ttcore::TileType::get(IntegerType::get(ctx, 32), tileShape);
+
+  TopKBufferPlans plans;
+  auto make = [](ArrayRef<int64_t> deviceShape, ttcore::TileType tileType,
+                 ttcore::MetalLayoutAttr layout) {
+    return TopKBufferPlan{RankedTensorType::get(deviceShape, tileType, layout)};
+  };
+  auto add = [&](ArrayRef<int64_t> deviceShape, ttcore::TileType tileType,
+                 ttcore::MetalLayoutAttr layout) {
+    plans.lowered.push_back(make(deviceShape, tileType, layout));
+  };
+
+  // The leaf input: banded `gridCols` ways along the reduction dim, sliced
+  // `ntShards` ways along the non-target dim.
+  const int64_t gridCols = strategy.multiCore ? strategy.numShards : 1;
+  llvm::SmallVector<int64_t> shardTiles(rank, 1);
+  shardTiles[dim] = strategy.paddedReductionTiles;
+  shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
+  llvm::SmallVector<int64_t> grid =
+      (dim == 1) ? llvm::SmallVector<int64_t>{strategy.ntShards, gridCols}
+                 : llvm::SmallVector<int64_t>{gridCols, strategy.ntShards};
+  ttcore::MetalLayoutAttr inputLayout = buildShardedTileLayout(
+      ctx, logicalInputType.getShape(), shardTiles, memSpace);
+  llvm::SmallVector<int64_t> inputShape =
+      inputLayout.getDeviceShape(grid, tileShape);
+
+  plans.input = make(inputShape, valTileType, inputLayout);
+
+  // A padding tail exists only when the grid times the shard overshoots the
+  // logical extent.
+  bool needsMask = false;
+  for (std::size_t i = 0; i < rank; ++i) {
+    needsMask |= inputShape[i] * inputShape[i + rank] * tileShape[0] >
+                 logicalInputType.getShape()[i];
+  }
+  if (needsMask) {
+    plans.inputMask = make(inputShape, valTileType, inputLayout);
+  }
+
+  // `topk_block` sorts down tile columns, so dim=1 transposes the shard first.
+  if (dim == 1) {
+    add(inputShape, valTileType, inputLayout);
+  }
+
+  // One scratch tile per core: the kernel derives the whole index buffer from
+  // it plus its own grid coordinate, so its content doesn't depend on the
+  // split.
+  llvm::SmallVector<int64_t> scratchShape(grid);
+  scratchShape.append({1, 1});
+  add(scratchShape, idxTileType,
+      ttcore::MetalLayoutAttr::get(ctx, llvm::SmallVector<int64_t>{1, 1},
+                                   ttcore::MemorySpace::DeviceL1,
+                                   ttcore::TensorMemoryLayout::Sharded));
+
+  add(inputShape, valTileType, inputLayout);
+  add(inputShape, idxTileType, inputLayout);
+
+  // Only banding produces wide partials worth narrowing, to keep them from
+  // staying live on every core and overflowing L1.
+  llvm::SmallVector<int64_t> levelShape(inputShape);
+  ttcore::MetalLayoutAttr levelLayout = inputLayout;
+  if (gridCols > 1) {
+    levelShape[deviceRedDim] = strategy.outputReductionTiles;
+    levelLayout = rebuildLayoutForDeviceShape(inputLayout, levelShape);
+    add(levelShape, valTileType, levelLayout);
+    add(levelShape, idxTileType, levelLayout);
+  }
+
+  // Each round re-splits the surviving extent: `numGroups` cores each holding
+  // `groupTiles` bands' worth of reduction tiles, so grid x shard is preserved.
+  int64_t bands = gridCols;
+  for (int64_t numGroups : strategy.mergeSchedule) {
+    const int64_t groupTiles = bands / numGroups;
+
+    llvm::SmallVector<int64_t> wideShape(levelShape);
+    wideShape[dim] = numGroups;
+    wideShape[deviceRedDim] = groupTiles * strategy.outputReductionTiles;
+    ttcore::MetalLayoutAttr wideLayout =
+        rebuildLayoutForDeviceShape(levelLayout, wideShape);
+
+    // The gather and the merge are separate generics: the DMA-expansion pass
+    // supports only one composite view per generic (#7600).
+    add(wideShape, valTileType, wideLayout);
+    add(wideShape, idxTileType, wideLayout);
+    add(wideShape, valTileType, wideLayout);
+    add(wideShape, idxTileType, wideLayout);
+
+    levelShape = wideShape;
+    levelShape[deviceRedDim] = strategy.outputReductionTiles;
+    levelLayout = rebuildLayoutForDeviceShape(wideLayout, levelShape);
+    add(levelShape, valTileType, levelLayout);
+    add(levelShape, idxTileType, levelLayout);
+
+    bands = numGroups;
+  }
+
+  // A data-parallel split must keep the extract's destination on the same
+  // cores as its source; anything else collects onto one.
+  llvm::SmallVector<int64_t> outLogicalShape(logicalInputType.getShape());
+  outLogicalShape[dim] = k;
+  llvm::SmallVector<int64_t> extractGrid =
+      strategy.dataParallel
+          ? ((dim == 1) ? llvm::SmallVector<int64_t>{strategy.ntShards, 1}
+                        : llvm::SmallVector<int64_t>{1, strategy.ntShards})
+          : llvm::SmallVector<int64_t>{1, 1};
+  llvm::SmallVector<int64_t> extractShardTiles(rank, 1);
+  extractShardTiles[dim] = strategy.outputReductionTiles;
+  extractShardTiles[1 - dim] =
+      strategy.dataParallel
+          ? strategy.paddedNonTargetTiles
+          : llvm::divideCeil(logicalInputType.getShape()[1 - dim], kTileWidth);
+
+  ttcore::MetalLayoutAttr extractLayout =
+      buildShardedTileLayout(ctx, outLogicalShape, extractShardTiles, memSpace);
+  llvm::SmallVector<int64_t> extractShape =
+      extractLayout.getDeviceShape(extractGrid, tileShape);
+
+  // dim == 0's extract casts on the way out; dim == 1's transposes instead, so
+  // the cast follows in a region of its own.
+  const bool castsInExtract = dim == 0;
+  auto extractIdxTileType = ttcore::TileType::get(
+      castsInExtract ? chain.indexElementType : IntegerType::get(ctx, 32),
+      tileShape);
+
+  add(extractShape, valTileType, extractLayout);
+  add(extractShape, extractIdxTileType, extractLayout);
+
+  // The cast is elementwise, so it follows its input's layout.
+  if (!castsInExtract) {
+    add(extractShape, ttcore::TileType::get(chain.indexElementType, tileShape),
+        extractLayout);
+  }
+
+  return plans;
 }
 
 } // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
+++ b/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
@@ -4,29 +4,61 @@
 
 #include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
 
+#include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Utils.h"
+
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
+#include <cassert>
 #include <optional>
 
 namespace mlir::tt::d2m {
 
 namespace {
-constexpr int64_t kTileWidth = 32;
-// L1-safe tile budget for one core's shard of a single buffer.
-constexpr int64_t kMaxTilesPerCore = 43;
-// k > kTileWidth partials span two tiles and fold through the large-k path, so
-// they get a fraction of the budget.
-constexpr int64_t kLargeKMergeDivisor = 4;
-} // namespace
+constexpr int64_t kTileWidth = ttcore::TileType::getDefaultShape()[1];
 
+// True when every result is a constant, i.e. the operand holds one fixed shard
+// regardless of how the reduction is banded.
+bool isConstantMap(AffineMap map) {
+  return llvm::all_of(map.getResults(), [](AffineExpr expr) {
+    return mlir::isa<AffineConstantExpr>(expr);
+  });
+}
+
+// Tiles in one core's shard, the trailing half of a `[grid..., shard...]` type.
+int64_t shardTileCount(mlir::RankedTensorType type) {
+  return ttmlir::utils::volume<int64_t>(
+      type.getShape().take_back(type.getShape().size() / 2));
+}
+
+/// Runs `accept` over core counts in [lo, hi], powers of two first, and returns
+/// true at the first count it accepts. Power-of-two counts close the shallowest
+/// merge chains, so they are worth trying ahead of a smaller odd count.
+bool scanPowerOfTwoFirst(int64_t lo, int64_t hi,
+                         llvm::function_ref<bool(int64_t)> accept) {
+  for (bool powerOfTwoOnly : {true, false}) {
+    for (int64_t cand = lo; cand <= hi; ++cand) {
+      if (powerOfTwoOnly && !llvm::isPowerOf2_64(cand)) {
+        continue;
+      }
+      if (accept(cand)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// Smallest legal group count for one merge round: divides `bands`, at most
+/// `mergeCap` bands per group, a core count this grid can hold. 0 when none.
 int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
                             llvm::ArrayRef<int64_t> workerGridShape) {
   for (int64_t groups = 1; groups < bands; ++groups) {
-    if (bands % groups != 0) {
-      continue;
-    }
-    if (bands / groups > mergeCap) {
+    if (bands % groups != 0 || bands / groups > mergeCap) {
       continue;
     }
     if (utils::findLegalPhysicalGridForVolume(groups, workerGridShape)
@@ -38,231 +70,249 @@ int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
   return 0;
 }
 
-// True when repeatedly applying pickMergeGroupCount reduces `bands` to 1.
-// Fails if any level has no divisor in [2, mergeCap] that is also grid-legal.
-static bool mergeChainCloses(int64_t bands, int64_t mergeCap,
-                             llvm::ArrayRef<int64_t> workerGridShape) {
+/// Walks the merge chain from `bands` down to 1, recording each round's group
+/// count. Nullopt when a level has no grid-legal divisor in [2, mergeCap].
+std::optional<llvm::SmallVector<int64_t>>
+buildMergeSchedule(int64_t bands, int64_t mergeCap,
+                   llvm::ArrayRef<int64_t> workerGridShape) {
+  llvm::SmallVector<int64_t> schedule;
   while (bands > 1) {
     int64_t groups = pickMergeGroupCount(bands, mergeCap, workerGridShape);
     if (groups == 0) {
-      return false;
+      return std::nullopt;
     }
+    schedule.push_back(groups);
     bands = groups;
   }
-  return true;
+  return schedule;
+}
+
+struct BandSplit {
+  int64_t bands;
+  int64_t bandTiles;
+  llvm::SmallVector<int64_t> schedule;
+};
+} // namespace
+
+TopKL1Budget topKL1Budget(GenericOp leaf, ttcore::ChipDescAttr chipDesc,
+                          int64_t numBuffers) {
+  TopKL1Budget budget;
+  budget.usableBytes = static_cast<int64_t>(chipDesc.getL1Size()) -
+                       static_cast<int64_t>(chipDesc.getL1UnreservedBase());
+
+  llvm::SmallVector<AffineMap> indexingMaps = leaf.getIndexingMapsValue();
+  for (auto [operand, map] :
+       llvm::zip_equal(leaf.getInputsAndOutputs(), indexingMaps)) {
+    auto type = mlir::cast<mlir::RankedTensorType>(operand.getType());
+    const int64_t bufferBytes =
+        static_cast<int64_t>(
+            ttcore::getElementSizeBytes(type.getElementType())) *
+        numBuffers;
+    if (isConstantMap(map)) {
+      // The rebuild emits a leaf of its own, so this is paid for twice.
+      budget.fixedBytes += 2 * bufferBytes * shardTileCount(type);
+    } else {
+      budget.bytesPerLeafTile += bufferBytes;
+    }
+  }
+  // Merge rounds carry the leaf's outputs, never its input.
+  for (Value output : leaf.getOutputs()) {
+    auto type = mlir::cast<mlir::RankedTensorType>(output.getType());
+    budget.bytesPerMergeTile +=
+        static_cast<int64_t>(
+            ttcore::getElementSizeBytes(type.getElementType())) *
+        numBuffers;
+  }
+  TT_assertv((budget.bytesPerLeafTile > 0 && budget.bytesPerMergeTile > 0),
+             "topk leaf has no shard-sized operand");
+  return budget;
+}
+
+TopKGeometry getTopKGeometry(int32_t dim, std::size_t physicalRank) {
+  assert((dim == 0 || dim == 1) && "topk geometry expects a 2D reduction dim");
+  assert(physicalRank >= 2u &&
+         "topk geometry expects a rank >= 2 device shape");
+
+  TopKGeometry geometry;
+  geometry.genRedDim = (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+  geometry.deviceRedDim = physicalRank + geometry.genRedDim;
+  geometry.deviceGridDim = static_cast<std::size_t>(dim);
+  geometry.extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
+  return geometry;
 }
 
 mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
     int64_t k, int32_t dim, llvm::ArrayRef<int64_t> inputShape,
-    llvm::ArrayRef<int64_t> workerGridShape, std::string &failureReason) {
+    llvm::ArrayRef<int64_t> workerGridShape, const TopKL1Budget &budget,
+    std::string &failureReason) {
+  // What a core can hold when nothing is left for a merge round.
+  const int64_t maxTilesPerCore = std::max<int64_t>(
+      (budget.usableBytes - budget.fixedBytes) / budget.bytesPerLeafTile, 1);
+  const int64_t nonTargetTiles =
+      llvm::divideCeil(inputShape[1 - dim], kTileWidth);
+  const int64_t fullReductionTiles =
+      llvm::divideCeil(inputShape[dim], kTileWidth);
+  // topk_block merges reduction tiles pairwise, so a core always holds two.
+  const int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
+  const int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
+
   TopKShardingStrategy strategy;
-  strategy.outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
-
-  int64_t fullReductionElems = inputShape[dim];
-  int64_t nonTargetElems = inputShape[1 - dim];
-  int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
-  int64_t fullReductionTiles =
-      (fullReductionElems + kTileWidth - 1) / kTileWidth;
-
-  int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
-
-  int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
-
-  strategy.ntTilesPerCore = nonTargetTiles;
-  strategy.paddedNonTargetTiles = nonTargetTiles;
-  // Bands need not divide fullReductionTiles evenly; the padding tail out to
-  // paddedReductionTiles is masked to -inf, as is the non-target tail out to
-  // paddedNonTargetTiles.
-  strategy.bandTiles = fullReductionTiles;
+  strategy.outputReductionTiles = llvm::divideCeil(k, kTileWidth);
+  // Shard counts need not divide the tile counts evenly; the tails out to
+  // paddedReductionTiles and paddedNonTargetTiles are masked to -inf.
   strategy.paddedReductionTiles = fullReductionTiles;
+  strategy.paddedNonTargetTiles = nonTargetTiles;
 
-  auto mergeCapFor = [&](int64_t reductionTilesPerCore) -> int64_t {
-    int64_t cap = reductionTilesPerCore / strategy.outputReductionTiles;
-    return (k > kTileWidth) ? cap / kLargeKMergeDivisor : cap;
+  // Bands one merge core may gather: L1 left over once its leaf shard and the
+  // fixed buffers are paid for, divided by what a band's partial costs there.
+  auto mergeCapFor = [&](int64_t leafTilesPerCore) {
+    const int64_t remaining = budget.usableBytes - budget.fixedBytes -
+                              leafTilesPerCore * budget.bytesPerLeafTile;
+    return remaining /
+           (budget.bytesPerMergeTile * strategy.outputReductionTiles);
   };
 
-  // A joint 2D split is the only option left once the non-target dim overflows
-  // a core AND the reduction dim is too big to ride along whole on every core,
-  // which is what the data-parallel split needs.
-  strategy.twoDim = nonTargetTiles > kMaxTilesPerCore &&
-                    localReductionTiles >= kMaxTilesPerCore;
-
-  if (strategy.twoDim) {
-    // Bands occupy the reduction dim's grid axis and non-target slices the
-    // other, placed directly so every core index is a real coordinate.
-    // dim==0 transposes the index grid, so its band count must fit both axes.
-    int64_t bandGridLimit =
+  // Neither one-dimensional split works once the non-target dim overflows a
+  // core and the reduction dim cannot ride along whole on every core.
+  if (nonTargetTiles > maxTilesPerCore &&
+      localReductionTiles >= maxTilesPerCore) {
+    // Bands take the reduction dim's grid axis and non-target slices the other;
+    // dim==0 transposes the index grid, so its bands must fit both axes.
+    const int64_t bandGridLimit =
         (dim == 1) ? workerGridShape[1]
                    : std::min(workerGridShape[0], workerGridShape[1]);
-    int64_t ntGridLimit = (dim == 1) ? workerGridShape[0] : workerGridShape[1];
+    const int64_t ntGridLimit =
+        (dim == 1) ? workerGridShape[0] : workerGridShape[1];
 
-    // Fewest bands first: non-target slices are independent, while every extra
-    // band level costs a merge round. Powers of two close the shallowest
-    // chains, so try those before any other count.
-    for (int pass = 0; pass < 2 && !strategy.multiCore; ++pass) {
-      bool powerOfTwoOnly = (pass == 0);
-      for (int64_t bands = 2; bands <= bandGridLimit; ++bands) {
-        if (powerOfTwoOnly && (bands & (bands - 1)) != 0) {
-          continue;
-        }
-        int64_t candBandTiles = (fullReductionTiles + bands - 1) / bands;
-        // topk_block merges reduction tiles pairwise, so a band needs two.
-        if (candBandTiles < 2) {
-          continue;
-        }
-        int64_t maxNtPerCore = kMaxTilesPerCore / candBandTiles;
-        if (maxNtPerCore < 1) {
-          continue;
-        }
-        int64_t minNtShards =
-            (nonTargetTiles + maxNtPerCore - 1) / maxNtPerCore;
-        if (minNtShards > ntGridLimit) {
-          continue;
-        }
-        // More non-target slices shrink each core's slice, which frees tile
-        // budget for the merge rounds, so walk up until the chain closes.
-        for (int64_t ntSh = minNtShards; ntSh <= ntGridLimit; ++ntSh) {
-          int64_t candNtTiles = (nonTargetTiles + ntSh - 1) / ntSh;
-          int64_t candMergeCap = mergeCapFor(kMaxTilesPerCore / candNtTiles);
-          if (candMergeCap < 2 ||
-              !mergeChainCloses(bands, candMergeCap, workerGridShape)) {
-            continue;
-          }
-          strategy.numShards = bands;
-          strategy.bandTiles = candBandTiles;
-          strategy.ntShards = ntSh;
-          strategy.ntTilesPerCore = candNtTiles;
-          strategy.mergeCap = candMergeCap;
-          strategy.dataParallel = true;
-          strategy.multiCore = true;
-          break;
-        }
-        if (strategy.multiCore) {
-          break;
-        }
+    // Fewest bands first: each extra band level costs a merge round.
+    bool found = scanPowerOfTwoFirst(2, bandGridLimit, [&](int64_t bands) {
+      int64_t bandTiles = llvm::divideCeil(fullReductionTiles, bands);
+      int64_t maxNtPerCore = maxTilesPerCore / bandTiles;
+      if (bandTiles < 2 || maxNtPerCore < 1) {
+        return false;
       }
-    }
-    if (!strategy.multiCore) {
+      // Thinner non-target slices free tile budget for the merge rounds, so
+      // walk up until the chain closes.
+      for (int64_t ntSh = llvm::divideCeil(nonTargetTiles, maxNtPerCore);
+           ntSh <= ntGridLimit; ++ntSh) {
+        int64_t ntTiles = llvm::divideCeil(nonTargetTiles, ntSh);
+        std::optional<llvm::SmallVector<int64_t>> schedule = buildMergeSchedule(
+            bands, mergeCapFor(bandTiles * ntTiles), workerGridShape);
+        if (!schedule) {
+          continue;
+        }
+        strategy.mergeSchedule = std::move(*schedule);
+        strategy.numShards = bands;
+        strategy.ntShards = ntSh;
+        strategy.paddedReductionTiles = bands * bandTiles;
+        strategy.paddedNonTargetTiles = ntSh * ntTiles;
+        return true;
+      }
+      return false;
+    });
+    if (!found) {
       failureReason = "D2M topk: no 2D split fits both dimensions within the "
                       "per-core tile budget with a merge tree this worker grid "
                       "can hold";
       return mlir::failure();
     }
-    strategy.paddedReductionTiles = strategy.numShards * strategy.bandTiles;
-    strategy.paddedNonTargetTiles = strategy.ntShards * strategy.ntTilesPerCore;
+    strategy.dataParallel = true;
+    strategy.multiCore = true;
     return strategy;
   }
 
-  // A core holds nonTargetTiles * localReductionTiles tiles, so the shard can
-  // overflow on the product even when neither dim alone exceeds the budget.
-  // Banding the reduction dim is the cheaper fix whenever it can get the
-  // product under budget on its own, because it shrinks what every core holds
-  // instead of relying on a thin non-target slice; the reduction dim needs two
-  // tiles per band to fold, so bands cap out at localReductionTiles / 2.
-  int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
-  bool overBudget = nonTargetTiles * localReductionTiles > kMaxTilesPerCore;
+  // A core holds the product of the two dims, so the shard can overflow even
+  // when neither dim alone exceeds the budget.
+  const bool overBudget =
+      nonTargetTiles * localReductionTiles > maxTilesPerCore;
+  // Reduction tiles left for a band once the un-sliced non-target dim is paid
+  // for.
+  const int64_t bandBudget = maxTilesPerCore / nonTargetTiles;
+  const int64_t minBands =
+      llvm::divideCeil(fullReductionTiles, std::max<int64_t>(bandBudget, 1));
 
-  // Searches for a band count that fits the reduction dim within the budget
-  // left by an un-sliced non-target dim and whose merge tree closes on this
-  // grid. Powers of two first: they always close and give the shallowest tree,
-  // then any count whose chain closes, which is what reaches past 64 bands on
-  // larger grids. Returns {bands, bandTiles}, or nullopt when none works.
-  int64_t bandBudget = kMaxTilesPerCore / std::max<int64_t>(nonTargetTiles, 1);
-  int64_t bandMergeCap = mergeCapFor(bandBudget);
-  auto findBandSplit =
-      [&](int64_t minShards) -> std::optional<std::pair<int64_t, int64_t>> {
-    for (int pass = 0; pass < 2; ++pass) {
-      bool powerOfTwoOnly = (pass == 0);
-      for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
-        if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
-          continue;
-        }
-        if (utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-                .empty()) {
-          continue;
-        }
-        int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
-        if (candBandTiles > bandBudget) {
-          continue;
-        }
-        if (!mergeChainCloses(cand, bandMergeCap, workerGridShape)) {
-          continue;
-        }
-        return std::make_pair(cand, candBandTiles);
+  // Smallest band count that fits the reduction dim in that budget and whose
+  // merge tree closes on this grid.
+  auto findBandSplit = [&](int64_t lo) -> std::optional<BandSplit> {
+    BandSplit split;
+    bool found = scanPowerOfTwoFirst(lo, maxGridCores, [&](int64_t bands) {
+      int64_t bandTiles = llvm::divideCeil(fullReductionTiles, bands);
+      if (bandTiles > bandBudget ||
+          utils::findLegalPhysicalGridForVolume(bands, workerGridShape)
+              .empty()) {
+        return false;
       }
+      std::optional<llvm::SmallVector<int64_t>> schedule = buildMergeSchedule(
+          bands, mergeCapFor(bandTiles * nonTargetTiles), workerGridShape);
+      if (!schedule) {
+        return false;
+      }
+      split = {bands, bandTiles, std::move(*schedule)};
+      return true;
+    });
+    if (!found) {
+      return std::nullopt;
     }
-    return std::nullopt;
+    return std::move(split);
   };
 
-  // Banding the reduction dim is the cheaper fix when it can get the shard
-  // under budget on its own, since it shrinks what every core holds instead of
-  // relying on a thin non-target slice. It only wins if a band count actually
-  // exists, though: a large-k shape with a short reduction dim has no merge
-  // budget to spend, and there data-parallel is the only split left.
-  std::optional<std::pair<int64_t, int64_t>> bandSplit;
+  // Banding preferred over data-parallel: it shrinks what every core holds
+  // rather than relying on a thin non-target slice. A large-k shape with a
+  // short reduction dim has no merge budget, leaving data-parallel as the only
+  // split.
+  std::optional<BandSplit> bandSplit;
   if (overBudget && bandBudget >= 2) {
-    bandSplit =
-        findBandSplit((fullReductionTiles + bandBudget - 1) / bandBudget);
+    bandSplit = findBandSplit(minBands);
   }
-  strategy.dataParallel =
-      maxNtTilesPerCore >= 1 && overBudget && !bandSplit.has_value();
+
+  const int64_t maxNtTilesPerCore = maxTilesPerCore / localReductionTiles;
+  strategy.dataParallel = overBudget && !bandSplit && maxNtTilesPerCore >= 1;
   if (strategy.dataParallel) {
-    int64_t minNtShards =
-        (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
-    // Slices are independent with no merge to pay for, so take the thinnest
-    // shard: walk down from one tile per core, past counts no grid can hold.
-    std::optional<int64_t> legalNtShards;
+    // No merge to pay for, so take the thinnest shard: walk down from one tile
+    // per core, past counts no grid can hold.
+    const int64_t minNtShards =
+        llvm::divideCeil(nonTargetTiles, maxNtTilesPerCore);
+    std::optional<int64_t> ntShards;
     for (int64_t cand = std::min(nonTargetTiles, maxGridCores);
          cand >= minNtShards; --cand) {
       if (!utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
                .empty()) {
-        legalNtShards = cand;
+        ntShards = cand;
         break;
       }
     }
-    if (!legalNtShards) {
+    if (!ntShards) {
       failureReason = "D2M topk: no core count splits the non-target dimension "
                       "within the per-core tile budget on this worker grid";
       return mlir::failure();
     }
-    strategy.ntShards = *legalNtShards;
-    strategy.ntTilesPerCore =
-        (nonTargetTiles + strategy.ntShards - 1) / strategy.ntShards;
-    strategy.paddedNonTargetTiles = strategy.ntShards * strategy.ntTilesPerCore;
+    const int64_t ntTiles = llvm::divideCeil(nonTargetTiles, *ntShards);
+    strategy.ntShards = *ntShards;
+    strategy.paddedNonTargetTiles = *ntShards * ntTiles;
+    strategy.paddedReductionTiles = localReductionTiles;
+    return strategy;
   }
 
-  int64_t maxReductionTilesPerCore = strategy.dataParallel
-                                         ? fullReductionTiles
-                                         : kMaxTilesPerCore / nonTargetTiles;
-
-  strategy.mergeCap = mergeCapFor(maxReductionTilesPerCore);
-
-  int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
-                      maxReductionTilesPerCore;
-  strategy.multiCore = !strategy.dataParallel && minShards > 1;
+  if (fullReductionTiles <= bandBudget) {
+    // One core already holds the whole reduction dim.
+    return strategy;
+  }
 
   // Bands are distributed one per core and folded onto the 2D worker grid by a
   // virtual-grid map attached when the leaf topk is emitted.
-  if (strategy.multiCore) {
-    // Reuse the split already found above when the budget it searched under
-    // matches; otherwise the shard fits the non-target dim whole and only the
-    // reduction dim needs splitting, so search now.
-    if (!bandSplit) {
-      bandSplit = findBandSplit(minShards);
-    }
-    if (!bandSplit) {
-      failureReason = "D2M topk: no band count fits the reduction dim within "
-                      "the per-core tile budget with a merge tree this worker "
-                      "grid can split evenly";
-      return mlir::failure();
-    }
-    strategy.numShards = bandSplit->first;
-    strategy.bandTiles = bandSplit->second;
-    strategy.paddedReductionTiles = strategy.numShards * strategy.bandTiles;
+  if (!bandSplit) {
+    bandSplit = findBandSplit(minBands);
   }
-  if (strategy.dataParallel) {
-    strategy.paddedReductionTiles = localReductionTiles;
+  if (!bandSplit) {
+    failureReason = "D2M topk: no band count fits the reduction dim within the "
+                    "per-core tile budget with a merge tree this worker grid "
+                    "can split evenly";
+    return mlir::failure();
   }
+  strategy.multiCore = true;
+  strategy.numShards = bandSplit->bands;
+  strategy.paddedReductionTiles = bandSplit->bands * bandSplit->bandTiles;
+  strategy.mergeSchedule = std::move(bandSplit->schedule);
   return strategy;
 }
 

--- a/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
+++ b/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
+
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+
+#include <algorithm>
+#include <optional>
+
+namespace mlir::tt::d2m {
+
+namespace {
+constexpr int64_t kTileWidth = 32;
+// L1-safe tile budget for one core's shard of a single buffer.
+constexpr int64_t kMaxTilesPerCore = 43;
+// k > kTileWidth partials span two tiles and fold through the large-k path, so
+// they get a fraction of the budget.
+constexpr int64_t kLargeKMergeDivisor = 4;
+} // namespace
+
+int64_t pickMergeGroupCount(int64_t bands, int64_t mergeCap,
+                            llvm::ArrayRef<int64_t> workerGridShape) {
+  for (int64_t groups = 1; groups < bands; ++groups) {
+    if (bands % groups != 0) {
+      continue;
+    }
+    if (bands / groups > mergeCap) {
+      continue;
+    }
+    if (utils::findLegalPhysicalGridForVolume(groups, workerGridShape)
+            .empty()) {
+      continue;
+    }
+    return groups;
+  }
+  return 0;
+}
+
+// True when repeatedly applying pickMergeGroupCount reduces `bands` to 1.
+// Fails if any level has no divisor in [2, mergeCap] that is also grid-legal.
+static bool mergeChainCloses(int64_t bands, int64_t mergeCap,
+                             llvm::ArrayRef<int64_t> workerGridShape) {
+  while (bands > 1) {
+    int64_t groups = pickMergeGroupCount(bands, mergeCap, workerGridShape);
+    if (groups == 0) {
+      return false;
+    }
+    bands = groups;
+  }
+  return true;
+}
+
+mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
+    int64_t k, int32_t dim, llvm::ArrayRef<int64_t> inputShape,
+    llvm::ArrayRef<int64_t> workerGridShape, std::string &failureReason) {
+  TopKShardingStrategy strategy;
+  strategy.outputReductionTiles = (k + kTileWidth - 1) / kTileWidth;
+
+  int64_t fullReductionElems = inputShape[dim];
+  int64_t nonTargetElems = inputShape[1 - dim];
+  int64_t nonTargetTiles = (nonTargetElems + kTileWidth - 1) / kTileWidth;
+  int64_t fullReductionTiles =
+      (fullReductionElems + kTileWidth - 1) / kTileWidth;
+
+  int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
+
+  int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
+
+  strategy.ntTilesPerCore = nonTargetTiles;
+  strategy.paddedNonTargetTiles = nonTargetTiles;
+  // Bands need not divide fullReductionTiles evenly; the padding tail out to
+  // paddedReductionTiles is masked to -inf, as is the non-target tail out to
+  // paddedNonTargetTiles.
+  strategy.bandTiles = fullReductionTiles;
+  strategy.paddedReductionTiles = fullReductionTiles;
+
+  auto mergeCapFor = [&](int64_t reductionTilesPerCore) -> int64_t {
+    int64_t cap = reductionTilesPerCore / strategy.outputReductionTiles;
+    return (k > kTileWidth) ? cap / kLargeKMergeDivisor : cap;
+  };
+
+  // A joint 2D split is the only option left once the non-target dim overflows
+  // a core AND the reduction dim is too big to ride along whole on every core,
+  // which is what the data-parallel split needs.
+  strategy.twoDim = nonTargetTiles > kMaxTilesPerCore &&
+                    localReductionTiles >= kMaxTilesPerCore;
+
+  if (strategy.twoDim) {
+    // Bands occupy the reduction dim's grid axis and non-target slices the
+    // other, placed directly so every core index is a real coordinate.
+    // dim==0 transposes the index grid, so its band count must fit both axes.
+    int64_t bandGridLimit =
+        (dim == 1) ? workerGridShape[1]
+                   : std::min(workerGridShape[0], workerGridShape[1]);
+    int64_t ntGridLimit = (dim == 1) ? workerGridShape[0] : workerGridShape[1];
+
+    // Fewest bands first: non-target slices are independent, while every extra
+    // band level costs a merge round. Powers of two close the shallowest
+    // chains, so try those before any other count.
+    for (int pass = 0; pass < 2 && !strategy.multiCore; ++pass) {
+      bool powerOfTwoOnly = (pass == 0);
+      for (int64_t bands = 2; bands <= bandGridLimit; ++bands) {
+        if (powerOfTwoOnly && (bands & (bands - 1)) != 0) {
+          continue;
+        }
+        int64_t candBandTiles = (fullReductionTiles + bands - 1) / bands;
+        // topk_block merges reduction tiles pairwise, so a band needs two.
+        if (candBandTiles < 2) {
+          continue;
+        }
+        int64_t maxNtPerCore = kMaxTilesPerCore / candBandTiles;
+        if (maxNtPerCore < 1) {
+          continue;
+        }
+        int64_t minNtShards =
+            (nonTargetTiles + maxNtPerCore - 1) / maxNtPerCore;
+        if (minNtShards > ntGridLimit) {
+          continue;
+        }
+        // More non-target slices shrink each core's slice, which frees tile
+        // budget for the merge rounds, so walk up until the chain closes.
+        for (int64_t ntSh = minNtShards; ntSh <= ntGridLimit; ++ntSh) {
+          int64_t candNtTiles = (nonTargetTiles + ntSh - 1) / ntSh;
+          int64_t candMergeCap = mergeCapFor(kMaxTilesPerCore / candNtTiles);
+          if (candMergeCap < 2 ||
+              !mergeChainCloses(bands, candMergeCap, workerGridShape)) {
+            continue;
+          }
+          strategy.numShards = bands;
+          strategy.bandTiles = candBandTiles;
+          strategy.ntShards = ntSh;
+          strategy.ntTilesPerCore = candNtTiles;
+          strategy.mergeCap = candMergeCap;
+          strategy.dataParallel = true;
+          strategy.multiCore = true;
+          break;
+        }
+        if (strategy.multiCore) {
+          break;
+        }
+      }
+    }
+    if (!strategy.multiCore) {
+      failureReason = "D2M topk: no 2D split fits both dimensions within the "
+                      "per-core tile budget with a merge tree this worker grid "
+                      "can hold";
+      return mlir::failure();
+    }
+    strategy.paddedReductionTiles = strategy.numShards * strategy.bandTiles;
+    strategy.paddedNonTargetTiles = strategy.ntShards * strategy.ntTilesPerCore;
+    return strategy;
+  }
+
+  // A core holds nonTargetTiles * localReductionTiles tiles, so the shard can
+  // overflow on the product even when neither dim alone exceeds the budget.
+  // Banding the reduction dim is the cheaper fix whenever it can get the
+  // product under budget on its own, because it shrinks what every core holds
+  // instead of relying on a thin non-target slice; the reduction dim needs two
+  // tiles per band to fold, so bands cap out at localReductionTiles / 2.
+  int64_t maxNtTilesPerCore = kMaxTilesPerCore / localReductionTiles;
+  bool overBudget = nonTargetTiles * localReductionTiles > kMaxTilesPerCore;
+
+  // Searches for a band count that fits the reduction dim within the budget
+  // left by an un-sliced non-target dim and whose merge tree closes on this
+  // grid. Powers of two first: they always close and give the shallowest tree,
+  // then any count whose chain closes, which is what reaches past 64 bands on
+  // larger grids. Returns {bands, bandTiles}, or nullopt when none works.
+  int64_t bandBudget = kMaxTilesPerCore / std::max<int64_t>(nonTargetTiles, 1);
+  int64_t bandMergeCap = mergeCapFor(bandBudget);
+  auto findBandSplit =
+      [&](int64_t minShards) -> std::optional<std::pair<int64_t, int64_t>> {
+    for (int pass = 0; pass < 2; ++pass) {
+      bool powerOfTwoOnly = (pass == 0);
+      for (int64_t cand = minShards; cand <= maxGridCores; ++cand) {
+        if (powerOfTwoOnly && (cand & (cand - 1)) != 0) {
+          continue;
+        }
+        if (utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+                .empty()) {
+          continue;
+        }
+        int64_t candBandTiles = (fullReductionTiles + cand - 1) / cand;
+        if (candBandTiles > bandBudget) {
+          continue;
+        }
+        if (!mergeChainCloses(cand, bandMergeCap, workerGridShape)) {
+          continue;
+        }
+        return std::make_pair(cand, candBandTiles);
+      }
+    }
+    return std::nullopt;
+  };
+
+  // Banding the reduction dim is the cheaper fix when it can get the shard
+  // under budget on its own, since it shrinks what every core holds instead of
+  // relying on a thin non-target slice. It only wins if a band count actually
+  // exists, though: a large-k shape with a short reduction dim has no merge
+  // budget to spend, and there data-parallel is the only split left.
+  std::optional<std::pair<int64_t, int64_t>> bandSplit;
+  if (overBudget && bandBudget >= 2) {
+    bandSplit =
+        findBandSplit((fullReductionTiles + bandBudget - 1) / bandBudget);
+  }
+  strategy.dataParallel =
+      maxNtTilesPerCore >= 1 && overBudget && !bandSplit.has_value();
+  if (strategy.dataParallel) {
+    int64_t minNtShards =
+        (nonTargetTiles + maxNtTilesPerCore - 1) / maxNtTilesPerCore;
+    // Slices are independent with no merge to pay for, so take the thinnest
+    // shard: walk down from one tile per core, past counts no grid can hold.
+    std::optional<int64_t> legalNtShards;
+    for (int64_t cand = std::min(nonTargetTiles, maxGridCores);
+         cand >= minNtShards; --cand) {
+      if (!utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
+               .empty()) {
+        legalNtShards = cand;
+        break;
+      }
+    }
+    if (!legalNtShards) {
+      failureReason = "D2M topk: no core count splits the non-target dimension "
+                      "within the per-core tile budget on this worker grid";
+      return mlir::failure();
+    }
+    strategy.ntShards = *legalNtShards;
+    strategy.ntTilesPerCore =
+        (nonTargetTiles + strategy.ntShards - 1) / strategy.ntShards;
+    strategy.paddedNonTargetTiles = strategy.ntShards * strategy.ntTilesPerCore;
+  }
+
+  int64_t maxReductionTilesPerCore = strategy.dataParallel
+                                         ? fullReductionTiles
+                                         : kMaxTilesPerCore / nonTargetTiles;
+
+  strategy.mergeCap = mergeCapFor(maxReductionTilesPerCore);
+
+  int64_t minShards = (fullReductionTiles + maxReductionTilesPerCore - 1) /
+                      maxReductionTilesPerCore;
+  strategy.multiCore = !strategy.dataParallel && minShards > 1;
+
+  // Bands are distributed one per core and folded onto the 2D worker grid by a
+  // virtual-grid map attached when the leaf topk is emitted.
+  if (strategy.multiCore) {
+    // Reuse the split already found above when the budget it searched under
+    // matches; otherwise the shard fits the non-target dim whole and only the
+    // reduction dim needs splitting, so search now.
+    if (!bandSplit) {
+      bandSplit = findBandSplit(minShards);
+    }
+    if (!bandSplit) {
+      failureReason = "D2M topk: no band count fits the reduction dim within "
+                      "the per-core tile budget with a merge tree this worker "
+                      "grid can split evenly";
+      return mlir::failure();
+    }
+    strategy.numShards = bandSplit->first;
+    strategy.bandTiles = bandSplit->second;
+    strategy.paddedReductionTiles = strategy.numShards * strategy.bandTiles;
+  }
+  if (strategy.dataParallel) {
+    strategy.paddedReductionTiles = localReductionTiles;
+  }
+  return strategy;
+}
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
+++ b/lib/Dialect/D2M/Analysis/TopKShardingStrategy.cpp
@@ -87,11 +87,6 @@ buildMergeSchedule(int64_t bands, int64_t mergeCap,
   return schedule;
 }
 
-struct BandSplit {
-  int64_t bands;
-  int64_t bandTiles;
-  llvm::SmallVector<int64_t> schedule;
-};
 } // namespace
 
 TopKL1Budget topKL1Budget(GenericOp leaf, ttcore::ChipDescAttr chipDesc,
@@ -133,9 +128,11 @@ TopKGeometry getTopKGeometry(int32_t dim, std::size_t physicalRank) {
   assert(physicalRank >= 2u &&
          "topk geometry expects a rank >= 2 device shape");
 
+  const std::size_t redDim =
+      (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
+
   TopKGeometry geometry;
-  geometry.genRedDim = (dim == 1) ? (physicalRank - 1) : (physicalRank - 2);
-  geometry.deviceRedDim = physicalRank + geometry.genRedDim;
+  geometry.deviceRedDim = physicalRank + redDim;
   geometry.deviceGridDim = static_cast<std::size_t>(dim);
   geometry.extractProjectDim = (dim == 1) ? (physicalRank - 1) : 0;
   return geometry;
@@ -155,6 +152,13 @@ mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
   // topk_block merges reduction tiles pairwise, so a core always holds two.
   const int64_t localReductionTiles = std::max<int64_t>(fullReductionTiles, 2);
   const int64_t maxGridCores = workerGridShape[0] * workerGridShape[1];
+  // Bands take the reduction dim's grid axis and non-target slices the other;
+  // dim==0 transposes the index grid, so its bands must fit both axes.
+  const int64_t bandGridLimit =
+      (dim == 1) ? workerGridShape[1]
+                 : std::min(workerGridShape[0], workerGridShape[1]);
+  const int64_t ntGridLimit =
+      (dim == 1) ? workerGridShape[0] : workerGridShape[1];
 
   TopKShardingStrategy strategy;
   strategy.outputReductionTiles = llvm::divideCeil(k, kTileWidth);
@@ -165,155 +169,96 @@ mlir::FailureOr<TopKShardingStrategy> selectTopKShardingStrategy(
 
   // Bands one merge core may gather: L1 left over once its leaf shard and the
   // fixed buffers are paid for, divided by what a band's partial costs there.
-  auto mergeCapFor = [&](int64_t leafTilesPerCore) {
+  // A gathered band spans the core's whole non-target extent.
+  auto mergeCapFor = [&](int64_t leafTilesPerCore, int64_t ntTiles) {
     const int64_t remaining = budget.usableBytes - budget.fixedBytes -
                               leafTilesPerCore * budget.bytesPerLeafTile;
     return remaining /
-           (budget.bytesPerMergeTile * strategy.outputReductionTiles);
+           (budget.bytesPerMergeTile * strategy.outputReductionTiles * ntTiles);
   };
 
-  // Neither one-dimensional split works once the non-target dim overflows a
-  // core and the reduction dim cannot ride along whole on every core.
-  if (nonTargetTiles > maxTilesPerCore &&
-      localReductionTiles >= maxTilesPerCore) {
-    // Bands take the reduction dim's grid axis and non-target slices the other;
-    // dim==0 transposes the index grid, so its bands must fit both axes.
-    const int64_t bandGridLimit =
-        (dim == 1) ? workerGridShape[1]
-                   : std::min(workerGridShape[0], workerGridShape[1]);
-    const int64_t ntGridLimit =
-        (dim == 1) ? workerGridShape[0] : workerGridShape[1];
-
-    // Fewest bands first: each extra band level costs a merge round.
-    bool found = scanPowerOfTwoFirst(2, bandGridLimit, [&](int64_t bands) {
-      int64_t bandTiles = llvm::divideCeil(fullReductionTiles, bands);
-      int64_t maxNtPerCore = maxTilesPerCore / bandTiles;
-      if (bandTiles < 2 || maxNtPerCore < 1) {
-        return false;
-      }
-      // Thinner non-target slices free tile budget for the merge rounds, so
-      // walk up until the chain closes.
-      for (int64_t ntSh = llvm::divideCeil(nonTargetTiles, maxNtPerCore);
-           ntSh <= ntGridLimit; ++ntSh) {
-        int64_t ntTiles = llvm::divideCeil(nonTargetTiles, ntSh);
-        std::optional<llvm::SmallVector<int64_t>> schedule = buildMergeSchedule(
-            bands, mergeCapFor(bandTiles * ntTiles), workerGridShape);
-        if (!schedule) {
-          continue;
-        }
-        strategy.mergeSchedule = std::move(*schedule);
-        strategy.numShards = bands;
-        strategy.ntShards = ntSh;
-        strategy.paddedReductionTiles = bands * bandTiles;
-        strategy.paddedNonTargetTiles = ntSh * ntTiles;
-        return true;
-      }
+  auto accept = [&](int64_t bands, int64_t ntShards) {
+    const int64_t bandTiles = (bands == 1)
+                                  ? localReductionTiles
+                                  : llvm::divideCeil(fullReductionTiles, bands);
+    const int64_t ntTiles = llvm::divideCeil(nonTargetTiles, ntShards);
+    // topk_block merges reduction tiles pairwise, so a band is never one tile.
+    if (bands > 1 && bandTiles < 2) {
       return false;
-    });
-    if (!found) {
-      failureReason = "D2M topk: no 2D split fits both dimensions within the "
-                      "per-core tile budget with a merge tree this worker grid "
-                      "can hold";
-      return mlir::failure();
     }
-    strategy.dataParallel = true;
-    strategy.multiCore = true;
-    return strategy;
-  }
-
-  // A core holds the product of the two dims, so the shard can overflow even
-  // when neither dim alone exceeds the budget.
-  const bool overBudget =
-      nonTargetTiles * localReductionTiles > maxTilesPerCore;
-  // Reduction tiles left for a band once the un-sliced non-target dim is paid
-  // for.
-  const int64_t bandBudget = maxTilesPerCore / nonTargetTiles;
-  const int64_t minBands =
-      llvm::divideCeil(fullReductionTiles, std::max<int64_t>(bandBudget, 1));
-
-  // Smallest band count that fits the reduction dim in that budget and whose
-  // merge tree closes on this grid.
-  auto findBandSplit = [&](int64_t lo) -> std::optional<BandSplit> {
-    BandSplit split;
-    bool found = scanPowerOfTwoFirst(lo, maxGridCores, [&](int64_t bands) {
-      int64_t bandTiles = llvm::divideCeil(fullReductionTiles, bands);
-      if (bandTiles > bandBudget ||
-          utils::findLegalPhysicalGridForVolume(bands, workerGridShape)
-              .empty()) {
-        return false;
-      }
+    if (bandTiles * ntTiles > maxTilesPerCore) {
+      return false;
+    }
+    // A one-dimensional split folds its cores onto the whole grid; a 2D one
+    // spends an axis per dim.
+    const bool placeable =
+        (bands > 1 && ntShards > 1)
+            ? (bands <= bandGridLimit && ntShards <= ntGridLimit)
+            : !utils::findLegalPhysicalGridForVolume(bands * ntShards,
+                                                     workerGridShape)
+                   .empty();
+    if (!placeable) {
+      return false;
+    }
+    if (bands > 1) {
       std::optional<llvm::SmallVector<int64_t>> schedule = buildMergeSchedule(
-          bands, mergeCapFor(bandTiles * nonTargetTiles), workerGridShape);
+          bands, mergeCapFor(bandTiles * ntTiles, ntTiles), workerGridShape);
       if (!schedule) {
         return false;
       }
-      split = {bands, bandTiles, std::move(*schedule)};
-      return true;
-    });
-    if (!found) {
-      return std::nullopt;
+      strategy.mergeSchedule = std::move(*schedule);
     }
-    return std::move(split);
+    strategy.multiCore = bands > 1;
+    strategy.dataParallel = ntShards > 1;
+    strategy.numShards = bands;
+    strategy.ntShards = ntShards;
+    strategy.paddedReductionTiles = bands * bandTiles;
+    strategy.paddedNonTargetTiles = ntShards * ntTiles;
+    return true;
   };
 
+  // One core holding both dims outright, then the splits in ascending cost.
+  if (accept(1, 1)) {
+    return strategy;
+  }
+
   // Banding preferred over data-parallel: it shrinks what every core holds
-  // rather than relying on a thin non-target slice. A large-k shape with a
-  // short reduction dim has no merge budget, leaving data-parallel as the only
-  // split.
-  std::optional<BandSplit> bandSplit;
-  if (overBudget && bandBudget >= 2) {
-    bandSplit = findBandSplit(minBands);
-  }
-
-  const int64_t maxNtTilesPerCore = maxTilesPerCore / localReductionTiles;
-  strategy.dataParallel = overBudget && !bandSplit && maxNtTilesPerCore >= 1;
-  if (strategy.dataParallel) {
-    // No merge to pay for, so take the thinnest shard: walk down from one tile
-    // per core, past counts no grid can hold.
-    const int64_t minNtShards =
-        llvm::divideCeil(nonTargetTiles, maxNtTilesPerCore);
-    std::optional<int64_t> ntShards;
-    for (int64_t cand = std::min(nonTargetTiles, maxGridCores);
-         cand >= minNtShards; --cand) {
-      if (!utils::findLegalPhysicalGridForVolume(cand, workerGridShape)
-               .empty()) {
-        ntShards = cand;
-        break;
-      }
-    }
-    if (!ntShards) {
-      failureReason = "D2M topk: no core count splits the non-target dimension "
-                      "within the per-core tile budget on this worker grid";
-      return mlir::failure();
-    }
-    const int64_t ntTiles = llvm::divideCeil(nonTargetTiles, *ntShards);
-    strategy.ntShards = *ntShards;
-    strategy.paddedNonTargetTiles = *ntShards * ntTiles;
-    strategy.paddedReductionTiles = localReductionTiles;
+  // rather than relying on a thin non-target slice. Fewest bands first, since
+  // each extra band level costs a merge round.
+  if (scanPowerOfTwoFirst(2, maxGridCores,
+                          [&](int64_t bands) { return accept(bands, 1); })) {
     return strategy;
   }
 
-  if (fullReductionTiles <= bandBudget) {
-    // One core already holds the whole reduction dim.
+  // A large-k shape with a short reduction dim has no merge budget, leaving
+  // data-parallel as the only split. No merge to pay for, so take the thinnest
+  // shard: walk down from one tile per core, past counts no grid can hold.
+  for (int64_t ntShards = std::min(nonTargetTiles, maxGridCores); ntShards >= 2;
+       --ntShards) {
+    if (accept(1, ntShards)) {
+      return strategy;
+    }
+  }
+
+  // Neither one-dimensional split works once the non-target dim overflows a
+  // core and the reduction dim cannot ride along whole on every core. Thinner
+  // non-target slices free tile budget for the merge rounds, so walk up until
+  // the chain closes.
+  if (scanPowerOfTwoFirst(2, bandGridLimit, [&](int64_t bands) {
+        for (int64_t ntShards = 2; ntShards <= ntGridLimit; ++ntShards) {
+          if (accept(bands, ntShards)) {
+            return true;
+          }
+        }
+        return false;
+      })) {
     return strategy;
   }
 
-  // Bands are distributed one per core and folded onto the 2D worker grid by a
-  // virtual-grid map attached when the leaf topk is emitted.
-  if (!bandSplit) {
-    bandSplit = findBandSplit(minBands);
-  }
-  if (!bandSplit) {
-    failureReason = "D2M topk: no band count fits the reduction dim within the "
-                    "per-core tile budget with a merge tree this worker grid "
-                    "can split evenly";
-    return mlir::failure();
-  }
-  strategy.multiCore = true;
-  strategy.numShards = bandSplit->bands;
-  strategy.paddedReductionTiles = bandSplit->bands * bandSplit->bandTiles;
-  strategy.mergeSchedule = std::move(bandSplit->schedule);
-  return strategy;
+  failureReason = "D2M topk: no split of the reduction and non-target "
+                  "dimensions fits the per-core tile budget with a merge tree "
+                  "this worker grid can hold";
+  return mlir::failure();
 }
 
 } // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1525,7 +1525,8 @@ TopkBlockOp::bufferize(mlir::RewriterBase &rewriter,
 
   rewriter.create<TopkBlockOp>(getLoc(), *maybeInputBuffer, *maybeScratchBuffer,
                                *maybeOutValsBuffer, *maybeOutIdxBuffer, getK(),
-                               getNumElements(), getStableSort(), getDim());
+                               getNumElements(), getStableSort(), getDim(),
+                               getGenerateIndices());
 
   mlir::bufferization::replaceOpWithBufferizedValues(
       rewriter, getOperation(),

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1422,8 +1422,8 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     return emitOpError("dim out of range.");
   }
 
-  // A single input is meaningful when that input is itself distributed: the
-  // view re-splits its grid x shard extent onto the consuming generic's grid.
+  // A single input regroups that input's grid x shard extent onto a coarser
+  // grid; two or more concatenate along `dim`.
   if (this->getInputs().empty()) {
     return emitOpError("must have at least one input.");
   }
@@ -2575,12 +2575,16 @@ createParallelizedGenericShell(d2m::GenericOp thisOp, OpBuilder &builder,
     newResultTypes.push_back(newOutputs[resultIndex].getType());
   }
 
-  return builder.create<d2m::GenericOp>(
+  auto newOp = builder.create<d2m::GenericOp>(
       thisOp.getLoc(), TypeRange(newResultTypes), newInputs, newOutputs,
       thisOp.getAdditionalArgs(), newGrid,
       builder.getI64ArrayAttr(newBlockFactors), thisOp.getIndexingMaps(),
       thisOp.getIteratorTypes(), thisOp.getThreads(),
       thisOp.getFabricConnectionConfigAttr(), thisOp.getNumRegions());
+  // Reparallelizing rewrites the grid, not what the op means: anything a pass
+  // marked this generic with has to survive.
+  newOp->setDiscardableAttrs(thisOp->getDiscardableAttrDictionary());
+  return newOp;
 }
 
 // Clone one generic region and retarget its block args to reblocked operands.

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1423,8 +1423,7 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
   }
 
   // A single input is meaningful when that input is itself distributed: the
-  // view then re-splits its grid x shard extent along `dim` onto the consuming
-  // generic's grid, i.e. a pure gather/reblock rather than a concatenation.
+  // view re-splits its grid x shard extent onto the consuming generic's grid.
   if (this->getInputs().empty()) {
     return emitOpError("must have at least one input.");
   }

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -1422,8 +1422,11 @@ mlir::LogicalResult d2m::CompositeViewOp::verify() {
     return emitOpError("dim out of range.");
   }
 
-  if (this->getInputs().size() < 2) {
-    return emitOpError("must have at least two inputs.");
+  // A single input is meaningful when that input is itself distributed: the
+  // view then re-splits its grid x shard extent along `dim` onto the consuming
+  // generic's grid, i.e. a pure gather/reblock rather than a concatenation.
+  if (this->getInputs().empty()) {
+    return emitOpError("must have at least one input.");
   }
 
   int64_t accum = 0;

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -119,7 +119,7 @@ void createD2MFrontendPipeline(OpPassManager &pm,
   }
   pm.addPass(d2m::createD2MMaterializeViewReturns());
   pm.addPass(d2m::createD2MGridSelection(gridOptOptions));
-  pm.addPass(d2m::createD2MLowerTopk());
+  pm.addPass(d2m::createD2MBuildTopkChain());
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(d2m::createD2MOptimizeMasks());
   pm.addPass(d2m::createD2MLowerToLayout());

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -118,8 +118,8 @@ void createD2MFrontendPipeline(OpPassManager &pm,
     gridOptOptions.ttnnMode = options.ttnnMode;
   }
   pm.addPass(d2m::createD2MMaterializeViewReturns());
-  pm.addPass(d2m::createD2MLowerTopk());
   pm.addPass(d2m::createD2MGridSelection(gridOptOptions));
+  pm.addPass(d2m::createD2MLowerTopk());
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(d2m::createD2MOptimizeMasks());
   pm.addPass(d2m::createD2MLowerToLayout());
@@ -184,7 +184,6 @@ void createD2MFrontendPipeline(OpPassManager &pm,
 
 void createD2MBackendPipeline(OpPassManager &pm,
                               const D2MPipelineOptions &options) {
-  // Emits arange_block, so must precede d2m-decompose-arange.
   pm.addPass(d2m::createD2MDecomposeTopk());
   pm.addPass(d2m::createD2MDecomposeArange());
 

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -110,6 +110,8 @@ void createD2MFrontendPipeline(OpPassManager &pm,
     toD2MOptions.enableMulticastInference = options.enableMulticastInference;
   }
   pm.addPass(tt::createTTIRToD2MPass(toD2MOptions));
+  // Must precede grid selection, which folds the logical grids it emits.
+  pm.addPass(d2m::createD2MLowerTopk());
   pm.addPass(d2m::createD2MScalarizeConstTensors());
   d2m::D2MGridSelectionOptions gridOptOptions;
   {
@@ -133,7 +135,6 @@ void createD2MFrontendPipeline(OpPassManager &pm,
   pm.addPass(mlir::createCanonicalizerPass());
   createTTIRBufferizationPipeline(pm, options);
   pm.addPass(d2m::createD2MInsertScratchBuffers());
-  pm.addPass(d2m::createD2MDecomposeTopk());
 
   d2m::D2MGenericApplyInterchangeOptions applyInterchangeOptions;
   {
@@ -184,6 +185,8 @@ void createD2MFrontendPipeline(OpPassManager &pm,
 
 void createD2MBackendPipeline(OpPassManager &pm,
                               const D2MPipelineOptions &options) {
+  // Emits arange_block, so must precede d2m-decompose-arange.
+  pm.addPass(d2m::createD2MDecomposeTopk());
   pm.addPass(d2m::createD2MDecomposeArange());
 
   d2m::D2MGenericTileComputeLoopsOptions tileComputeLoopsOptions;

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -110,8 +110,6 @@ void createD2MFrontendPipeline(OpPassManager &pm,
     toD2MOptions.enableMulticastInference = options.enableMulticastInference;
   }
   pm.addPass(tt::createTTIRToD2MPass(toD2MOptions));
-  // Must precede grid selection, which folds the logical grids it emits.
-  pm.addPass(d2m::createD2MLowerTopk());
   pm.addPass(d2m::createD2MScalarizeConstTensors());
   d2m::D2MGridSelectionOptions gridOptOptions;
   {
@@ -120,6 +118,7 @@ void createD2MFrontendPipeline(OpPassManager &pm,
     gridOptOptions.ttnnMode = options.ttnnMode;
   }
   pm.addPass(d2m::createD2MMaterializeViewReturns());
+  pm.addPass(d2m::createD2MLowerTopk());
   pm.addPass(d2m::createD2MGridSelection(gridOptOptions));
   pm.addPass(createCanonicalizerPassWithOptions(options));
   pm.addPass(d2m::createD2MOptimizeMasks());

--- a/lib/Dialect/D2M/Transforms/BuildTopkChain.cpp
+++ b/lib/Dialect/D2M/Transforms/BuildTopkChain.cpp
@@ -18,7 +18,7 @@
 #include "llvm/Support/MathExtras.h"
 
 namespace mlir::tt::d2m {
-#define GEN_PASS_DEF_D2MLOWERTOPK
+#define GEN_PASS_DEF_D2MBUILDTOPKCHAIN
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
@@ -391,9 +391,10 @@ void emitPlannedTopK(RewriterBase &rewriter, SingleCoreTopK chain, int32_t k,
   rewriter.eraseOp(chain.leaf);
 }
 
-class D2MLowerTopk final : public impl::D2MLowerTopkBase<D2MLowerTopk> {
+class D2MBuildTopkChain final
+    : public impl::D2MBuildTopkChainBase<D2MBuildTopkChain> {
 public:
-  using impl::D2MLowerTopkBase<D2MLowerTopk>::D2MLowerTopkBase;
+  using impl::D2MBuildTopkChainBase<D2MBuildTopkChain>::D2MBuildTopkChainBase;
 
   void runOnOperation() override {
     // Collected up front because the build emits generics of its own; only the

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_dialect_library(MLIRD2MTransforms
         InsertTileMatmulBlock.cpp
         LinalgToAffine.cpp
         LowerScratchAllocate.cpp
+        LowerTopk.cpp
         LowerToLayout/LowerToLayout.cpp
         LowerToLayout/Plan.cpp
         MaterializeViewReturns.cpp

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRD2MTransforms
         Allocate.cpp
+        BuildTopkChain.cpp
         DMAOptimizations.cpp
         DecomposeArange.cpp
         DecomposeMasking.cpp
@@ -18,7 +19,6 @@ add_mlir_dialect_library(MLIRD2MTransforms
         InsertTileMatmulBlock.cpp
         LinalgToAffine.cpp
         LowerScratchAllocate.cpp
-        LowerTopk.cpp
         LowerToLayout/LowerToLayout.cpp
         LowerToLayout/Plan.cpp
         MaterializeViewReturns.cpp

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
@@ -21,13 +22,6 @@ namespace mlir::tt::d2m {
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-
-// Must match kTopkLaneTileRows in d2m-insert-scratch-buffers.
-constexpr int64_t kLaneTileRows = 2;
-
-// Duplicated in d2m-insert-scratch-buffers, which sets them.
-constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
-constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
 
 template <typename T>
 static int32_t floorLog2(T n) {
@@ -46,9 +40,9 @@ struct TopkIndexBuffers {
 static std::optional<TopkIndexBuffers> findIndexBuffers(GenericOp genericOp) {
   TopkIndexBuffers buffers;
   genericOp.getRegion(0).walk([&](memref::AllocOp allocOp) {
-    if (allocOp->hasAttr(kTopkIndexBufferAttr)) {
+    if (allocOp->hasAttr(utils::kTopkIndexBufferAttr)) {
       buffers.idxBuf = allocOp.getResult();
-    } else if (allocOp->hasAttr(kTopkLaneBufferAttr)) {
+    } else if (allocOp->hasAttr(utils::kTopkLaneBufferAttr)) {
       buffers.laneBuf = allocOp.getResult();
     }
   });
@@ -113,11 +107,12 @@ static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
   auto genericOp = op->getParentOfType<GenericOp>();
   TT_assertv(genericOp, "topk_block must be inside a generic");
   ArrayRef<int64_t> gridShape = genericOp.getGrid().getShape();
-  int64_t totalTileRows = kLaneTileRows * gridShape[gridShape.size() - 2];
+  int64_t totalTileRows =
+      utils::kTopkLaneTileRows * gridShape[gridShape.size() - 2];
   Value arangeBase = rewriter.create<arith::AddIOp>(
       loc,
       rewriter.create<arith::MulIOp>(loc, coreIndex(0),
-                                     idxVal(kLaneTileRows * 32)),
+                                     idxVal(utils::kTopkLaneTileRows * 32)),
       rewriter.create<arith::MulIOp>(loc, coreIndex(1),
                                      idxVal(totalTileRows * 32 * 32)));
 

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -5,7 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -14,11 +14,20 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
+#include <optional>
+
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MDECOMPOSETOPK
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
+
+// Must match kTopkLaneTileRows in d2m-insert-scratch-buffers.
+constexpr int64_t kLaneTileRows = 2;
+
+// Duplicated in d2m-insert-scratch-buffers, which sets them.
+constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
+constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
 
 template <typename T>
 static int32_t floorLog2(T n) {
@@ -29,69 +38,96 @@ static int32_t floorLog2(T n) {
   return result;
 }
 
-// Builds this core's index buffer: the tile at reduction position t holds
-// t * 32 + i at element (i, j), i.e. the reduction coordinate of the value
-// tile's element at the same position, constant along the non-target axis j.
-//
-// The reduction runs down tile ROWS in both orientations -- dim==1 inputs are
-// tile-transposed upstream so their reduction lands on rows too -- so the
-// within-tile term is always the row index i. `fill_arange_tile` writes
-// 32 * i + j, and shifting that right by 5 drops j and leaves i in every
-// column, which keeps the whole computation on the SFPU in Int32.
-//
-// `core_index(dim)` supplies the offset of this core's band, so a banded or
-// data-parallel shard needs no upstream arange and no cross-core broadcast:
-// each core derives exactly the slice it reduces.
-//
-// This must stay the FIRST L1 access in the kernel. D2MToTTKernel derives the
-// startup pack/unpack data format from the first L1 load/store it finds, and
-// these are Int32; the merge tree that follows reconfigures the packer per
-// buffer on its own (emitTopkGroupEnd), but a plain memref.store does not, so
-// moving this fill after the merge tree would pack indices as float.
+struct TopkIndexBuffers {
+  Value idxBuf;
+  Value laneBuf;
+};
+
+static std::optional<TopkIndexBuffers> findIndexBuffers(GenericOp genericOp) {
+  TopkIndexBuffers buffers;
+  genericOp.getRegion(0).walk([&](memref::AllocOp allocOp) {
+    if (allocOp->hasAttr(kTopkIndexBufferAttr)) {
+      buffers.idxBuf = allocOp.getResult();
+    } else if (allocOp->hasAttr(kTopkLaneBufferAttr)) {
+      buffers.laneBuf = allocOp.getResult();
+    }
+  });
+  if (!buffers.idxBuf || !buffers.laneBuf) {
+    return std::nullopt;
+  }
+  return buffers;
+}
+
+static void eraseScratchAnchors(PatternRewriter &rewriter, GenericOp genericOp,
+                                const TopkIndexBuffers &buffers) {
+  SmallVector<ScratchInitOp> anchors;
+  genericOp.getRegion(0).walk([&](ScratchInitOp initOp) {
+    if (initOp.getScratch() == buffers.idxBuf ||
+        initOp.getScratch() == buffers.laneBuf) {
+      anchors.push_back(initOp);
+    }
+  });
+  for (ScratchInitOp initOp : anchors) {
+    rewriter.eraseOp(initOp);
+  }
+}
+
+// Builds this core's index buffer: tile t, element (i, j) holds t * 32 + i
+// (row index i plus this core's band offset from core_index(dim)), constant
+// along non-target axis j.
 static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
                               TopkBlockOp op, MemRefType inputType,
-                              int64_t dimIdx, int64_t numTilesInner) {
+                              int64_t dimIdx, int64_t numTilesInner,
+                              Value idxBuf, Value laneBuf) {
   MLIRContext *ctx = rewriter.getContext();
   ArrayRef<int64_t> shape = inputType.getShape();
   TT_assertv(shape.size() == 2ul,
              "in-kernel index generation expects a 2D shard");
 
-  Value laneScratch = op.getScratchIdxTile();
   auto idxTileType = mlir::cast<ttcore::TileType>(
       mlir::cast<MemRefType>(op.getOutIndices().getType()).getElementType());
-  auto elemType = mlir::dyn_cast<IntegerType>(idxTileType.getElementType());
-  TT_assertv(elemType, "topk index tiles must have an integer element type");
-  // arith requires signless integers; tile element types may be si32/ui32.
-  auto scalarType = IntegerType::get(ctx, elemType.getWidth());
-
-  auto l1MemorySpace =
-      ttcore::MemorySpaceAttr::get(ctx, ttcore::MemorySpace::DeviceL1);
-  auto idxBufType = MemRefType::get(shape, idxTileType,
-                                    MemRefLayoutAttrInterface{}, l1MemorySpace);
-  auto idxBuf = rewriter.create<memref::AllocOp>(loc, idxBufType);
-  // Compute-local L1 buffer: no DM thread touches it, so it takes the
-  // single-buffered scratch path (no streaming, no CB handshake).
-  idxBuf->setAttr("d2m.scratch_buffer", rewriter.getUnitAttr());
-
-  // Written once; every tile derives its values from this one lane pattern.
-  rewriter.create<FillArangeTileOp>(loc, laneScratch);
+  // emitLeafTopk always picks an integer index type; arith wants it signless.
+  Type scalarType = IntegerType::get(
+      ctx, mlir::cast<IntegerType>(idxTileType.getElementType()).getWidth());
 
   auto idxVal = [&](int64_t v) -> Value {
     return rewriter.create<arith::ConstantIndexOp>(loc, v);
   };
+  auto coreIndex = [&](int64_t dim) -> Value {
+    return rewriter.create<CoreIndexOp>(loc, dim);
+  };
   Value zeroIdx = idxVal(0);
   Value oneIdx = idxVal(1);
   Value const32Idx = idxVal(32);
-  Value shiftVal = rewriter.create<arith::ConstantOp>(
-      loc, scalarType, rewriter.getIntegerAttr(scalarType, 5));
+
+  // Written once; every tile derives its values from this one lane pattern. A
+  // column-major arange puts i in column 0, which a Col bcast then replicates.
+  rewriter.create<ArangeBlockOp>(loc, op.getScratchIdxTile(), laneBuf,
+                                 /*numElements=*/32, /*start=*/0, /*step=*/1,
+                                 /*colMajor=*/true);
+  // The loop below reads this back out of L1, so the pack must land first.
+  rewriter.create<UnpackStallOnPackOp>(loc);
+
+  // arange_block folds this core's grid position into every element; the
+  // per-tile offset below subtracts it back out.
+  auto genericOp = op->getParentOfType<GenericOp>();
+  TT_assertv(genericOp, "topk_block must be inside a generic");
+  ArrayRef<int64_t> gridShape = genericOp.getGrid().getShape();
+  int64_t totalTileRows = kLaneTileRows * gridShape[gridShape.size() - 2];
+  Value arangeBase = rewriter.create<arith::AddIOp>(
+      loc,
+      rewriter.create<arith::MulIOp>(loc, coreIndex(0),
+                                     idxVal(kLaneTileRows * 32)),
+      rewriter.create<arith::MulIOp>(loc, coreIndex(1),
+                                     idxVal(totalTileRows * 32 * 32)));
 
   // Tiles this core's band starts at, in whole tiles of the reduction dim.
-  Value bandOffset = rewriter.create<arith::MulIOp>(
-      loc, rewriter.create<CoreIndexOp>(loc, dimIdx), idxVal(numTilesInner));
+  Value bandOffset = rewriter.create<arith::MulIOp>(loc, coreIndex(dimIdx),
+                                                    idxVal(numTilesInner));
 
   // The reduction dim is iterated innermost so the compute-root tag lands on a
-  // loop that can never be folded away for having a single trip: a shard always
-  // spans at least two reduction tiles, since topk_block merges them pairwise.
+  // loop that can never fold away for a single trip: topk_block merges
+  // reduction tiles pairwise, so a shard always spans at least two.
   bool reductionIsRow = (dimIdx == 0);
   int64_t outerTiles = reductionIsRow ? shape[1] : shape[0];
   int64_t innerTiles = reductionIsRow ? shape[0] : shape[1];
@@ -101,11 +137,8 @@ static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
   rewriter.setInsertionPointToStart(outerLoop.getBody());
   auto innerLoop =
       rewriter.create<scf::ForOp>(loc, zeroIdx, idxVal(innerTiles), oneIdx);
-  // Mark the INNER loop as the compute root, since that's where the actual
-  // compute operations are emitted. This ensures DST syncs are placed inside
-  // the inner loop body, not the outer. Since we emit an scf.for directly, we
-  // must tag this here since linalg-to-affine and d2m-op-scheduler won't
-  // process this.
+  // Tagged here rather than by linalg-to-affine or d2m-op-scheduler, neither of
+  // which processes a directly emitted scf.for; DST syncs go in the inner body.
   innerLoop->setAttr("d2m.linalg_root", rewriter.getUnitAttr());
   innerLoop->setAttr("d2m.scheduled", rewriter.getUnitAttr());
   rewriter.setInsertionPointToStart(innerLoop.getBody());
@@ -116,25 +149,25 @@ static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
   Value colIdx = reductionIsRow ? outerIdx : reductionTile;
 
   Value laneTile = rewriter.create<memref::LoadOp>(
-      loc, laneScratch, ValueRange{zeroIdx, zeroIdx});
-  // A tile RHS is required: D2MToTTKernel's scalar-RHS dispatch has no branch
-  // for tile_right_shift and would silently drop the shift.
-  Value shiftTile =
-      rewriter.create<TileFillOp>(loc, idxTileType, shiftVal).getResult();
+      loc, laneBuf, ValueRange{zeroIdx, zeroIdx});
   Value rowTile =
-      rewriter.create<TileRightShiftOp>(loc, idxTileType, laneTile, shiftTile)
+      rewriter
+          .create<TileBcastOp>(loc, idxTileType, laneTile, TileBcastType::Col)
           .getResult();
 
-  Value tileOffsetIdx = rewriter.create<arith::MulIOp>(
-      loc, rewriter.create<arith::AddIOp>(loc, bandOffset, reductionTile),
-      const32Idx);
+  Value tileOffsetIdx = rewriter.create<arith::SubIOp>(
+      loc,
+      rewriter.create<arith::MulIOp>(
+          loc, rewriter.create<arith::AddIOp>(loc, bandOffset, reductionTile),
+          const32Idx),
+      arangeBase);
   Value tileOffset =
       rewriter.create<arith::IndexCastOp>(loc, scalarType, tileOffsetIdx);
   Value indexTile =
       rewriter.create<TileAddOp>(loc, idxTileType, rowTile, tileOffset)
           .getResult();
 
-  rewriter.create<memref::StoreOp>(loc, indexTile, idxBuf.getResult(),
+  rewriter.create<memref::StoreOp>(loc, indexTile, idxBuf,
                                    ValueRange{rowIdx, colIdx});
 
   rewriter.setInsertionPointAfter(outerLoop);
@@ -142,7 +175,7 @@ static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
   // writes must land before the first copy_tile reads them.
   rewriter.create<UnpackStallOnPackOp>(loc);
 
-  return idxBuf.getResult();
+  return idxBuf;
 }
 
 // Decomposes TopkBlockOp into tile_topk_{local_sort,merge,rebuild} ops with
@@ -174,12 +207,22 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     int64_t dimIdx = op.getDim();
     int64_t numTilesInner = inputShape[dimIdx];
 
-    // A leaf topk builds its index buffer here, one core at a time; a merge
-    // stage is handed the real indices its children produced.
-    Value bufIdxFilled = op.getGenerateIndices()
-                             ? buildIndexBuffer(rewriter, loc, op, inputType,
-                                                dimIdx, numTilesInner)
-                             : scratchIdxTile;
+    // A leaf builds its own index buffer; a merge stage is handed the real
+    // indices its children produced.
+    Value bufIdxFilled = scratchIdxTile;
+    if (op.getGenerateIndices()) {
+      auto parentGeneric = op->getParentOfType<GenericOp>();
+      TT_assertv(parentGeneric, "topk_block must be inside a generic");
+      std::optional<TopkIndexBuffers> buffers = findIndexBuffers(parentGeneric);
+      if (!buffers) {
+        return failure();
+      }
+      // d2m-lower-scratch-allocate reads a leftover anchor as the spill pool.
+      eraseScratchAnchors(rewriter, parentGeneric, *buffers);
+      bufIdxFilled =
+          buildIndexBuffer(rewriter, loc, op, inputType, dimIdx, numTilesInner,
+                           buffers->idxBuf, buffers->laneBuf);
+    }
 
     // logWt is the merge-tree depth; ceilLog2 ensures the final fold always
     // runs for non-power-of-2 tile counts.

--- a/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/DecomposeTopk.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -26,6 +27,122 @@ static int32_t floorLog2(T n) {
     ++result;
   }
   return result;
+}
+
+// Builds this core's index buffer: the tile at reduction position t holds
+// t * 32 + i at element (i, j), i.e. the reduction coordinate of the value
+// tile's element at the same position, constant along the non-target axis j.
+//
+// The reduction runs down tile ROWS in both orientations -- dim==1 inputs are
+// tile-transposed upstream so their reduction lands on rows too -- so the
+// within-tile term is always the row index i. `fill_arange_tile` writes
+// 32 * i + j, and shifting that right by 5 drops j and leaves i in every
+// column, which keeps the whole computation on the SFPU in Int32.
+//
+// `core_index(dim)` supplies the offset of this core's band, so a banded or
+// data-parallel shard needs no upstream arange and no cross-core broadcast:
+// each core derives exactly the slice it reduces.
+//
+// This must stay the FIRST L1 access in the kernel. D2MToTTKernel derives the
+// startup pack/unpack data format from the first L1 load/store it finds, and
+// these are Int32; the merge tree that follows reconfigures the packer per
+// buffer on its own (emitTopkGroupEnd), but a plain memref.store does not, so
+// moving this fill after the merge tree would pack indices as float.
+static Value buildIndexBuffer(PatternRewriter &rewriter, Location loc,
+                              TopkBlockOp op, MemRefType inputType,
+                              int64_t dimIdx, int64_t numTilesInner) {
+  MLIRContext *ctx = rewriter.getContext();
+  ArrayRef<int64_t> shape = inputType.getShape();
+  TT_assertv(shape.size() == 2ul,
+             "in-kernel index generation expects a 2D shard");
+
+  Value laneScratch = op.getScratchIdxTile();
+  auto idxTileType = mlir::cast<ttcore::TileType>(
+      mlir::cast<MemRefType>(op.getOutIndices().getType()).getElementType());
+  auto elemType = mlir::dyn_cast<IntegerType>(idxTileType.getElementType());
+  TT_assertv(elemType, "topk index tiles must have an integer element type");
+  // arith requires signless integers; tile element types may be si32/ui32.
+  auto scalarType = IntegerType::get(ctx, elemType.getWidth());
+
+  auto l1MemorySpace =
+      ttcore::MemorySpaceAttr::get(ctx, ttcore::MemorySpace::DeviceL1);
+  auto idxBufType = MemRefType::get(shape, idxTileType,
+                                    MemRefLayoutAttrInterface{}, l1MemorySpace);
+  auto idxBuf = rewriter.create<memref::AllocOp>(loc, idxBufType);
+  // Compute-local L1 buffer: no DM thread touches it, so it takes the
+  // single-buffered scratch path (no streaming, no CB handshake).
+  idxBuf->setAttr("d2m.scratch_buffer", rewriter.getUnitAttr());
+
+  // Written once; every tile derives its values from this one lane pattern.
+  rewriter.create<FillArangeTileOp>(loc, laneScratch);
+
+  auto idxVal = [&](int64_t v) -> Value {
+    return rewriter.create<arith::ConstantIndexOp>(loc, v);
+  };
+  Value zeroIdx = idxVal(0);
+  Value oneIdx = idxVal(1);
+  Value const32Idx = idxVal(32);
+  Value shiftVal = rewriter.create<arith::ConstantOp>(
+      loc, scalarType, rewriter.getIntegerAttr(scalarType, 5));
+
+  // Tiles this core's band starts at, in whole tiles of the reduction dim.
+  Value bandOffset = rewriter.create<arith::MulIOp>(
+      loc, rewriter.create<CoreIndexOp>(loc, dimIdx), idxVal(numTilesInner));
+
+  // The reduction dim is iterated innermost so the compute-root tag lands on a
+  // loop that can never be folded away for having a single trip: a shard always
+  // spans at least two reduction tiles, since topk_block merges them pairwise.
+  bool reductionIsRow = (dimIdx == 0);
+  int64_t outerTiles = reductionIsRow ? shape[1] : shape[0];
+  int64_t innerTiles = reductionIsRow ? shape[0] : shape[1];
+
+  auto outerLoop =
+      rewriter.create<scf::ForOp>(loc, zeroIdx, idxVal(outerTiles), oneIdx);
+  rewriter.setInsertionPointToStart(outerLoop.getBody());
+  auto innerLoop =
+      rewriter.create<scf::ForOp>(loc, zeroIdx, idxVal(innerTiles), oneIdx);
+  // Mark the INNER loop as the compute root, since that's where the actual
+  // compute operations are emitted. This ensures DST syncs are placed inside
+  // the inner loop body, not the outer. Since we emit an scf.for directly, we
+  // must tag this here since linalg-to-affine and d2m-op-scheduler won't
+  // process this.
+  innerLoop->setAttr("d2m.linalg_root", rewriter.getUnitAttr());
+  innerLoop->setAttr("d2m.scheduled", rewriter.getUnitAttr());
+  rewriter.setInsertionPointToStart(innerLoop.getBody());
+
+  Value outerIdx = outerLoop.getInductionVar();
+  Value reductionTile = innerLoop.getInductionVar();
+  Value rowIdx = reductionIsRow ? reductionTile : outerIdx;
+  Value colIdx = reductionIsRow ? outerIdx : reductionTile;
+
+  Value laneTile = rewriter.create<memref::LoadOp>(
+      loc, laneScratch, ValueRange{zeroIdx, zeroIdx});
+  // A tile RHS is required: D2MToTTKernel's scalar-RHS dispatch has no branch
+  // for tile_right_shift and would silently drop the shift.
+  Value shiftTile =
+      rewriter.create<TileFillOp>(loc, idxTileType, shiftVal).getResult();
+  Value rowTile =
+      rewriter.create<TileRightShiftOp>(loc, idxTileType, laneTile, shiftTile)
+          .getResult();
+
+  Value tileOffsetIdx = rewriter.create<arith::MulIOp>(
+      loc, rewriter.create<arith::AddIOp>(loc, bandOffset, reductionTile),
+      const32Idx);
+  Value tileOffset =
+      rewriter.create<arith::IndexCastOp>(loc, scalarType, tileOffsetIdx);
+  Value indexTile =
+      rewriter.create<TileAddOp>(loc, idxTileType, rowTile, tileOffset)
+          .getResult();
+
+  rewriter.create<memref::StoreOp>(loc, indexTile, idxBuf.getResult(),
+                                   ValueRange{rowIdx, colIdx});
+
+  rewriter.setInsertionPointAfter(outerLoop);
+  // The merge tree unpacks these tiles straight out of L1, so the packer's
+  // writes must land before the first copy_tile reads them.
+  rewriter.create<UnpackStallOnPackOp>(loc);
+
+  return idxBuf.getResult();
 }
 
 // Decomposes TopkBlockOp into tile_topk_{local_sort,merge,rebuild} ops with
@@ -49,11 +166,6 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
                "input must have at least 2 dimensions");
 
     int32_t k = op.getK();
-
-    // The index buffer is pre-filled upstream (in TTIRToD2M via arange +
-    // broadcast generics) and passed in as scratch_idx_tile.
-    Value bufIdxFilled = scratchIdxTile;
-
     int32_t logk = floorLog2(k);
 
     // When k>32 the result spans 2 tiles. The large-k path left-folds over
@@ -61,6 +173,14 @@ struct DecomposeTopkBlockPattern : OpRewritePattern<TopkBlockOp> {
     bool useLargeK = (k > 32);
     int64_t dimIdx = op.getDim();
     int64_t numTilesInner = inputShape[dimIdx];
+
+    // A leaf topk builds its index buffer here, one core at a time; a merge
+    // stage is handed the real indices its children produced.
+    Value bufIdxFilled = op.getGenerateIndices()
+                             ? buildIndexBuffer(rewriter, loc, op, inputType,
+                                                dimIdx, numTilesInner)
+                             : scratchIdxTile;
+
     // logWt is the merge-tree depth; ceilLog2 ensures the final fold always
     // runs for non-power-of-2 tile counts.
     bool numTilesPow2 =

--- a/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
+++ b/lib/Dialect/D2M/Transforms/ExpandDMAReadCompositeView.cpp
@@ -446,7 +446,9 @@ static LogicalResult expandCompositeViewsInGeneric(IRRewriter &rewriter,
   TT_assert(compositeSource != nullptr);
 
   SmallVector<Value> compositeInputs = compositeView.getCompositeInputs();
-  TT_assert(compositeInputs.size() > 1u);
+  // One input is legal and expands to the degenerate if-else chain: every
+  // destination tile resolves against that single input's grid x shard extent.
+  TT_assert(!compositeInputs.empty());
 
   int64_t extraNumInputs = static_cast<int64_t>(compositeInputs.size() - 1);
 

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -122,12 +122,32 @@ static void verifySingleGenericConsumerThroughViewsAndMasks(Value root) {
         worklist.push_back(maskOp.getResult());
         continue;
       }
+      if (auto compositeView = dyn_cast<d2m::CompositeViewOp>(user)) {
+        worklist.push_back(compositeView.getResult());
+        continue;
+      }
       if (isa<d2m::SpatialOp>(user)) {
         continue;
       }
       recordGenericConsumer(user, parentGeneric);
     }
   }
+}
+
+// A pinned operand keeps its type verbatim: its dim alignments encode padded
+// shard extents chosen by the lowering, which tensorWithOptimalGrid would
+// recompute away. Only the virtual grid mapping is missing, and that lives on
+// the EmptyOp.
+static RankedTensorType gridAdjustedType(RankedTensorType oldType,
+                                         bool ttnnMode,
+                                         ArrayRef<int64_t> selectedGrid,
+                                         ArrayRef<int64_t> paddingTileShape,
+                                         bool pinned) {
+  if (pinned) {
+    return oldType;
+  }
+  return utils::tensorWithOptimalGrid(oldType, ttnnMode, selectedGrid,
+                                      paddingTileShape);
 }
 
 static llvm::SmallVector<int64_t>
@@ -150,15 +170,17 @@ static void
 optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
                      const EffectiveTargetGridRange &effectiveTargetGridRange,
                      bool ttnnMode, ArrayRef<int64_t> optimalGrid,
-                     OpBuilder &builder) {
+                     OpBuilder &builder, bool forceRebuild = false) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
   if (!emptyOp) {
     return;
   }
 
-  // Check if we're already at the target grid.
+  // Check if we're already at the target grid. Pinned operands always are, but
+  // still need the rebuild below to pick up the virtual grid mapping.
   auto emptyType = mlir::cast<mlir::RankedTensorType>(emptyOp.getType());
-  if (emptyType.getShape().take_front(2) == llvm::ArrayRef(optimalGrid)) {
+  if (!forceRebuild &&
+      emptyType.getShape().take_front(2) == llvm::ArrayRef(optimalGrid)) {
     return;
   }
 
@@ -169,7 +191,7 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
     return;
   }
 
-  bool needsOptimization = false;
+  bool needsOptimization = forceRebuild;
   for (int64_t g : optimalGrid) {
     if (g > 1) {
       needsOptimization = true;
@@ -187,8 +209,8 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
 
   llvm::SmallVector<int64_t> paddingTileShape =
       getScalarBridgePaddingTileShape(toLayoutOp, outputType);
-  RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
-      outputType, ttnnMode, optimalGrid, paddingTileShape);
+  RankedTensorType newTensorType = gridAdjustedType(
+      outputType, ttnnMode, optimalGrid, paddingTileShape, forceRebuild);
   builder.setInsertionPoint(emptyOp);
 
   // VGM is NOT propagated from the to_layout's input here — the output EmptyOp
@@ -340,7 +362,7 @@ applyToLayoutUpdate(const OperandGridInfo &info,
                     bool ttnnMode, OpBuilder &builder) {
   auto toLayoutOp = info.getLiveOperand().getDefiningOp<d2m::ToLayoutOp>();
   optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                       ttnnMode, info.selectedGrid, builder);
+                       ttnnMode, info.selectedGrid, builder, info.forceRebuild);
 }
 
 static void applyBehindViewToLayoutUpdate(
@@ -365,20 +387,22 @@ applyMaskUpdate(const OperandGridInfo &info,
 
   if (auto toLayoutOp = maskOp.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
     optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                         ttnnMode, info.selectedGrid, builder);
+                         ttnnMode, info.selectedGrid, builder,
+                         info.forceRebuild);
   } else if (auto view = maskOp.getInput().getDefiningOp<d2m::ViewLayoutOp>()) {
     if (auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
       optimizeToLayoutGrid(toLayoutOp, info.targetGrid,
                            effectiveTargetGridRange, ttnnMode,
-                           info.selectedGrid, builder);
+                           info.selectedGrid, builder, info.forceRebuild);
     }
   }
 
   auto oldResultType =
       mlir::cast<RankedTensorType>(maskOp.getResult().getType());
-  RankedTensorType newResultType = utils::tensorWithOptimalGrid(
-      oldResultType, ttnnMode, info.selectedGrid, info.paddingTileShape);
-  if (newResultType == oldResultType) {
+  RankedTensorType newResultType =
+      gridAdjustedType(oldResultType, ttnnMode, info.selectedGrid,
+                       info.paddingTileShape, info.forceRebuild);
+  if (newResultType == oldResultType && !info.forceRebuild) {
     return;
   }
 
@@ -504,8 +528,9 @@ static void applyCompositeViewUpdate(
   auto outType =
       mlir::cast<RankedTensorType>(compositeView.getResult().getType());
 
-  RankedTensorType newOutType = utils::tensorWithOptimalGrid(
-      outType, ttnnMode, info.selectedGrid, info.paddingTileShape);
+  RankedTensorType newOutType =
+      gridAdjustedType(outType, ttnnMode, info.selectedGrid,
+                       info.paddingTileShape, info.forceRebuild);
 
   TT_assertv(info.compositeInputInfos.size() ==
                  compositeView.getInputs().size(),
@@ -537,8 +562,9 @@ applyEmptyOpUpdate(const OperandGridInfo &info,
   EmptyOp emptyOp = info.getLiveOperand().getDefiningOp<d2m::EmptyOp>();
   auto emptyType =
       mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
-  RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
-      emptyType, ttnnMode, info.selectedGrid, info.paddingTileShape);
+  RankedTensorType newTensorType =
+      gridAdjustedType(emptyType, ttnnMode, info.selectedGrid,
+                       info.paddingTileShape, info.forceRebuild);
   builder.setInsertionPoint(emptyOp);
 
   // The selected grid may differ from the EmptyOp's previous grid.
@@ -615,8 +641,9 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
       mlir::cast<RankedTensorType>(viewOp.getResult().getType());
   auto oldLayout =
       mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
-  RankedTensorType newResultType = utils::tensorWithOptimalGrid(
-      oldResultType, ttnnMode, info.selectedGrid, info.paddingTileShape);
+  RankedTensorType newResultType =
+      gridAdjustedType(oldResultType, ttnnMode, info.selectedGrid,
+                       info.paddingTileShape, info.forceRebuild);
 
   // Compose the original remapping with a reblock map that maps from the
   // old output shape to the new output shape.
@@ -678,6 +705,14 @@ recreateGenericOp(d2m::GenericOp genericOp,
   ArrayRef<int64_t> outputGridShape = optimalOperandGrids[outputOperandIndex];
   ttcore::GridAttr grid =
       deriveGenericGridAttr(genericOp, optimalOperandGrids, builder);
+
+  // Explicit datamovement form has no maps to reparallelize against; only the
+  // grid attr needs refreshing.
+  if (genericOp.isExplicitDatamovementForm()) {
+    genericOp.setGridAttr(grid);
+    return genericOp;
+  }
+
   SmallVector<int64_t> blockFactors = utils::deriveBlockFactorsFromOperandGrids(
       genericOp.getIndexingMapsValue(), optimalOperandGrids, outputGridShape);
   auto ret = genericOp.withParallelization(builder, grid, blockFactors,

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -6,9 +6,13 @@
 
 #include "ttmlir/AffineMapUtils.h"
 #include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h"
 #include "ttmlir/Dialect/D2M/Analysis/GridAnalysis.h"
+#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/Utils/GridSelectionUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/SpatialOpNormalizeUtil.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
@@ -21,6 +25,7 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/SmallVector.h"
@@ -134,14 +139,9 @@ static void verifySingleGenericConsumerThroughViewsAndMasks(Value root) {
   }
 }
 
-// A pinned operand keeps its type verbatim: its dim alignments encode padded
-// shard extents that tensorWithOptimalGrid would recompute away.
 static RankedTensorType gridAdjustedType(const OperandGridInfo &info,
                                          RankedTensorType oldType,
                                          bool ttnnMode) {
-  if (info.pinned) {
-    return oldType;
-  }
   return utils::tensorWithOptimalGrid(oldType, ttnnMode, info.selectedGrid,
                                       info.paddingTileShape);
 }
@@ -166,17 +166,14 @@ static void
 optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
                      const EffectiveTargetGridRange &effectiveTargetGridRange,
                      bool ttnnMode, ArrayRef<int64_t> optimalGrid,
-                     OpBuilder &builder, bool pinned = false) {
+                     OpBuilder &builder) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
   if (!emptyOp) {
     return;
   }
 
-  // A pinned operand already sits at its grid, but the rebuild below is what
-  // stamps its virtual grid mapping, so it must not take these early outs.
   auto emptyType = mlir::cast<mlir::RankedTensorType>(emptyOp.getType());
-  if (!pinned &&
-      emptyType.getShape().take_front(2) == llvm::ArrayRef(optimalGrid)) {
+  if (emptyType.getShape().take_front(2) == llvm::ArrayRef(optimalGrid)) {
     return;
   }
 
@@ -187,7 +184,7 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
     return;
   }
 
-  bool needsOptimization = pinned;
+  bool needsOptimization = false;
   for (int64_t g : optimalGrid) {
     if (g > 1) {
       needsOptimization = true;
@@ -205,10 +202,8 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
 
   llvm::SmallVector<int64_t> paddingTileShape =
       getScalarBridgePaddingTileShape(toLayoutOp, outputType);
-  RankedTensorType newTensorType =
-      pinned ? outputType
-             : utils::tensorWithOptimalGrid(outputType, ttnnMode, optimalGrid,
-                                            paddingTileShape);
+  RankedTensorType newTensorType = utils::tensorWithOptimalGrid(
+      outputType, ttnnMode, optimalGrid, paddingTileShape);
   builder.setInsertionPoint(emptyOp);
 
   // VGM is NOT propagated from the to_layout's input here — the output EmptyOp
@@ -360,7 +355,7 @@ applyToLayoutUpdate(const OperandGridInfo &info,
                     bool ttnnMode, OpBuilder &builder) {
   auto toLayoutOp = info.getLiveOperand().getDefiningOp<d2m::ToLayoutOp>();
   optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                       ttnnMode, info.selectedGrid, builder, info.pinned);
+                       ttnnMode, info.selectedGrid, builder);
 }
 
 static void applyBehindViewToLayoutUpdate(
@@ -385,12 +380,12 @@ applyMaskUpdate(const OperandGridInfo &info,
 
   if (auto toLayoutOp = maskOp.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
     optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                         ttnnMode, info.selectedGrid, builder, info.pinned);
+                         ttnnMode, info.selectedGrid, builder);
   } else if (auto view = maskOp.getInput().getDefiningOp<d2m::ViewLayoutOp>()) {
     if (auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
       optimizeToLayoutGrid(toLayoutOp, info.targetGrid,
                            effectiveTargetGridRange, ttnnMode,
-                           info.selectedGrid, builder, info.pinned);
+                           info.selectedGrid, builder);
     }
   }
 
@@ -398,7 +393,7 @@ applyMaskUpdate(const OperandGridInfo &info,
       mlir::cast<RankedTensorType>(maskOp.getResult().getType());
   RankedTensorType newResultType =
       gridAdjustedType(info, oldResultType, ttnnMode);
-  if (!info.pinned && newResultType == oldResultType) {
+  if (newResultType == oldResultType) {
     return;
   }
 
@@ -696,13 +691,6 @@ recreateGenericOp(d2m::GenericOp genericOp,
   ArrayRef<int64_t> outputGridShape = optimalOperandGrids[outputOperandIndex];
   ttcore::GridAttr grid =
       deriveGenericGridAttr(genericOp, optimalOperandGrids, builder);
-
-  // Explicit datamovement form has no maps to reparallelize against.
-  if (genericOp.isExplicitDatamovementForm()) {
-    genericOp.setGridAttr(grid);
-    return genericOp;
-  }
-
   SmallVector<int64_t> blockFactors = utils::deriveBlockFactorsFromOperandGrids(
       genericOp.getIndexingMapsValue(), optimalOperandGrids, outputGridShape);
   auto ret = genericOp.withParallelization(builder, grid, blockFactors,
@@ -822,6 +810,111 @@ static LogicalResult applyGridDecisions(d2m::GenericOp genericOp,
   return success();
 }
 
+// A topk's split decides how many generics the lowering will build, so this
+// phase folds a grid per planned buffer from shape and target range alone,
+// without those buffers existing yet.
+static TopKPlacementAttr
+foldTopKBuffer(const TopKBufferPlan &buffer,
+               const EffectiveTargetGridRange &effectiveTargetGridRange,
+               OpBuilder &builder) {
+  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(buffer.type.getEncoding());
+  llvm::SmallVector<int64_t> gridShape =
+      llvm::to_vector(layout.getGridShape(buffer.type));
+
+  auto [virtualGridInverseMapping, virtualGridForwardMapping] =
+      deriveVirtualGridAttrs(gridShape, effectiveTargetGridRange, builder);
+
+  // Mirrors deriveGridAttrForOutput: derive rather than store the same maps
+  // twice under two meanings.
+  ttcore::GridAttr grid = builder.getAttr<ttcore::GridAttr>(gridShape);
+  if (virtualGridForwardMapping && virtualGridInverseMapping) {
+    if (auto maps = utils::getGridMapsFromVirtualGridMapping(
+            virtualGridForwardMapping.getAffineMap(),
+            virtualGridInverseMapping.getAffineMap(), gridShape)) {
+      grid = builder.getAttr<ttcore::GridAttr>(gridShape, maps->first,
+                                               maps->second);
+    }
+  }
+
+  return builder.getAttr<TopKPlacementAttr>(
+      buffer.type, grid, virtualGridForwardMapping, virtualGridInverseMapping);
+}
+
+// Lays out and masks the topk's input on the planned cores.
+static Value placeTopKInput(IRRewriter &rewriter, SingleCoreTopK chain,
+                            TopKPlacementAttr input,
+                            TopKPlacementAttr inputMask) {
+  Location loc = chain.leaf->getLoc();
+  rewriter.setInsertionPoint(chain.leaf);
+
+  auto emptyFor = [&](TopKPlacementAttr placement) {
+    return rewriter
+        .create<EmptyOp>(loc, placement.getType(), placement.getVgmInverse(),
+                         placement.getVgmForward())
+        .getResult();
+  };
+
+  Value laidOut =
+      rewriter.create<ToLayoutOp>(loc, chain.logicalInput, emptyFor(input))
+          .getResult(0);
+  // A mask is planned only when grid times shard overshoots the logical extent,
+  // leaving a padding tail that would otherwise win the reduction.
+  if (inputMask) {
+    auto layout =
+        mlir::cast<ttcore::MetalLayoutAttr>(inputMask.getType().getEncoding());
+    laidOut =
+        rewriter
+            .create<MaskOp>(loc, laidOut, emptyFor(inputMask),
+                            layout.getLogicalShape(), ttcore::OOBVal::NegInf)
+            .getResult();
+  }
+  return laidOut;
+}
+
+static LogicalResult planTopKPlacement(GenericOp leaf,
+                                       ArrayRef<int64_t> deviceGridShape,
+                                       ttcore::ChipDescAttr chipDesc) {
+  auto topkBlock = *leaf->getRegion(0).getOps<TopkBlockOp>().begin();
+  const int32_t dim = topkBlock.getDim();
+  const int64_t k = topkBlock.getK();
+  SingleCoreTopK chain = readSingleCoreTopK(leaf);
+
+  std::string failureReason;
+  auto strategy = selectTopKShardingStrategy(
+      k, dim,
+      mlir::cast<RankedTensorType>(chain.logicalInput.getType()).getShape(),
+      deviceGridShape,
+      topKL1Budget(leaf, chipDesc, BlockFactorAnalysis::Options{}.numBuffers),
+      failureReason);
+  if (failed(strategy)) {
+    return topkBlock->emitOpError(failureReason);
+  }
+
+  IRRewriter rewriter(leaf->getContext());
+  const EffectiveTargetGridRange effectiveTargetGridRange =
+      getTargetGridRange(leaf, deviceGridShape);
+
+  TopKBufferPlans plans = planTopKBuffers(chain, *strategy, k, dim);
+  auto fold = [&](const TopKBufferPlan &buffer) {
+    return foldTopKBuffer(buffer, effectiveTargetGridRange, rewriter);
+  };
+  llvm::SmallVector<TopKPlacementAttr> placements;
+  for (const TopKBufferPlan &buffer : plans.lowered) {
+    placements.push_back(fold(buffer));
+  }
+  auto plan =
+      rewriter.getAttr<TopKPlanAttr>(strategy->numShards, strategy->ntShards,
+                                     strategy->mergeSchedule, placements);
+
+  Value laidOut = placeTopKInput(rewriter, chain, fold(plans.input),
+                                 plans.inputMask.type ? fold(plans.inputMask)
+                                                      : TopKPlacementAttr());
+  laidOut.getDefiningOp()->setAttr(utils::kTopKInputAttr,
+                                   rewriter.getUnitAttr());
+  leaf->setAttr(utils::kTopKPlanAttr, plan);
+  return success();
+}
+
 // ----------------------------------------------------------------------------
 // Pass implementation
 // ----------------------------------------------------------------------------
@@ -869,9 +962,40 @@ public:
         return;
       }
     }
+
+    if (failed(planTopKPlacements(module))) {
+      signalPassFailure();
+      return;
+    }
   }
 
 private:
+  // A leaf reduces raw input (`generate_indices`). Collected before any leaf is
+  // rebuilt, so the replacements this phase emits are not walked again.
+  LogicalResult planTopKPlacements(ModuleOp module) {
+    llvm::SmallVector<GenericOp> leaves;
+    module.walk([&](TopkBlockOp op) {
+      GenericOp leaf = op->getParentOfType<GenericOp>();
+      if (op.getGenerateIndices() && leaf && leaf.getInputs().size() == 2 &&
+          leaf->getNumResults() == 2) {
+        leaves.push_back(leaf);
+      }
+    });
+    if (leaves.empty()) {
+      return success();
+    }
+
+    llvm::SmallVector<int64_t> deviceGridShape = getDeviceGridShape();
+    ttcore::ChipDescAttr chipDesc =
+        ttcore::getCurrentScopeSystemDesc(module).getChipDesc(0);
+    for (GenericOp leaf : leaves) {
+      if (failed(planTopKPlacement(leaf, deviceGridShape, chipDesc))) {
+        return failure();
+      }
+    }
+    return success();
+  }
+
   // Returns the device-wide grid shape (worker grid or override).
   llvm::SmallVector<int64_t> getDeviceGridShape() {
     if (!overrideDeviceShape.empty()) {

--- a/lib/Dialect/D2M/Transforms/GridSelection.cpp
+++ b/lib/Dialect/D2M/Transforms/GridSelection.cpp
@@ -135,19 +135,15 @@ static void verifySingleGenericConsumerThroughViewsAndMasks(Value root) {
 }
 
 // A pinned operand keeps its type verbatim: its dim alignments encode padded
-// shard extents chosen by the lowering, which tensorWithOptimalGrid would
-// recompute away. Only the virtual grid mapping is missing, and that lives on
-// the EmptyOp.
-static RankedTensorType gridAdjustedType(RankedTensorType oldType,
-                                         bool ttnnMode,
-                                         ArrayRef<int64_t> selectedGrid,
-                                         ArrayRef<int64_t> paddingTileShape,
-                                         bool pinned) {
-  if (pinned) {
+// shard extents that tensorWithOptimalGrid would recompute away.
+static RankedTensorType gridAdjustedType(const OperandGridInfo &info,
+                                         RankedTensorType oldType,
+                                         bool ttnnMode) {
+  if (info.pinned) {
     return oldType;
   }
-  return utils::tensorWithOptimalGrid(oldType, ttnnMode, selectedGrid,
-                                      paddingTileShape);
+  return utils::tensorWithOptimalGrid(oldType, ttnnMode, info.selectedGrid,
+                                      info.paddingTileShape);
 }
 
 static llvm::SmallVector<int64_t>
@@ -170,16 +166,16 @@ static void
 optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
                      const EffectiveTargetGridRange &effectiveTargetGridRange,
                      bool ttnnMode, ArrayRef<int64_t> optimalGrid,
-                     OpBuilder &builder, bool forceRebuild = false) {
+                     OpBuilder &builder, bool pinned = false) {
   auto emptyOp = toLayoutOp.getOutput().getDefiningOp<d2m::EmptyOp>();
   if (!emptyOp) {
     return;
   }
 
-  // Check if we're already at the target grid. Pinned operands always are, but
-  // still need the rebuild below to pick up the virtual grid mapping.
+  // A pinned operand already sits at its grid, but the rebuild below is what
+  // stamps its virtual grid mapping, so it must not take these early outs.
   auto emptyType = mlir::cast<mlir::RankedTensorType>(emptyOp.getType());
-  if (!forceRebuild &&
+  if (!pinned &&
       emptyType.getShape().take_front(2) == llvm::ArrayRef(optimalGrid)) {
     return;
   }
@@ -191,7 +187,7 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
     return;
   }
 
-  bool needsOptimization = forceRebuild;
+  bool needsOptimization = pinned;
   for (int64_t g : optimalGrid) {
     if (g > 1) {
       needsOptimization = true;
@@ -209,8 +205,10 @@ optimizeToLayoutGrid(d2m::ToLayoutOp toLayoutOp, ArrayRef<int64_t> targetGrid,
 
   llvm::SmallVector<int64_t> paddingTileShape =
       getScalarBridgePaddingTileShape(toLayoutOp, outputType);
-  RankedTensorType newTensorType = gridAdjustedType(
-      outputType, ttnnMode, optimalGrid, paddingTileShape, forceRebuild);
+  RankedTensorType newTensorType =
+      pinned ? outputType
+             : utils::tensorWithOptimalGrid(outputType, ttnnMode, optimalGrid,
+                                            paddingTileShape);
   builder.setInsertionPoint(emptyOp);
 
   // VGM is NOT propagated from the to_layout's input here — the output EmptyOp
@@ -362,7 +360,7 @@ applyToLayoutUpdate(const OperandGridInfo &info,
                     bool ttnnMode, OpBuilder &builder) {
   auto toLayoutOp = info.getLiveOperand().getDefiningOp<d2m::ToLayoutOp>();
   optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                       ttnnMode, info.selectedGrid, builder, info.forceRebuild);
+                       ttnnMode, info.selectedGrid, builder, info.pinned);
 }
 
 static void applyBehindViewToLayoutUpdate(
@@ -387,22 +385,20 @@ applyMaskUpdate(const OperandGridInfo &info,
 
   if (auto toLayoutOp = maskOp.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
     optimizeToLayoutGrid(toLayoutOp, info.targetGrid, effectiveTargetGridRange,
-                         ttnnMode, info.selectedGrid, builder,
-                         info.forceRebuild);
+                         ttnnMode, info.selectedGrid, builder, info.pinned);
   } else if (auto view = maskOp.getInput().getDefiningOp<d2m::ViewLayoutOp>()) {
     if (auto toLayoutOp = view.getInput().getDefiningOp<d2m::ToLayoutOp>()) {
       optimizeToLayoutGrid(toLayoutOp, info.targetGrid,
                            effectiveTargetGridRange, ttnnMode,
-                           info.selectedGrid, builder, info.forceRebuild);
+                           info.selectedGrid, builder, info.pinned);
     }
   }
 
   auto oldResultType =
       mlir::cast<RankedTensorType>(maskOp.getResult().getType());
   RankedTensorType newResultType =
-      gridAdjustedType(oldResultType, ttnnMode, info.selectedGrid,
-                       info.paddingTileShape, info.forceRebuild);
-  if (newResultType == oldResultType && !info.forceRebuild) {
+      gridAdjustedType(info, oldResultType, ttnnMode);
+  if (!info.pinned && newResultType == oldResultType) {
     return;
   }
 
@@ -528,9 +524,7 @@ static void applyCompositeViewUpdate(
   auto outType =
       mlir::cast<RankedTensorType>(compositeView.getResult().getType());
 
-  RankedTensorType newOutType =
-      gridAdjustedType(outType, ttnnMode, info.selectedGrid,
-                       info.paddingTileShape, info.forceRebuild);
+  RankedTensorType newOutType = gridAdjustedType(info, outType, ttnnMode);
 
   TT_assertv(info.compositeInputInfos.size() ==
                  compositeView.getInputs().size(),
@@ -562,9 +556,7 @@ applyEmptyOpUpdate(const OperandGridInfo &info,
   EmptyOp emptyOp = info.getLiveOperand().getDefiningOp<d2m::EmptyOp>();
   auto emptyType =
       mlir::cast<mlir::RankedTensorType>(emptyOp.getResult().getType());
-  RankedTensorType newTensorType =
-      gridAdjustedType(emptyType, ttnnMode, info.selectedGrid,
-                       info.paddingTileShape, info.forceRebuild);
+  RankedTensorType newTensorType = gridAdjustedType(info, emptyType, ttnnMode);
   builder.setInsertionPoint(emptyOp);
 
   // The selected grid may differ from the EmptyOp's previous grid.
@@ -642,8 +634,7 @@ static void applyViewLayoutUpdate(const OperandGridInfo &info, bool ttnnMode,
   auto oldLayout =
       mlir::cast<ttcore::MetalLayoutAttr>(oldResultType.getEncoding());
   RankedTensorType newResultType =
-      gridAdjustedType(oldResultType, ttnnMode, info.selectedGrid,
-                       info.paddingTileShape, info.forceRebuild);
+      gridAdjustedType(info, oldResultType, ttnnMode);
 
   // Compose the original remapping with a reblock map that maps from the
   // old output shape to the new output shape.
@@ -706,8 +697,7 @@ recreateGenericOp(d2m::GenericOp genericOp,
   ttcore::GridAttr grid =
       deriveGenericGridAttr(genericOp, optimalOperandGrids, builder);
 
-  // Explicit datamovement form has no maps to reparallelize against; only the
-  // grid attr needs refreshing.
+  // Explicit datamovement form has no maps to reparallelize against.
   if (genericOp.isExplicitDatamovementForm()) {
     genericOp.setGridAttr(grid);
     return genericOp;

--- a/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
@@ -111,6 +111,18 @@ traceCBUse(OpOperand &startUse, GenericOp generic) {
   return std::nullopt;
 }
 
+// Scratch and reduction-scaler buffers are compute-local L1 allocations, not
+// CBs: no datamovement thread ever fills or drains them, so they take part in
+// no wait/push handshake. `traceCBUse` already refuses them on the memref
+// access path; synchronizable compute ops must refuse them on theirs too, or a
+// consumer that names one as an operand (d2m.tile_topk_* naming its index
+// buffer, say) gets a wait that nothing can ever satisfy.
+static bool isComputeLocalBuffer(Value cb) {
+  Operation *definingOp = cb.getDefiningOp();
+  return definingOp && (definingOp->getAttr("d2m.scratch_buffer") ||
+                        utils::isReductionScalerBuffer(definingOp));
+}
+
 // collapse_shape / subview compute an address into a CB; they do not wait
 // for or produce tiles. They are often hoisted above the loop that uses them.
 static bool isCBViewOp(Operation *op) {
@@ -344,6 +356,9 @@ static LogicalResult insertCBOpsForCompute(
       }
     }
     for (OpOperand &operand : op->getOpOperands()) {
+      if (isComputeLocalBuffer(operand.get())) {
+        continue;
+      }
       if (sync.isConsumer(operand)) {
         add(consumers, operand.get(), op, &operand);
       }

--- a/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
@@ -419,18 +419,21 @@ static LogicalResult insertCBOpsForCompute(
   // enclosing loop (which lives *outside* `block`), and including it unlifted
   // would drag the bracket out of the transfer-depth block.
   //
-  // includeViewOwners: producers need views in the bracket so they can be
+  // skipViewOwners: producers need views in the bracket so they can be
   // rewritten next to the reserve. Self-produced consumers must not -- a
-  // hoisted view would pull the wait before this region's own push.
+  // hoisted view would pull the wait before this region's own push -- unless
+  // the views are all there is, since an empty bracket has nowhere to sync.
   auto bracket =
       [&](CBSync &sync, Block *block,
-          bool includeViewOwners) -> std::pair<Operation *, Operation *> {
+          bool skipViewOwners) -> std::pair<Operation *, Operation *> {
     SmallVector<Operation *> boundary;
-    auto lift = [&](Operation *op) {
+    SmallVector<Operation *> viewOwners;
+    auto liftInto = [&](Operation *op, SmallVector<Operation *> &into) {
       if (Operation *a = block->findAncestorOpInBlock(*op)) {
-        boundary.push_back(a);
+        into.push_back(a);
       }
     };
+    auto lift = [&](Operation *op) { liftInto(op, boundary); };
     for (Operation *anchor : sync.anchors) {
       lift(anchor);
       // A CB read into an SSA value (e.g. a hoisted, loop-invariant reduction
@@ -446,12 +449,14 @@ static LogicalResult insertCBOpsForCompute(
       }
     }
     for (OpOperand *use : sync.uses) {
-      if (!includeViewOwners && isCBViewOp(use->getOwner())) {
-        continue;
-      }
-      lift(use->getOwner());
+      Operation *owner = use->getOwner();
+      bool deferred = skipViewOwners && isCBViewOp(owner);
+      liftInto(owner, deferred ? viewOwners : boundary);
     }
 
+    if (boundary.empty()) {
+      boundary = std::move(viewOwners);
+    }
     if (boundary.empty()) {
       return {nullptr, nullptr};
     }
@@ -476,11 +481,8 @@ static LogicalResult insertCBOpsForCompute(
 
     // If this region also produces `cb`, ignore hoisted views so the wait
     // lands at the real read (after the push), not at the shared view.
-    auto [first, last] = bracket(sync, anchorBlock,
-                                 /*includeViewOwners=*/!producers.count(cb));
-    if (!first) {
-      std::tie(first, last) = bracket(sync, anchorBlock, true);
-    }
+    auto [first, last] =
+        bracket(sync, anchorBlock, /*skipViewOwners=*/producers.count(cb) > 0);
 
     rewriter.setInsertionPoint(first);
     auto cbHandle =
@@ -535,7 +537,7 @@ static LogicalResult insertCBOpsForCompute(
                 "fan-out is not yet supported (would deadlock on a "
                 "reserve/push cadence mismatch)";
     }
-    auto [first, last] = bracket(sync, anchorBlock, /*includeViewOwners=*/true);
+    auto [first, last] = bracket(sync, anchorBlock, /*skipViewOwners=*/false);
 
     rewriter.setInsertionPoint(first);
     auto cbHandle =

--- a/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
@@ -111,12 +111,8 @@ traceCBUse(OpOperand &startUse, GenericOp generic) {
   return std::nullopt;
 }
 
-// Scratch and reduction-scaler buffers are compute-local L1 allocations, not
-// CBs: no datamovement thread ever fills or drains them, so they take part in
-// no wait/push handshake. `traceCBUse` already refuses them on the memref
-// access path; synchronizable compute ops must refuse them on theirs too, or a
-// consumer that names one as an operand (d2m.tile_topk_* naming its index
-// buffer, say) gets a wait that nothing can ever satisfy.
+// Compute-local L1 allocations, not CBs: no datamovement thread fills or drains
+// them, so a consumer naming one as an operand must not get a CB wait.
 static bool isComputeLocalBuffer(Value cb) {
   Operation *definingOp = cb.getDefiningOp();
   return definingOp && (definingOp->getAttr("d2m.scratch_buffer") ||

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -5,7 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
@@ -145,9 +145,7 @@ static void addScratchToGeneric(GenericOp genericOp) {
 }
 
 static void addTopkIndexBuffers(GenericOp genericOp) {
-  if (genericOp.getNumRegions() == 0) {
-    return;
-  }
+  assert(genericOp.getNumRegions() != 0 && "d2m.generic must have a region");
 
   // At most one generate_indices topk_block per generic.
   TopkBlockOp topkBlock = nullptr;
@@ -160,14 +158,13 @@ static void addTopkIndexBuffers(GenericOp genericOp) {
     return;
   }
 
-  // Post-bufferization only; nothing to allocate while still on tensors.
+  // Runs after bufferization, so these are always memrefs.
   auto inputType =
       mlir::dyn_cast<MemRefType>(topkBlock.getInputValues().getType());
   auto indicesType =
       mlir::dyn_cast<MemRefType>(topkBlock.getOutIndices().getType());
-  if (!inputType || !indicesType) {
-    return;
-  }
+  assert(inputType && indicesType &&
+         "topk_block operands must be memrefs post-bufferization");
 
   auto l1MemorySpace = ttcore::MemorySpaceAttr::get(
       genericOp.getContext(), ttcore::MemorySpace::DeviceL1);

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -25,6 +25,13 @@ namespace {
 // intermediate spills.
 constexpr size_t kScratchSizeBytes = 128 * 1024;
 
+// Duplicated in d2m-decompose-topk, which consumes them.
+constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
+constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
+
+// Must exceed 1: a single row folds arange_block's compute root loop away.
+constexpr int64_t kTopkLaneTileRows = 2;
+
 // Get the tile type from a memref type, if it has one.
 static ttcore::TileType getTileType(MemRefType memrefType) {
   return mlir::dyn_cast<ttcore::TileType>(memrefType.getElementType());
@@ -143,6 +150,52 @@ static void addScratchToGeneric(GenericOp genericOp) {
   builder.create<ScratchInitOp>(genericOp.getLoc(), scratchAlloc.getResult());
 }
 
+static void addTopkIndexBuffers(GenericOp genericOp) {
+  if (genericOp.getNumRegions() == 0) {
+    return;
+  }
+
+  // At most one generate_indices topk_block per generic.
+  TopkBlockOp topkBlock = nullptr;
+  genericOp.getRegion(0).walk([&](TopkBlockOp op) {
+    if (op.getGenerateIndices()) {
+      topkBlock = op;
+    }
+  });
+  if (!topkBlock) {
+    return;
+  }
+
+  // Post-bufferization only; nothing to allocate while still on tensors.
+  auto inputType =
+      mlir::dyn_cast<MemRefType>(topkBlock.getInputValues().getType());
+  auto indicesType =
+      mlir::dyn_cast<MemRefType>(topkBlock.getOutIndices().getType());
+  if (!inputType || !indicesType) {
+    return;
+  }
+
+  auto l1MemorySpace = ttcore::MemorySpaceAttr::get(
+      genericOp.getContext(), ttcore::MemorySpace::DeviceL1);
+
+  Block &block = genericOp.getRegion(0).front();
+  OpBuilder builder(&block, block.begin());
+
+  auto allocScratch = [&](ArrayRef<int64_t> bufShape, StringRef roleAttr) {
+    auto bufType = MemRefType::get(bufShape, indicesType.getElementType(),
+                                   MemRefLayoutAttrInterface{}, l1MemorySpace);
+    auto allocOp = builder.create<memref::AllocOp>(topkBlock.getLoc(), bufType);
+    allocOp->setAttr("d2m.scratch_buffer", builder.getUnitAttr());
+    allocOp->setAttr(roleAttr, builder.getUnitAttr());
+    // Without this the canonicalizer erases the still-unused alloc.
+    builder.create<ScratchInitOp>(topkBlock.getLoc(), allocOp.getResult());
+  };
+
+  // One index tile per value tile, plus the lane pattern they all derive from.
+  allocScratch(inputType.getShape(), kTopkIndexBufferAttr);
+  allocScratch({kTopkLaneTileRows, 1}, kTopkLaneBufferAttr);
+}
+
 class D2MInsertScratchBuffers
     : public impl::D2MInsertScratchBuffersBase<D2MInsertScratchBuffers> {
   using D2MInsertScratchBuffersBase::D2MInsertScratchBuffersBase;
@@ -157,6 +210,7 @@ class D2MInsertScratchBuffers
     for (GenericOp genericOp : genericsToProcess) {
       transferBlockingMaps(genericOp);
       addScratchToGeneric(genericOp);
+      addTopkIndexBuffers(genericOp);
     }
   }
 };

--- a/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertScratchBuffers.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 
@@ -24,13 +25,6 @@ namespace {
 // Fixed scratch buffer size used for every fused d2m.generic that needs
 // intermediate spills.
 constexpr size_t kScratchSizeBytes = 128 * 1024;
-
-// Duplicated in d2m-decompose-topk, which consumes them.
-constexpr llvm::StringLiteral kTopkIndexBufferAttr = "d2m.topk_index_buffer";
-constexpr llvm::StringLiteral kTopkLaneBufferAttr = "d2m.topk_lane_buffer";
-
-// Must exceed 1: a single row folds arange_block's compute root loop away.
-constexpr int64_t kTopkLaneTileRows = 2;
 
 // Get the tile type from a memref type, if it has one.
 static ttcore::TileType getTileType(MemRefType memrefType) {
@@ -192,8 +186,8 @@ static void addTopkIndexBuffers(GenericOp genericOp) {
   };
 
   // One index tile per value tile, plus the lane pattern they all derive from.
-  allocScratch(inputType.getShape(), kTopkIndexBufferAttr);
-  allocScratch({kTopkLaneTileRows, 1}, kTopkLaneBufferAttr);
+  allocScratch(inputType.getShape(), utils::kTopkIndexBufferAttr);
+  allocScratch({utils::kTopkLaneTileRows, 1}, utils::kTopkLaneBufferAttr);
 }
 
 class D2MInsertScratchBuffers

--- a/lib/Dialect/D2M/Transforms/LowerTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerTopk.cpp
@@ -3,12 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Asserts.h"
-#include "ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h"
 #include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
-#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCore.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 
@@ -16,7 +15,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/PatternMatch.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/Support/MathExtras.h"
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MLOWERTOPK
@@ -26,177 +25,50 @@ namespace {
 
 constexpr int64_t kTileWidth = ttcore::TileType::getDefaultShape()[1];
 
-//===----------------------------------------------------------------------===//
-// Layout and region helpers
-//===----------------------------------------------------------------------===//
+// Reads the placement plan: every buffer this pass builds comes from here, in
+// the order `planTopKBuffers` listed them, and grid selection already chose and
+// folded each one.
+class PlanReader {
+public:
+  explicit PlanReader(TopKPlanAttr plan) : plan(plan) {}
 
-/// Rebuild `layout`'s logical shape from a [grid..., shard...] `deviceShape` of
-/// even rank, carrying every other layout field over unchanged.
-ttcore::MetalLayoutAttr
-rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
-                            ArrayRef<int64_t> deviceShape) {
-  TT_assert(deviceShape.size() % 2 == 0u);
-  const std::size_t physicalRank = deviceShape.size() / 2;
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-
-  llvm::SmallVector<int64_t> logicalShape;
-  logicalShape.reserve(physicalRank);
-  for (std::size_t i = 0; i < physicalRank; ++i) {
-    logicalShape.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
-                           tileDim);
+  utils::PlacedBuffer next() {
+    TT_assertv(cursor < plan.getPlacements().size(),
+               "topk emission asked for more buffers than the plan holds; the "
+               "plan and the emission have drifted apart");
+    TopKPlacementAttr placement = plan.getPlacements()[cursor++];
+    return {placement.getType(), placement.getVgmForward(),
+            placement.getVgmInverse(), placement.getGrid()};
   }
-  return ttcore::MetalLayoutAttr::get(
-      layout.getContext(), logicalShape, layout.getDimAlignments(),
-      layout.getCollapsedIntervals(), layout.getMemorySpace(),
-      layout.getMemoryLayout());
-}
 
-//===----------------------------------------------------------------------===//
-// Recovering TTIRToD2M's single-core lowering
-//===----------------------------------------------------------------------===//
+  /// Every placement must be read by the time emission finishes, or the plan
+  /// and the emission have drifted apart.
+  void assertFullyConsumed() const {
+    TT_assertv(cursor == plan.getPlacements().size(),
+               "topk plan holds {} placements but the emission built {}",
+               plan.getPlacements().size(), cursor);
+  }
 
-/// The pieces this pass replaces, all reachable from the leaf `topk_block`.
-struct SingleCoreTopK {
-  GenericOp leaf;
-  /// Pre-layout input, so the pass shards it rather than re-sharding a layout.
-  Value logicalInput;
-  GenericOp extractValues;
-  GenericOp extractIndices;
-  /// Follows the index extract when `dim != 0`, else null.
-  GenericOp indexCast;
+private:
+  TopKPlanAttr plan;
+  std::size_t cursor = 0;
 };
 
-/// Walks back from the leaf's input through the `to_layout`s that materialize
-/// buffers, the padding-tail `mask`, and the tile-transpose generic dim=1 adds.
-Value findLogicalInput(Value value) {
-  auto isDevice = [](Value v) {
-    auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
-    return type &&
-           mlir::isa_and_nonnull<ttcore::MetalLayoutAttr>(type.getEncoding());
-  };
-  while (isDevice(value)) {
-    Operation *def = value.getDefiningOp();
-    if (auto toLayout = mlir::dyn_cast_if_present<ToLayoutOp>(def)) {
-      value = toLayout.getInput();
-    } else if (auto mask = mlir::dyn_cast_if_present<MaskOp>(def)) {
-      value = mask.getInput();
-    } else if (auto generic = mlir::dyn_cast_if_present<GenericOp>(def);
-               generic && generic.getInputs().size() == 1) {
-      value = generic.getInputs()[0];
-    } else {
-      return nullptr;
-    }
-  }
-  return value;
-}
-
-/// The single generic consuming `value`, looking through the `to_layout` that
-/// materializes it. Null when the use pattern is not the one TTIRToD2M emits.
-GenericOp findConsumingGeneric(Value value) {
-  for (int hop = 0; hop < 2; ++hop) {
-    Operation *consumer = nullptr;
-    for (Operation *user : value.getUsers()) {
-      // A generic reads its operands back through `remote_load`, so each
-      // operand has a nested use as well as a direct one, both naming that
-      // generic.
-      if (GenericOp owner = user->getParentOfType<GenericOp>()) {
-        user = owner;
-      }
-      if (consumer && consumer != user) {
-        return nullptr;
-      }
-      consumer = user;
-    }
-    if (auto generic = mlir::dyn_cast_if_present<GenericOp>(consumer)) {
-      return generic;
-    }
-    // to_layout is DPS: a use as its output does not continue the chain.
-    auto toLayout = mlir::dyn_cast_if_present<ToLayoutOp>(consumer);
-    if (!toLayout || toLayout.getInput() != value) {
-      return nullptr;
-    }
-    value = toLayout.getResult(0);
-  }
-  return nullptr;
-}
-
-mlir::FailureOr<SingleCoreTopK> recoverSingleCoreTopK(GenericOp leaf) {
-  SingleCoreTopK recovered;
-  recovered.leaf = leaf;
-  recovered.logicalInput = findLogicalInput(leaf.getInputs()[0]);
-  recovered.extractValues = findConsumingGeneric(leaf->getResult(0));
-  recovered.extractIndices = findConsumingGeneric(leaf->getResult(1));
-  if (!recovered.logicalInput || !recovered.extractValues ||
-      !recovered.extractIndices) {
-    return mlir::failure();
-  }
-
-  // dim != 0 casts the extracted indices to the user's index type in a region
-  // of its own; dim == 0 folds that cast into the extract itself.
-  GenericOp next = findConsumingGeneric(recovered.extractIndices->getResult(0));
-  bool isCast =
-      next && next != recovered.extractIndices &&
-      next->walk([](TileTypecastOp) { return WalkResult::interrupt(); })
-          .wasInterrupted();
-  recovered.indexCast = isCast ? next : GenericOp();
-  return recovered;
-}
-
-/// The logical tensor type a device-layout value stands for.
-RankedTensorType getLogicalType(Value deviceValue) {
-  auto type = mlir::cast<RankedTensorType>(deviceValue.getType());
-  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(type.getEncoding());
-  return RankedTensorType::get(
-      layout.getLogicalShape(),
-      mlir::cast<ttcore::TileType>(type.getElementType()).getElementType());
-}
-
-/// Erases `roots` and everything upstream they were the last user of. The chain
-/// being replaced is straight-line, so this bottoms out at the logical input.
-void eraseDeadChain(RewriterBase &rewriter, ArrayRef<Operation *> roots) {
-  llvm::SmallVector<Operation *> worklist(roots);
-  llvm::SmallPtrSet<Operation *, 16> erased;
-  while (!worklist.empty()) {
-    Operation *op = worklist.pop_back_val();
-    if (erased.contains(op) || !op->use_empty()) {
-      continue;
-    }
-    for (Value operand : op->getOperands()) {
-      if (Operation *def = operand.getDefiningOp()) {
-        worklist.push_back(def);
-      }
-    }
-    erased.insert(op);
-    rewriter.eraseOp(op);
-  }
-}
-
-//===----------------------------------------------------------------------===//
-// Multi-core emission
-//===----------------------------------------------------------------------===//
-
-/// Narrows every core's shard down to its leading `outputReductionTiles`, so
-/// the wide partials do not stay live on every core and overflow L1.
+/// Narrows every core's shard down to `narrow`'s reduction extent, so the wide
+/// partials do not stay live on every core and overflow L1.
 Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
-                          int64_t outputReductionTiles, int32_t dim) {
+                          const utils::PlacedBuffer &narrow) {
   auto wideType = mlir::cast<RankedTensorType>(partial.getType());
   auto tileType = mlir::cast<ttcore::TileType>(wideType.getElementType());
-  std::size_t rank = wideType.getShape().size() / 2;
-  TopKGeometry geometry = getTopKGeometry(dim, rank);
+  const std::size_t rank = wideType.getShape().size() / 2;
 
-  llvm::SmallVector<int64_t> narrowShape(wideType.getShape());
-  narrowShape[geometry.deviceRedDim] = outputReductionTiles;
-  auto narrowEmpty = rewriter.create<EmptyOp>(
-      loc, narrowShape, tileType,
-      rebuildLayoutForDeviceShape(
-          mlir::cast<ttcore::MetalLayoutAttr>(wideType.getEncoding()),
-          narrowShape));
-  auto narrowType = mlir::cast<RankedTensorType>(narrowEmpty.getType());
+  Value narrowEmpty = rewriter
+                          .create<EmptyOp>(loc, narrow.type, narrow.vgmInverse,
+                                           narrow.vgmForward)
+                          .getResult();
   auto generic = rewriter.create<GenericOp>(
-      loc, TypeRange{narrowType}, ValueRange{partial},
-      ValueRange{narrowEmpty.getResult()}, /*additionalArgs=*/ValueRange(),
-      rewriter.getAttr<ttcore::GridAttr>(
-          ArrayRef<int64_t>(narrowShape).take_front(rank)),
+      loc, TypeRange{narrow.type}, ValueRange{partial}, ValueRange{narrowEmpty},
+      /*additionalArgs=*/ValueRange(), narrow.grid,
       /*block_factors=*/rewriter.getI64ArrayAttr({}),
       /*indexing_maps=*/rewriter.getArrayAttr({}),
       /*iterator_types=*/rewriter.getArrayAttr({}),
@@ -206,9 +78,8 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
   {
     OpBuilder::InsertionGuard guard(rewriter);
     rewriter.createBlock(&generic->getRegion(0));
-    auto shardType = [&](RankedTensorType deviceType) {
-      return RankedTensorType::get(deviceType.getShape().take_back(rank),
-                                   tileType);
+    auto shardShape = [&](RankedTensorType deviceType) {
+      return deviceType.getShape().take_back(rank);
     };
     llvm::SmallVector<Value> coreIndices;
     coreIndices.reserve(rank);
@@ -216,14 +87,16 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
       coreIndices.push_back(
           rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i)));
     }
-    auto loadBuf = rewriter.create<tensor::EmptyOp>(
-        loc, shardType(wideType).getShape(), tileType);
-    Value loaded = rewriter
-                       .create<RemoteLoadOp>(loc, shardType(wideType), loadBuf,
-                                             partial, coreIndices)
-                       .getResult();
-    auto outBuf = rewriter.create<tensor::EmptyOp>(
-        loc, shardType(narrowType).getShape(), tileType);
+    auto loadBuf =
+        rewriter.create<tensor::EmptyOp>(loc, shardShape(wideType), tileType);
+    Value loaded =
+        rewriter
+            .create<RemoteLoadOp>(
+                loc, RankedTensorType::get(shardShape(wideType), tileType),
+                loadBuf, partial, coreIndices)
+            .getResult();
+    auto outBuf = rewriter.create<tensor::EmptyOp>(loc, shardShape(narrow.type),
+                                                   tileType);
     AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(rank);
     Value narrowed =
         rewriter
@@ -231,237 +104,291 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
                 loc, loaded, outBuf.getResult(),
                 rewriter.getAffineMapArrayAttr({shardIdentity, shardIdentity}))
             .getResult();
-    Value stored =
-        rewriter
-            .create<RemoteStoreOp>(loc, narrowType, narrowEmpty.getResult(),
-                                   coreIndices, narrowed)
-            .getResult();
+    Value stored = rewriter
+                       .create<RemoteStoreOp>(loc, narrow.type, narrowEmpty,
+                                              coreIndices, narrowed)
+                       .getResult();
     rewriter.create<YieldOp>(loc, ValueRange{stored});
   }
-  utils::markPinnedGrid(generic);
 
-  return utils::materializeToLayout(rewriter, loc, generic->getResult(0));
+  return utils::materializeToLayout(rewriter, loc, generic->getResult(0),
+                                    narrow);
 }
 
-/// Lays `rawInput` out banded `gridCols` ways along the reduction dim and/or
-/// sliced `ntCores` ways along the non-target dim, then runs one leaf topk per
-/// core. Buffers carry logical grids only; GridSelection folds them onto cores.
-std::pair<Value, Value> emitShardedLeaves(RewriterBase &rewriter, Location loc,
-                                          Value rawInput, int32_t k,
-                                          int32_t dim,
-                                          const TopKShardingStrategy &strategy,
-                                          ttcore::MemorySpace memSpace,
-                                          int64_t gridCols, int64_t ntCores) {
-  auto inputType = mlir::cast<RankedTensorType>(rawInput.getType());
-  llvm::SmallVector<int64_t> shardTiles(inputType.getRank(), 1);
-  shardTiles[dim] = strategy.paddedReductionTiles;
-  shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
-  llvm::SmallVector<int64_t> grid =
-      (dim == 1) ? llvm::SmallVector<int64_t>{ntCores, gridCols}
-                 : llvm::SmallVector<int64_t>{gridCols, ntCores};
-  Value input =
-      utils::layoutAndMask(rewriter, loc, rawInput, shardTiles, grid, memSpace);
-
-  auto [vals, idx] = utils::emitLeafTopk(rewriter, loc, input, k, dim,
-                                         inputType.getShape()[dim]);
-  if (gridCols == 1) {
-    return {utils::materializeToLayout(rewriter, loc, vals),
-            utils::materializeToLayout(rewriter, loc, idx)};
-  }
-  return {compactReductionDim(rewriter, loc, vals,
-                              strategy.outputReductionTiles, dim),
-          compactReductionDim(rewriter, loc, idx, strategy.outputReductionTiles,
-                              dim)};
-}
-
-/// Collapses `bands` partials, one per core, down to `numGroups`: core g merges
-/// the groupTiles bands starting at g * groupTiles, gathered by a composite
-/// view that D2MExpandDMAReadCompositeView resolves per tile into a DMA read.
+/// Collapses one merge round: each surviving core merges the bands gathered
+/// through a composite view (resolved into DMA reads by
+/// D2MExpandDMAReadCompositeView).
 std::pair<Value, Value> emitMergeRound(RewriterBase &rewriter, Location loc,
                                        Value valsIn, Value idxIn, int32_t k,
-                                       int32_t dim,
-                                       int64_t outputReductionTiles,
-                                       int64_t bands, int64_t numGroups) {
+                                       int32_t dim, PlanReader &plan) {
   MLIRContext *ctx = rewriter.getContext();
-  int64_t groupTiles = bands / numGroups;
-  TT_assertv(groupTiles * numGroups == bands,
-             "merge round must divide the band count evenly");
-
   auto valsInType = mlir::cast<RankedTensorType>(valsIn.getType());
-  std::size_t rank = valsInType.getShape().size() / 2;
-  TopKGeometry geometry = getTopKGeometry(dim, rank);
+  const std::size_t rank = valsInType.getShape().size() / 2;
   AffineMap identityMap = rewriter.getMultiDimIdentityMap(rank);
   llvm::SmallVector<Attribute> iterators(
       rank, ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
 
-  // The input's extent re-split: numGroups cores each holding groupTiles bands'
-  // worth of reduction tiles, so the grid x shard product is preserved.
-  llvm::SmallVector<int64_t> wideShape(valsInType.getShape());
-  wideShape[geometry.deviceGridDim] = numGroups;
-  wideShape[geometry.deviceRedDim] = groupTiles * outputReductionTiles;
-  auto wideTypeOf = [&](Value in) {
-    auto inType = mlir::cast<RankedTensorType>(in.getType());
-    return RankedTensorType::get(
-        wideShape, inType.getElementType(),
-        rebuildLayoutForDeviceShape(
-            mlir::cast<ttcore::MetalLayoutAttr>(inType.getEncoding()),
-            wideShape));
-  };
-
   // Separate generics: the DMA-expansion pass supports only one composite view
   // per GenericOp (#7600).
   auto gather = [&](Value in) -> Value {
-    RankedTensorType wideType = wideTypeOf(in);
+    utils::PlacedBuffer wide = plan.next();
     auto composite = rewriter.create<CompositeViewOp>(
-        loc, wideType, ValueRange{in}, dim, /*logicalSizes=*/nullptr);
-    auto out = rewriter.create<EmptyOp>(
-        loc, wideShape, wideType.getElementType(), wideType.getEncoding());
+        loc, wide.type, ValueRange{in}, dim, /*logicalSizes=*/nullptr);
     llvm::SmallVector<Value> ins = {composite.getResult()};
-    llvm::SmallVector<Value> outs = {out.getResult()};
+    llvm::SmallVector<Value> outs = {
+        rewriter
+            .create<EmptyOp>(loc, wide.type, wide.vgmInverse, wide.vgmForward)
+            .getResult()};
     auto generic = rewriter.create<GenericOp>(
         loc, ins, outs, /*additionalArgs=*/ValueRange(),
         rewriter.getAffineMapArrayAttr(
             llvm::SmallVector<AffineMap>{identityMap, identityMap}),
-        rewriter.getArrayAttr(iterators));
+        rewriter.getArrayAttr(iterators), ThreadType::Unified, wide.grid);
     utils::buildParallelGenericRegion(
         rewriter, loc, generic, ins, outs,
         [](ArrayRef<Value> args) -> llvm::SmallVector<Value> {
           return {args[0]};
         });
-    utils::markPinnedGrid(generic);
-    return utils::materializeToLayout(rewriter, loc, generic->getResult(0));
+    return utils::materializeToLayout(rewriter, loc, generic->getResult(0),
+                                      wide);
   };
 
+  // Braced init so the two gathers draw from the plan in order.
   llvm::SmallVector<Value> ins = {gather(valsIn), gather(idxIn)};
+
+  utils::PlacedBuffer mergeVals = plan.next();
+  utils::PlacedBuffer mergeIdx = plan.next();
   llvm::SmallVector<Value> outs = {
       rewriter
-          .create<EmptyOp>(loc, wideShape, valsInType.getElementType(),
-                           wideTypeOf(valsIn).getEncoding())
+          .create<EmptyOp>(loc, mergeVals.type, mergeVals.vgmInverse,
+                           mergeVals.vgmForward)
           .getResult(),
       rewriter
-          .create<EmptyOp>(
-              loc, wideShape,
-              mlir::cast<RankedTensorType>(idxIn.getType()).getElementType(),
-              wideTypeOf(idxIn).getEncoding())
+          .create<EmptyOp>(loc, mergeIdx.type, mergeIdx.vgmInverse,
+                           mergeIdx.vgmForward)
           .getResult()};
+
+  const int64_t numElements =
+      mergeVals.type.getShape()[rank + dim] * kTileWidth;
+
   auto merge = rewriter.create<GenericOp>(
       loc, ins, outs, /*additionalArgs=*/ValueRange(),
       rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
           identityMap, identityMap, identityMap, identityMap}),
-      rewriter.getArrayAttr(iterators));
+      rewriter.getArrayAttr(iterators), ThreadType::Unified, mergeVals.grid);
   utils::buildParallelGenericRegion(
       rewriter, loc, merge, ins, outs,
       [&](ArrayRef<Value> args) -> llvm::SmallVector<Value> {
         // No generate_indices: these indices are an earlier stage's results and
         // cannot be recomputed from a coordinate.
         auto block = rewriter.create<TopkBlockOp>(
-            loc, args[0], args[1], args[2], args[3], k,
-            /*numElements=*/groupTiles * outputReductionTiles * kTileWidth,
+            loc, args[0], args[1], args[2], args[3], k, numElements,
             /*stableSort=*/false, dim);
         return {block.getResultValues(), block.getResultIndices()};
       });
-  utils::markPinnedGrid(merge);
 
-  return {compactReductionDim(
-              rewriter, loc,
-              utils::materializeToLayout(rewriter, loc, merge->getResult(0)),
-              outputReductionTiles, dim),
-          compactReductionDim(
-              rewriter, loc,
-              utils::materializeToLayout(rewriter, loc, merge->getResult(1)),
-              outputReductionTiles, dim)};
+  utils::PlacedBuffer compactVals = plan.next();
+  utils::PlacedBuffer compactIdx = plan.next();
+  return {compactReductionDim(rewriter, loc,
+                              utils::materializeToLayout(rewriter, loc,
+                                                         merge->getResult(0),
+                                                         mergeVals),
+                              compactVals),
+          compactReductionDim(rewriter, loc,
+                              utils::materializeToLayout(
+                                  rewriter, loc, merge->getResult(1), mergeIdx),
+                              compactIdx)};
 }
 
-/// Rebuilds the recovered single-core topk across the grid. `recovered` comes
-/// by value because MLIR op accessors are non-const.
-void emitMultiCore(RewriterBase &rewriter, SingleCoreTopK recovered, int32_t k,
-                   int32_t dim, const TopKShardingStrategy &strategy) {
-  Location loc = recovered.leaf->getLoc();
-  TopKGeometry geometry = getTopKGeometry(
-      dim,
-      mlir::cast<RankedTensorType>(recovered.logicalInput.getType()).getRank());
+/// Collapses the reduction dim to tile 0, undoing what `emitLeafTopk` did.
+/// `outputReductionTiles` is ceil(k / 32).
+GenericOp emitTopKExtract(RewriterBase &rewriter, Location loc,
+                          Value topkResult, Value extractOutput, int32_t dim,
+                          int64_t outputReductionTiles, ttcore::GridAttr grid) {
+  const auto extractProjectDim = static_cast<std::size_t>(dim);
+  MLIRContext *ctx = rewriter.getContext();
+  std::size_t extractRank =
+      ttcore::getDeviceLayout(extractOutput).getRank() / 2;
+  AffineMap extractIdentity = rewriter.getMultiDimIdentityMap(extractRank);
+  llvm::SmallVector<Attribute> extractIters(
+      extractRank,
+      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
 
-  // Everything the rebuild reads -- the logical input and both extract
-  // destinations -- is defined by the values extract.
-  rewriter.setInsertionPoint(recovered.extractValues);
+  llvm::SmallVector<AffineExpr> inputMapExprs;
+  for (std::size_t i = 0; i < extractRank; ++i) {
+    inputMapExprs.push_back(i == extractProjectDim
+                                ? rewriter.getAffineConstantExpr(0)
+                                : rewriter.getAffineDimExpr(i));
+  }
+  AffineMap inputProjectedMap =
+      AffineMap::get(extractRank, 0, inputMapExprs, ctx);
 
-  auto inputLayout = mlir::cast<ttcore::MetalLayoutAttr>(
-      mlir::cast<RankedTensorType>(recovered.leaf.getInputs()[0].getType())
-          .getEncoding());
-  // Non-target slices exchange no data, so a 2D split runs the band-and-merge
-  // pipeline once per slice row.
-  std::pair<Value, Value> level = emitShardedLeaves(
-      rewriter, loc, recovered.logicalInput, k, dim, strategy,
-      inputLayout.getMemorySpace(),
-      /*gridCols=*/strategy.multiCore ? strategy.numShards : 1,
-      /*ntCores=*/strategy.ntShards);
+  llvm::SmallVector<Value> extractInputs = {topkResult};
+  llvm::SmallVector<Value> extractOutputs = {extractOutput};
+  auto generic = rewriter.create<GenericOp>(
+      loc, extractInputs, extractOutputs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(
+          llvm::SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
+      rewriter.getArrayAttr(extractIters), ThreadType::Unified, grid);
 
-  int64_t bands = strategy.multiCore ? strategy.numShards : 1;
-  for (int64_t numGroups : strategy.mergeSchedule) {
-    level = emitMergeRound(rewriter, loc, level.first, level.second, k, dim,
-                           strategy.outputReductionTiles, bands, numGroups);
-    bands = numGroups;
+  utils::buildParallelGenericRegion(
+      rewriter, loc, generic, extractInputs, extractOutputs,
+      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
+        Value input = blockArgs[0];
+        Value output = blockArgs[1];
+        std::size_t outShardRank =
+            cast<RankedTensorType>(output.getType()).getRank();
+        int64_t inReductionExtent = cast<RankedTensorType>(input.getType())
+                                        .getShape()[extractProjectDim];
+        AffineExpr projExpr =
+            outputReductionTiles == 1
+                ? rewriter.getAffineConstantExpr(0)
+                : rewriter.getAffineDimExpr(extractProjectDim) %
+                      inReductionExtent;
+        llvm::SmallVector<AffineExpr> mapFirstExprs;
+        for (std::size_t i = 0; i < outShardRank; ++i) {
+          mapFirstExprs.push_back(
+              i == extractProjectDim ? projExpr : rewriter.getAffineDimExpr(i));
+        }
+        AffineMap mapFirst =
+            AffineMap::get(outShardRank, 0, mapFirstExprs, ctx);
+        AffineMap outIdentity = rewriter.getMultiDimIdentityMap(outShardRank);
+        llvm::SmallVector<mlir::utils::IteratorType> linalgIters(
+            outShardRank, mlir::utils::IteratorType::parallel);
+
+        auto linalgOp = rewriter.create<linalg::GenericOp>(
+            loc, output.getType(), input, output,
+            llvm::SmallVector<AffineMap>{mapFirst, outIdentity}, linalgIters,
+            [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+              Value result;
+              if (dim == 1) {
+                result = b.create<TileTransposeOp>(bodyLoc, args[1].getType(),
+                                                   args[0]);
+              } else {
+                result = b.create<TileTypecastOp>(bodyLoc, args[1].getType(),
+                                                  args[0]);
+              }
+              b.create<linalg::YieldOp>(bodyLoc, result);
+            });
+        return {linalgOp->getResult(0)};
+      });
+
+  return generic;
+}
+
+/// The laid-out and masked input d2m-grid-selection emitted off `logicalInput`,
+/// marked because the placeholder leaf cannot hold it as an operand.
+Value findPlacedInput(Value logicalInput) {
+  // The mark sits on the to_layout, or on the mask when one was planned, and
+  // is dropped on the way out so no marker outlives the pass.
+  auto take = [](Operation *op) -> Value {
+    if (!op->hasAttr(utils::kTopKInputAttr)) {
+      return {};
+    }
+    op->removeAttr(utils::kTopKInputAttr);
+    return op->getResult(0);
+  };
+  for (Operation *toLayout : logicalInput.getUsers()) {
+    if (Value placed = take(toLayout)) {
+      return placed;
+    }
+    for (Operation *mask : toLayout->getUsers()) {
+      if (Value placed = take(mask)) {
+        return placed;
+      }
+    }
+  }
+  TT_assertv(false, "topk leaf has no input placed by d2m-grid-selection");
+  return {};
+}
+
+/// Builds the topk the plan describes, replacing the leaf d2m-grid-selection
+/// placed. `chain` comes by value because MLIR op accessors are non-const.
+void emitPlannedTopK(RewriterBase &rewriter, SingleCoreTopK chain, int32_t k,
+                     int32_t dim, TopKPlanAttr planAttr) {
+  Location loc = chain.leaf->getLoc();
+  PlanReader plan(planAttr);
+  auto logicalInputType =
+      mlir::cast<RankedTensorType>(chain.logicalInput.getType());
+
+  // The only thing the build reads is the input chain grid selection laid out
+  // and masked onto the split; everything else it re-emits from the plan.
+  rewriter.setInsertionPoint(chain.leaf);
+  Value input = findPlacedInput(chain.logicalInput);
+
+  utils::LeafTopKBuffers leafBuffers;
+  if (dim == 1) {
+    leafBuffers.transpose = plan.next();
+  }
+  leafBuffers.scratch = plan.next();
+  leafBuffers.values = plan.next();
+  leafBuffers.indices = plan.next();
+  auto [leafVals, leafIdx] =
+      utils::emitLeafTopk(rewriter, loc, input, k, dim,
+                          logicalInputType.getShape()[dim], leafBuffers);
+
+  // Banding is what produces wide partials worth narrowing; a purely
+  // data-parallel split leaves each core's result already final.
+  std::pair<Value, Value> level;
+  if (planAttr.getNumShards() > 1) {
+    utils::PlacedBuffer compactVals = plan.next();
+    utils::PlacedBuffer compactIdx = plan.next();
+    level = {compactReductionDim(rewriter, loc, leafVals, compactVals),
+             compactReductionDim(rewriter, loc, leafIdx, compactIdx)};
+  } else {
+    level = {
+        utils::materializeToLayout(rewriter, loc, leafVals, leafBuffers.values),
+        utils::materializeToLayout(rewriter, loc, leafIdx,
+                                   leafBuffers.indices)};
   }
 
-  // A data-parallel split must keep each extract's destination on the same
-  // cores as its source; otherwise the conversion's destination still fits.
-  auto rebuildExtract = [&](GenericOp oldExtract, Value newInput) -> Value {
-    Value output = oldExtract.getOutputs()[0];
-    if (strategy.dataParallel) {
-      RankedTensorType logicalType = getLogicalType(output);
-      llvm::SmallVector<int64_t> tileShape =
-          llvm::to_vector(ttcore::TileType::getDefaultShape());
-      llvm::SmallVector<int64_t> shardTiles(logicalType.getRank(), 1);
-      shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
-      auto layout = utils::buildShardedTileLayout(
-          rewriter.getContext(), logicalType.getShape(), shardTiles,
-          mlir::cast<ttcore::MetalLayoutAttr>(
-              mlir::cast<RankedTensorType>(output.getType()).getEncoding())
-              .getMemorySpace());
-      llvm::SmallVector<int64_t> grid =
-          (dim == 1) ? llvm::SmallVector<int64_t>{strategy.ntShards, 1}
-                     : llvm::SmallVector<int64_t>{1, strategy.ntShards};
-      output =
-          rewriter
-              .create<EmptyOp>(loc, layout.getDeviceShape(grid, tileShape),
-                               ttcore::TileType::get(
-                                   logicalType.getElementType(), tileShape),
-                               layout)
-              .getResult();
-    }
-    return utils::emitTopKExtract(rewriter, loc, newInput, output,
-                                  geometry.extractProjectDim,
-                                  strategy.outputReductionTiles, dim)
+  for (std::size_t round = 0; round < planAttr.getMergeSchedule().size();
+       ++round) {
+    level =
+        emitMergeRound(rewriter, loc, level.first, level.second, k, dim, plan);
+  }
+
+  auto emitExtract = [&](Value newInput) -> Value {
+    utils::PlacedBuffer placed = plan.next();
+    // Width comes from `k`, not the input's reduction extent: a data-parallel
+    // split has no merge tree to narrow it, so the partial is still full width.
+    return emitTopKExtract(rewriter, loc, newInput,
+                           rewriter
+                               .create<EmptyOp>(loc, placed.type,
+                                                placed.vgmInverse,
+                                                placed.vgmForward)
+                               .getResult(),
+                           dim, llvm::divideCeil(k, kTileWidth), placed.grid)
         ->getResult(0);
   };
 
-  Value newVals = rebuildExtract(recovered.extractValues, level.first);
-  Value newIdx = rebuildExtract(recovered.extractIndices, level.second);
+  Value newVals = emitExtract(level.first);
+  Value newIdx = emitExtract(level.second);
 
-  GenericOp lastIdxOp = recovered.extractIndices;
-  if (recovered.indexCast) {
-    // Elementwise, so it follows its input's layout.
-    auto idxType = mlir::cast<RankedTensorType>(newIdx.getType());
-    auto castTileType = ttcore::TileType::get(
-        getLogicalType(recovered.indexCast->getResult(0)).getElementType(),
-        mlir::cast<ttcore::TileType>(idxType.getElementType()).getShape());
-    auto castEmpty = rewriter.create<EmptyOp>(
-        loc, idxType.getShape(), castTileType, idxType.getEncoding());
+  // dim == 0's extract casts to the user's index type on the way out; dim == 1
+  // transposes instead, so its cast needs a region of its own.
+  if (dim != 0) {
+    utils::PlacedBuffer castBuffer = plan.next();
     newIdx = utils::emitUnaryGeneric(
-        rewriter, loc, newIdx, castEmpty.getResult(),
+        rewriter, loc, newIdx,
+        rewriter
+            .create<EmptyOp>(loc, castBuffer.type, castBuffer.vgmInverse,
+                             castBuffer.vgmForward)
+            .getResult(),
         [&](OpBuilder &b, Location l, ValueRange args) {
           return b.create<TileTypecastOp>(l, args[1].getType(), args[0])
               .getResult();
-        });
-    utils::markPinnedGrid(newIdx.getDefiningOp());
-    lastIdxOp = recovered.indexCast;
+        },
+        castBuffer.grid);
   }
 
-  rewriter.replaceAllUsesWith(recovered.extractValues->getResult(0), newVals);
-  rewriter.replaceAllUsesWith(lastIdxOp->getResult(0), newIdx);
-  eraseDeadChain(rewriter, {recovered.extractValues.getOperation(),
-                            lastIdxOp.getOperation(),
-                            recovered.extractIndices.getOperation()});
+  plan.assertFullyConsumed();
+
+  // The placed leaf's results feed nothing but the `to_layout`s that hand the
+  // topk back to its user, and those check neither shape nor element type.
+  rewriter.replaceAllUsesWith(chain.leaf->getResult(0), newVals);
+  rewriter.replaceAllUsesWith(chain.leaf->getResult(1), newIdx);
+  rewriter.eraseOp(chain.leaf);
 }
 
 class D2MLowerTopk final : public impl::D2MLowerTopkBase<D2MLowerTopk> {
@@ -469,61 +396,22 @@ public:
   using impl::D2MLowerTopkBase<D2MLowerTopk>::D2MLowerTopkBase;
 
   void runOnOperation() override {
-    // Collected up front: the rebuild emits already-sharded leaf topk_blocks of
-    // its own. generate_indices distinguishes a leaf from a merge stage.
+    // Collected up front because the build emits generics of its own; only the
+    // leaf d2m-grid-selection placed carries a plan.
     llvm::SmallVector<GenericOp> leaves;
-    getOperation().walk([&](TopkBlockOp op) {
-      GenericOp leaf = op->getParentOfType<GenericOp>();
-      if (op.getGenerateIndices() && leaf && leaf.getInputs().size() == 2 &&
-          leaf->getNumResults() == 2) {
-        leaves.push_back(leaf);
+    getOperation().walk([&](GenericOp generic) {
+      if (generic->hasAttr(utils::kTopKPlanAttr)) {
+        leaves.push_back(generic);
       }
     });
-    if (leaves.empty()) {
-      return;
-    }
 
-    auto workerGrid = llvm::to_vector(
-        ttcore::lookupDevice(getOperation()).getWorkerGrid().getShape());
-    auto chipDesc =
-        ttcore::getCurrentScopeSystemDesc(getOperation()).getChipDesc(0);
     IRRewriter rewriter(&getContext());
-
     for (GenericOp leaf : leaves) {
       auto topkBlock = *leaf->getRegion(0).getOps<TopkBlockOp>().begin();
-      int32_t k = topkBlock.getK();
-      int32_t dim = topkBlock.getDim();
-      // Taken from the leaf's own operand, since the strategy has to be known
-      // before deciding whether the chain around it matters.
-      auto inputLayout = mlir::cast<ttcore::MetalLayoutAttr>(
-          mlir::cast<RankedTensorType>(leaf.getInputs()[0].getType())
-              .getEncoding());
+      auto plan = leaf->getAttrOfType<TopKPlanAttr>(utils::kTopKPlanAttr);
 
-      std::string failureReason;
-      auto strategy = selectTopKShardingStrategy(
-          k, dim, inputLayout.getLogicalShape(), workerGrid,
-          topKL1Budget(leaf, chipDesc,
-                       BlockFactorAnalysis::Options{}.numBuffers),
-          failureReason);
-      if (failed(strategy)) {
-        // D2M has no fallback for a topk it cannot place.
-        topkBlock->emitOpError(failureReason);
-        return signalPassFailure();
-      }
-      // One core already holds the whole reduction, so ttir-to-d2m's output is
-      // final and the chain around it never has to be recovered.
-      if (!strategy->multiCore && !strategy->dataParallel) {
-        continue;
-      }
-
-      auto recovered = recoverSingleCoreTopK(leaf);
-      if (failed(recovered)) {
-        topkBlock->emitOpError(
-            "needs to be split across cores, but the layout and extract chain "
-            "around it is not the one ttir-to-d2m emits");
-        return signalPassFailure();
-      }
-      emitMultiCore(rewriter, *recovered, k, dim, *strategy);
+      emitPlannedTopK(rewriter, readSingleCoreTopK(leaf), topkBlock.getK(),
+                      topkBlock.getDim(), plan);
     }
   }
 };

--- a/lib/Dialect/D2M/Transforms/LowerTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerTopk.cpp
@@ -51,39 +51,6 @@ rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
       layout.getMemoryLayout());
 }
 
-/// True when `deviceShape` allocates more elements than `logicalShape` occupies
-/// along any dim, i.e. there is a padding tail that must be masked.
-bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
-                             ArrayRef<int64_t> logicalShape) {
-  TT_assert(deviceShape.size() == 2 * logicalShape.size());
-  const std::size_t physicalRank = logicalShape.size();
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-
-  for (std::size_t i = 0; i < physicalRank; ++i) {
-    int64_t allocatedElems =
-        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
-    if (allocatedElems > logicalShape[i]) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/// Emit a `local_copy` narrowing `input` to `output`'s leading tiles. The
-/// copy's iteration domain is the destination shape, so identity maps against a
-/// wider source read exactly the leading tiles -- no compute-side tile op is
-/// involved.
-Value emitLeadingTileSelect(OpBuilder &builder, Location loc, Value input,
-                            Value output) {
-  std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
-  AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
-  return builder
-      .create<LocalCopyOp>(
-          loc, input, output,
-          builder.getAffineMapArrayAttr({shardIdentity, shardIdentity}))
-      .getResult();
-}
-
 //===----------------------------------------------------------------------===//
 // Recovering TTIRToD2M's single-core lowering
 //===----------------------------------------------------------------------===//
@@ -212,7 +179,6 @@ void eraseDeadChain(RewriterBase &rewriter, ArrayRef<Operation *> roots) {
 /// the wide partials do not stay live on every core and overflow L1.
 Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
                           int64_t outputReductionTiles, int32_t dim) {
-  MLIRContext *ctx = rewriter.getContext();
   auto wideType = mlir::cast<RankedTensorType>(partial.getType());
   auto tileType = mlir::cast<ttcore::TileType>(wideType.getElementType());
   std::size_t rank = wideType.getShape().size() / 2;
@@ -225,22 +191,17 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
       rebuildLayoutForDeviceShape(
           mlir::cast<ttcore::MetalLayoutAttr>(wideType.getEncoding()),
           narrowShape));
-
-  AffineMap identityMap = rewriter.getMultiDimIdentityMap(rank);
-  llvm::SmallVector<Attribute> iterators(
-      rank, ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-  // A constant input map keeps the wide operand out of the generic's shard
-  // extent comparison, which the narrower output would fail.
+  auto narrowType = mlir::cast<RankedTensorType>(narrowEmpty.getType());
   auto generic = rewriter.create<GenericOp>(
-      loc, ValueRange{partial}, ValueRange{narrowEmpty.getResult()},
-      /*additionalArgs=*/ValueRange(),
-      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
-          AffineMap::get(rank, 0,
-                         llvm::SmallVector<AffineExpr>(
-                             rank, rewriter.getAffineConstantExpr(0)),
-                         ctx),
-          identityMap}),
-      rewriter.getArrayAttr(iterators));
+      loc, TypeRange{narrowType}, ValueRange{partial},
+      ValueRange{narrowEmpty.getResult()}, /*additionalArgs=*/ValueRange(),
+      rewriter.getAttr<ttcore::GridAttr>(
+          ArrayRef<int64_t>(narrowShape).take_front(rank)),
+      /*block_factors=*/rewriter.getI64ArrayAttr({}),
+      /*indexing_maps=*/rewriter.getArrayAttr({}),
+      /*iterator_types=*/rewriter.getArrayAttr({}),
+      rewriter.getArrayAttr(rewriter.getAttr<ThreadAttr>(ThreadType::Unified)),
+      /*fabricConnectionConfig=*/nullptr, /*numRegions=*/1);
 
   {
     OpBuilder::InsertionGuard guard(rewriter);
@@ -249,7 +210,6 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
       return RankedTensorType::get(deviceType.getShape().take_back(rank),
                                    tileType);
     };
-    auto narrowType = mlir::cast<RankedTensorType>(narrowEmpty.getType());
     llvm::SmallVector<Value> coreIndices;
     coreIndices.reserve(rank);
     for (std::size_t i = 0; i < rank; ++i) {
@@ -264,8 +224,13 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
                        .getResult();
     auto outBuf = rewriter.create<tensor::EmptyOp>(
         loc, shardType(narrowType).getShape(), tileType);
+    AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(rank);
     Value narrowed =
-        emitLeadingTileSelect(rewriter, loc, loaded, outBuf.getResult());
+        rewriter
+            .create<LocalCopyOp>(
+                loc, loaded, outBuf.getResult(),
+                rewriter.getAffineMapArrayAttr({shardIdentity, shardIdentity}))
+            .getResult();
     Value stored =
         rewriter
             .create<RemoteStoreOp>(loc, narrowType, narrowEmpty.getResult(),
@@ -273,11 +238,6 @@ Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
             .getResult();
     rewriter.create<YieldOp>(loc, ValueRange{stored});
   }
-  // Opt out of reblocking, whose broadcast inference would discard the region
-  // hand-built above.
-  generic.setBlockFactorsAttr(rewriter.getI64ArrayAttr({}));
-  generic.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr({}));
-  generic.setIteratorTypesAttr(rewriter.getArrayAttr({}));
   utils::markPinnedGrid(generic);
 
   return utils::materializeToLayout(rewriter, loc, generic->getResult(0));
@@ -293,30 +253,14 @@ std::pair<Value, Value> emitShardedLeaves(RewriterBase &rewriter, Location loc,
                                           ttcore::MemorySpace memSpace,
                                           int64_t gridCols, int64_t ntCores) {
   auto inputType = mlir::cast<RankedTensorType>(rawInput.getType());
-  llvm::SmallVector<int64_t> tileShape =
-      llvm::to_vector(ttcore::TileType::getDefaultShape());
-  auto tileType = ttcore::TileType::get(inputType.getElementType(), tileShape);
-
   llvm::SmallVector<int64_t> shardTiles(inputType.getRank(), 1);
   shardTiles[dim] = strategy.paddedReductionTiles;
   shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
-  auto layout = utils::buildShardedTileLayout(
-      rewriter.getContext(), inputType.getShape(), shardTiles, memSpace);
   llvm::SmallVector<int64_t> grid =
       (dim == 1) ? llvm::SmallVector<int64_t>{ntCores, gridCols}
                  : llvm::SmallVector<int64_t>{gridCols, ntCores};
-  llvm::SmallVector<int64_t> deviceShape =
-      layout.getDeviceShape(grid, tileShape);
-
-  auto empty = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
-  Value input = rewriter.create<ToLayoutOp>(loc, rawInput, empty).getResult(0);
-  if (deviceShapeNeedsPadding(deviceShape, inputType.getShape())) {
-    auto maskOut = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
-    input = rewriter
-                .create<MaskOp>(loc, input, maskOut, layout.getLogicalShape(),
-                                ttcore::OOBVal::NegInf)
-                .getResult();
-  }
+  Value input =
+      utils::layoutAndMask(rewriter, loc, rawInput, shardTiles, grid, memSpace);
 
   auto [vals, idx] = utils::emitLeafTopk(rewriter, loc, input, k, dim,
                                          inputType.getShape()[dim]);
@@ -503,14 +447,9 @@ void emitMultiCore(RewriterBase &rewriter, SingleCoreTopK recovered, int32_t k,
         mlir::cast<ttcore::TileType>(idxType.getElementType()).getShape());
     auto castEmpty = rewriter.create<EmptyOp>(
         loc, idxType.getShape(), castTileType, idxType.getEncoding());
-    std::size_t rank = idxType.getShape().size() / 2;
     newIdx = utils::emitUnaryGeneric(
         rewriter, loc, newIdx, castEmpty.getResult(),
-        rewriter.getMultiDimIdentityMap(rank),
-        llvm::SmallVector<Attribute>(
-            rank, ttcore::IteratorTypeAttr::get(
-                      rewriter.getContext(), ttcore::IteratorType::Parallel)),
-        /*shardMap=*/nullptr, [&](OpBuilder &b, Location l, ValueRange args) {
+        [&](OpBuilder &b, Location l, ValueRange args) {
           return b.create<TileTypecastOp>(l, args[1].getType(), args[0])
               .getResult();
         });
@@ -540,6 +479,9 @@ public:
         leaves.push_back(leaf);
       }
     });
+    if (leaves.empty()) {
+      return;
+    }
 
     auto workerGrid = llvm::to_vector(
         ttcore::lookupDevice(getOperation()).getWorkerGrid().getShape());

--- a/lib/Dialect/D2M/Transforms/LowerTopk.cpp
+++ b/lib/Dialect/D2M/Transforms/LowerTopk.cpp
@@ -1,0 +1,590 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/Analysis/BlockFactorAnalysis.h"
+#include "ttmlir/Dialect/D2M/Analysis/TopKShardingStrategy.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+#include "ttmlir/Dialect/D2M/Utils/Utils.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MLOWERTOPK
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+namespace {
+
+constexpr int64_t kTileWidth = ttcore::TileType::getDefaultShape()[1];
+
+//===----------------------------------------------------------------------===//
+// Layout and region helpers
+//===----------------------------------------------------------------------===//
+
+/// Rebuild `layout`'s logical shape from a [grid..., shard...] `deviceShape` of
+/// even rank, carrying every other layout field over unchanged.
+ttcore::MetalLayoutAttr
+rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
+                            ArrayRef<int64_t> deviceShape) {
+  TT_assert(deviceShape.size() % 2 == 0u);
+  const std::size_t physicalRank = deviceShape.size() / 2;
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  llvm::SmallVector<int64_t> logicalShape;
+  logicalShape.reserve(physicalRank);
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    logicalShape.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
+                           tileDim);
+  }
+  return ttcore::MetalLayoutAttr::get(
+      layout.getContext(), logicalShape, layout.getDimAlignments(),
+      layout.getCollapsedIntervals(), layout.getMemorySpace(),
+      layout.getMemoryLayout());
+}
+
+/// True when `deviceShape` allocates more elements than `logicalShape` occupies
+/// along any dim, i.e. there is a padding tail that must be masked.
+bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
+                             ArrayRef<int64_t> logicalShape) {
+  TT_assert(deviceShape.size() == 2 * logicalShape.size());
+  const std::size_t physicalRank = logicalShape.size();
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    int64_t allocatedElems =
+        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
+    if (allocatedElems > logicalShape[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Emit a `local_copy` narrowing `input` to `output`'s leading tiles. The
+/// copy's iteration domain is the destination shape, so identity maps against a
+/// wider source read exactly the leading tiles -- no compute-side tile op is
+/// involved.
+Value emitLeadingTileSelect(OpBuilder &builder, Location loc, Value input,
+                            Value output) {
+  std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
+  AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
+  return builder
+      .create<LocalCopyOp>(
+          loc, input, output,
+          builder.getAffineMapArrayAttr({shardIdentity, shardIdentity}))
+      .getResult();
+}
+
+//===----------------------------------------------------------------------===//
+// Recovering TTIRToD2M's single-core lowering
+//===----------------------------------------------------------------------===//
+
+/// The pieces this pass replaces, all reachable from the leaf `topk_block`.
+struct SingleCoreTopK {
+  GenericOp leaf;
+  /// Pre-layout input, so the pass shards it rather than re-sharding a layout.
+  Value logicalInput;
+  GenericOp extractValues;
+  GenericOp extractIndices;
+  /// Follows the index extract when `dim != 0`, else null.
+  GenericOp indexCast;
+};
+
+/// Walks back from the leaf's input through the `to_layout`s that materialize
+/// buffers, the padding-tail `mask`, and the tile-transpose generic dim=1 adds.
+Value findLogicalInput(Value value) {
+  auto isDevice = [](Value v) {
+    auto type = mlir::dyn_cast<RankedTensorType>(v.getType());
+    return type &&
+           mlir::isa_and_nonnull<ttcore::MetalLayoutAttr>(type.getEncoding());
+  };
+  while (isDevice(value)) {
+    Operation *def = value.getDefiningOp();
+    if (auto toLayout = mlir::dyn_cast_if_present<ToLayoutOp>(def)) {
+      value = toLayout.getInput();
+    } else if (auto mask = mlir::dyn_cast_if_present<MaskOp>(def)) {
+      value = mask.getInput();
+    } else if (auto generic = mlir::dyn_cast_if_present<GenericOp>(def);
+               generic && generic.getInputs().size() == 1) {
+      value = generic.getInputs()[0];
+    } else {
+      return nullptr;
+    }
+  }
+  return value;
+}
+
+/// The single generic consuming `value`, looking through the `to_layout` that
+/// materializes it. Null when the use pattern is not the one TTIRToD2M emits.
+GenericOp findConsumingGeneric(Value value) {
+  for (int hop = 0; hop < 2; ++hop) {
+    Operation *consumer = nullptr;
+    for (Operation *user : value.getUsers()) {
+      // A generic reads its operands back through `remote_load`, so each
+      // operand has a nested use as well as a direct one, both naming that
+      // generic.
+      if (GenericOp owner = user->getParentOfType<GenericOp>()) {
+        user = owner;
+      }
+      if (consumer && consumer != user) {
+        return nullptr;
+      }
+      consumer = user;
+    }
+    if (auto generic = mlir::dyn_cast_if_present<GenericOp>(consumer)) {
+      return generic;
+    }
+    // to_layout is DPS: a use as its output does not continue the chain.
+    auto toLayout = mlir::dyn_cast_if_present<ToLayoutOp>(consumer);
+    if (!toLayout || toLayout.getInput() != value) {
+      return nullptr;
+    }
+    value = toLayout.getResult(0);
+  }
+  return nullptr;
+}
+
+mlir::FailureOr<SingleCoreTopK> recoverSingleCoreTopK(GenericOp leaf) {
+  SingleCoreTopK recovered;
+  recovered.leaf = leaf;
+  recovered.logicalInput = findLogicalInput(leaf.getInputs()[0]);
+  recovered.extractValues = findConsumingGeneric(leaf->getResult(0));
+  recovered.extractIndices = findConsumingGeneric(leaf->getResult(1));
+  if (!recovered.logicalInput || !recovered.extractValues ||
+      !recovered.extractIndices) {
+    return mlir::failure();
+  }
+
+  // dim != 0 casts the extracted indices to the user's index type in a region
+  // of its own; dim == 0 folds that cast into the extract itself.
+  GenericOp next = findConsumingGeneric(recovered.extractIndices->getResult(0));
+  bool isCast =
+      next && next != recovered.extractIndices &&
+      next->walk([](TileTypecastOp) { return WalkResult::interrupt(); })
+          .wasInterrupted();
+  recovered.indexCast = isCast ? next : GenericOp();
+  return recovered;
+}
+
+/// The logical tensor type a device-layout value stands for.
+RankedTensorType getLogicalType(Value deviceValue) {
+  auto type = mlir::cast<RankedTensorType>(deviceValue.getType());
+  auto layout = mlir::cast<ttcore::MetalLayoutAttr>(type.getEncoding());
+  return RankedTensorType::get(
+      layout.getLogicalShape(),
+      mlir::cast<ttcore::TileType>(type.getElementType()).getElementType());
+}
+
+/// Erases `roots` and everything upstream they were the last user of. The chain
+/// being replaced is straight-line, so this bottoms out at the logical input.
+void eraseDeadChain(RewriterBase &rewriter, ArrayRef<Operation *> roots) {
+  llvm::SmallVector<Operation *> worklist(roots);
+  llvm::SmallPtrSet<Operation *, 16> erased;
+  while (!worklist.empty()) {
+    Operation *op = worklist.pop_back_val();
+    if (erased.contains(op) || !op->use_empty()) {
+      continue;
+    }
+    for (Value operand : op->getOperands()) {
+      if (Operation *def = operand.getDefiningOp()) {
+        worklist.push_back(def);
+      }
+    }
+    erased.insert(op);
+    rewriter.eraseOp(op);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Multi-core emission
+//===----------------------------------------------------------------------===//
+
+/// Narrows every core's shard down to its leading `outputReductionTiles`, so
+/// the wide partials do not stay live on every core and overflow L1.
+Value compactReductionDim(RewriterBase &rewriter, Location loc, Value partial,
+                          int64_t outputReductionTiles, int32_t dim) {
+  MLIRContext *ctx = rewriter.getContext();
+  auto wideType = mlir::cast<RankedTensorType>(partial.getType());
+  auto tileType = mlir::cast<ttcore::TileType>(wideType.getElementType());
+  std::size_t rank = wideType.getShape().size() / 2;
+  TopKGeometry geometry = getTopKGeometry(dim, rank);
+
+  llvm::SmallVector<int64_t> narrowShape(wideType.getShape());
+  narrowShape[geometry.deviceRedDim] = outputReductionTiles;
+  auto narrowEmpty = rewriter.create<EmptyOp>(
+      loc, narrowShape, tileType,
+      rebuildLayoutForDeviceShape(
+          mlir::cast<ttcore::MetalLayoutAttr>(wideType.getEncoding()),
+          narrowShape));
+
+  AffineMap identityMap = rewriter.getMultiDimIdentityMap(rank);
+  llvm::SmallVector<Attribute> iterators(
+      rank, ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+  // A constant input map keeps the wide operand out of the generic's shard
+  // extent comparison, which the narrower output would fail.
+  auto generic = rewriter.create<GenericOp>(
+      loc, ValueRange{partial}, ValueRange{narrowEmpty.getResult()},
+      /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
+          AffineMap::get(rank, 0,
+                         llvm::SmallVector<AffineExpr>(
+                             rank, rewriter.getAffineConstantExpr(0)),
+                         ctx),
+          identityMap}),
+      rewriter.getArrayAttr(iterators));
+
+  {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.createBlock(&generic->getRegion(0));
+    auto shardType = [&](RankedTensorType deviceType) {
+      return RankedTensorType::get(deviceType.getShape().take_back(rank),
+                                   tileType);
+    };
+    auto narrowType = mlir::cast<RankedTensorType>(narrowEmpty.getType());
+    llvm::SmallVector<Value> coreIndices;
+    coreIndices.reserve(rank);
+    for (std::size_t i = 0; i < rank; ++i) {
+      coreIndices.push_back(
+          rewriter.create<CoreIndexOp>(loc, static_cast<int64_t>(i)));
+    }
+    auto loadBuf = rewriter.create<tensor::EmptyOp>(
+        loc, shardType(wideType).getShape(), tileType);
+    Value loaded = rewriter
+                       .create<RemoteLoadOp>(loc, shardType(wideType), loadBuf,
+                                             partial, coreIndices)
+                       .getResult();
+    auto outBuf = rewriter.create<tensor::EmptyOp>(
+        loc, shardType(narrowType).getShape(), tileType);
+    Value narrowed =
+        emitLeadingTileSelect(rewriter, loc, loaded, outBuf.getResult());
+    Value stored =
+        rewriter
+            .create<RemoteStoreOp>(loc, narrowType, narrowEmpty.getResult(),
+                                   coreIndices, narrowed)
+            .getResult();
+    rewriter.create<YieldOp>(loc, ValueRange{stored});
+  }
+  // Opt out of reblocking, whose broadcast inference would discard the region
+  // hand-built above.
+  generic.setBlockFactorsAttr(rewriter.getI64ArrayAttr({}));
+  generic.setIndexingMapsAttr(rewriter.getAffineMapArrayAttr({}));
+  generic.setIteratorTypesAttr(rewriter.getArrayAttr({}));
+  utils::markPinnedGrid(generic);
+
+  return utils::materializeToLayout(rewriter, loc, generic->getResult(0));
+}
+
+/// Lays `rawInput` out banded `gridCols` ways along the reduction dim and/or
+/// sliced `ntCores` ways along the non-target dim, then runs one leaf topk per
+/// core. Buffers carry logical grids only; GridSelection folds them onto cores.
+std::pair<Value, Value> emitShardedLeaves(RewriterBase &rewriter, Location loc,
+                                          Value rawInput, int32_t k,
+                                          int32_t dim,
+                                          const TopKShardingStrategy &strategy,
+                                          ttcore::MemorySpace memSpace,
+                                          int64_t gridCols, int64_t ntCores) {
+  auto inputType = mlir::cast<RankedTensorType>(rawInput.getType());
+  llvm::SmallVector<int64_t> tileShape =
+      llvm::to_vector(ttcore::TileType::getDefaultShape());
+  auto tileType = ttcore::TileType::get(inputType.getElementType(), tileShape);
+
+  llvm::SmallVector<int64_t> shardTiles(inputType.getRank(), 1);
+  shardTiles[dim] = strategy.paddedReductionTiles;
+  shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
+  auto layout = utils::buildShardedTileLayout(
+      rewriter.getContext(), inputType.getShape(), shardTiles, memSpace);
+  llvm::SmallVector<int64_t> grid =
+      (dim == 1) ? llvm::SmallVector<int64_t>{ntCores, gridCols}
+                 : llvm::SmallVector<int64_t>{gridCols, ntCores};
+  llvm::SmallVector<int64_t> deviceShape =
+      layout.getDeviceShape(grid, tileShape);
+
+  auto empty = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
+  Value input = rewriter.create<ToLayoutOp>(loc, rawInput, empty).getResult(0);
+  if (deviceShapeNeedsPadding(deviceShape, inputType.getShape())) {
+    auto maskOut = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
+    input = rewriter
+                .create<MaskOp>(loc, input, maskOut, layout.getLogicalShape(),
+                                ttcore::OOBVal::NegInf)
+                .getResult();
+  }
+
+  auto [vals, idx] = utils::emitLeafTopk(rewriter, loc, input, k, dim,
+                                         inputType.getShape()[dim]);
+  if (gridCols == 1) {
+    return {utils::materializeToLayout(rewriter, loc, vals),
+            utils::materializeToLayout(rewriter, loc, idx)};
+  }
+  return {compactReductionDim(rewriter, loc, vals,
+                              strategy.outputReductionTiles, dim),
+          compactReductionDim(rewriter, loc, idx, strategy.outputReductionTiles,
+                              dim)};
+}
+
+/// Collapses `bands` partials, one per core, down to `numGroups`: core g merges
+/// the groupTiles bands starting at g * groupTiles, gathered by a composite
+/// view that D2MExpandDMAReadCompositeView resolves per tile into a DMA read.
+std::pair<Value, Value> emitMergeRound(RewriterBase &rewriter, Location loc,
+                                       Value valsIn, Value idxIn, int32_t k,
+                                       int32_t dim,
+                                       int64_t outputReductionTiles,
+                                       int64_t bands, int64_t numGroups) {
+  MLIRContext *ctx = rewriter.getContext();
+  int64_t groupTiles = bands / numGroups;
+  TT_assertv(groupTiles * numGroups == bands,
+             "merge round must divide the band count evenly");
+
+  auto valsInType = mlir::cast<RankedTensorType>(valsIn.getType());
+  std::size_t rank = valsInType.getShape().size() / 2;
+  TopKGeometry geometry = getTopKGeometry(dim, rank);
+  AffineMap identityMap = rewriter.getMultiDimIdentityMap(rank);
+  llvm::SmallVector<Attribute> iterators(
+      rank, ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+  // The input's extent re-split: numGroups cores each holding groupTiles bands'
+  // worth of reduction tiles, so the grid x shard product is preserved.
+  llvm::SmallVector<int64_t> wideShape(valsInType.getShape());
+  wideShape[geometry.deviceGridDim] = numGroups;
+  wideShape[geometry.deviceRedDim] = groupTiles * outputReductionTiles;
+  auto wideTypeOf = [&](Value in) {
+    auto inType = mlir::cast<RankedTensorType>(in.getType());
+    return RankedTensorType::get(
+        wideShape, inType.getElementType(),
+        rebuildLayoutForDeviceShape(
+            mlir::cast<ttcore::MetalLayoutAttr>(inType.getEncoding()),
+            wideShape));
+  };
+
+  // Separate generics: the DMA-expansion pass supports only one composite view
+  // per GenericOp (#7600).
+  auto gather = [&](Value in) -> Value {
+    RankedTensorType wideType = wideTypeOf(in);
+    auto composite = rewriter.create<CompositeViewOp>(
+        loc, wideType, ValueRange{in}, dim, /*logicalSizes=*/nullptr);
+    auto out = rewriter.create<EmptyOp>(
+        loc, wideShape, wideType.getElementType(), wideType.getEncoding());
+    llvm::SmallVector<Value> ins = {composite.getResult()};
+    llvm::SmallVector<Value> outs = {out.getResult()};
+    auto generic = rewriter.create<GenericOp>(
+        loc, ins, outs, /*additionalArgs=*/ValueRange(),
+        rewriter.getAffineMapArrayAttr(
+            llvm::SmallVector<AffineMap>{identityMap, identityMap}),
+        rewriter.getArrayAttr(iterators));
+    utils::buildParallelGenericRegion(
+        rewriter, loc, generic, ins, outs,
+        [](ArrayRef<Value> args) -> llvm::SmallVector<Value> {
+          return {args[0]};
+        });
+    utils::markPinnedGrid(generic);
+    return utils::materializeToLayout(rewriter, loc, generic->getResult(0));
+  };
+
+  llvm::SmallVector<Value> ins = {gather(valsIn), gather(idxIn)};
+  llvm::SmallVector<Value> outs = {
+      rewriter
+          .create<EmptyOp>(loc, wideShape, valsInType.getElementType(),
+                           wideTypeOf(valsIn).getEncoding())
+          .getResult(),
+      rewriter
+          .create<EmptyOp>(
+              loc, wideShape,
+              mlir::cast<RankedTensorType>(idxIn.getType()).getElementType(),
+              wideTypeOf(idxIn).getEncoding())
+          .getResult()};
+  auto merge = rewriter.create<GenericOp>(
+      loc, ins, outs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
+          identityMap, identityMap, identityMap, identityMap}),
+      rewriter.getArrayAttr(iterators));
+  utils::buildParallelGenericRegion(
+      rewriter, loc, merge, ins, outs,
+      [&](ArrayRef<Value> args) -> llvm::SmallVector<Value> {
+        // No generate_indices: these indices are an earlier stage's results and
+        // cannot be recomputed from a coordinate.
+        auto block = rewriter.create<TopkBlockOp>(
+            loc, args[0], args[1], args[2], args[3], k,
+            /*numElements=*/groupTiles * outputReductionTiles * kTileWidth,
+            /*stableSort=*/false, dim);
+        return {block.getResultValues(), block.getResultIndices()};
+      });
+  utils::markPinnedGrid(merge);
+
+  return {compactReductionDim(
+              rewriter, loc,
+              utils::materializeToLayout(rewriter, loc, merge->getResult(0)),
+              outputReductionTiles, dim),
+          compactReductionDim(
+              rewriter, loc,
+              utils::materializeToLayout(rewriter, loc, merge->getResult(1)),
+              outputReductionTiles, dim)};
+}
+
+/// Rebuilds the recovered single-core topk across the grid. `recovered` comes
+/// by value because MLIR op accessors are non-const.
+void emitMultiCore(RewriterBase &rewriter, SingleCoreTopK recovered, int32_t k,
+                   int32_t dim, const TopKShardingStrategy &strategy) {
+  Location loc = recovered.leaf->getLoc();
+  TopKGeometry geometry = getTopKGeometry(
+      dim,
+      mlir::cast<RankedTensorType>(recovered.logicalInput.getType()).getRank());
+
+  // Everything the rebuild reads -- the logical input and both extract
+  // destinations -- is defined by the values extract.
+  rewriter.setInsertionPoint(recovered.extractValues);
+
+  auto inputLayout = mlir::cast<ttcore::MetalLayoutAttr>(
+      mlir::cast<RankedTensorType>(recovered.leaf.getInputs()[0].getType())
+          .getEncoding());
+  // Non-target slices exchange no data, so a 2D split runs the band-and-merge
+  // pipeline once per slice row.
+  std::pair<Value, Value> level = emitShardedLeaves(
+      rewriter, loc, recovered.logicalInput, k, dim, strategy,
+      inputLayout.getMemorySpace(),
+      /*gridCols=*/strategy.multiCore ? strategy.numShards : 1,
+      /*ntCores=*/strategy.ntShards);
+
+  int64_t bands = strategy.multiCore ? strategy.numShards : 1;
+  for (int64_t numGroups : strategy.mergeSchedule) {
+    level = emitMergeRound(rewriter, loc, level.first, level.second, k, dim,
+                           strategy.outputReductionTiles, bands, numGroups);
+    bands = numGroups;
+  }
+
+  // A data-parallel split must keep each extract's destination on the same
+  // cores as its source; otherwise the conversion's destination still fits.
+  auto rebuildExtract = [&](GenericOp oldExtract, Value newInput) -> Value {
+    Value output = oldExtract.getOutputs()[0];
+    if (strategy.dataParallel) {
+      RankedTensorType logicalType = getLogicalType(output);
+      llvm::SmallVector<int64_t> tileShape =
+          llvm::to_vector(ttcore::TileType::getDefaultShape());
+      llvm::SmallVector<int64_t> shardTiles(logicalType.getRank(), 1);
+      shardTiles[1 - dim] = strategy.paddedNonTargetTiles;
+      auto layout = utils::buildShardedTileLayout(
+          rewriter.getContext(), logicalType.getShape(), shardTiles,
+          mlir::cast<ttcore::MetalLayoutAttr>(
+              mlir::cast<RankedTensorType>(output.getType()).getEncoding())
+              .getMemorySpace());
+      llvm::SmallVector<int64_t> grid =
+          (dim == 1) ? llvm::SmallVector<int64_t>{strategy.ntShards, 1}
+                     : llvm::SmallVector<int64_t>{1, strategy.ntShards};
+      output =
+          rewriter
+              .create<EmptyOp>(loc, layout.getDeviceShape(grid, tileShape),
+                               ttcore::TileType::get(
+                                   logicalType.getElementType(), tileShape),
+                               layout)
+              .getResult();
+    }
+    return utils::emitTopKExtract(rewriter, loc, newInput, output,
+                                  geometry.extractProjectDim,
+                                  strategy.outputReductionTiles, dim)
+        ->getResult(0);
+  };
+
+  Value newVals = rebuildExtract(recovered.extractValues, level.first);
+  Value newIdx = rebuildExtract(recovered.extractIndices, level.second);
+
+  GenericOp lastIdxOp = recovered.extractIndices;
+  if (recovered.indexCast) {
+    // Elementwise, so it follows its input's layout.
+    auto idxType = mlir::cast<RankedTensorType>(newIdx.getType());
+    auto castTileType = ttcore::TileType::get(
+        getLogicalType(recovered.indexCast->getResult(0)).getElementType(),
+        mlir::cast<ttcore::TileType>(idxType.getElementType()).getShape());
+    auto castEmpty = rewriter.create<EmptyOp>(
+        loc, idxType.getShape(), castTileType, idxType.getEncoding());
+    std::size_t rank = idxType.getShape().size() / 2;
+    newIdx = utils::emitUnaryGeneric(
+        rewriter, loc, newIdx, castEmpty.getResult(),
+        rewriter.getMultiDimIdentityMap(rank),
+        llvm::SmallVector<Attribute>(
+            rank, ttcore::IteratorTypeAttr::get(
+                      rewriter.getContext(), ttcore::IteratorType::Parallel)),
+        /*shardMap=*/nullptr, [&](OpBuilder &b, Location l, ValueRange args) {
+          return b.create<TileTypecastOp>(l, args[1].getType(), args[0])
+              .getResult();
+        });
+    utils::markPinnedGrid(newIdx.getDefiningOp());
+    lastIdxOp = recovered.indexCast;
+  }
+
+  rewriter.replaceAllUsesWith(recovered.extractValues->getResult(0), newVals);
+  rewriter.replaceAllUsesWith(lastIdxOp->getResult(0), newIdx);
+  eraseDeadChain(rewriter, {recovered.extractValues.getOperation(),
+                            lastIdxOp.getOperation(),
+                            recovered.extractIndices.getOperation()});
+}
+
+class D2MLowerTopk final : public impl::D2MLowerTopkBase<D2MLowerTopk> {
+public:
+  using impl::D2MLowerTopkBase<D2MLowerTopk>::D2MLowerTopkBase;
+
+  void runOnOperation() override {
+    // Collected up front: the rebuild emits already-sharded leaf topk_blocks of
+    // its own. generate_indices distinguishes a leaf from a merge stage.
+    llvm::SmallVector<GenericOp> leaves;
+    getOperation().walk([&](TopkBlockOp op) {
+      GenericOp leaf = op->getParentOfType<GenericOp>();
+      if (op.getGenerateIndices() && leaf && leaf.getInputs().size() == 2 &&
+          leaf->getNumResults() == 2) {
+        leaves.push_back(leaf);
+      }
+    });
+
+    auto workerGrid = llvm::to_vector(
+        ttcore::lookupDevice(getOperation()).getWorkerGrid().getShape());
+    auto chipDesc =
+        ttcore::getCurrentScopeSystemDesc(getOperation()).getChipDesc(0);
+    IRRewriter rewriter(&getContext());
+
+    for (GenericOp leaf : leaves) {
+      auto topkBlock = *leaf->getRegion(0).getOps<TopkBlockOp>().begin();
+      int32_t k = topkBlock.getK();
+      int32_t dim = topkBlock.getDim();
+      // Taken from the leaf's own operand, since the strategy has to be known
+      // before deciding whether the chain around it matters.
+      auto inputLayout = mlir::cast<ttcore::MetalLayoutAttr>(
+          mlir::cast<RankedTensorType>(leaf.getInputs()[0].getType())
+              .getEncoding());
+
+      std::string failureReason;
+      auto strategy = selectTopKShardingStrategy(
+          k, dim, inputLayout.getLogicalShape(), workerGrid,
+          topKL1Budget(leaf, chipDesc,
+                       BlockFactorAnalysis::Options{}.numBuffers),
+          failureReason);
+      if (failed(strategy)) {
+        // D2M has no fallback for a topk it cannot place.
+        topkBlock->emitOpError(failureReason);
+        return signalPassFailure();
+      }
+      // One core already holds the whole reduction, so ttir-to-d2m's output is
+      // final and the chain around it never has to be recovered.
+      if (!strategy->multiCore && !strategy->dataParallel) {
+        continue;
+      }
+
+      auto recovered = recoverSingleCoreTopK(leaf);
+      if (failed(recovered)) {
+        topkBlock->emitOpError(
+            "needs to be split across cores, but the layout and extract chain "
+            "around it is not the one ttir-to-d2m emits");
+        return signalPassFailure();
+      }
+      emitMultiCore(rewriter, *recovered, k, dim, *strategy);
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Utils/CMakeLists.txt
+++ b/lib/Dialect/D2M/Utils/CMakeLists.txt
@@ -17,4 +17,5 @@ add_mlir_library(MLIRD2MUtils
   MLIRIR
   MLIRAffineDialect
   MLIRAffineUtils
+  MLIRLinalgDialect
 )

--- a/lib/Dialect/D2M/Utils/CMakeLists.txt
+++ b/lib/Dialect/D2M/Utils/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(MLIRD2MUtils
   DstRegisterAnalysis.cpp
   GridSelectionUtils.cpp
   SpatialOpNormalizeUtil.cpp
+  TopKUtils.cpp
   Utils.cpp
   AffineMapAnalysis.cpp
   VirtualGrid.cpp

--- a/lib/Dialect/D2M/Utils/TopKUtils.cpp
+++ b/lib/Dialect/D2M/Utils/TopKUtils.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Utils/TopKUtils.h"
+#include "ttmlir/Asserts.h"
+#include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/AffineExpr.h"
+
+#include <cstdint>
+
+namespace mlir::tt::d2m::utils {
+
+std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
+                                     Value layoutedInput, int32_t k,
+                                     int32_t dim, int64_t reductionDimSize,
+                                     const LeafTopKBuffers &buffers) {
+  MLIRContext *ctx = rewriter.getContext();
+  auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
+  auto metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
+  auto valTileType = cast<ttcore::TileType>(layoutedType.getElementType());
+  ArrayRef<int64_t> deviceShape = layoutedType.getShape();
+  std::size_t physicalRank = deviceShape.size() / 2;
+
+  auto parallel =
+      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
+  llvm::SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+  AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+
+  // TopkBlockOp sorts down tile columns; dim=1 puts the sort dim on tile rows.
+  Value topkInput = layoutedInput;
+  if (buffers.transpose.isPlaced()) {
+    Value transposed = emitUnaryGeneric(
+        rewriter, loc, layoutedInput,
+        rewriter
+            .create<EmptyOp>(loc, buffers.transpose.type,
+                             buffers.transpose.vgmInverse,
+                             buffers.transpose.vgmForward)
+            .getResult(),
+        [&](OpBuilder &b, Location l, ValueRange args) {
+          return b.create<TileTransposeOp>(l, args[1].getType(), args[0])
+              .getResult();
+        },
+        buffers.transpose.grid);
+    topkInput =
+        materializeToLayout(rewriter, loc, transposed, buffers.transpose);
+  }
+
+  auto idxTileType = ttcore::TileType::get(rewriter.getI32Type());
+
+  // One scratch tile per core for the lane pattern; the kernel derives the
+  // whole index buffer from it plus its own grid coordinate.
+  Value idxScratchEmpty;
+  if (buffers.scratch.isPlaced()) {
+    idxScratchEmpty = rewriter
+                          .create<EmptyOp>(loc, buffers.scratch.type,
+                                           buffers.scratch.vgmInverse,
+                                           buffers.scratch.vgmForward)
+                          .getResult();
+  } else {
+    ArrayRef<int64_t> idxGridShape = metalLayout.getGridShape(layoutedType);
+    llvm::SmallVector<int64_t> idxScratchShape(idxGridShape.begin(),
+                                               idxGridShape.end());
+    idxScratchShape.append({1, 1});
+    auto idxScratchLayout = ttcore::MetalLayoutAttr::get(
+        ctx, llvm::SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
+        ttcore::TensorMemoryLayout::Sharded);
+    idxScratchEmpty = rewriter
+                          .create<EmptyOp>(loc, idxScratchShape, idxTileType,
+                                           idxScratchLayout)
+                          .getResult();
+  }
+
+  Value topkValsEmpty =
+      buffers.values.isPlaced()
+          ? rewriter
+                .create<EmptyOp>(loc, buffers.values.type,
+                                 buffers.values.vgmInverse,
+                                 buffers.values.vgmForward)
+                .getResult()
+          : rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout)
+                .getResult();
+  Value topkIdxEmpty =
+      buffers.indices.isPlaced()
+          ? rewriter
+                .create<EmptyOp>(loc, buffers.indices.type,
+                                 buffers.indices.vgmInverse,
+                                 buffers.indices.vgmForward)
+                .getResult()
+          : rewriter.create<EmptyOp>(loc, deviceShape, idxTileType, metalLayout)
+                .getResult();
+
+  llvm::SmallVector<Value> topkInputs = {topkInput, idxScratchEmpty};
+  llvm::SmallVector<Value> topkOutputs = {topkValsEmpty, topkIdxEmpty};
+  // A constant map keeps the 1x1 scratch shard out of the generic's
+  // shard-extent comparison against the full-shard operands.
+  llvm::SmallVector<AffineExpr> idxConstExprs(
+      physicalRank, rewriter.getAffineConstantExpr(0));
+  AffineMap idxConstMap = AffineMap::get(physicalRank, 0, idxConstExprs, ctx);
+  auto topkGeneric = rewriter.create<GenericOp>(
+      loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
+          identityMap, idxConstMap, identityMap, identityMap}),
+      rewriter.getArrayAttr(iteratorTypes), ThreadType::Unified,
+      buffers.values.isPlaced() ? buffers.values.grid : nullptr);
+
+  buildParallelGenericRegion(
+      rewriter, loc, topkGeneric, topkInputs, topkOutputs,
+      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
+        auto topkBlock = rewriter.create<TopkBlockOp>(
+            loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
+            reductionDimSize, /*stableSort=*/false, dim,
+            /*generateIndices=*/true);
+        return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
+      });
+
+  return {topkGeneric->getResult(0), topkGeneric->getResult(1)};
+}
+
+} // namespace mlir::tt::d2m::utils

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -18,6 +18,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/AffineExpr.h"
 
 #include <cassert>
@@ -146,25 +148,6 @@ ShapedType reblockShapedType(ShapedType oldType,
 }
 
 ttcore::MetalLayoutAttr
-rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
-                            ArrayRef<int64_t> deviceShape) {
-  TT_assert(deviceShape.size() % 2 == 0u);
-  const std::size_t physicalRank = deviceShape.size() / 2;
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-
-  SmallVector<int64_t> logicalShape;
-  logicalShape.reserve(physicalRank);
-  for (std::size_t i = 0; i < physicalRank; ++i) {
-    logicalShape.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
-                           tileDim);
-  }
-  return ttcore::MetalLayoutAttr::get(
-      layout.getContext(), logicalShape, layout.getDimAlignments(),
-      layout.getCollapsedIntervals(), layout.getMemorySpace(),
-      layout.getMemoryLayout());
-}
-
-ttcore::MetalLayoutAttr
 buildShardedTileLayout(MLIRContext *ctx, ArrayRef<int64_t> logicalShape,
                        ArrayRef<int64_t> tilesPerDim,
                        ttcore::MemorySpace memorySpace) {
@@ -181,22 +164,6 @@ buildShardedTileLayout(MLIRContext *ctx, ArrayRef<int64_t> logicalShape,
       ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
           ctx, logicalShape.size()),
       dimAlignments);
-}
-
-bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
-                             ArrayRef<int64_t> logicalShape) {
-  TT_assert(deviceShape.size() == 2 * logicalShape.size());
-  const std::size_t physicalRank = logicalShape.size();
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-
-  for (std::size_t i = 0; i < physicalRank; ++i) {
-    int64_t allocatedElems =
-        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
-    if (allocatedElems > logicalShape[i]) {
-      return true;
-    }
-  }
-  return false;
 }
 
 Type cloneWithShardShape(Value referenceOperand, Type typeToRetype) {
@@ -302,48 +269,6 @@ SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
 
   TT_assert(indices.size() == indexingMap.getNumResults());
   return indices;
-}
-
-SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
-                                    std::size_t gridRank) {
-  SmallVector<Value> indices;
-  indices.reserve(gridRank);
-  for (std::size_t i = 0; i < gridRank; ++i) {
-    indices.push_back(
-        builder.create<CoreIndexOp>(loc, static_cast<int64_t>(i)));
-  }
-  return indices;
-}
-
-void makeExplicitDatamovementForm(OpBuilder &builder, GenericOp generic) {
-  generic.setBlockFactorsAttr(builder.getI64ArrayAttr({}));
-  generic.setIndexingMapsAttr(builder.getAffineMapArrayAttr({}));
-  generic.setIteratorTypesAttr(builder.getArrayAttr({}));
-}
-
-linalg::GenericOp emitLeadingTileCopy(OpBuilder &builder, Location loc,
-                                      Value input, Value output,
-                                      std::optional<std::size_t> shardRedDim) {
-  MLIRContext *ctx = builder.getContext();
-  auto inShardType = cast<RankedTensorType>(input.getType());
-  std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
-  SmallVector<AffineExpr> inExprs;
-  for (std::size_t i = 0; i < shardRank; ++i) {
-    AffineExpr idx = builder.getAffineDimExpr(i);
-    inExprs.push_back(i == shardRedDim ? idx % inShardType.getShape()[i] : idx);
-  }
-  AffineMap shardInMap = AffineMap::get(shardRank, 0, inExprs, ctx);
-  AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
-  SmallVector<mlir::utils::IteratorType> linalgIters(
-      shardRank, mlir::utils::IteratorType::parallel);
-  return builder.create<linalg::GenericOp>(
-      loc, output.getType(), input, output,
-      SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
-      [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-        Value copied =
-            b.create<TileTypecastOp>(bodyLoc, args[1].getType(), args[0]);
-        b.create<linalg::YieldOp>(bodyLoc, copied);
-      });
 }
 
 static llvm::SmallVector<int64_t>
@@ -1111,6 +1036,267 @@ getNocElementAlignment(Operation *op, ttcore::MemorySpace memorySpace,
 int32_t getNocElementAlignmentL1(
     Operation *op, const std::variant<RankedTensorType, MemRefType> &type) {
   return getNocElementAlignment(op, ttcore::MemorySpace::DeviceL1, type);
+}
+
+void buildParallelGenericRegion(
+    RewriterBase &rewriter, Location loc, GenericOp generic, ValueRange inputs,
+    ValueRange outputs,
+    llvm::function_ref<llvm::SmallVector<Value>(ArrayRef<Value>)> body) {
+  auto shardTypeOf = [](Value operand) {
+    auto tensorType = cast<RankedTensorType>(operand.getType());
+    auto layout = cast<ttcore::MetalLayoutAttr>(tensorType.getEncoding());
+    return RankedTensorType::get(layout.getShardShape(tensorType),
+                                 tensorType.getElementType());
+  };
+  auto localBuffer = [&](RankedTensorType shardType) {
+    return rewriter
+        .create<tensor::EmptyOp>(loc, shardType.getShape(),
+                                 shardType.getElementType())
+        .getResult();
+  };
+
+  auto insertPoint = rewriter.saveInsertionPoint();
+  rewriter.startOpModification(generic);
+  {
+    rewriter.createBlock(&generic->getRegions().front());
+
+    llvm::SmallVector<Value> blockArgs;
+    for (auto [i, input] : llvm::enumerate(inputs)) {
+      RankedTensorType shardType = shardTypeOf(input);
+      blockArgs.push_back(
+          rewriter
+              .create<RemoteLoadOp>(
+                  loc, shardType, localBuffer(shardType),
+                  generic->getOperand(i),
+                  buildGridIndices(rewriter, loc, generic.getIndexingMap(i)))
+              .getResult());
+    }
+    for (Value output : outputs) {
+      blockArgs.push_back(localBuffer(shardTypeOf(output)));
+    }
+
+    llvm::SmallVector<Value> computedResults = body(blockArgs);
+    assert(computedResults.size() == outputs.size());
+
+    llvm::SmallVector<Value> storeResults;
+    for (auto [outputIdx, result] : llvm::enumerate(computedResults)) {
+      size_t operandIdx = inputs.size() + outputIdx;
+      Value genericOperand = generic->getOperand(operandIdx);
+      storeResults.push_back(
+          rewriter
+              .create<RemoteStoreOp>(
+                  loc, genericOperand.getType(), genericOperand,
+                  buildGridIndices(rewriter, loc,
+                                   generic.getIndexingMap(operandIdx)),
+                  result)
+              .getResult());
+    }
+    rewriter.create<YieldOp>(loc, storeResults);
+  }
+  rewriter.finalizeOpModification(generic);
+  rewriter.restoreInsertionPoint(insertPoint);
+}
+
+Value emitUnaryGeneric(
+    RewriterBase &rewriter, Location loc, Value src, Value out,
+    AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
+    llvm::function_ref<AffineMap(std::size_t)> shardMap,
+    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile) {
+  std::size_t physicalRank = iteratorTypes.size();
+  AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+  llvm::SmallVector<Value> ins = {src};
+  llvm::SmallVector<Value> outs = {out};
+  auto generic = rewriter.create<GenericOp>(
+      loc, ins, outs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(
+          llvm::SmallVector<AffineMap>{gridMap, identityMap}),
+      rewriter.getArrayAttr(iteratorTypes));
+  buildParallelGenericRegion(
+      rewriter, loc, generic, ins, outs,
+      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
+        Value input = blockArgs[0];
+        Value output = blockArgs[1];
+        std::size_t shardRank =
+            cast<RankedTensorType>(output.getType()).getRank();
+        AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
+        AffineMap shardIn = shardMap ? shardMap(shardRank) : shardIdentity;
+        llvm::SmallVector<mlir::utils::IteratorType> linalgIters(
+            shardRank, mlir::utils::IteratorType::parallel);
+        auto linalgOp = rewriter.create<linalg::GenericOp>(
+            loc, output.getType(), input, output,
+            llvm::SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
+            [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+              b.create<linalg::YieldOp>(bodyLoc, makeTile(b, bodyLoc, args));
+            });
+        return {linalgOp->getResult(0)};
+      });
+  return generic->getResult(0);
+}
+
+Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value) {
+  auto valueType = cast<RankedTensorType>(value.getType());
+  auto emptyOp = rewriter.create<EmptyOp>(loc, valueType.getShape(),
+                                          valueType.getElementType(),
+                                          valueType.getEncoding());
+  return rewriter.create<ToLayoutOp>(loc, value, emptyOp).getResult(0);
+}
+
+std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
+                                     Value layoutedInput, int32_t k,
+                                     int32_t dim, int64_t reductionDimSize) {
+  MLIRContext *ctx = rewriter.getContext();
+  auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
+  auto metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
+  auto valTileType = cast<ttcore::TileType>(layoutedType.getElementType());
+  ArrayRef<int64_t> deviceShape = layoutedType.getShape();
+  std::size_t physicalRank = deviceShape.size() / 2;
+
+  auto parallel =
+      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
+  llvm::SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
+  AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+
+  // TopkBlockOp sorts down tile columns; dim=1 puts the sort dim on tile rows.
+  Value topkInput = layoutedInput;
+  if (dim == 1) {
+    auto empty =
+        rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout);
+    Value transposed = emitUnaryGeneric(
+        rewriter, loc, layoutedInput, empty.getResult(), identityMap,
+        iteratorTypes, /*shardMap=*/nullptr,
+        [&](OpBuilder &b, Location l, ValueRange args) {
+          return b.create<TileTransposeOp>(l, args[1].getType(), args[0])
+              .getResult();
+        });
+    markPinnedGrid(transposed.getDefiningOp());
+    topkInput = materializeToLayout(rewriter, loc, transposed);
+  }
+
+  auto idxTileType = ttcore::TileType::get(rewriter.getI32Type());
+
+  // One scratch tile per core for the lane pattern; the kernel derives the
+  // whole index buffer from it plus its own grid coordinate.
+  ArrayRef<int64_t> idxGridShape = metalLayout.getGridShape(layoutedType);
+  llvm::SmallVector<int64_t> idxScratchShape(idxGridShape.begin(),
+                                             idxGridShape.end());
+  idxScratchShape.append({1, 1});
+  auto idxScratchLayout = ttcore::MetalLayoutAttr::get(
+      ctx, llvm::SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
+      ttcore::TensorMemoryLayout::Sharded);
+  auto idxScratchEmpty = rewriter.create<EmptyOp>(
+      loc, idxScratchShape, idxTileType, idxScratchLayout);
+
+  auto topkValsEmpty =
+      rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout);
+  auto topkIdxEmpty =
+      rewriter.create<EmptyOp>(loc, deviceShape, idxTileType, metalLayout);
+
+  llvm::SmallVector<Value> topkInputs = {topkInput,
+                                         idxScratchEmpty.getResult()};
+  llvm::SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
+                                          topkIdxEmpty.getResult()};
+  // A constant map keeps the 1x1 scratch shard out of the generic's
+  // shard-extent comparison against the full-shard operands.
+  llvm::SmallVector<AffineExpr> idxConstExprs(
+      physicalRank, rewriter.getAffineConstantExpr(0));
+  AffineMap idxConstMap = AffineMap::get(physicalRank, 0, idxConstExprs, ctx);
+  auto topkGeneric = rewriter.create<GenericOp>(
+      loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
+          identityMap, idxConstMap, identityMap, identityMap}),
+      rewriter.getArrayAttr(iteratorTypes));
+
+  buildParallelGenericRegion(
+      rewriter, loc, topkGeneric, topkInputs, topkOutputs,
+      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
+        auto topkBlock = rewriter.create<TopkBlockOp>(
+            loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
+            reductionDimSize, /*stableSort=*/false, dim,
+            /*generateIndices=*/true);
+        return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
+      });
+  markPinnedGrid(topkGeneric);
+
+  return {topkGeneric->getResult(0), topkGeneric->getResult(1)};
+}
+
+GenericOp emitTopKExtract(RewriterBase &rewriter, Location loc,
+                          Value topkResult, Value extractOutput,
+                          std::size_t extractProjectDim,
+                          int64_t outputReductionTiles, int32_t dim) {
+  MLIRContext *ctx = rewriter.getContext();
+  std::size_t extractRank =
+      ttcore::getDeviceLayout(extractOutput).getRank() / 2;
+  AffineMap extractIdentity = rewriter.getMultiDimIdentityMap(extractRank);
+  llvm::SmallVector<Attribute> extractIters(
+      extractRank,
+      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
+
+  llvm::SmallVector<AffineExpr> inputMapExprs;
+  for (std::size_t i = 0; i < extractRank; ++i) {
+    inputMapExprs.push_back(i == extractProjectDim
+                                ? rewriter.getAffineConstantExpr(0)
+                                : rewriter.getAffineDimExpr(i));
+  }
+  AffineMap inputProjectedMap =
+      AffineMap::get(extractRank, 0, inputMapExprs, ctx);
+
+  llvm::SmallVector<Value> extractInputs = {topkResult};
+  llvm::SmallVector<Value> extractOutputs = {extractOutput};
+  auto generic = rewriter.create<GenericOp>(
+      loc, extractInputs, extractOutputs, /*additionalArgs=*/ValueRange(),
+      rewriter.getAffineMapArrayAttr(
+          llvm::SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
+      rewriter.getArrayAttr(extractIters));
+
+  buildParallelGenericRegion(
+      rewriter, loc, generic, extractInputs, extractOutputs,
+      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
+        Value input = blockArgs[0];
+        Value output = blockArgs[1];
+        std::size_t outShardRank =
+            cast<RankedTensorType>(output.getType()).getRank();
+        int64_t inReductionExtent = cast<RankedTensorType>(input.getType())
+                                        .getShape()[extractProjectDim];
+
+        // The input map must stay non-invertible, or linalg takes the loop
+        // bound from the wide input and rejects the narrower output shard; the
+        // mod leaves in-range reads unchanged.
+        AffineExpr projExpr =
+            outputReductionTiles == 1
+                ? rewriter.getAffineConstantExpr(0)
+                : rewriter.getAffineDimExpr(extractProjectDim) %
+                      inReductionExtent;
+        llvm::SmallVector<AffineExpr> mapFirstExprs;
+        for (std::size_t i = 0; i < outShardRank; ++i) {
+          mapFirstExprs.push_back(
+              i == extractProjectDim ? projExpr : rewriter.getAffineDimExpr(i));
+        }
+        AffineMap mapFirst =
+            AffineMap::get(outShardRank, 0, mapFirstExprs, ctx);
+        AffineMap outIdentity = rewriter.getMultiDimIdentityMap(outShardRank);
+        llvm::SmallVector<mlir::utils::IteratorType> linalgIters(
+            outShardRank, mlir::utils::IteratorType::parallel);
+
+        auto linalgOp = rewriter.create<linalg::GenericOp>(
+            loc, output.getType(), input, output,
+            llvm::SmallVector<AffineMap>{mapFirst, outIdentity}, linalgIters,
+            [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+              Value result;
+              if (dim == 1) {
+                result = b.create<TileTransposeOp>(bodyLoc, args[1].getType(),
+                                                   args[0]);
+              } else {
+                result = b.create<TileTypecastOp>(bodyLoc, args[1].getType(),
+                                                  args[0]);
+              }
+              b.create<linalg::YieldOp>(bodyLoc, result);
+            });
+        return {linalgOp->getResult(0)};
+      });
+  markPinnedGrid(generic);
+
+  return generic;
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -1099,17 +1099,19 @@ void buildParallelGenericRegion(
 
 Value emitUnaryGeneric(
     RewriterBase &rewriter, Location loc, Value src, Value out,
-    AffineMap gridMap, ArrayRef<Attribute> iteratorTypes,
-    llvm::function_ref<AffineMap(std::size_t)> shardMap,
     llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile) {
-  std::size_t physicalRank = iteratorTypes.size();
+  std::size_t physicalRank =
+      cast<RankedTensorType>(out.getType()).getRank() / 2;
   AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
+  llvm::SmallVector<Attribute> iteratorTypes(
+      physicalRank, ttcore::IteratorTypeAttr::get(
+                        rewriter.getContext(), ttcore::IteratorType::Parallel));
   llvm::SmallVector<Value> ins = {src};
   llvm::SmallVector<Value> outs = {out};
   auto generic = rewriter.create<GenericOp>(
       loc, ins, outs, /*additionalArgs=*/ValueRange(),
       rewriter.getAffineMapArrayAttr(
-          llvm::SmallVector<AffineMap>{gridMap, identityMap}),
+          llvm::SmallVector<AffineMap>{identityMap, identityMap}),
       rewriter.getArrayAttr(iteratorTypes));
   buildParallelGenericRegion(
       rewriter, loc, generic, ins, outs,
@@ -1119,13 +1121,12 @@ Value emitUnaryGeneric(
         std::size_t shardRank =
             cast<RankedTensorType>(output.getType()).getRank();
         AffineMap shardIdentity = rewriter.getMultiDimIdentityMap(shardRank);
-        AffineMap shardIn = shardMap ? shardMap(shardRank) : shardIdentity;
         llvm::SmallVector<mlir::utils::IteratorType> linalgIters(
             shardRank, mlir::utils::IteratorType::parallel);
         auto linalgOp = rewriter.create<linalg::GenericOp>(
             loc, output.getType(), input, output,
-            llvm::SmallVector<AffineMap>{shardIn, shardIdentity}, linalgIters,
-            [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+            llvm::SmallVector<AffineMap>{shardIdentity, shardIdentity},
+            linalgIters, [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
               b.create<linalg::YieldOp>(bodyLoc, makeTile(b, bodyLoc, args));
             });
         return {linalgOp->getResult(0)};
@@ -1139,6 +1140,39 @@ Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value) {
                                           valueType.getElementType(),
                                           valueType.getEncoding());
   return rewriter.create<ToLayoutOp>(loc, value, emptyOp).getResult(0);
+}
+
+Value layoutAndMask(RewriterBase &rewriter, Location loc, Value value,
+                    ArrayRef<int64_t> tilesPerDim, ArrayRef<int64_t> grid,
+                    ttcore::MemorySpace memorySpace) {
+  auto valueType = cast<RankedTensorType>(value.getType());
+  llvm::SmallVector<int64_t> tileShape =
+      llvm::to_vector(ttcore::TileType::getDefaultShape());
+  auto tileType = ttcore::TileType::get(valueType.getElementType(), tileShape);
+  ttcore::MetalLayoutAttr layout = buildShardedTileLayout(
+      rewriter.getContext(), valueType.getShape(), tilesPerDim, memorySpace);
+  llvm::SmallVector<int64_t> deviceShape =
+      layout.getDeviceShape(grid, tileShape);
+
+  auto empty = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
+  Value laidOut = rewriter.create<ToLayoutOp>(loc, value, empty).getResult(0);
+
+  const std::size_t physicalRank = deviceShape.size() / 2;
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+  bool needsMask = false;
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    const int64_t allocatedElems =
+        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
+    needsMask |= allocatedElems > valueType.getShape()[i];
+  }
+  if (!needsMask) {
+    return laidOut;
+  }
+  auto maskOut = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
+  return rewriter
+      .create<MaskOp>(loc, laidOut, maskOut, layout.getLogicalShape(),
+                      ttcore::OOBVal::NegInf)
+      .getResult();
 }
 
 std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
@@ -1162,8 +1196,7 @@ std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
     auto empty =
         rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout);
     Value transposed = emitUnaryGeneric(
-        rewriter, loc, layoutedInput, empty.getResult(), identityMap,
-        iteratorTypes, /*shardMap=*/nullptr,
+        rewriter, loc, layoutedInput, empty.getResult(),
         [&](OpBuilder &b, Location l, ValueRange args) {
           return b.create<TileTransposeOp>(l, args[1].getType(), args[0])
               .getResult();

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -16,6 +16,7 @@
 
 #include "mlir/Dialect/Affine/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/AffineExpr.h"
 
@@ -144,6 +145,60 @@ ShapedType reblockShapedType(ShapedType oldType,
                          oldMemRefType.getMemorySpace());
 }
 
+ttcore::MetalLayoutAttr
+rebuildLayoutForDeviceShape(ttcore::MetalLayoutAttr layout,
+                            ArrayRef<int64_t> deviceShape) {
+  TT_assert(deviceShape.size() % 2 == 0u);
+  const std::size_t physicalRank = deviceShape.size() / 2;
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  SmallVector<int64_t> logicalShape;
+  logicalShape.reserve(physicalRank);
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    logicalShape.push_back(deviceShape[i] * deviceShape[i + physicalRank] *
+                           tileDim);
+  }
+  return ttcore::MetalLayoutAttr::get(
+      layout.getContext(), logicalShape, layout.getDimAlignments(),
+      layout.getCollapsedIntervals(), layout.getMemorySpace(),
+      layout.getMemoryLayout());
+}
+
+ttcore::MetalLayoutAttr
+buildShardedTileLayout(MLIRContext *ctx, ArrayRef<int64_t> logicalShape,
+                       ArrayRef<int64_t> tilesPerDim,
+                       ttcore::MemorySpace memorySpace) {
+  TT_assert(tilesPerDim.size() == logicalShape.size());
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  SmallVector<int64_t> dimAlignments;
+  dimAlignments.reserve(tilesPerDim.size());
+  for (int64_t tiles : tilesPerDim) {
+    dimAlignments.push_back(tiles * tileDim);
+  }
+  return ttcore::MetalLayoutAttr::get(
+      ctx, logicalShape, memorySpace, ttcore::TensorMemoryLayout::Sharded,
+      ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
+          ctx, logicalShape.size()),
+      dimAlignments);
+}
+
+bool deviceShapeNeedsPadding(ArrayRef<int64_t> deviceShape,
+                             ArrayRef<int64_t> logicalShape) {
+  TT_assert(deviceShape.size() == 2 * logicalShape.size());
+  const std::size_t physicalRank = logicalShape.size();
+  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
+
+  for (std::size_t i = 0; i < physicalRank; ++i) {
+    int64_t allocatedElems =
+        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
+    if (allocatedElems > logicalShape[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
 Type cloneWithShardShape(Value referenceOperand, Type typeToRetype) {
   auto operandShapedType =
       mlir::dyn_cast<ShapedType>(referenceOperand.getType());
@@ -247,6 +302,48 @@ SmallVector<Value> buildGridIndices(OpBuilder &builder, Location loc,
 
   TT_assert(indices.size() == indexingMap.getNumResults());
   return indices;
+}
+
+SmallVector<Value> buildCoreIndices(OpBuilder &builder, Location loc,
+                                    std::size_t gridRank) {
+  SmallVector<Value> indices;
+  indices.reserve(gridRank);
+  for (std::size_t i = 0; i < gridRank; ++i) {
+    indices.push_back(
+        builder.create<CoreIndexOp>(loc, static_cast<int64_t>(i)));
+  }
+  return indices;
+}
+
+void makeExplicitDatamovementForm(OpBuilder &builder, GenericOp generic) {
+  generic.setBlockFactorsAttr(builder.getI64ArrayAttr({}));
+  generic.setIndexingMapsAttr(builder.getAffineMapArrayAttr({}));
+  generic.setIteratorTypesAttr(builder.getArrayAttr({}));
+}
+
+linalg::GenericOp emitLeadingTileCopy(OpBuilder &builder, Location loc,
+                                      Value input, Value output,
+                                      std::optional<std::size_t> shardRedDim) {
+  MLIRContext *ctx = builder.getContext();
+  auto inShardType = cast<RankedTensorType>(input.getType());
+  std::size_t shardRank = cast<RankedTensorType>(output.getType()).getRank();
+  SmallVector<AffineExpr> inExprs;
+  for (std::size_t i = 0; i < shardRank; ++i) {
+    AffineExpr idx = builder.getAffineDimExpr(i);
+    inExprs.push_back(i == shardRedDim ? idx % inShardType.getShape()[i] : idx);
+  }
+  AffineMap shardInMap = AffineMap::get(shardRank, 0, inExprs, ctx);
+  AffineMap shardIdentity = builder.getMultiDimIdentityMap(shardRank);
+  SmallVector<mlir::utils::IteratorType> linalgIters(
+      shardRank, mlir::utils::IteratorType::parallel);
+  return builder.create<linalg::GenericOp>(
+      loc, output.getType(), input, output,
+      SmallVector<AffineMap>{shardInMap, shardIdentity}, linalgIters,
+      [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+        Value copied =
+            b.create<TileTypecastOp>(bodyLoc, args[1].getType(), args[0]);
+        b.create<linalg::YieldOp>(bodyLoc, copied);
+      });
 }
 
 static llvm::SmallVector<int64_t>

--- a/lib/Dialect/D2M/Utils/Utils.cpp
+++ b/lib/Dialect/D2M/Utils/Utils.cpp
@@ -147,25 +147,6 @@ ShapedType reblockShapedType(ShapedType oldType,
                          oldMemRefType.getMemorySpace());
 }
 
-ttcore::MetalLayoutAttr
-buildShardedTileLayout(MLIRContext *ctx, ArrayRef<int64_t> logicalShape,
-                       ArrayRef<int64_t> tilesPerDim,
-                       ttcore::MemorySpace memorySpace) {
-  TT_assert(tilesPerDim.size() == logicalShape.size());
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-
-  SmallVector<int64_t> dimAlignments;
-  dimAlignments.reserve(tilesPerDim.size());
-  for (int64_t tiles : tilesPerDim) {
-    dimAlignments.push_back(tiles * tileDim);
-  }
-  return ttcore::MetalLayoutAttr::get(
-      ctx, logicalShape, memorySpace, ttcore::TensorMemoryLayout::Sharded,
-      ttcore::MetalLayoutAttr::computeDefaultCollapsedIntervals(
-          ctx, logicalShape.size()),
-      dimAlignments);
-}
-
 Type cloneWithShardShape(Value referenceOperand, Type typeToRetype) {
   auto operandShapedType =
       mlir::dyn_cast<ShapedType>(referenceOperand.getType());
@@ -555,6 +536,15 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
   if (!invMap || !fwdMap) {
     return std::nullopt;
   }
+  return getGridMapsFromVirtualGridMapping(*fwdMap, *invMap, gridShape);
+}
+
+std::optional<std::pair<AffineMap, AffineMap>>
+getGridMapsFromVirtualGridMapping(AffineMap forwardMap, AffineMap inverseMap,
+                                  ArrayRef<int64_t> gridShape) {
+  if (!forwardMap || !inverseMap) {
+    return std::nullopt;
+  }
 
   // Full VGM maps are shaped as:
   //   (virtual grid dims, shard dims) -> (physical grid dims, shard dims)
@@ -562,13 +552,13 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
   // the apparent grid rank, the stored VGM describes the backing value instead
   // and must not be attached to this GridAttr.
   const unsigned rank = gridShape.size();
-  if (rank == 0 || fwdMap->getNumDims() != 2 * rank ||
-      fwdMap->getNumResults() != rank + 2 || invMap->getNumDims() != 2 ||
-      invMap->getNumResults() != rank + 1) {
+  if (rank == 0 || forwardMap.getNumDims() != 2 * rank ||
+      forwardMap.getNumResults() != rank + 2 || inverseMap.getNumDims() != 2 ||
+      inverseMap.getNumResults() != rank + 1) {
     return std::nullopt;
   }
 
-  AffineMap gridFwdMap = *fwdMap;
+  AffineMap gridFwdMap = forwardMap;
   gridFwdMap = ttmlir::utils::affineMapDropBackResults(gridFwdMap, rank);
   for (int64_t i = static_cast<int64_t>(rank) - 1; i >= 0; --i) {
     gridFwdMap =
@@ -591,7 +581,7 @@ getGridMapsFromVirtualGridMapping(Value val, ArrayRef<int64_t> gridShape) {
     return std::nullopt;
   }
 
-  return std::make_pair(gridFwdMap, *invMap);
+  return std::make_pair(gridFwdMap, inverseMap);
 }
 
 std::optional<AffineMap> getAssociatedRemapping(Value val) {
@@ -1099,7 +1089,8 @@ void buildParallelGenericRegion(
 
 Value emitUnaryGeneric(
     RewriterBase &rewriter, Location loc, Value src, Value out,
-    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile) {
+    llvm::function_ref<Value(OpBuilder &, Location, ValueRange)> makeTile,
+    ttcore::GridAttr grid) {
   std::size_t physicalRank =
       cast<RankedTensorType>(out.getType()).getRank() / 2;
   AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
@@ -1112,7 +1103,7 @@ Value emitUnaryGeneric(
       loc, ins, outs, /*additionalArgs=*/ValueRange(),
       rewriter.getAffineMapArrayAttr(
           llvm::SmallVector<AffineMap>{identityMap, identityMap}),
-      rewriter.getArrayAttr(iteratorTypes));
+      rewriter.getArrayAttr(iteratorTypes), ThreadType::Unified, grid);
   buildParallelGenericRegion(
       rewriter, loc, generic, ins, outs,
       [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
@@ -1134,202 +1125,14 @@ Value emitUnaryGeneric(
   return generic->getResult(0);
 }
 
-Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value) {
-  auto valueType = cast<RankedTensorType>(value.getType());
-  auto emptyOp = rewriter.create<EmptyOp>(loc, valueType.getShape(),
-                                          valueType.getElementType(),
-                                          valueType.getEncoding());
-  return rewriter.create<ToLayoutOp>(loc, value, emptyOp).getResult(0);
-}
-
-Value layoutAndMask(RewriterBase &rewriter, Location loc, Value value,
-                    ArrayRef<int64_t> tilesPerDim, ArrayRef<int64_t> grid,
-                    ttcore::MemorySpace memorySpace) {
-  auto valueType = cast<RankedTensorType>(value.getType());
-  llvm::SmallVector<int64_t> tileShape =
-      llvm::to_vector(ttcore::TileType::getDefaultShape());
-  auto tileType = ttcore::TileType::get(valueType.getElementType(), tileShape);
-  ttcore::MetalLayoutAttr layout = buildShardedTileLayout(
-      rewriter.getContext(), valueType.getShape(), tilesPerDim, memorySpace);
-  llvm::SmallVector<int64_t> deviceShape =
-      layout.getDeviceShape(grid, tileShape);
-
-  auto empty = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
-  Value laidOut = rewriter.create<ToLayoutOp>(loc, value, empty).getResult(0);
-
-  const std::size_t physicalRank = deviceShape.size() / 2;
-  const int64_t tileDim = ttcore::TileType::getDefaultShape()[0];
-  bool needsMask = false;
-  for (std::size_t i = 0; i < physicalRank; ++i) {
-    const int64_t allocatedElems =
-        deviceShape[i] * deviceShape[i + physicalRank] * tileDim;
-    needsMask |= allocatedElems > valueType.getShape()[i];
-  }
-  if (!needsMask) {
-    return laidOut;
-  }
-  auto maskOut = rewriter.create<EmptyOp>(loc, deviceShape, tileType, layout);
-  return rewriter
-      .create<MaskOp>(loc, laidOut, maskOut, layout.getLogicalShape(),
-                      ttcore::OOBVal::NegInf)
-      .getResult();
-}
-
-std::pair<Value, Value> emitLeafTopk(RewriterBase &rewriter, Location loc,
-                                     Value layoutedInput, int32_t k,
-                                     int32_t dim, int64_t reductionDimSize) {
-  MLIRContext *ctx = rewriter.getContext();
-  auto layoutedType = cast<RankedTensorType>(layoutedInput.getType());
-  auto metalLayout = cast<ttcore::MetalLayoutAttr>(layoutedType.getEncoding());
-  auto valTileType = cast<ttcore::TileType>(layoutedType.getElementType());
-  ArrayRef<int64_t> deviceShape = layoutedType.getShape();
-  std::size_t physicalRank = deviceShape.size() / 2;
-
-  auto parallel =
-      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel);
-  llvm::SmallVector<Attribute> iteratorTypes(physicalRank, parallel);
-  AffineMap identityMap = rewriter.getMultiDimIdentityMap(physicalRank);
-
-  // TopkBlockOp sorts down tile columns; dim=1 puts the sort dim on tile rows.
-  Value topkInput = layoutedInput;
-  if (dim == 1) {
-    auto empty =
-        rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout);
-    Value transposed = emitUnaryGeneric(
-        rewriter, loc, layoutedInput, empty.getResult(),
-        [&](OpBuilder &b, Location l, ValueRange args) {
-          return b.create<TileTransposeOp>(l, args[1].getType(), args[0])
-              .getResult();
-        });
-    markPinnedGrid(transposed.getDefiningOp());
-    topkInput = materializeToLayout(rewriter, loc, transposed);
-  }
-
-  auto idxTileType = ttcore::TileType::get(rewriter.getI32Type());
-
-  // One scratch tile per core for the lane pattern; the kernel derives the
-  // whole index buffer from it plus its own grid coordinate.
-  ArrayRef<int64_t> idxGridShape = metalLayout.getGridShape(layoutedType);
-  llvm::SmallVector<int64_t> idxScratchShape(idxGridShape.begin(),
-                                             idxGridShape.end());
-  idxScratchShape.append({1, 1});
-  auto idxScratchLayout = ttcore::MetalLayoutAttr::get(
-      ctx, llvm::SmallVector<int64_t>{1, 1}, ttcore::MemorySpace::DeviceL1,
-      ttcore::TensorMemoryLayout::Sharded);
-  auto idxScratchEmpty = rewriter.create<EmptyOp>(
-      loc, idxScratchShape, idxTileType, idxScratchLayout);
-
-  auto topkValsEmpty =
-      rewriter.create<EmptyOp>(loc, deviceShape, valTileType, metalLayout);
-  auto topkIdxEmpty =
-      rewriter.create<EmptyOp>(loc, deviceShape, idxTileType, metalLayout);
-
-  llvm::SmallVector<Value> topkInputs = {topkInput,
-                                         idxScratchEmpty.getResult()};
-  llvm::SmallVector<Value> topkOutputs = {topkValsEmpty.getResult(),
-                                          topkIdxEmpty.getResult()};
-  // A constant map keeps the 1x1 scratch shard out of the generic's
-  // shard-extent comparison against the full-shard operands.
-  llvm::SmallVector<AffineExpr> idxConstExprs(
-      physicalRank, rewriter.getAffineConstantExpr(0));
-  AffineMap idxConstMap = AffineMap::get(physicalRank, 0, idxConstExprs, ctx);
-  auto topkGeneric = rewriter.create<GenericOp>(
-      loc, topkInputs, topkOutputs, /*additionalArgs=*/ValueRange(),
-      rewriter.getAffineMapArrayAttr(llvm::SmallVector<AffineMap>{
-          identityMap, idxConstMap, identityMap, identityMap}),
-      rewriter.getArrayAttr(iteratorTypes));
-
-  buildParallelGenericRegion(
-      rewriter, loc, topkGeneric, topkInputs, topkOutputs,
-      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
-        auto topkBlock = rewriter.create<TopkBlockOp>(
-            loc, blockArgs[0], blockArgs[1], blockArgs[2], blockArgs[3], k,
-            reductionDimSize, /*stableSort=*/false, dim,
-            /*generateIndices=*/true);
-        return {topkBlock.getResultValues(), topkBlock.getResultIndices()};
-      });
-  markPinnedGrid(topkGeneric);
-
-  return {topkGeneric->getResult(0), topkGeneric->getResult(1)};
-}
-
-GenericOp emitTopKExtract(RewriterBase &rewriter, Location loc,
-                          Value topkResult, Value extractOutput,
-                          std::size_t extractProjectDim,
-                          int64_t outputReductionTiles, int32_t dim) {
-  MLIRContext *ctx = rewriter.getContext();
-  std::size_t extractRank =
-      ttcore::getDeviceLayout(extractOutput).getRank() / 2;
-  AffineMap extractIdentity = rewriter.getMultiDimIdentityMap(extractRank);
-  llvm::SmallVector<Attribute> extractIters(
-      extractRank,
-      ttcore::IteratorTypeAttr::get(ctx, ttcore::IteratorType::Parallel));
-
-  llvm::SmallVector<AffineExpr> inputMapExprs;
-  for (std::size_t i = 0; i < extractRank; ++i) {
-    inputMapExprs.push_back(i == extractProjectDim
-                                ? rewriter.getAffineConstantExpr(0)
-                                : rewriter.getAffineDimExpr(i));
-  }
-  AffineMap inputProjectedMap =
-      AffineMap::get(extractRank, 0, inputMapExprs, ctx);
-
-  llvm::SmallVector<Value> extractInputs = {topkResult};
-  llvm::SmallVector<Value> extractOutputs = {extractOutput};
-  auto generic = rewriter.create<GenericOp>(
-      loc, extractInputs, extractOutputs, /*additionalArgs=*/ValueRange(),
-      rewriter.getAffineMapArrayAttr(
-          llvm::SmallVector<AffineMap>{inputProjectedMap, extractIdentity}),
-      rewriter.getArrayAttr(extractIters));
-
-  buildParallelGenericRegion(
-      rewriter, loc, generic, extractInputs, extractOutputs,
-      [&](ArrayRef<Value> blockArgs) -> llvm::SmallVector<Value> {
-        Value input = blockArgs[0];
-        Value output = blockArgs[1];
-        std::size_t outShardRank =
-            cast<RankedTensorType>(output.getType()).getRank();
-        int64_t inReductionExtent = cast<RankedTensorType>(input.getType())
-                                        .getShape()[extractProjectDim];
-
-        // The input map must stay non-invertible, or linalg takes the loop
-        // bound from the wide input and rejects the narrower output shard; the
-        // mod leaves in-range reads unchanged.
-        AffineExpr projExpr =
-            outputReductionTiles == 1
-                ? rewriter.getAffineConstantExpr(0)
-                : rewriter.getAffineDimExpr(extractProjectDim) %
-                      inReductionExtent;
-        llvm::SmallVector<AffineExpr> mapFirstExprs;
-        for (std::size_t i = 0; i < outShardRank; ++i) {
-          mapFirstExprs.push_back(
-              i == extractProjectDim ? projExpr : rewriter.getAffineDimExpr(i));
-        }
-        AffineMap mapFirst =
-            AffineMap::get(outShardRank, 0, mapFirstExprs, ctx);
-        AffineMap outIdentity = rewriter.getMultiDimIdentityMap(outShardRank);
-        llvm::SmallVector<mlir::utils::IteratorType> linalgIters(
-            outShardRank, mlir::utils::IteratorType::parallel);
-
-        auto linalgOp = rewriter.create<linalg::GenericOp>(
-            loc, output.getType(), input, output,
-            llvm::SmallVector<AffineMap>{mapFirst, outIdentity}, linalgIters,
-            [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
-              Value result;
-              if (dim == 1) {
-                result = b.create<TileTransposeOp>(bodyLoc, args[1].getType(),
-                                                   args[0]);
-              } else {
-                result = b.create<TileTypecastOp>(bodyLoc, args[1].getType(),
-                                                  args[0]);
-              }
-              b.create<linalg::YieldOp>(bodyLoc, result);
-            });
-        return {linalgOp->getResult(0)};
-      });
-  markPinnedGrid(generic);
-
-  return generic;
+Value materializeToLayout(RewriterBase &rewriter, Location loc, Value value,
+                          const PlacedBuffer &destination) {
+  Value empty =
+      rewriter
+          .create<EmptyOp>(loc, destination.type, destination.vgmInverse,
+                           destination.vgmForward)
+          .getResult();
+  return rewriter.create<ToLayoutOp>(loc, value, empty).getResult(0);
 }
 
 } // namespace mlir::tt::d2m::utils

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -99,7 +99,7 @@ SINGLE_CORE_TOPK_SHAPES = [
     pytest.param((32, 32), 32, -1, id="32x32_k32_dim1"),
     pytest.param((32, 32), 16, 0, id="32x32_k16_dim0"),
     # Single-tile target dim, dim=1 and dim=0
-    pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
+    pytest.param((32, 1376), 16, -1, id="32x256_k16_dim1"),
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
     pytest.param((256, 32), 16, 1, id="256x32_k16_dim1"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
@@ -116,11 +116,23 @@ SINGLE_CORE_TOPK_SHAPES = [
 MULTI_CORE_TOPK_SHAPES = [
     # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
     # any multiple of 32.
-    pytest.param((32, 8192), 16, -1, id="32x8192_k16_dim1"),
-    pytest.param((32, 23552), 16, -1, id="32x23552_k16_dim1"),
-    pytest.param((32, 32768), 16, -1, id="32x32768_k16_dim1"),
+    pytest.param((32, 5504), 16, -1, id="32x5504_k16_dim1"),
     pytest.param((32, 33792), 16, -1, id="32x33792_k16_dim1"),
-    pytest.param((32, 65536), 16, -1, id="32x65536_k16_dim1"),
+    pytest.param((32, 65536), 16, -1, id="32x88064_k16_dim1"),
+    pytest.param((35, 7639), 16, -1, id="35x7639_k16_dim1"),
+    # Transposed equivalents: non-target dim is a single tile (32), on dim 1;
+    # target dim (dim=0) is any multiple of 32.
+    pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
+    pytest.param((33792, 32), 16, 0, id="33792x32_k16_dim0"),
+    pytest.param((65536, 32), 16, 0, id="65536x32_k16_dim0"),
+    pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
+    # k > 32: each core's local top-k spans two reduction tiles (winner +
+    # loser); the gather and merge tree carry outputReductionTiles=2 tiles per
+    # partial. dim=1 and transposed dim=0.
+    pytest.param((32, 8192), 48, -1, id="32x8192_k48_dim1"),
+    pytest.param((32, 33792), 64, -1, id="32x33792_k64_dim1"),
+    pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
+    pytest.param((33792, 32), 64, 0, id="33792x32_k64_dim0"),
 ]
 
 
@@ -197,6 +209,10 @@ def test_topk_single_core(shape, k, dim, target, request, device):
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize("shape,k,dim", MULTI_CORE_TOPK_SHAPES)
 def test_topk_multi_core(shape, k, dim, target, request, device):
+    # Computed before `module` so the nested `topk` closure can capture it.
+    input_tensor = torch.randn(shape) * 50
+    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
+
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
         def topk(
@@ -242,10 +258,6 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
         print_ir=kwargs.get("print_ir", False),
     )
 
-    # Recompute golden from a fresh random input for a valid comparison.
-    input_tensor = torch.randn(shape) * 50
-    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
-
     mesh_shape = (1, 1)
     io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
     io_goldens[0]["output_0"] = GoldenMapTensor(
@@ -274,7 +286,7 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
         golden_topk,
         dim,
         output_tensors,
-        check_gathered=True,
+        check_gathered=False,
         check_indices=False,
     )
 
@@ -339,7 +351,7 @@ SINGLE_CORE_TILE_DIST_SHAPES = [
     # Large reduction dim, still <= 1024.
     pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
     # Ragged (non-power-of-2): odd tile count
-    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
+    pytest.param((32, 544), 16, -1, id="32x544_k16_dim1"),  # 3 tiles, odd
     # Multi-tile non-target dim
     pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
 ]
@@ -347,7 +359,7 @@ SINGLE_CORE_TILE_DIST_SHAPES = [
 MULTI_CORE_TILE_DIST_SHAPES = [
     # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
     # any multiple of 32.
-    pytest.param((32, 544), 16, -1, id="32x544_k16_dim1"),  # 17 tiles, odd
+    pytest.param((32, 2080), 16, -1, id="32x2080_k16_dim1"),  # 65 tiles, odd
 ]
 
 
@@ -486,17 +498,12 @@ def test_topk_tile_distribution_multi_core(
         print_ir=kwargs.get("print_ir", False),
     )
 
-    # Replace the random input with our adversarial tensor and recompute the
-    # expected output so the golden comparison is valid.
-    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
-    golden_output = torch.topk(adversarial_input, k=k, dim=dim, largest=True).values
-
     mesh_shape = (1, 1)
     io_goldens[0]["input_0"] = GoldenMapTensor(
         {0: adversarial_input}, mesh_shape=mesh_shape
     )
     io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_output}, mesh_shape=mesh_shape
+        {0: golden_topk.values}, mesh_shape=mesh_shape
     )
 
     # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
@@ -517,6 +524,6 @@ def test_topk_tile_distribution_multi_core(
         golden_topk,
         dim,
         output_tensors,
-        check_gathered=True,
+        check_gathered=False,
         check_indices=False,
     )

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -54,20 +54,16 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.9
     """PCC-checks topk device outputs against the golden via check_outputs.
 
     Both values and indices go through the same check_outputs() PCC engine that
-    execute_fb uses, so a failure raises TTBuilderGoldenException. Values are
-    compared order-robustly. Indices are validated on the values they point to,
-    gathered from the input, rather than raw positions.
+    execute_fb uses, so a failure raises TTBuilderGoldenException. Values and
+    indices are both compared positionally.
     """
-    d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
     device_values = prog["device_output_0"][0]
     device_indices = prog["device_output_1"][0].long()
 
-    dv_sorted, _ = torch.sort(device_values, dim=d)
-    gv_sorted, _ = torch.sort(golden_topk.values, dim=d)
     check_outputs(
-        gv_sorted,
-        dv_sorted,
+        golden_topk.values,
+        device_values,
         "topk_values",
         pcc,
         1e-08,
@@ -77,17 +73,10 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.9
         check_rtol=False,
     )
 
-    # The pointed-to values are compared in bf16.
-    device_gathered = torch.gather(input_tensor, d, device_indices).to(torch.bfloat16)
-    golden_gathered = torch.gather(input_tensor, d, golden_topk.indices).to(
-        torch.bfloat16
-    )
-    dg_sorted, _ = torch.sort(device_gathered, dim=d)
-    gg_sorted, _ = torch.sort(golden_gathered, dim=d)
     check_outputs(
-        gg_sorted,
-        dg_sorted,
-        "topk_index_values",
+        golden_topk.indices.float(),
+        device_indices.float(),
+        "topk_indices",
         pcc,
         1e-08,
         1e-05,
@@ -98,12 +87,17 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.9
 
 
 SINGLE_CORE_TOPK_SHAPES = [
+    # Single-tile reduction dim (exactly 32 elements): no merge/rebuild, just
+    # local_sort.
+    pytest.param((32, 28), 16, -1, id="32x28_k16_dim1"),
+    pytest.param((32, 32), 32, -1, id="32x32_k32_dim1"),
+    pytest.param((32, 32), 16, 0, id="32x32_k16_dim0"),
     # Single-tile target dim, dim=1 and dim=0
     pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
     pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-    # Large target dim (many tiles in reduction), still <= 1024.
+    # Large target dim (many tiles in reduction
     pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
     pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
     # Ragged (non-power-of-2 tile count)
@@ -116,7 +110,7 @@ SINGLE_CORE_TOPK_SHAPES = [
 MULTI_CORE_TOPK_SHAPES = [
     # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
     # any multiple of 32.
-    pytest.param((32, 2048), 16, -1, id="32x2048_k16_dim1"),
+    pytest.param((32, 8192), 16, -1, id="32x8192_k16_dim1"),
 ]
 
 

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -111,6 +111,8 @@ MULTI_CORE_TOPK_SHAPES = [
     # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
     # any multiple of 32.
     pytest.param((32, 8192), 16, -1, id="32x8192_k16_dim1"),
+    pytest.param((32, 23552), 16, -1, id="32x23552_k16_dim1"),
+    pytest.param((32, 32768), 16, -1, id="32x32768_k16_dim1"),
 ]
 
 

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -23,43 +23,25 @@ pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
 
 
-def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
-    """PCC-checks topk device outputs against the golden.
+def _verify_topk_outputs(
+    input_tensor, golden_topk, dim, output_tensors, pcc=0.99, check_gathered=True
+):
+    """PCC-checks topk device outputs against the golden via check_outputs.
 
-    Values are compared order-robustly. Indices are validated on the values
-    they point to, gathered from the input, rather than raw positions.
+    Values go through the same check_outputs() PCC engine that execute_fb
+    uses, so a failure raises TTBuilderGoldenException.
+
+    check_gathered=True additionally validates the device's indices by
+    gathering the values they point to from the original input and
+    PCC-comparing those against the device's topk values. This is
+    order-robust (doesn't depend on positional/tie-break ordering).
+    check_gathered=False skips index validation entirely and only checks
+    values, which is used on multi-core tests due to a known indices gather
+    corruption bug that doesn't affect values.
     """
     d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
     device_values = prog["device_output_0"][0]
-    device_indices = prog["device_output_1"][0].long()
-
-    dv_sorted, _ = torch.sort(device_values, dim=d)
-    gv_sorted, _ = torch.sort(golden_topk.values, dim=d)
-    _, _, values_pcc = get_atol_rtol_pcc(gv_sorted, dv_sorted, 1e-08, 1e-05)
-    assert values_pcc >= 0.99, f"values PCC {values_pcc} < 0.99"
-
-    # The pointed-to values are compared in bf16.
-    device_gathered = torch.gather(input_tensor, d, device_indices).to(torch.bfloat16)
-    golden_gathered = torch.gather(input_tensor, d, golden_topk.indices).to(
-        torch.bfloat16
-    )
-    dg_sorted, _ = torch.sort(device_gathered, dim=d)
-    gg_sorted, _ = torch.sort(golden_gathered, dim=d)
-    _, _, index_value_pcc = get_atol_rtol_pcc(gg_sorted, dg_sorted, 1e-08, 1e-05)
-    assert index_value_pcc >= 0.99, f"index-value PCC {index_value_pcc} < 0.99"
-
-
-def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.99):
-    """PCC-checks topk device outputs against the golden via check_outputs.
-
-    Both values and indices go through the same check_outputs() PCC engine that
-    execute_fb uses, so a failure raises TTBuilderGoldenException. Values and
-    indices are both compared positionally.
-    """
-    prog = output_tensors["program_0"]
-    device_values = prog["device_output_0"][0]
-    device_indices = prog["device_output_1"][0].long()
 
     check_outputs(
         golden_topk.values,
@@ -73,17 +55,20 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.9
         check_rtol=False,
     )
 
-    check_outputs(
-        golden_topk.indices.float(),
-        device_indices.float(),
-        "topk_indices",
-        pcc,
-        1e-08,
-        1e-05,
-        check_pcc=True,
-        check_atol=False,
-        check_rtol=False,
-    )
+    if check_gathered:
+        device_indices = prog["device_output_1"][0].long()
+        gathered_values = torch.gather(input_tensor.float(), dim, device_indices)
+        check_outputs(
+            device_values.float(),
+            gathered_values,
+            "topk_gathered_values",
+            pcc,
+            1e-08,
+            1e-05,
+            check_pcc=True,
+            check_atol=False,
+            check_rtol=False,
+        )
 
 
 SINGLE_CORE_TOPK_SHAPES = [
@@ -113,6 +98,8 @@ MULTI_CORE_TOPK_SHAPES = [
     pytest.param((32, 8192), 16, -1, id="32x8192_k16_dim1"),
     pytest.param((32, 23552), 16, -1, id="32x23552_k16_dim1"),
     pytest.param((32, 32768), 16, -1, id="32x32768_k16_dim1"),
+    pytest.param((32, 33792), 16, -1, id="32x33792_k16_dim1"),
+    pytest.param((32, 65536), 16, -1, id="32x65536_k16_dim1"),
 ]
 
 
@@ -261,7 +248,9 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
         artifact_dir=artifact_dir,
     )
 
-    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
+    _verify_topk_outputs(
+        input_tensor, golden_topk, dim, output_tensors, check_gathered=False
+    )
 
 
 def _build_tile_distribution_input(
@@ -497,4 +486,6 @@ def test_topk_tile_distribution_multi_core(
         artifact_dir=artifact_dir,
     )
 
-    _verify_topk_outputs(adversarial_input, golden_topk, dim, output_tensors)
+    _verify_topk_outputs(
+        adversarial_input, golden_topk, dim, output_tensors, check_gathered=False
+    )

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -24,7 +24,13 @@ torch.manual_seed(0)
 
 
 def _verify_topk_outputs(
-    input_tensor, golden_topk, dim, output_tensors, pcc=0.99, check_gathered=True
+    input_tensor,
+    golden_topk,
+    dim,
+    output_tensors,
+    pcc=0.99,
+    check_gathered=True,
+    check_indices=False,
 ):
     """PCC-checks topk device outputs against the golden via check_outputs.
 
@@ -34,10 +40,11 @@ def _verify_topk_outputs(
     check_gathered=True additionally validates the device's indices by
     gathering the values they point to from the original input and
     PCC-comparing those against the device's topk values. This is
-    order-robust (doesn't depend on positional/tie-break ordering).
-    check_gathered=False skips index validation entirely and only checks
-    values, which is used on multi-core tests due to a known indices gather
-    corruption bug that doesn't affect values.
+    order-robust (doesn't depend on positional/tie-break ordering). Used on
+    single-core tests.
+
+    check_indices=True instead PCC-compares the device's indices positionally
+    against the golden indices. Used on multi-core tests.
     """
     d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
@@ -55,13 +62,27 @@ def _verify_topk_outputs(
         check_rtol=False,
     )
 
+    device_indices = prog["device_output_1"][0].long()
+
     if check_gathered:
-        device_indices = prog["device_output_1"][0].long()
         gathered_values = torch.gather(input_tensor.float(), dim, device_indices)
         check_outputs(
             device_values.float(),
             gathered_values,
             "topk_gathered_values",
+            pcc,
+            1e-08,
+            1e-05,
+            check_pcc=True,
+            check_atol=False,
+            check_rtol=False,
+        )
+
+    if check_indices:
+        check_outputs(
+            golden_topk.indices.float(),
+            device_indices.float(),
+            "topk_indices",
             pcc,
             1e-08,
             1e-05,
@@ -80,7 +101,7 @@ SINGLE_CORE_TOPK_SHAPES = [
     # Single-tile target dim, dim=1 and dim=0
     pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-    pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
+    pytest.param((256, 32), 16, 1, id="256x32_k16_dim1"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
     # Large target dim (many tiles in reduction
     pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
@@ -249,7 +270,12 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
     )
 
     _verify_topk_outputs(
-        input_tensor, golden_topk, dim, output_tensors, check_gathered=False
+        input_tensor,
+        golden_topk,
+        dim,
+        output_tensors,
+        check_gathered=True,
+        check_indices=False,
     )
 
 
@@ -487,5 +513,10 @@ def test_topk_tile_distribution_multi_core(
     )
 
     _verify_topk_outputs(
-        adversarial_input, golden_topk, dim, output_tensors, check_gathered=False
+        adversarial_input,
+        golden_topk,
+        dim,
+        output_tensors,
+        check_gathered=True,
+        check_indices=False,
     )

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -23,6 +23,17 @@ pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
 
 
+def _topk_index_dtype(shape: Tuple[int, ...], dim: int) -> torch.dtype:
+    """Index dtype the topk op declares for this input, mirroring
+    ttir_topk_golden / the TTNN topk workaround: UInt16 while the tile-padded
+    reduction dim fits in a uint16, else UInt32. Test-side goldens must match
+    this so execute_fb doesn't dtype-mismatch the device index output."""
+    TILE_SIZE = 32
+    reduction_dim = dim if dim >= 0 else dim + len(shape)
+    padded = ((shape[reduction_dim] + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+    return torch.uint16 if padded <= 0xFFFF else torch.uint32
+
+
 def _verify_topk_outputs(
     input_tensor,
     golden_topk,
@@ -112,13 +123,11 @@ MULTI_CORE_TOPK_SHAPES = [
     # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
     # any multiple of 32.
     pytest.param((32, 5504), 16, -1, id="32x5504_k16_dim1"),
-    pytest.param((32, 33792), 16, -1, id="32x33792_k16_dim1"),
     pytest.param((32, 88064), 16, -1, id="32x88064_k16_dim1"),
     pytest.param((35, 7639), 16, -1, id="35x7639_k16_dim1"),
     # Transposed equivalents: non-target dim is a single tile (32), on dim 1;
     # target dim (dim=0) is any multiple of 32.
     pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
-    pytest.param((33792, 32), 16, 0, id="33792x32_k16_dim0"),
     pytest.param((88064, 32), 16, 0, id="88064x32_k16_dim0"),
     pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
     # k > 32: each core's local top-k spans two reduction tiles (winner +
@@ -182,7 +191,8 @@ def test_topk_single_core(shape, k, dim, target, request, device):
     )
     # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
+        mesh_shape=mesh_shape,
     )
 
     # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
@@ -198,14 +208,7 @@ def test_topk_single_core(shape, k, dim, target, request, device):
         artifact_dir=artifact_dir,
     )
 
-    _verify_topk_outputs(
-        input_tensor,
-        golden_topk,
-        dim,
-        output_tensors,
-        check_gathered=False,
-        check_indices=False,
-    )
+    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -235,7 +238,7 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
                 {in0: input_tensor},
                 {
                     values: golden_topk.values,
-                    indices: golden_topk.indices.to(torch.uint16),
+                    indices: golden_topk.indices.to(_topk_index_dtype(shape, dim)),
                 },
             )
             return values, indices
@@ -267,7 +270,8 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
     )
     # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
+        mesh_shape=mesh_shape,
     )
 
     # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
@@ -288,7 +292,7 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
         golden_topk,
         dim,
         output_tensors,
-        check_gathered=False,
+        check_gathered=True,
         check_indices=False,
     )
 
@@ -424,7 +428,8 @@ def test_topk_tile_distribution_single_core(
     )
     # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
     io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
+        mesh_shape=mesh_shape,
     )
 
     # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
@@ -475,7 +480,7 @@ def test_topk_tile_distribution_multi_core(
                 {in0: adversarial_input},
                 {
                     values: golden_topk.values,
-                    indices: golden_topk.indices.to(torch.uint16),
+                    indices: golden_topk.indices.to(_topk_index_dtype(shape, dim)),
                 },
             )
             return values, indices
@@ -525,6 +530,6 @@ def test_topk_tile_distribution_multi_core(
         golden_topk,
         dim,
         output_tensors,
-        check_gathered=False,
+        check_gathered=True,
         check_indices=False,
     )

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -95,19 +95,14 @@ def _verify_topk_outputs(
 SINGLE_CORE_TOPK_SHAPES = [
     # Single-tile reduction dim (exactly 32 elements): no merge/rebuild, just
     # local_sort.
-    pytest.param((32, 28), 16, -1, id="32x28_k16_dim1"),
-    pytest.param((32, 32), 32, -1, id="32x32_k32_dim1"),
-    pytest.param((32, 32), 16, 0, id="32x32_k16_dim0"),
-    # Single-tile target dim, dim=1 and dim=0
-    pytest.param((32, 1376), 16, -1, id="32x256_k16_dim1"),
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-    pytest.param((256, 32), 16, 1, id="256x32_k16_dim1"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-    # Large target dim (many tiles in reduction
-    pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
-    pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
+    # Large target dim (many tiles in reduction), k > 32.
+    pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
+    pytest.param((1760, 32), 64, 0, id="1760x32_k64_dim0"),
     # Ragged (non-power-of-2 tile count)
     pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
+    pytest.param((1536, 32), 16, 0, id="1536x32_k16_dim0"),
     # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
     pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
     pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
@@ -118,21 +113,21 @@ MULTI_CORE_TOPK_SHAPES = [
     # any multiple of 32.
     pytest.param((32, 5504), 16, -1, id="32x5504_k16_dim1"),
     pytest.param((32, 33792), 16, -1, id="32x33792_k16_dim1"),
-    pytest.param((32, 65536), 16, -1, id="32x88064_k16_dim1"),
+    pytest.param((32, 88064), 16, -1, id="32x88064_k16_dim1"),
     pytest.param((35, 7639), 16, -1, id="35x7639_k16_dim1"),
     # Transposed equivalents: non-target dim is a single tile (32), on dim 1;
     # target dim (dim=0) is any multiple of 32.
     pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
     pytest.param((33792, 32), 16, 0, id="33792x32_k16_dim0"),
-    pytest.param((65536, 32), 16, 0, id="65536x32_k16_dim0"),
+    pytest.param((88064, 32), 16, 0, id="88064x32_k16_dim0"),
     pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
     # k > 32: each core's local top-k spans two reduction tiles (winner +
     # loser); the gather and merge tree carry outputReductionTiles=2 tiles per
     # partial. dim=1 and transposed dim=0.
     pytest.param((32, 8192), 48, -1, id="32x8192_k48_dim1"),
-    pytest.param((32, 33792), 64, -1, id="32x33792_k64_dim1"),
+    pytest.param((32, 88064), 64, -1, id="32x88064_k64_dim1"),
     pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
-    pytest.param((33792, 32), 64, 0, id="33792x32_k64_dim0"),
+    pytest.param((88064, 32), 64, 0, id="88064x32_k64_dim0"),
 ]
 
 
@@ -203,7 +198,14 @@ def test_topk_single_core(shape, k, dim, target, request, device):
         artifact_dir=artifact_dir,
     )
 
-    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
+    _verify_topk_outputs(
+        input_tensor,
+        golden_topk,
+        dim,
+        output_tensors,
+        check_gathered=False,
+        check_indices=False,
+    )
 
 
 @pytest.mark.parametrize("target", ["ttmetal"])
@@ -345,13 +347,12 @@ def _build_tile_distribution_input(
 
 
 SINGLE_CORE_TILE_DIST_SHAPES = [
-    # pow2 tile count, dim=1 and dim=0
-    pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
+    # pow2 tile count, dim=0
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
     # Large reduction dim, still <= 1024.
     pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
     # Ragged (non-power-of-2): odd tile count
-    pytest.param((32, 544), 16, -1, id="32x544_k16_dim1"),  # 3 tiles, odd
+    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
     # Multi-tile non-target dim
     pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
 ]

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -7,8 +7,11 @@ import torch
 
 from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
-from builder.base.builder_apis import compile_ttir_to_flatbuffer
-from builder.base.builder_runtime import execute_fb
+from builder.base.builder_apis import (
+    compile_and_execute_ttir,
+    compile_ttir_to_flatbuffer,
+)
+from builder.base.builder_runtime import execute_fb, check_outputs
 from builder.base.builder_apis import get_artifact_dir
 from golden import get_atol_rtol_pcc
 from golden.mapping import GoldenMapTensor
@@ -47,32 +50,149 @@ def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
     assert index_value_pcc >= 0.99, f"index-value PCC {index_value_pcc} < 0.99"
 
 
+def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors, pcc=0.99):
+    """PCC-checks topk device outputs against the golden via check_outputs.
+
+    Both values and indices go through the same check_outputs() PCC engine that
+    execute_fb uses, so a failure raises TTBuilderGoldenException. Values are
+    compared order-robustly. Indices are validated on the values they point to,
+    gathered from the input, rather than raw positions.
+    """
+    d = dim % input_tensor.ndim
+    prog = output_tensors["program_0"]
+    device_values = prog["device_output_0"][0]
+    device_indices = prog["device_output_1"][0].long()
+
+    dv_sorted, _ = torch.sort(device_values, dim=d)
+    gv_sorted, _ = torch.sort(golden_topk.values, dim=d)
+    check_outputs(
+        gv_sorted,
+        dv_sorted,
+        "topk_values",
+        pcc,
+        1e-08,
+        1e-05,
+        check_pcc=True,
+        check_atol=False,
+        check_rtol=False,
+    )
+
+    # The pointed-to values are compared in bf16.
+    device_gathered = torch.gather(input_tensor, d, device_indices).to(torch.bfloat16)
+    golden_gathered = torch.gather(input_tensor, d, golden_topk.indices).to(
+        torch.bfloat16
+    )
+    dg_sorted, _ = torch.sort(device_gathered, dim=d)
+    gg_sorted, _ = torch.sort(golden_gathered, dim=d)
+    check_outputs(
+        gg_sorted,
+        dg_sorted,
+        "topk_index_values",
+        pcc,
+        1e-08,
+        1e-05,
+        check_pcc=True,
+        check_atol=False,
+        check_rtol=False,
+    )
+
+
+SINGLE_CORE_TOPK_SHAPES = [
+    # Single-tile target dim, dim=1 and dim=0
+    pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
+    pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
+    pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
+    pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+    # Large target dim (many tiles in reduction), still <= 1024.
+    pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
+    pytest.param((1024, 32), 64, 0, id="1024x32_k64_dim0"),
+    # Ragged (non-power-of-2 tile count)
+    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
+    # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
+    pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
+    pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
+]
+
+MULTI_CORE_TOPK_SHAPES = [
+    # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
+    # any multiple of 32.
+    pytest.param((32, 2048), 16, -1, id="32x2048_k16_dim1"),
+]
+
+
 @pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize(
-    "shape,k,dim",
-    [
-        # Single-tile target dim, dim=1 and dim=0
-        pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-        pytest.param((256, 32), 16, 0, id="256x32_k16_dim0"),
-        pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-        # Large target dim (many tiles in reduction)
-        pytest.param((32, 1376), 16, -1, id="32x1376_k16_dim1"),
-        pytest.param((1760, 32), 16, 0, id="1760x32_k16_dim0"),
-        pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
-        pytest.param((1760, 32), 64, 0, id="1760x32_k64_dim0"),
-        # Ragged (non-power-of-2 tile count)
-        pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
-        pytest.param((1536, 32), 16, 0, id="1536x32_k16_dim0"),
-        # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
-        pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
-        pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
-    ],
-)
-def test_topk(shape, k, dim, target, request, device):
+@pytest.mark.parametrize("shape,k,dim", SINGLE_CORE_TOPK_SHAPES)
+def test_topk_single_core(shape, k, dim, target, request, device):
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [torch.float32])
+        def topk(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            values = builder.topk(
+                in0,
+                k=k,
+                dim=dim,
+                largest=True,
+                sorted=False,
+                unit_attrs=unit_attrs,
+            )
+            indices = builder.topk_indices(values)
+            return values, indices
+
+    kwargs = get_request_kwargs(request)
+    artifact_dir = get_artifact_dir(
+        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
+    )
+
+    (
+        builder,
+        compiled_bin,
+        io_goldens,
+        intermediate_goldens,
+    ) = compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=kwargs["system_desc_path"],
+        artifact_dir=artifact_dir,
+        target=target,
+        save_artifacts=True,
+        print_ir=kwargs.get("print_ir", False),
+    )
+
+    # Recompute golden from a fresh random input for a valid comparison.
     input_tensor = torch.randn(shape) * 50
     golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
 
+    mesh_shape = (1, 1)
+    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
+    io_goldens[0]["output_0"] = GoldenMapTensor(
+        {0: golden_topk.values}, mesh_shape=mesh_shape
+    )
+    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    io_goldens[0]["output_1"] = GoldenMapTensor(
+        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+    )
+
+    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
+    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    _, output_tensors = execute_fb(
+        compiled_bin,
+        input_output_goldens=io_goldens,
+        intermediate_goldens=intermediate_goldens,
+        device=device,
+        pcc=0.99,
+        check_pcc=False,
+        save_artifacts=True,
+        artifact_dir=artifact_dir,
+    )
+
+    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("shape,k,dim", MULTI_CORE_TOPK_SHAPES)
+def test_topk_multi_core(shape, k, dim, target, request, device):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
         def topk(
@@ -113,10 +233,27 @@ def test_topk(shape, k, dim, target, request, device):
         system_desc_path=kwargs["system_desc_path"],
         artifact_dir=artifact_dir,
         target=target,
-        pipeline_options=["override-device-shape=1,1"],
+        # pipeline_options=["override-device-shape=1,1"],
         save_artifacts=True,
+        print_ir=kwargs.get("print_ir", False),
     )
 
+    # Recompute golden from a fresh random input for a valid comparison.
+    input_tensor = torch.randn(shape) * 50
+    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
+
+    mesh_shape = (1, 1)
+    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
+    io_goldens[0]["output_0"] = GoldenMapTensor(
+        {0: golden_topk.values}, mesh_shape=mesh_shape
+    )
+    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    io_goldens[0]["output_1"] = GoldenMapTensor(
+        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+    )
+
+    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
+    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -184,24 +321,110 @@ def _build_tile_distribution_input(
     return tensor
 
 
+SINGLE_CORE_TILE_DIST_SHAPES = [
+    # pow2 tile count, dim=1 and dim=0
+    pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
+    pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+    # Large reduction dim, still <= 1024.
+    pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
+    # Ragged (non-power-of-2): odd tile count
+    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
+    # Multi-tile non-target dim
+    pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
+]
+
+MULTI_CORE_TILE_DIST_SHAPES = [
+    # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
+    # any multiple of 32.
+    pytest.param((32, 544), 16, -1, id="32x544_k16_dim1"),  # 17 tiles, odd
+]
+
+
 @pytest.mark.parametrize("target", ["ttmetal"])
 @pytest.mark.parametrize("pattern", ["first_tiles", "last_tiles", "strided"])
-@pytest.mark.parametrize(
-    "shape,k,dim",
-    [
-        # pow2 tile count, dim=1 and dim=0
-        pytest.param((32, 256), 16, -1, id="32x256_k16_dim1"),
-        pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-        # Large reduction dim
-        pytest.param((32, 1024), 64, -1, id="32x1024_k64_dim1"),
-        # Ragged (non-power-of-2): odd tile count, even tile count
-        pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
-        pytest.param((544, 32), 16, 0, id="544x32_k16_dim0"),  # 17 tiles, odd
-        # Multi-tile non-target dim
-        pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
-    ],
-)
-def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device):
+@pytest.mark.parametrize("shape,k,dim", SINGLE_CORE_TILE_DIST_SHAPES)
+def test_topk_tile_distribution_single_core(
+    shape, k, dim, pattern, target, request, device
+):
+    """Run topk with hand-crafted inputs that concentrate top values in
+    specific tiles, stressing the merge-tree reduction logic."""
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape], [torch.float32])
+        def topk(
+            in0: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            values = builder.topk(
+                in0,
+                k=k,
+                dim=dim,
+                largest=True,
+                sorted=False,
+                unit_attrs=unit_attrs,
+            )
+            indices = builder.topk_indices(values)
+            return values, indices
+
+    kwargs = get_request_kwargs(request)
+    artifact_dir = get_artifact_dir(
+        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
+    )
+
+    (
+        builder,
+        compiled_bin,
+        io_goldens,
+        intermediate_goldens,
+    ) = compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=kwargs["system_desc_path"],
+        artifact_dir=artifact_dir,
+        target=target,
+        save_artifacts=True,
+        print_ir=kwargs.get("print_ir", False),
+    )
+
+    # Replace the random input with our adversarial tensor and recompute the
+    # expected output so the golden comparison is valid.
+    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
+    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
+
+    mesh_shape = (1, 1)
+    io_goldens[0]["input_0"] = GoldenMapTensor(
+        {0: adversarial_input}, mesh_shape=mesh_shape
+    )
+    io_goldens[0]["output_0"] = GoldenMapTensor(
+        {0: golden_topk.values}, mesh_shape=mesh_shape
+    )
+    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    io_goldens[0]["output_1"] = GoldenMapTensor(
+        {0: golden_topk.indices.to(torch.uint16)}, mesh_shape=mesh_shape
+    )
+
+    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
+    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    _, output_tensors = execute_fb(
+        compiled_bin,
+        input_output_goldens=io_goldens,
+        intermediate_goldens=intermediate_goldens,
+        device=device,
+        pcc=0.99,
+        check_pcc=False,
+        save_artifacts=True,
+        artifact_dir=artifact_dir,
+    )
+
+    _verify_topk_outputs(adversarial_input, golden_topk, dim, output_tensors)
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("pattern", ["first_tiles", "last_tiles", "strided"])
+@pytest.mark.parametrize("shape,k,dim", MULTI_CORE_TILE_DIST_SHAPES)
+def test_topk_tile_distribution_multi_core(
+    shape, k, dim, pattern, target, request, device
+):
     """Run topk with hand-crafted inputs that concentrate top values in
     specific tiles, stressing the merge-tree reduction logic."""
 
@@ -248,10 +471,25 @@ def test_topk_tile_distribution(shape, k, dim, pattern, target, request, device)
         system_desc_path=kwargs["system_desc_path"],
         artifact_dir=artifact_dir,
         target=target,
-        pipeline_options=["override-device-shape=1,1"],
         save_artifacts=True,
+        print_ir=kwargs.get("print_ir", False),
     )
 
+    # Replace the random input with our adversarial tensor and recompute the
+    # expected output so the golden comparison is valid.
+    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
+    golden_output = torch.topk(adversarial_input, k=k, dim=dim, largest=True).values
+
+    mesh_shape = (1, 1)
+    io_goldens[0]["input_0"] = GoldenMapTensor(
+        {0: adversarial_input}, mesh_shape=mesh_shape
+    )
+    io_goldens[0]["output_0"] = GoldenMapTensor(
+        {0: golden_output}, mesh_shape=mesh_shape
+    )
+
+    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
+    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -137,6 +137,9 @@ MULTI_CORE_TOPK_SHAPES = [
     pytest.param((32, 88064), 64, -1, id="32x88064_k64_dim1"),
     pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
     pytest.param((88064, 32), 64, 0, id="88064x32_k64_dim0"),
+    # data parallel
+    pytest.param((32, 8192), 16, 0, id="32x8192_k16_dim0"),
+    pytest.param((8192, 32), 16, -1, id="8192x32_k16_dim1"),
 ]
 
 

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -7,13 +7,9 @@ import torch
 
 from builder.base.builder_utils import Operand
 from builder.ttir.ttir_builder import TTIRBuilder
-from builder.base.builder_apis import (
-    compile_and_execute_ttir,
-    compile_ttir_to_flatbuffer,
-)
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
 from builder.base.builder_runtime import execute_fb, check_outputs
 from builder.base.builder_apis import get_artifact_dir
-from golden import get_atol_rtol_pcc
 from golden.mapping import GoldenMapTensor
 from conftest import get_request_kwargs
 from typing import Optional, List, Tuple
@@ -23,34 +19,12 @@ pytestmark = pytest.mark.frontend("ttir")
 torch.manual_seed(0)
 
 
-def _topk_index_dtype(shape: Tuple[int, ...], dim: int) -> torch.dtype:
-    """UInt16 while the tile-padded reduction dim fits in a uint16, else UInt32.
-
-    Mirrors ttir_topk_golden and the TTNN topk workaround; goldens here must match
-    it or execute_fb dtype-mismatches the device index output.
-    """
-    TILE_SIZE = 32
-    reduction_dim = dim if dim >= 0 else dim + len(shape)
-    padded = ((shape[reduction_dim] + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
-    return torch.uint16 if padded <= 0xFFFF else torch.uint32
-
-
-def _verify_topk_outputs(
-    input_tensor,
-    golden_topk,
-    dim,
-    output_tensors,
-    pcc=0.99,
-    check_gathered=True,
-    check_indices=False,
-):
+def _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors):
     """PCC-checks topk device outputs against the golden via check_outputs.
 
-    check_gathered validates indices order-robustly: it gathers the values they
-    point to out of the input and PCC-compares those against the device's values.
-    check_indices instead compares indices positionally against the golden.
+    Indices are checked order-robustly: gather the values they point to out of
+    the input and PCC-compare those against the device's values.
     """
-    d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
     device_values = prog["device_output_0"][0]
 
@@ -58,7 +32,7 @@ def _verify_topk_outputs(
         golden_topk.values,
         device_values,
         "topk_values",
-        pcc,
+        0.99,
         1e-08,
         1e-05,
         check_pcc=True,
@@ -67,225 +41,22 @@ def _verify_topk_outputs(
     )
 
     device_indices = prog["device_output_1"][0].long()
-
-    if check_gathered:
-        gathered_values = torch.gather(input_tensor.float(), dim, device_indices)
-        check_outputs(
-            device_values.float(),
-            gathered_values,
-            "topk_gathered_values",
-            pcc,
-            1e-08,
-            1e-05,
-            check_pcc=True,
-            check_atol=False,
-            check_rtol=False,
-        )
-
-    if check_indices:
-        check_outputs(
-            golden_topk.indices.float(),
-            device_indices.float(),
-            "topk_indices",
-            pcc,
-            1e-08,
-            1e-05,
-            check_pcc=True,
-            check_atol=False,
-            check_rtol=False,
-        )
-
-
-SINGLE_CORE_TOPK_SHAPES = [
-    # Single-tile non-target dim; the reduction dim still merges and rebuilds.
-    pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
-    pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
-    # Large target dim (many tiles in reduction), k > 32.
-    pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
-    pytest.param((1376, 32), 64, 0, id="1376x32_k64_dim0"),
-    # Ragged (non-power-of-2 tile count)
-    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
-    pytest.param((1208, 32), 16, 0, id="1208x32_k16_dim0"),
-    # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
-    pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
-    pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
-]
-
-MULTI_CORE_TOPK_SHAPES = [
-    # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
-    # any multiple of 32.
-    pytest.param((32, 5504), 16, -1, id="32x5504_k16_dim1"),
-    pytest.param((32, 88064), 16, -1, id="32x88064_k16_dim1"),
-    pytest.param((35, 7639), 16, -1, id="35x7639_k16_dim1"),
-    # Transposed equivalents: non-target dim is a single tile (32), on dim 1;
-    # target dim (dim=0) is any multiple of 32.
-    pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
-    pytest.param((88064, 32), 16, 0, id="88064x32_k16_dim0"),
-    pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
-    # k > 32: each core's partial spans two reduction tiles.
-    pytest.param((32, 8192), 48, -1, id="32x8192_k48_dim1"),
-    pytest.param((32, 88064), 64, -1, id="32x88064_k64_dim1"),
-    pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
-    pytest.param((88064, 32), 64, 0, id="88064x32_k64_dim0"),
-    # data parallel
-    pytest.param((32, 8192), 16, 0, id="32x8192_k16_dim0"),
-    pytest.param((8192, 32), 16, -1, id="8192x32_k16_dim1"),
-]
-
-
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("shape,k,dim", SINGLE_CORE_TOPK_SHAPES)
-def test_topk_single_core(shape, k, dim, target, request, device):
-    def module(builder: TTIRBuilder):
-        @builder.func([shape], [torch.float32])
-        def topk(
-            in0: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            values = builder.topk(
-                in0,
-                k=k,
-                dim=dim,
-                largest=True,
-                sorted=False,
-                unit_attrs=unit_attrs,
-            )
-            indices = builder.topk_indices(values)
-            return values, indices
-
-    kwargs = get_request_kwargs(request)
-    artifact_dir = get_artifact_dir(
-        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
+    gathered_values = torch.gather(input_tensor.float(), dim, device_indices)
+    check_outputs(
+        device_values.float(),
+        gathered_values,
+        "topk_gathered_values",
+        0.99,
+        1e-08,
+        1e-05,
+        check_pcc=True,
+        check_atol=False,
+        check_rtol=False,
     )
 
-    (
-        builder,
-        compiled_bin,
-        io_goldens,
-        intermediate_goldens,
-    ) = compile_ttir_to_flatbuffer(
-        module,
-        system_desc_path=kwargs["system_desc_path"],
-        artifact_dir=artifact_dir,
-        target=target,
-        save_artifacts=True,
-        print_ir=kwargs.get("print_ir", False),
-    )
 
-    input_tensor = torch.randn(shape) * 50
-    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
-
-    mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
-    io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_topk.values}, mesh_shape=mesh_shape
-    )
-    # Device index dtype must match, though the raw index is ignored below.
-    io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
-        mesh_shape=mesh_shape,
-    )
-
-    # Positional PCC is invalid for unsorted values and tie-unstable indices;
-    # _verify_topk_outputs checks both order-robustly instead.
-    _, output_tensors = execute_fb(
-        compiled_bin,
-        input_output_goldens=io_goldens,
-        intermediate_goldens=intermediate_goldens,
-        device=device,
-        pcc=0.99,
-        check_pcc=False,
-        save_artifacts=True,
-        artifact_dir=artifact_dir,
-    )
-
-    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)
-
-
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("shape,k,dim", MULTI_CORE_TOPK_SHAPES)
-def test_topk_multi_core(shape, k, dim, target, request, device):
-    # Computed before `module` so the nested `topk` closure can capture it.
-    input_tensor = torch.randn(shape) * 50
-    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
-
-    def module(builder: TTIRBuilder):
-        @builder.func([shape], [torch.float32])
-        def topk(
-            in0: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            values = builder.topk(
-                in0,
-                k=k,
-                dim=dim,
-                largest=True,
-                sorted=False,
-                unit_attrs=unit_attrs,
-            )
-            indices = builder.topk_indices(values)
-            builder.set_goldens(
-                {in0: input_tensor},
-                {
-                    values: golden_topk.values,
-                    indices: golden_topk.indices.to(_topk_index_dtype(shape, dim)),
-                },
-            )
-            return values, indices
-
-    kwargs = get_request_kwargs(request)
-    artifact_dir = get_artifact_dir(
-        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
-    )
-
-    (
-        builder,
-        compiled_bin,
-        io_goldens,
-        intermediate_goldens,
-    ) = compile_ttir_to_flatbuffer(
-        module,
-        system_desc_path=kwargs["system_desc_path"],
-        artifact_dir=artifact_dir,
-        target=target,
-        save_artifacts=True,
-        print_ir=kwargs.get("print_ir", False),
-    )
-
-    mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
-    io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_topk.values}, mesh_shape=mesh_shape
-    )
-    # Device index dtype must match, though the raw index is ignored below.
-    io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
-        mesh_shape=mesh_shape,
-    )
-
-    # Positional PCC is invalid for unsorted values and tie-unstable indices;
-    # _verify_topk_outputs checks both order-robustly instead.
-    _, output_tensors = execute_fb(
-        compiled_bin,
-        input_output_goldens=io_goldens,
-        intermediate_goldens=intermediate_goldens,
-        device=device,
-        pcc=0.99,
-        check_pcc=False,
-        save_artifacts=True,
-        artifact_dir=artifact_dir,
-    )
-
-    _verify_topk_outputs(
-        input_tensor,
-        golden_topk,
-        dim,
-        output_tensors,
-        check_gathered=True,
-        check_indices=False,
-    )
+def _random_input(shape: Tuple[int, ...], k: int, dim: int) -> torch.Tensor:
+    return torch.randn(shape) * 50
 
 
 def _build_tile_distribution_input(
@@ -341,7 +112,45 @@ def _build_tile_distribution_input(
     return tensor
 
 
-SINGLE_CORE_TILE_DIST_SHAPES = [
+SINGLE_CORE_TOPK_SHAPES = [
+    # Single-tile non-target dim; the reduction dim still merges and rebuilds.
+    pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
+    pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
+    # Large target dim (many tiles in reduction), k > 32.
+    pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
+    pytest.param((1376, 32), 64, 0, id="1376x32_k64_dim0"),
+    # Ragged (non-power-of-2 tile count)
+    pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
+    pytest.param((1208, 32), 16, 0, id="1208x32_k16_dim0"),
+    # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
+    pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
+    pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),
+]
+
+MULTI_CORE_TOPK_SHAPES = [
+    # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
+    # any multiple of 32.
+    pytest.param((32, 5504), 16, -1, id="32x5504_k16_dim1"),
+    pytest.param((32, 96256), 16, -1, id="32x96256_k16_dim1"),
+    pytest.param((35, 7639), 16, -1, id="35x7639_k16_dim1"),
+    # Transposed equivalents: non-target dim is a single tile (32), on dim 1;
+    # target dim (dim=0) is any multiple of 32.
+    pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
+    pytest.param((96256, 32), 16, 0, id="96256x32_k16_dim0"),
+    pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
+    # k > 32: each core's partial spans two reduction tiles.
+    pytest.param((32, 8192), 48, -1, id="32x8192_k48_dim1"),
+    pytest.param((32, 96256), 64, -1, id="32x96256_k64_dim1"),
+    pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
+    pytest.param((96256, 32), 64, 0, id="96256x32_k64_dim0"),
+    # data parallel
+    pytest.param((32, 8192), 16, 0, id="32x8192_k16_dim0"),
+    pytest.param((8192, 32), 16, -1, id="8192x32_k16_dim1"),
+]
+
+# Shapes worth running against inputs whose top values sit in specific tiles,
+# which stresses the merge tree.
+TILE_DIST_SHAPES = [
     # pow2 tile count, dim=0
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
     # Large reduction dim, still <= 1024.
@@ -350,23 +159,40 @@ SINGLE_CORE_TILE_DIST_SHAPES = [
     pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),  # 3 tiles, odd
     # Multi-tile non-target dim
     pytest.param((64, 256), 64, -1, id="64x256_k64_dim1"),  # ht=2, large-k
-]
-
-MULTI_CORE_TILE_DIST_SHAPES = [
-    # Non-target dim is a single tile (32), on dim 0; target dim (dim=1) is
-    # any multiple of 32.
+    # Multi-core: non-target dim is a single tile (32), on dim 0.
     pytest.param((32, 2080), 16, -1, id="32x2080_k16_dim1"),  # 65 tiles, odd
 ]
 
 
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("pattern", ["first_tiles", "last_tiles", "strided"])
-@pytest.mark.parametrize("shape,k,dim", SINGLE_CORE_TILE_DIST_SHAPES)
-def test_topk_tile_distribution_single_core(
-    shape, k, dim, pattern, target, request, device
-):
-    """Concentrate the top values in specific tiles to stress the merge tree."""
+def _cases(shapes, input_fn, id_suffix=""):
+    return [
+        pytest.param(
+            *shape.values, input_fn, id=shape.id + id_suffix, marks=shape.marks
+        )
+        for shape in shapes
+    ]
 
+
+TOPK_CASES = [
+    *_cases(SINGLE_CORE_TOPK_SHAPES, _random_input),
+    *_cases(MULTI_CORE_TOPK_SHAPES, _random_input),
+    *[
+        case
+        for pattern in ("first_tiles", "last_tiles", "strided")
+        for case in _cases(
+            TILE_DIST_SHAPES,
+            lambda shape, k, dim, pattern=pattern: _build_tile_distribution_input(
+                shape, k, dim, pattern
+            ),
+            f"_{pattern}",
+        )
+    ],
+]
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+@pytest.mark.parametrize("shape,k,dim,input_fn", TOPK_CASES)
+def test_topk(shape, k, dim, input_fn, target, request, device):
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
         def topk(
@@ -404,20 +230,17 @@ def test_topk_tile_distribution_single_core(
         print_ir=kwargs.get("print_ir", False),
     )
 
-    # Recompute the golden against the adversarial tensor.
-    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
-    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
+    input_tensor = input_fn(shape, k, dim)
+    golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
 
     mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor(
-        {0: adversarial_input}, mesh_shape=mesh_shape
-    )
+    io_goldens[0]["input_0"] = GoldenMapTensor({0: input_tensor}, mesh_shape=mesh_shape)
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
     # Device index dtype must match, though the raw index is ignored below.
     io_goldens[0]["output_1"] = GoldenMapTensor(
-        {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
+        {0: golden_topk.indices.to(io_goldens[0]["output_1"].dtype)},
         mesh_shape=mesh_shape,
     )
 
@@ -434,90 +257,4 @@ def test_topk_tile_distribution_single_core(
         artifact_dir=artifact_dir,
     )
 
-    _verify_topk_outputs(adversarial_input, golden_topk, dim, output_tensors)
-
-
-@pytest.mark.parametrize("target", ["ttmetal"])
-@pytest.mark.parametrize("pattern", ["first_tiles", "last_tiles", "strided"])
-@pytest.mark.parametrize("shape,k,dim", MULTI_CORE_TILE_DIST_SHAPES)
-def test_topk_tile_distribution_multi_core(
-    shape, k, dim, pattern, target, request, device
-):
-    """Concentrate the top values in specific tiles to stress the merge tree."""
-
-    adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
-    golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
-
-    def module(builder: TTIRBuilder):
-        @builder.func([shape], [torch.float32])
-        def topk(
-            in0: Operand,
-            builder: TTIRBuilder,
-            unit_attrs: Optional[List[str]] = None,
-        ):
-            values = builder.topk(
-                in0,
-                k=k,
-                dim=dim,
-                largest=True,
-                sorted=False,
-                unit_attrs=unit_attrs,
-            )
-            indices = builder.topk_indices(values)
-            builder.set_goldens(
-                {in0: adversarial_input},
-                {
-                    values: golden_topk.values,
-                    indices: golden_topk.indices.to(_topk_index_dtype(shape, dim)),
-                },
-            )
-            return values, indices
-
-    kwargs = get_request_kwargs(request)
-    artifact_dir = get_artifact_dir(
-        kwargs["output_root"], "TTIRBuilder", kwargs["test_base"], make_dir=True
-    )
-
-    (
-        builder,
-        compiled_bin,
-        io_goldens,
-        intermediate_goldens,
-    ) = compile_ttir_to_flatbuffer(
-        module,
-        system_desc_path=kwargs["system_desc_path"],
-        artifact_dir=artifact_dir,
-        target=target,
-        save_artifacts=True,
-        print_ir=kwargs.get("print_ir", False),
-    )
-
-    mesh_shape = (1, 1)
-    io_goldens[0]["input_0"] = GoldenMapTensor(
-        {0: adversarial_input}, mesh_shape=mesh_shape
-    )
-    io_goldens[0]["output_0"] = GoldenMapTensor(
-        {0: golden_topk.values}, mesh_shape=mesh_shape
-    )
-
-    # Positional PCC is invalid for unsorted values and tie-unstable indices;
-    # _verify_topk_outputs checks both order-robustly instead.
-    _, output_tensors = execute_fb(
-        compiled_bin,
-        input_output_goldens=io_goldens,
-        intermediate_goldens=intermediate_goldens,
-        device=device,
-        pcc=0.99,
-        check_pcc=False,
-        save_artifacts=True,
-        artifact_dir=artifact_dir,
-    )
-
-    _verify_topk_outputs(
-        adversarial_input,
-        golden_topk,
-        dim,
-        output_tensors,
-        check_gathered=True,
-        check_indices=False,
-    )
+    _verify_topk_outputs(input_tensor, golden_topk, dim, output_tensors)

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -24,10 +24,11 @@ torch.manual_seed(0)
 
 
 def _topk_index_dtype(shape: Tuple[int, ...], dim: int) -> torch.dtype:
-    """Index dtype the topk op declares for this input, mirroring
-    ttir_topk_golden / the TTNN topk workaround: UInt16 while the tile-padded
-    reduction dim fits in a uint16, else UInt32. Test-side goldens must match
-    this so execute_fb doesn't dtype-mismatch the device index output."""
+    """UInt16 while the tile-padded reduction dim fits in a uint16, else UInt32.
+
+    Mirrors ttir_topk_golden and the TTNN topk workaround; goldens here must match
+    it or execute_fb dtype-mismatches the device index output.
+    """
     TILE_SIZE = 32
     reduction_dim = dim if dim >= 0 else dim + len(shape)
     padded = ((shape[reduction_dim] + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
@@ -45,17 +46,9 @@ def _verify_topk_outputs(
 ):
     """PCC-checks topk device outputs against the golden via check_outputs.
 
-    Values go through the same check_outputs() PCC engine that execute_fb
-    uses, so a failure raises TTBuilderGoldenException.
-
-    check_gathered=True additionally validates the device's indices by
-    gathering the values they point to from the original input and
-    PCC-comparing those against the device's topk values. This is
-    order-robust (doesn't depend on positional/tie-break ordering). Used by
-    both single-core and multi-core tests in this file.
-
-    check_indices=True instead PCC-compares the device's indices positionally
-    against the golden indices. Not currently exercised by any test here.
+    check_gathered validates indices order-robustly: it gathers the values they
+    point to out of the input and PCC-compares those against the device's values.
+    check_indices instead compares indices positionally against the golden.
     """
     d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
@@ -104,8 +97,7 @@ def _verify_topk_outputs(
 
 
 SINGLE_CORE_TOPK_SHAPES = [
-    # Single-tile non-target dim (exactly 32 elements); reduction dim (256,
-    # 8 tiles) still goes through merge/rebuild.
+    # Single-tile non-target dim; the reduction dim still merges and rebuilds.
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
     # Large target dim (many tiles in reduction), k > 32.
@@ -130,9 +122,7 @@ MULTI_CORE_TOPK_SHAPES = [
     pytest.param((8192, 32), 16, 0, id="8192x32_k16_dim0"),
     pytest.param((88064, 32), 16, 0, id="88064x32_k16_dim0"),
     pytest.param((7639, 35), 16, 0, id="7639x35_k16_dim0"),
-    # k > 32: each core's local top-k spans two reduction tiles (winner +
-    # loser); the gather and merge tree carry outputReductionTiles=2 tiles per
-    # partial. dim=1 and transposed dim=0.
+    # k > 32: each core's partial spans two reduction tiles.
     pytest.param((32, 8192), 48, -1, id="32x8192_k48_dim1"),
     pytest.param((32, 88064), 64, -1, id="32x88064_k64_dim1"),
     pytest.param((8192, 32), 48, 0, id="8192x32_k48_dim0"),
@@ -183,7 +173,6 @@ def test_topk_single_core(shape, k, dim, target, request, device):
         print_ir=kwargs.get("print_ir", False),
     )
 
-    # Recompute golden from a fresh random input for a valid comparison.
     input_tensor = torch.randn(shape) * 50
     golden_topk = torch.topk(input_tensor, k=k, dim=dim, largest=True)
 
@@ -192,14 +181,14 @@ def test_topk_single_core(shape, k, dim, target, request, device):
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
-    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    # Device index dtype must match, though the raw index is ignored below.
     io_goldens[0]["output_1"] = GoldenMapTensor(
         {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
         mesh_shape=mesh_shape,
     )
 
-    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
-    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    # Positional PCC is invalid for unsorted values and tie-unstable indices;
+    # _verify_topk_outputs checks both order-robustly instead.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -261,7 +250,6 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
         system_desc_path=kwargs["system_desc_path"],
         artifact_dir=artifact_dir,
         target=target,
-        # pipeline_options=["override-device-shape=1,1"],
         save_artifacts=True,
         print_ir=kwargs.get("print_ir", False),
     )
@@ -271,14 +259,14 @@ def test_topk_multi_core(shape, k, dim, target, request, device):
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
-    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    # Device index dtype must match, though the raw index is ignored below.
     io_goldens[0]["output_1"] = GoldenMapTensor(
         {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
         mesh_shape=mesh_shape,
     )
 
-    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
-    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    # Positional PCC is invalid for unsorted values and tie-unstable indices;
+    # _verify_topk_outputs checks both order-robustly instead.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -377,8 +365,7 @@ MULTI_CORE_TILE_DIST_SHAPES = [
 def test_topk_tile_distribution_single_core(
     shape, k, dim, pattern, target, request, device
 ):
-    """Run topk with hand-crafted inputs that concentrate top values in
-    specific tiles, stressing the merge-tree reduction logic."""
+    """Concentrate the top values in specific tiles to stress the merge tree."""
 
     def module(builder: TTIRBuilder):
         @builder.func([shape], [torch.float32])
@@ -417,8 +404,7 @@ def test_topk_tile_distribution_single_core(
         print_ir=kwargs.get("print_ir", False),
     )
 
-    # Replace the random input with our adversarial tensor and recompute the
-    # expected output so the golden comparison is valid.
+    # Recompute the golden against the adversarial tensor.
     adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
     golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
 
@@ -429,14 +415,14 @@ def test_topk_tile_distribution_single_core(
     io_goldens[0]["output_0"] = GoldenMapTensor(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
-    # Match device index dtype to avoid execute_fb dtype mismatch; raw index is ignored.
+    # Device index dtype must match, though the raw index is ignored below.
     io_goldens[0]["output_1"] = GoldenMapTensor(
         {0: golden_topk.indices.to(_topk_index_dtype(shape, dim))},
         mesh_shape=mesh_shape,
     )
 
-    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
-    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    # Positional PCC is invalid for unsorted values and tie-unstable indices;
+    # _verify_topk_outputs checks both order-robustly instead.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,
@@ -457,8 +443,7 @@ def test_topk_tile_distribution_single_core(
 def test_topk_tile_distribution_multi_core(
     shape, k, dim, pattern, target, request, device
 ):
-    """Run topk with hand-crafted inputs that concentrate top values in
-    specific tiles, stressing the merge-tree reduction logic."""
+    """Concentrate the top values in specific tiles to stress the merge tree."""
 
     adversarial_input = _build_tile_distribution_input(shape, k, dim, pattern)
     golden_topk = torch.topk(adversarial_input, k=k, dim=dim, largest=True)
@@ -515,8 +500,8 @@ def test_topk_tile_distribution_multi_core(
         {0: golden_topk.values}, mesh_shape=mesh_shape
     )
 
-    # execute_fb's positional PCC is invalid for unsorted values / tie-unstable
-    # indices; both are PCC-checked order-robustly in _verify_topk_outputs.
+    # Positional PCC is invalid for unsorted values and tie-unstable indices;
+    # _verify_topk_outputs checks both order-robustly instead.
     _, output_tensors = execute_fb(
         compiled_bin,
         input_output_goldens=io_goldens,

--- a/test/python/golden/d2m/test_topk.py
+++ b/test/python/golden/d2m/test_topk.py
@@ -51,11 +51,11 @@ def _verify_topk_outputs(
     check_gathered=True additionally validates the device's indices by
     gathering the values they point to from the original input and
     PCC-comparing those against the device's topk values. This is
-    order-robust (doesn't depend on positional/tie-break ordering). Used on
-    single-core tests.
+    order-robust (doesn't depend on positional/tie-break ordering). Used by
+    both single-core and multi-core tests in this file.
 
     check_indices=True instead PCC-compares the device's indices positionally
-    against the golden indices. Used on multi-core tests.
+    against the golden indices. Not currently exercised by any test here.
     """
     d = dim % input_tensor.ndim
     prog = output_tensors["program_0"]
@@ -104,16 +104,16 @@ def _verify_topk_outputs(
 
 
 SINGLE_CORE_TOPK_SHAPES = [
-    # Single-tile reduction dim (exactly 32 elements): no merge/rebuild, just
-    # local_sort.
+    # Single-tile non-target dim (exactly 32 elements); reduction dim (256,
+    # 8 tiles) still goes through merge/rebuild.
     pytest.param((32, 256), 64, -1, id="32x256_k64_dim1"),
     pytest.param((256, 32), 64, 0, id="256x32_k64_dim0"),
     # Large target dim (many tiles in reduction), k > 32.
     pytest.param((32, 1376), 64, -1, id="32x1376_k64_dim1"),
-    pytest.param((1760, 32), 64, 0, id="1760x32_k64_dim0"),
+    pytest.param((1376, 32), 64, 0, id="1376x32_k64_dim0"),
     # Ragged (non-power-of-2 tile count)
     pytest.param((32, 96), 16, -1, id="32x96_k16_dim1"),
-    pytest.param((1536, 32), 16, 0, id="1536x32_k16_dim0"),
+    pytest.param((1208, 32), 16, 0, id="1208x32_k16_dim0"),
     # Multi-tile non-target dim (ht>1 for dim=1, wt>1 for dim=0)
     pytest.param((96, 446), 32, -1, id="96x446_k32_dim1"),
     pytest.param((383, 96), 63, 0, id="383x96_k63_dim0"),

--- a/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
@@ -9,10 +9,13 @@
 // 32x64 input: 1 merge iteration (logWt=1), small k, rebuild is emitted.
 // CHECK-LABEL: func.func @topk_dim1_k16
 func.func @topk_dim1_k16(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
-  // The topk kernel builds its own index CB: the lane pattern, shifted right by
-  // 5 to keep the within-tile row index, plus this core's tile offset.
+  // The topk kernel builds its own index CB. The lane tile is written once: a
+  // fill_arange plus the transpose that column-major arange emits, leaving the
+  // within-tile row index in column 0. Every index tile then broadcasts that
+  // column across the tile and adds its own offset within this core's band.
   // CHECK: ttkernel.experimental.fill_arange_tile
-  // CHECK: ttkernel.binary_right_shift_tile
+  // CHECK: ttkernel.transpose_wh_tile
+  // CHECK: ttkernel.unary_bcast
 
   // The sort-merge-rebuild group processes tile pair (0, 1).
   // CHECK: ttkernel.topk_tile_init
@@ -43,7 +46,8 @@ func.func @topk_k32_no_rebuild(%arg0: tensor<32x64xf32>) -> (tensor<32x32xf32>, 
 
 // ---- dim=0, k=16, 2-tile input ----
 
-// 64x32 with dim=0: no pre-transpose is needed; the TTKernel ops are the same as dim=1.
+// 64x32 with dim=0: the values need no pre-transpose. The lane tile comes from
+// a column-major arange for either dim, so transpose_wh_tile is emitted anyway.
 // CHECK-LABEL: func.func @topk_dim0_k16
 func.func @topk_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
   // CHECK: ttkernel.experimental.fill_arange_tile

--- a/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
+++ b/test/ttmlir/Conversion/D2MToTTKernel/topk.mlir
@@ -9,8 +9,10 @@
 // 32x64 input: 1 merge iteration (logWt=1), small k, rebuild is emitted.
 // CHECK-LABEL: func.func @topk_dim1_k16
 func.func @topk_dim1_k16(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
-  // The arange kernel initializes the index CB with sequential tile indices.
+  // The topk kernel builds its own index CB: the lane pattern, shifted right by
+  // 5 to keep the within-tile row index, plus this core's tile offset.
   // CHECK: ttkernel.experimental.fill_arange_tile
+  // CHECK: ttkernel.binary_right_shift_tile
 
   // The sort-merge-rebuild group processes tile pair (0, 1).
   // CHECK: ttkernel.topk_tile_init

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -55,11 +55,14 @@ module {
   // ---- dim=0, k<=32 ----
 
   // 2D topk along dim 0 with k=16 on a 64x32 input (2 tiles tall).
-  // No pre-transpose is needed for dim=0; extract uses tile_typecast.
+  // The value input needs no pre-transpose for dim=0, but the index buffer is
+  // built row-major on a shape-swapped [wt, ht] buffer and full-transposed
+  // (grid + tile) back to [ht, wt], so a tile_transpose DOES appear (on the
+  // index buffer, before topk_block). Extract uses tile_typecast.
   // CHECK-LABEL: func @topk_dim0_k16
   func.func @topk_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
-    // No pre-transpose is needed for dim=0.
-    // CHECK-NOT: d2m.tile_transpose
+    // The index buffer's full-transpose emits a tile_transpose before topk.
+    // CHECK: d2m.tile_transpose
 
     // The TopK generic op contains topk_block.
     // CHECK: d2m.generic
@@ -101,11 +104,12 @@ module {
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
   }
 
-  // k=64 along dim=0 uses tile_typecast for extract.
+  // k=64 along dim=0 uses tile_typecast for extract. The index buffer is
+  // built row-major + full-transposed, so a tile_transpose appears before topk.
   // CHECK-LABEL: func @topk_dim0_k64
   func.func @topk_dim0_k64(%arg0: tensor<256x32xf32>) -> (tensor<64x32xf32>, tensor<64x32xsi32>) {
-    // No pre-transpose is needed for dim=0.
-    // CHECK-NOT: d2m.tile_transpose
+    // The index buffer's full-transpose emits a tile_transpose before topk.
+    // CHECK: d2m.tile_transpose
     // CHECK: d2m.generic
     // CHECK: d2m.topk_block
     // CHECK-SAME: dim = 0
@@ -169,4 +173,51 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
-}
+
+  // ---- Multi-core (reduction dim split into per-core bands) ----
+  //
+  // When the reduction dim needs more tiles than one core's budget
+  // (kMaxTilesPerCore / nonTargetTiles), the lowering splits it into numShards
+  // bands (one per core), runs a local topk_block per band, then merges the
+  // per-band partials via a composite_view + a final topk_block. A wide
+  // non-target dim (4 tiles here) shrinks the per-core reduction budget to
+  // 43/4 = 10 tiles, so a 16-reduction-tile input needs >= 2 cores.
+
+  // dim=1 multi-core: 128x512, k=16. Rows=128 (4 non-target tiles), cols=512
+  // (16 reduction tiles) -> multi-core band split.
+  // CHECK-LABEL: func @topk_dim1_multicore
+  func.func @topk_dim1_multicore(%arg0: tensor<128x512xf32>) -> (tensor<128x16xf32>, tensor<128x16xsi32>) {
+    // Per-band local topk (transpose + topk_block) ...
+    // CHECK: d2m.tile_transpose
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 1
+    // CHECK-SAME: k = 16
+    // ... then the merge gathers the per-band partials via composite_view ...
+    // CHECK: d2m.composite_view
+    // ... and a final merge topk_block selects the global top-k.
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 1
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<128x512xf32>) -> (tensor<128x16xf32>, tensor<128x16xsi32>)
+    return %values, %indices : tensor<128x16xf32>, tensor<128x16xsi32>
+  }
+
+  // dim=0 multi-core: 512x128, k=16. Rows=512 (16 reduction tiles), cols=128
+  // (4 non-target tiles) -> multi-core band split. Exercises the row-major
+  // arange + full-transpose (grid + tile) index construction under a
+  // gridColsx1 band grid.
+  // CHECK-LABEL: func @topk_dim0_multicore
+  func.func @topk_dim0_multicore(%arg0: tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>) {
+    // The index buffer's full-transpose emits a tile_transpose ...
+    // CHECK: d2m.tile_transpose
+    // ... the per-band local topk ...
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 0
+    // CHECK-SAME: k = 16
+    // ... the merge gathers per-band partials via composite_view ...
+    // CHECK: d2m.composite_view
+    // ... and a final merge topk_block selects the global top-k.
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 0
+    %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>)
+    return %values, %indices : tensor<16x128xf32>, tensor<16x128xsi32>
+  }

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --d2m-lower-topk --d2m-materialize-view-returns -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --d2m-build-topk-chain --d2m-materialize-view-returns -o %t %s
 // RUN: FileCheck %s --input-file=%t
 // RUN: FileCheck %s --input-file=%t --check-prefix=CONSUMED
 // RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection -o %t.plan %s
@@ -6,9 +6,9 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
 // ttir-to-d2m emits only a placeholder leaf; d2m-grid-selection chooses the
-// split and folds every buffer it implies onto the leaf, and d2m-lower-topk
-// builds exactly those ops. So every plan entry is consumed and no plan
-// survives the lowering.
+// split and folds every buffer it implies onto the leaf, and
+// d2m-build-topk-chain builds exactly those ops. So every plan entry is
+// consumed and no plan survives the lowering.
 // The scan starts at the first function so it skips the ttcore.device
 // attribute.
 // CONSUMED-LABEL: func.func @topk_dim1_k16
@@ -202,7 +202,7 @@ module {
   //
   // When the reduction dim needs more tiles than one core's budget
   // (kMaxTilesPerCore / nonTargetTiles), grid selection plans numShards bands
-  // (one per core) and d2m-lower-topk builds them, each running a local
+  // (one per core) and d2m-build-topk-chain builds them, each running a local
   // topk_block and then narrowing its partial to ceil(k/32) tiles. The bands
   // stay distributed: a merge round gathers them with one composite_view per
   // operand (values and indices need separate generics), re-splitting that

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -223,4 +223,43 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>)
     return %values, %indices : tensor<16x128xf32>, tensor<16x128xsi32>
   }
+
+  // ---- Multi-core (non-target dim split, data-parallel) ----
+  //
+  // When the NON-TARGET dim alone overflows the per-core budget (64 tiles here
+  // against kMaxTilesPerCore = 43), banding the reduction dim cannot help: the
+  // whole non-target dim lives on every band core. topk is independent per
+  // slice, so the lowering splits the non-target dim across cores instead and
+  // each one runs the entire reduction locally. Nothing to merge, so no
+  // composite_view and a single topk_block.
+
+  // dim=1 data-parallel: 2048x128, k=8. Rows=2048 (64 non-target tiles) split
+  // across cores, cols=128 (4 reduction tiles) kept whole on each.
+  // CHECK-LABEL: func @topk_dim1_data_parallel
+  func.func @topk_dim1_data_parallel(%arg0: tensor<2048x128xf32>) -> (tensor<2048x8xf32>, tensor<2048x8xsi32>) {
+    // The value input is still pre-transposed for dim=1 ...
+    // CHECK: d2m.tile_transpose
+    // ... and a lone local topk produces the final answer per slice.
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 1
+    // CHECK-SAME: k = 8
+    // CHECK-NOT: d2m.composite_view
+    %values, %indices = "ttir.topk"(%arg0) <{k = 8 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<2048x128xf32>) -> (tensor<2048x8xf32>, tensor<2048x8xsi32>)
+    return %values, %indices : tensor<2048x8xf32>, tensor<2048x8xsi32>
+  }
+
+  // dim=0 data-parallel: the transpose of the above. Cols=2048 (64 non-target
+  // tiles) split across cores, rows=128 (4 reduction tiles) kept whole.
+  // CHECK-LABEL: func @topk_dim0_data_parallel
+  func.func @topk_dim0_data_parallel(%arg0: tensor<128x2048xf32>) -> (tensor<8x2048xf32>, tensor<8x2048xsi32>) {
+    // The index buffer's full-transpose emits a tile_transpose ...
+    // CHECK: d2m.tile_transpose
+    // ... then the per-slice topk.
+    // CHECK: d2m.topk_block
+    // CHECK-SAME: dim = 0
+    // CHECK-SAME: k = 8
+    // CHECK-NOT: d2m.composite_view
+    %values, %indices = "ttir.topk"(%arg0) <{k = 8 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<128x2048xf32>) -> (tensor<8x2048xf32>, tensor<8x2048xsi32>)
+    return %values, %indices : tensor<8x2048xf32>, tensor<8x2048xsi32>
+  }
 }

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -1,9 +1,10 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-lower-topk --d2m-materialize-view-returns -o %t %s
 // RUN: FileCheck %s --input-file=%t
 // RUN: FileCheck %s --input-file=%t --check-prefix=UNPLACED
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
-// Grids are emitted unfolded; d2m-grid-selection maps them onto physical cores.
+// Grids are emitted unfolded and tagged d2m.pinned_grid; d2m-grid-selection
+// only folds them onto physical cores.
 // The scan starts at the first function so it skips the ttcore.device
 // attribute, whose workerGrid always carries the device's own fold maps.
 // UNPLACED-LABEL: func.func @topk_dim1_k16
@@ -17,7 +18,8 @@ module {
 
   // 2D topk along dim 1 with k=16 on a 32x64 input (2 tiles wide).
   // The lowering must:
-  //   1. Transpose tiles (dim=1 operates on rows, TopkBlockOp on columns).
+  //   1. Transpose tiles (topk_block sorts down tile columns; dim=1 puts the
+  //      sort dim on tile rows).
   //   2. Run topk_block with correct k and num_elements.
   //   3. Extract results with tile_transpose (untranspose).
   // CHECK-LABEL: func @topk_dim1_k16
@@ -64,13 +66,13 @@ module {
   // ---- dim=0, k<=32 ----
 
   // 2D topk along dim 0 with k=16 on a 64x32 input (2 tiles tall).
-  // Nothing is transposed for dim=0: the value input already reduces down tile
-  // rows, and the index buffer is built inside the topk kernel rather than by
-  // an upstream arange that would need reorienting. Extract uses tile_typecast.
+  // Nothing is transposed for dim=0: the sort dim already runs down tile
+  // columns, which is the orientation topk_block wants. Extract uses
+  // tile_typecast, which also converts the si32 indices to the user's type.
   // CHECK-LABEL: func @topk_dim0_k16
   func.func @topk_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
-    // No index buffer is materialized upstream, so nothing is transposed and
-    // no arange runs before topk_block.
+    // The index buffer is built inside the topk kernel, so no arange runs
+    // upstream and nothing is transposed.
     // CHECK-NOT: d2m.tile_transpose
     // CHECK-NOT: d2m.arange_block
 
@@ -93,7 +95,8 @@ module {
 
   // ---- Large k (k>32) ----
 
-  // k=64 requires 2 output tiles and a 3-sub-merge tree.
+  // k=64 spans 2 output tiles; the reduction stays one topk_block here and only
+  // d2m-decompose-topk splits it into the large-k left fold.
   // CHECK-LABEL: func @topk_dim1_k64
   func.func @topk_dim1_k64(%arg0: tensor<32x256xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // Pre-transpose the input tiles.
@@ -114,8 +117,7 @@ module {
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
   }
 
-  // k=64 along dim=0 uses tile_typecast for extract, and needs no transpose
-  // anywhere: the index buffer is built in-kernel.
+  // k=64 along dim=0 uses tile_typecast for extract and needs no transpose.
   // CHECK-LABEL: func @topk_dim0_k64
   func.func @topk_dim0_k64(%arg0: tensor<256x32xf32>) -> (tensor<64x32xf32>, tensor<64x32xsi32>) {
     // CHECK-NOT: d2m.tile_transpose
@@ -165,8 +167,8 @@ module {
     // CHECK: d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, si32>
     // Values keep the full 2x1 reduction shape ...
     // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, f32>
-    // ... and the indices ride along as si32 (typecast to the user output
-    // after extract).
+    // ... and the indices ride along as si32 (dim=0 folds the typecast to the
+    // user's index type into the extract itself).
     // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, si32>
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
@@ -174,10 +176,10 @@ module {
 
   // ---- Non-power-of-2 tile counts (ragged), k<=32 ----
 
-  // 32x544 with k=16: Wt=17 (non-pow2) now converts successfully.
+  // 32x544 with k=16: Wt=17, a non-power-of-2 reduction tile count.
   // CHECK-LABEL: func @topk_dim1_k16_nonpow2
   func.func @topk_dim1_k16_nonpow2(%arg0: tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
-    // Pre-transpose and topk_block emit normally.
+    // The ragged tile count is the merge tree's problem, not this level's.
     // CHECK: d2m.generic
     // CHECK: d2m.tile_transpose
     // CHECK: d2m.generic
@@ -195,12 +197,13 @@ module {
   // ---- Multi-core (reduction dim split into per-core bands) ----
   //
   // When the reduction dim needs more tiles than one core's budget
-  // (kMaxTilesPerCore / nonTargetTiles), the lowering splits it into numShards
-  // bands (one per core) and runs a local topk_block per band. The bands stay
-  // distributed: each merge round gathers them with a single composite_view
-  // over the whole grid-wide result, which re-splits that grid x shard extent
-  // onto the merge grid, then runs one topk_block for every group at once. A
-  // wide non-target dim (4 tiles here) shrinks the per-core reduction budget to
+  // (kMaxTilesPerCore / nonTargetTiles), d2m-lower-topk rebuilds the chain as
+  // numShards bands (one per core), each running a local topk_block and then
+  // narrowing its partial to ceil(k/32) tiles. The bands stay distributed: a
+  // merge round gathers them with one composite_view per operand (values and
+  // indices need separate generics), re-splitting that grid x shard extent onto
+  // the merge grid, then runs one topk_block for every group at once. A wide
+  // non-target dim (4 tiles here) shrinks the per-core reduction budget to
   // 43/4 = 10 tiles, so a 16-reduction-tile input needs >= 2 cores.
 
   // dim=1 multi-core: 128x512, k=16. Rows=128 (4 non-target tiles), cols=512
@@ -246,10 +249,11 @@ module {
   //
   // When the NON-TARGET dim alone overflows the per-core budget (64 tiles here
   // against kMaxTilesPerCore = 43), banding the reduction dim cannot help: the
-  // whole non-target dim lives on every band core. topk is independent per
-  // slice, so the lowering splits the non-target dim across cores instead and
-  // each one runs the entire reduction locally. Nothing to merge, so no
-  // composite_view and a single topk_block.
+  // whole non-target dim still lives on every band core, leaving it under the
+  // two reduction tiles a band needs. topk is independent per slice, so the
+  // lowering splits the non-target dim across cores instead and each one runs
+  // the entire reduction locally. Nothing to merge, so no composite_view and a
+  // single topk_block.
 
   // dim=1 data-parallel: 2048x128, k=8. Rows=2048 (64 non-target tiles) split
   // across cores, cols=128 (4 reduction tiles) kept whole on each.

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -1,16 +1,18 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-lower-topk --d2m-materialize-view-returns -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection --d2m-lower-topk --d2m-materialize-view-returns -o %t %s
 // RUN: FileCheck %s --input-file=%t
-// RUN: FileCheck %s --input-file=%t --check-prefix=UNPLACED
+// RUN: FileCheck %s --input-file=%t --check-prefix=CONSUMED
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-grid-selection -o %t.plan %s
+// RUN: FileCheck %s --input-file=%t.plan --check-prefix=PLAN
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
-// Grids are emitted unfolded and tagged d2m.pinned_grid; d2m-grid-selection
-// only folds them onto physical cores.
+// ttir-to-d2m emits only a placeholder leaf; d2m-grid-selection chooses the
+// split and folds every buffer it implies onto the leaf, and d2m-lower-topk
+// builds exactly those ops. So every plan entry is consumed and no plan
+// survives the lowering.
 // The scan starts at the first function so it skips the ttcore.device
-// attribute, whose workerGrid always carries the device's own fold maps.
-// UNPLACED-LABEL: func.func @topk_dim1_k16
-// UNPLACED-NOT: virt_to_physical_map
-// UNPLACED-NOT: physical_to_virt_map
-// UNPLACED-NOT: d2m.skip_grid_selection
+// attribute.
+// CONSUMED-LABEL: func.func @topk_dim1_k16
+// CONSUMED-NOT: d2m.topk_plan
 
 module {
 
@@ -23,6 +25,10 @@ module {
   //   2. Run topk_block with correct k and num_elements.
   //   3. Extract results with tile_transpose (untranspose).
   // CHECK-LABEL: func @topk_dim1_k16
+  // Every topk gets a plan, single core or not: it is the only thing that says
+  // what buffers to build.
+  // PLAN-LABEL: func.func @topk_dim1_k16
+  // PLAN: d2m.topk_plan
   func.func @topk_dim1_k16(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // The pre-transpose is a generic op wrapping tile_transpose.
     // CHECK: d2m.generic
@@ -141,9 +147,8 @@ module {
   // 32x64 input maps to 1x2 tiles (Ht=1, Wt=2).
   // CHECK-LABEL: func @topk_dim1_tile_shapes
   func.func @topk_dim1_tile_shapes(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
-    // The input layout is 1x2 tiles of f32.
-    // CHECK: d2m.to_layout
-    // CHECK-SAME: tensor<1x1x1x2x!ttcore.tile<32x32, f32>
+    // The input is gathered onto one core as 1x2 tiles of f32.
+    // CHECK: d2m.to_layout %arg0{{.*}} -> tensor<1x1x1x2x!ttcore.tile<32x32, f32>
     // The pre-transpose buffer is 1x2 tiles of f32.
     // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
     // The index input is a single si32 scratch tile per core: the kernel
@@ -161,8 +166,7 @@ module {
   // Verify tiled shapes for dim=0: 64x32 maps to 2x1 tiles.
   // CHECK-LABEL: func @topk_dim0_tile_shapes
   func.func @topk_dim0_tile_shapes(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
-    // CHECK: d2m.to_layout
-    // CHECK-SAME: tensor<1x1x2x1x!ttcore.tile<32x32, f32>
+    // CHECK: d2m.to_layout %arg0{{.*}} -> tensor<1x1x2x1x!ttcore.tile<32x32, f32>
     // The index input is a single si32 scratch tile per core.
     // CHECK: d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, si32>
     // Values keep the full 2x1 reduction shape ...
@@ -197,16 +201,19 @@ module {
   // ---- Multi-core (reduction dim split into per-core bands) ----
   //
   // When the reduction dim needs more tiles than one core's budget
-  // (kMaxTilesPerCore / nonTargetTiles), d2m-lower-topk rebuilds the chain as
-  // numShards bands (one per core), each running a local topk_block and then
-  // narrowing its partial to ceil(k/32) tiles. The bands stay distributed: a
-  // merge round gathers them with one composite_view per operand (values and
-  // indices need separate generics), re-splitting that grid x shard extent onto
-  // the merge grid, then runs one topk_block for every group at once.
+  // (kMaxTilesPerCore / nonTargetTiles), grid selection plans numShards bands
+  // (one per core) and d2m-lower-topk builds them, each running a local
+  // topk_block and then narrowing its partial to ceil(k/32) tiles. The bands
+  // stay distributed: a merge round gathers them with one composite_view per
+  // operand (values and indices need separate generics), re-splitting that
+  // grid x shard extent onto the merge grid, then runs one topk_block for every
+  // group at once.
 
   // dim=1 multi-core: 128x512, k=16. Rows=128 (4 non-target tiles), cols=512
   // (16 reduction tiles) -> multi-core band split.
   // CHECK-LABEL: func @topk_dim1_multicore
+  // PLAN-LABEL: func.func @topk_dim1_multicore
+  // PLAN: d2m.topk_plan
   func.func @topk_dim1_multicore(%arg0: tensor<128x512xf32>) -> (tensor<128x16xf32>, tensor<128x16xsi32>) {
     // Per-band local topk (transpose + topk_block) ...
     // CHECK: d2m.tile_transpose
@@ -227,6 +234,8 @@ module {
   // own index slice from its grid coordinate, so no index buffer is built or
   // moved across cores.
   // CHECK-LABEL: func @topk_dim0_multicore
+  // PLAN-LABEL: func.func @topk_dim0_multicore
+  // PLAN: d2m.topk_plan
   func.func @topk_dim0_multicore(%arg0: tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>) {
     // CHECK-NOT: d2m.tile_transpose
     // CHECK-NOT: d2m.arange_block
@@ -255,6 +264,8 @@ module {
   // dim=1 data-parallel: 2048x128, k=8. Rows=2048 (64 non-target tiles) split
   // across cores, cols=128 (4 reduction tiles) kept whole on each.
   // CHECK-LABEL: func @topk_dim1_data_parallel
+  // PLAN-LABEL: func.func @topk_dim1_data_parallel
+  // PLAN: d2m.topk_plan
   func.func @topk_dim1_data_parallel(%arg0: tensor<2048x128xf32>) -> (tensor<2048x8xf32>, tensor<2048x8xsi32>) {
     // The value input is still pre-transposed for dim=1 ...
     // CHECK: d2m.tile_transpose
@@ -270,6 +281,8 @@ module {
   // dim=0 data-parallel: the transpose of the above. Cols=2048 (64 non-target
   // tiles) split across cores, rows=128 (4 reduction tiles) kept whole.
   // CHECK-LABEL: func @topk_dim0_data_parallel
+  // PLAN-LABEL: func.func @topk_dim0_data_parallel
+  // PLAN: d2m.topk_plan
   func.func @topk_dim0_data_parallel(%arg0: tensor<128x2048xf32>) -> (tensor<8x2048xf32>, tensor<8x2048xsi32>) {
     // Every slice reduces the whole dim locally and builds its own indices, so
     // there is no shared index buffer to broadcast across the slice cores.

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -178,9 +178,11 @@ module {
   //
   // When the reduction dim needs more tiles than one core's budget
   // (kMaxTilesPerCore / nonTargetTiles), the lowering splits it into numShards
-  // bands (one per core), runs a local topk_block per band, then merges the
-  // per-band partials via a composite_view + a final topk_block. A wide
-  // non-target dim (4 tiles here) shrinks the per-core reduction budget to
+  // bands (one per core) and runs a local topk_block per band. The bands stay
+  // distributed: each merge round gathers them with a single composite_view
+  // over the whole grid-wide result, which re-splits that grid x shard extent
+  // onto the merge grid, then runs one topk_block for every group at once. A
+  // wide non-target dim (4 tiles here) shrinks the per-core reduction budget to
   // 43/4 = 10 tiles, so a 16-reduction-tile input needs >= 2 cores.
 
   // dim=1 multi-core: 128x512, k=16. Rows=128 (4 non-target tiles), cols=512
@@ -221,3 +223,4 @@ module {
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>)
     return %values, %indices : tensor<16x128xf32>, tensor<16x128xsi32>
   }
+}

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -202,9 +202,7 @@ module {
   // narrowing its partial to ceil(k/32) tiles. The bands stay distributed: a
   // merge round gathers them with one composite_view per operand (values and
   // indices need separate generics), re-splitting that grid x shard extent onto
-  // the merge grid, then runs one topk_block for every group at once. A wide
-  // non-target dim (4 tiles here) shrinks the per-core reduction budget to
-  // 43/4 = 10 tiles, so a 16-reduction-tile input needs >= 2 cores.
+  // the merge grid, then runs one topk_block for every group at once.
 
   // dim=1 multi-core: 128x512, k=16. Rows=128 (4 non-target tiles), cols=512
   // (16 reduction tiles) -> multi-core band split.
@@ -252,8 +250,7 @@ module {
   // whole non-target dim still lives on every band core, leaving it under the
   // two reduction tiles a band needs. topk is independent per slice, so the
   // lowering splits the non-target dim across cores instead and each one runs
-  // the entire reduction locally. Nothing to merge, so no composite_view and a
-  // single topk_block.
+  // the entire reduction locally.
 
   // dim=1 data-parallel: 2048x128, k=8. Rows=2048 (64 non-target tiles) split
   // across cores, cols=128 (4 reduction tiles) kept whole on each.

--- a/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
+++ b/test/ttmlir/Conversion/TTIRToD2M/topk.mlir
@@ -1,6 +1,15 @@
 // RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns -o %t %s
 // RUN: FileCheck %s --input-file=%t
+// RUN: FileCheck %s --input-file=%t --check-prefix=UNPLACED
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
+
+// Grids are emitted unfolded; d2m-grid-selection maps them onto physical cores.
+// The scan starts at the first function so it skips the ttcore.device
+// attribute, whose workerGrid always carries the device's own fold maps.
+// UNPLACED-LABEL: func.func @topk_dim1_k16
+// UNPLACED-NOT: virt_to_physical_map
+// UNPLACED-NOT: physical_to_virt_map
+// UNPLACED-NOT: d2m.skip_grid_selection
 
 module {
 
@@ -55,14 +64,15 @@ module {
   // ---- dim=0, k<=32 ----
 
   // 2D topk along dim 0 with k=16 on a 64x32 input (2 tiles tall).
-  // The value input needs no pre-transpose for dim=0, but the index buffer is
-  // built row-major on a shape-swapped [wt, ht] buffer and full-transposed
-  // (grid + tile) back to [ht, wt], so a tile_transpose DOES appear (on the
-  // index buffer, before topk_block). Extract uses tile_typecast.
+  // Nothing is transposed for dim=0: the value input already reduces down tile
+  // rows, and the index buffer is built inside the topk kernel rather than by
+  // an upstream arange that would need reorienting. Extract uses tile_typecast.
   // CHECK-LABEL: func @topk_dim0_k16
   func.func @topk_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
-    // The index buffer's full-transpose emits a tile_transpose before topk.
-    // CHECK: d2m.tile_transpose
+    // No index buffer is materialized upstream, so nothing is transposed and
+    // no arange runs before topk_block.
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK-NOT: d2m.arange_block
 
     // The TopK generic op contains topk_block.
     // CHECK: d2m.generic
@@ -104,12 +114,12 @@ module {
     return %values, %indices : tensor<32x64xf32>, tensor<32x64xsi32>
   }
 
-  // k=64 along dim=0 uses tile_typecast for extract. The index buffer is
-  // built row-major + full-transposed, so a tile_transpose appears before topk.
+  // k=64 along dim=0 uses tile_typecast for extract, and needs no transpose
+  // anywhere: the index buffer is built in-kernel.
   // CHECK-LABEL: func @topk_dim0_k64
   func.func @topk_dim0_k64(%arg0: tensor<256x32xf32>) -> (tensor<64x32xf32>, tensor<64x32xsi32>) {
-    // The index buffer's full-transpose emits a tile_transpose before topk.
-    // CHECK: d2m.tile_transpose
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK-NOT: d2m.arange_block
     // CHECK: d2m.generic
     // CHECK: d2m.topk_block
     // CHECK-SAME: dim = 0
@@ -132,11 +142,16 @@ module {
     // The input layout is 1x2 tiles of f32.
     // CHECK: d2m.to_layout
     // CHECK-SAME: tensor<1x1x1x2x!ttcore.tile<32x32, f32>
+    // The pre-transpose buffer is 1x2 tiles of f32.
+    // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
+    // The index input is a single si32 scratch tile per core: the kernel
+    // derives the whole index buffer from it.
+    // CHECK: d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, si32>
     // The TopK values output is 1x2 tiles (full reduction shape before extract).
     // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
-    // The TopK indices output is 1x2 tiles of f32 (index buffer carried as
-    // fp32; typecast to the si32 user output happens after extract).
-    // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, f32>
+    // The TopK indices output is 1x2 si32 tiles (typecast to the user output
+    // happens after extract).
+    // CHECK: d2m.empty() : tensor<1x1x1x2x!ttcore.tile<32x32, si32>
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = -1 : i32, largest = true, sorted = false}> : (tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>)
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
@@ -146,10 +161,13 @@ module {
   func.func @topk_dim0_tile_shapes(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK: d2m.to_layout
     // CHECK-SAME: tensor<1x1x2x1x!ttcore.tile<32x32, f32>
+    // The index input is a single si32 scratch tile per core.
+    // CHECK: d2m.empty() : tensor<1x1x1x1x!ttcore.tile<32x32, si32>
+    // Values keep the full 2x1 reduction shape ...
     // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, f32>
-    // Index buffer is carried as fp32 (typecast to si32 user output after
-    // extract).
-    // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, f32>
+    // ... and the indices ride along as si32 (typecast to the user output
+    // after extract).
+    // CHECK: d2m.empty() : tensor<1x1x2x1x!ttcore.tile<32x32, si32>
     %values, %indices = "ttir.topk"(%arg0) <{k = 16 : i32, dim = 0 : i32, largest = true, sorted = false}> : (tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>)
     return %values, %indices : tensor<16x32xf32>, tensor<16x32xsi32>
   }
@@ -204,14 +222,14 @@ module {
   }
 
   // dim=0 multi-core: 512x128, k=16. Rows=512 (16 reduction tiles), cols=128
-  // (4 non-target tiles) -> multi-core band split. Exercises the row-major
-  // arange + full-transpose (grid + tile) index construction under a
-  // gridColsx1 band grid.
+  // (4 non-target tiles) -> multi-core band split. Each band core derives its
+  // own index slice from its grid coordinate, so no index buffer is built or
+  // moved across cores.
   // CHECK-LABEL: func @topk_dim0_multicore
   func.func @topk_dim0_multicore(%arg0: tensor<512x128xf32>) -> (tensor<16x128xf32>, tensor<16x128xsi32>) {
-    // The index buffer's full-transpose emits a tile_transpose ...
-    // CHECK: d2m.tile_transpose
-    // ... the per-band local topk ...
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK-NOT: d2m.arange_block
+    // The per-band local topk ...
     // CHECK: d2m.topk_block
     // CHECK-SAME: dim = 0
     // CHECK-SAME: k = 16
@@ -252,9 +270,11 @@ module {
   // tiles) split across cores, rows=128 (4 reduction tiles) kept whole.
   // CHECK-LABEL: func @topk_dim0_data_parallel
   func.func @topk_dim0_data_parallel(%arg0: tensor<128x2048xf32>) -> (tensor<8x2048xf32>, tensor<8x2048xsi32>) {
-    // The index buffer's full-transpose emits a tile_transpose ...
-    // CHECK: d2m.tile_transpose
-    // ... then the per-slice topk.
+    // Every slice reduces the whole dim locally and builds its own indices, so
+    // there is no shared index buffer to broadcast across the slice cores.
+    // CHECK-NOT: d2m.tile_transpose
+    // CHECK-NOT: d2m.arange_block
+    // The per-slice topk.
     // CHECK: d2m.topk_block
     // CHECK-SAME: dim = 0
     // CHECK-SAME: k = 8

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -100,7 +100,7 @@ module {
     // CHECK: d2m.arange_block
     // CHECK-SAME: num_elements = 128
 
-    // Outer scf.for is the non-target-row loop (one row here).
+    // Non-target loop wraps the whole merge tree.
     // CHECK: scf.for
     // Initial accumulator built from tiles (0,1).
     // CHECK: d2m.tile_topk_local_sort
@@ -108,11 +108,11 @@ module {
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
     // Fold loop over complete right pairs.
     // CHECK: scf.for
-    // Build the complete right pair (2,3) from raw input.
+    // Build the complete right block q = (t, t+1).
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64
     // CHECK: d2m.tile_topk_rebuild{{.*}}k = 64
-    // 3-sub-merge combine of acc=(0,1) with the pair.
+    // 3-sub-merge combine of acc=(0,1) with q=(t,t+1).
     // Sub 1: merge winner tiles.
     // CHECK: d2m.tile_topk_local_sort
     // CHECK: d2m.tile_topk_merge{{.*}}k = 64

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -2,8 +2,8 @@
 // RUN: FileCheck %s --input-file=%t
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
-// Verify that d2m-decompose-topk replaces topk_block with arange_block +
-// scf.for loops (one per merge iteration) containing
+// Verify that d2m-decompose-topk replaces topk_block with an in-kernel index
+// buffer fill followed by scf.for loops (one per merge iteration) containing
 // tile_topk_{local_sort,merge,rebuild} ops.
 
 module {
@@ -16,9 +16,12 @@ module {
     // The topk_block must be fully replaced.
     // CHECK-NOT: d2m.topk_block
 
-    // Index initialization is done via arange_block.
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 64
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // logWt=1, so level 0 is also the last level: emitted unrolled (no outer
     // scf.for), with an inner scf.for over tile pairs and an unconditional
@@ -41,8 +44,12 @@ module {
   func.func @decompose_k16_8tiles(%arg0: tensor<32x256xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 256
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // Level 0 is emitted unrolled, levels [1,logWt-1) run in a
     // middle scf.for with no rebuild, and the last level is emitted unrolled
@@ -74,8 +81,12 @@ module {
   func.func @decompose_k64_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 64
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // Non-target loop wraps the whole merge tree.
     // CHECK: scf.for
@@ -97,8 +108,12 @@ module {
   func.func @decompose_k64_4tiles(%arg0: tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 128
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // Non-target loop wraps the whole merge tree.
     // CHECK: scf.for
@@ -139,8 +154,12 @@ module {
   func.func @decompose_k64_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 192
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // Outer scf.for is the non-target-row loop.
     // CHECK: scf.for
@@ -180,8 +199,12 @@ module {
   func.func @decompose_k64_5tiles(%arg0: tensor<32x160xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 160
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // Outer scf.for is the non-target-row loop.
     // CHECK: scf.for
@@ -226,8 +249,12 @@ module {
   func.func @decompose_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 64
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
 
     // logWt=1: level 0 is also the last level, so rebuild is emitted
     // unconditionally.
@@ -251,7 +278,12 @@ module {
   func.func @decompose_k32_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // CHECK: d2m.arange_block
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
@@ -270,8 +302,12 @@ module {
   // CHECK-LABEL: func @decompose_k16_3tiles
   func.func @decompose_k16_3tiles(%arg0: tensor<32x96xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 96
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
     // Level 0 (unrolled): local_sort+merge, plus the odd-tail standalone sort
     // for tile 2 (emitted unconditionally at level 0).
     // CHECK: scf.for
@@ -294,8 +330,12 @@ module {
   // CHECK-LABEL: func @decompose_k16_6tiles
   func.func @decompose_k16_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 192
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
     // Level 0 (unrolled).
     // CHECK: scf.for
     // CHECK: scf.for
@@ -320,8 +360,12 @@ module {
   // CHECK-LABEL: func @decompose_k16_17tiles
   func.func @decompose_k16_17tiles(%arg0: tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 544
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
     // Level 0 (unrolled), plus odd-tail standalone sort for tile 16.
     // CHECK: scf.for
     // CHECK: scf.for
@@ -347,8 +391,12 @@ module {
   // CHECK-LABEL: func @decompose_k16_3tiles_dim0
   func.func @decompose_k16_3tiles_dim0(%arg0: tensor<96x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // CHECK: d2m.arange_block
-    // CHECK-SAME: num_elements = 96
+    // Index generation runs first: the kernel fills its own index buffer from
+    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
+    // reduction-tile offset.
+    // CHECK: d2m.fill_arange_tile
+    // CHECK: d2m.tile_right_shift
+    // CHECK: d2m.tile_add
     // Level 0 (unrolled), plus odd-tail standalone sort for tile 2.
     // CHECK: scf.for
     // CHECK: scf.for

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -1,31 +1,37 @@
-// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns --ttcore-one-shot-bufferize --d2m-decompose-topk -o %t %s
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-materialize-view-returns --ttcore-one-shot-bufferize --d2m-insert-scratch-buffers --d2m-decompose-topk -o %t %s
 // RUN: FileCheck %s --input-file=%t
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline -o %t.ttmetal %s
 
 // Verify that d2m-decompose-topk replaces topk_block with an in-kernel index
-// buffer fill followed by scf.for loops (one per merge iteration) containing
+// buffer fill followed by a non-target loop wrapping the merge tree, whose
+// levels are scf.for loops over tile pairs holding
 // tile_topk_{local_sort,merge,rebuild} ops.
+//
+// The index fill runs only for a topk_block with generate_indices (a leaf); a
+// merge-stage block is handed the indices its children produced. It writes one
+// lane tile with a column-major arange, so the within-tile row index lands in
+// column 0, then per tile broadcasts that column across the tile and adds the
+// tile's offset within this core's band. Every function below is single-core,
+// so every topk_block is a leaf.
 
 module {
 
   // ---- Small k (k<=32), 2 tiles: 1 merge iteration ----
 
-  // 32x64 with k=16: Wt=2, logWt=1 → outer scf.for with nested inner scf.for.
+  // 32x64 with k=16: Wt=2, logWt=1.
   // CHECK-LABEL: func @decompose_k16_2tiles
   func.func @decompose_k16_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // The topk_block must be fully replaced.
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
-    // logWt=1, so level 0 is also the last level: emitted unrolled (no outer
-    // scf.for), with an inner scf.for over tile pairs and an unconditional
-    // rebuild.
+    // logWt=1, so level 0 is also the last level: emitted unrolled with an
+    // unconditional rebuild. The two loops are the non-target loop and level
+    // 0's own loop over tile pairs; there is no middle-level loop.
     // CHECK: scf.for
     // CHECK: scf.for
     // CHECK: d2m.tile_topk_local_sort
@@ -38,17 +44,15 @@ module {
 
   // ---- Small k (k<=32), 8 tiles: 3 merge iterations ----
 
-  // 32x256 with k=16: Wt=8, logWt=3.
-  // Single outer scf.for (3 iterations) with nested inner scf.for.
+  // 32x256 with k=16: Wt=8, logWt=3. Level 0 and level 2 are unrolled; only
+  // level 1 runs in the middle scf.for.
   // CHECK-LABEL: func @decompose_k16_8tiles
   func.func @decompose_k16_8tiles(%arg0: tensor<32x256xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // Level 0 is emitted unrolled, levels [1,logWt-1) run in a
@@ -81,11 +85,9 @@ module {
   func.func @decompose_k64_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // Non-target loop wraps the whole merge tree.
@@ -108,11 +110,9 @@ module {
   func.func @decompose_k64_4tiles(%arg0: tensor<32x128xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // Non-target loop wraps the whole merge tree.
@@ -154,11 +154,9 @@ module {
   func.func @decompose_k64_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // Outer scf.for is the non-target-row loop.
@@ -199,11 +197,9 @@ module {
   func.func @decompose_k64_5tiles(%arg0: tensor<32x160xf32>) -> (tensor<32x64xf32>, tensor<32x64xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // Outer scf.for is the non-target-row loop.
@@ -249,11 +245,9 @@ module {
   func.func @decompose_dim0_k16(%arg0: tensor<64x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
 
     // logWt=1: level 0 is also the last level, so rebuild is emitted
@@ -278,11 +272,9 @@ module {
   func.func @decompose_k32_2tiles(%arg0: tensor<32x64xf32>) -> (tensor<32x32xf32>, tensor<32x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
 
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
     // CHECK: scf.for
     // CHECK: scf.for
@@ -298,15 +290,14 @@ module {
 
   // 32x96 with k=16: Wt=3 (odd, ragged), ceilLog2=2 iterations.
   // Level 0 pairs (0,1); tile 2 is odd tail → standalone local_sort at level 0.
-  // Level 1 pairs (0,2).
+  // Level 1 pairs (0,2). logWt=2 leaves the middle loop with zero trips, so
+  // the ops it contains never run.
   // CHECK-LABEL: func @decompose_k16_3tiles
   func.func @decompose_k16_3tiles(%arg0: tensor<32x96xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
     // Level 0 (unrolled): local_sort+merge, plus the odd-tail standalone sort
     // for tile 2 (emitted unconditionally at level 0).
@@ -330,11 +321,9 @@ module {
   // CHECK-LABEL: func @decompose_k16_6tiles
   func.func @decompose_k16_6tiles(%arg0: tensor<32x192xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
     // Level 0 (unrolled).
     // CHECK: scf.for
@@ -360,11 +349,9 @@ module {
   // CHECK-LABEL: func @decompose_k16_17tiles
   func.func @decompose_k16_17tiles(%arg0: tensor<32x544xf32>) -> (tensor<32x16xf32>, tensor<32x16xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
     // Level 0 (unrolled), plus odd-tail standalone sort for tile 16.
     // CHECK: scf.for
@@ -387,15 +374,14 @@ module {
     return %values, %indices : tensor<32x16xf32>, tensor<32x16xsi32>
   }
 
-  // dim=0 non-pow2: 96x32 with k=16, Ht=3 (odd, ragged), ceilLog2=2.
+  // dim=0 non-pow2: 96x32 with k=16, Ht=3 (odd, ragged), ceilLog2=2, so the
+  // middle loop is emitted with zero trips as in @decompose_k16_3tiles.
   // CHECK-LABEL: func @decompose_k16_3tiles_dim0
   func.func @decompose_k16_3tiles_dim0(%arg0: tensor<96x32xf32>) -> (tensor<16x32xf32>, tensor<16x32xsi32>) {
     // CHECK-NOT: d2m.topk_block
-    // Index generation runs first: the kernel fills its own index buffer from
-    // the lane pattern (>> 5 keeps the within-tile row index) plus this core's
-    // reduction-tile offset.
-    // CHECK: d2m.fill_arange_tile
-    // CHECK: d2m.tile_right_shift
+    // Index generation runs first.
+    // CHECK: d2m.arange_block
+    // CHECK: d2m.tile_bcast
     // CHECK: d2m.tile_add
     // Level 0 (unrolled), plus odd-tail standalone sort for tile 2.
     // CHECK: scf.for

--- a/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/decompose_topk.mlir
@@ -11,8 +11,7 @@
 // merge-stage block is handed the indices its children produced. It writes one
 // lane tile with a column-major arange, so the within-tile row index lands in
 // column 0, then per tile broadcasts that column across the tile and adds the
-// tile's offset within this core's band. Every function below is single-core,
-// so every topk_block is a leaf.
+// tile's offset within this core's band.
 
 module {
 

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -5909,12 +5909,7 @@ def ttir_topk_golden(
         input_tensor, k=k, dim=dim, largest=largest, sorted=True
     )
 
-    # Index output dtype is size-dependent, mirroring the TTNN topk workaround
-    # (createTopKOpOperandsWorkarounds): the largest index is bounded by the
-    # tile-padded reduction dim, so UInt16 suffices while that padded size fits
-    # in a uint16, else UInt32. The D2M topk lowering computes indices in i32
-    # internally and narrows to whatever dtype this declared result type says,
-    # so this choice drives the final index element type end-to-end.
+    # Index dtype is UInt16 if the tile-padded reduction dim fits, else UInt32.
     TILE_SIZE = 32
     reduction_dim = dim if dim >= 0 else dim + input_tensor.ndim
     reduction_size = input_tensor.shape[reduction_dim]

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -5909,7 +5909,19 @@ def ttir_topk_golden(
         input_tensor, k=k, dim=dim, largest=largest, sorted=True
     )
 
-    return values.to(output_dtype), indices.to(torch.uint16)
+    # Index output dtype is size-dependent, mirroring the TTNN topk workaround
+    # (createTopKOpOperandsWorkarounds): the largest index is bounded by the
+    # tile-padded reduction dim, so UInt16 suffices while that padded size fits
+    # in a uint16, else UInt32. The D2M topk lowering computes indices in i32
+    # internally and narrows to whatever dtype this declared result type says,
+    # so this choice drives the final index element type end-to-end.
+    TILE_SIZE = 32
+    reduction_dim = dim if dim >= 0 else dim + input_tensor.ndim
+    reduction_size = input_tensor.shape[reduction_dim]
+    padded_reduction_size = ((reduction_size + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
+    index_dtype = torch.uint16 if padded_reduction_size <= 0xFFFF else torch.uint32
+
+    return values.to(output_dtype), indices.to(index_dtype)
 
 
 def ttir_topk_router_gpt_golden(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Previously topk was only supported for a single core, severely restricting the size of tensors we could support. Testing also forced index ouput to uint16, which caused errors for inputs that had a reduction dim greater than 65535.

### What's changed

**Topk multi-core algorithm**
- Multi-level sharding and merge tree, accounting for a large reduction dimension size that could overflow a single core's L1.
- Custom sharding and grid selection logic based on a measured maximum of 43 tiles for the single core implementation.
- Shard input and indices across cores -> compute a local topk at each core -> gather only the output tiles -> if needed shard intermediate results across a few number of cores for the merge tree. Eventually collapses to a final topk into one core and return result.
- Band count is chosen by a two-pass search: powers of two first (shallowest tree), then any count whose full merge chain closes. A candidate must factor onto the physical worker grid, fit its bands within the per-core budget, and have a legal group count at every level of the resulting tree.
- Bands need not divide the reduction dim evenly; the padding tail is masked to `-inf` so those lanes can never win top-k and are never NaN.

**Data-parallel path (non-target dim split)**
- When the *non-target* dim alone overflows the per-core budget, banding the reduction dim cannot help — the whole non-target dim lives on every band core regardless. Since topk is independent per slice, the non-target dim is split across cores instead and each core runs its entire reduction locally, with no merge tree.

**Inter-Core Gather**
- Load the required amount of tiles for each core into a buffer that is then fed into the topk block op.
- Utilize `composite_view` lowering to `DMAReadOp` to write tiles to specific indices in buffer. The view re-splits the same `grid × shard` extent onto the merge grid — fewer cores, wider shards — which sizes the destination buffer; `ExpandDMAReadCompositeView` then fills it with one per-tile read resolved to whichever core owns that tile. No shard-sized transfers occur.
- Per-band compaction runs *before* the gather, so each core's source holds only its top-k tiles rather than its full-width band result, which would otherwise stay resident on every core and overflow L1.
- Values and indices gather through separate generics, since the expansion pass supports only one composite view per `GenericOp` (#7600).

**CompositeViewOp validation**
- Changed `CompositeViewOp::verify` to allow a single input if it is distributed, as this is meaningful for gather/reblock operations. Updated error messages and related assertions in transformation code to match.
- `expandCompositeDMAReadTiled` already handled the one-input case without modification: its per-input extent is `gridExtent * shardExtent` and it resolves each destination tile by `div`/`rem` on the source shard extent, so a grid-`1xN` source lands correctly.


### Checklist
- [ ] New/Existing tests provide coverage for changes
