### PR TITLE
[TT-Lang] Support multi-output tt-lang kernels

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/DecomposeCustomCallTuples.cpp
+++ b/lib/Dialect/StableHLO/Transforms/DecomposeCustomCallTuples.cpp
@@ -8,9 +8,15 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 
+#include "llvm/ADT/StringRef.h"
+
 namespace mlir::tt::stablehlo {
 #define GEN_PASS_DEF_DECOMPOSECUSTOMCALLTUPLESPASS
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+namespace {
+constexpr llvm::StringLiteral TTLangTargetName = "tt.tt_lang_op";
+} // namespace
 
 struct DecomposeCustomCallTuplesPass
     : public impl::DecomposeCustomCallTuplesPassBase<
@@ -22,8 +28,6 @@ public:
   void runOnOperation() override {
     IRRewriter rewriter(getOperation().getContext());
 
-    // Rewrite 1: stablehlo.tuple ops - forward operands to
-    // get_tuple_element users directly.
     SmallVector<mlir::stablehlo::TupleOp> tupleOps;
     getOperation().walk(
         [&](mlir::stablehlo::TupleOp op) { tupleOps.push_back(op); });
@@ -42,6 +46,80 @@ public:
         rewriter.eraseOp(op);
       }
     }
+
+    // Convert all tt.tt_lang_op custom calls with a tuple result into a
+    // multi-result custom call.
+    SmallVector<mlir::stablehlo::CustomCallOp> tupleCustomCalls;
+    getOperation().walk([&](mlir::stablehlo::CustomCallOp op) {
+      if (op.getCallTargetName() == TTLangTargetName &&
+          op.getNumResults() == 1 &&
+          mlir::isa<mlir::TupleType>(op.getResult(0).getType())) {
+        tupleCustomCalls.push_back(op);
+      }
+    });
+
+    for (mlir::stablehlo::CustomCallOp op : tupleCustomCalls) {
+      if (mlir::failed(decomposeTupleResult(op, rewriter))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+
+private:
+  static mlir::LogicalResult
+  decomposeTupleResult(mlir::stablehlo::CustomCallOp op, IRRewriter &rewriter) {
+    auto tupleType = mlir::cast<mlir::TupleType>(op.getResult(0).getType());
+    mlir::Value oldResult = op.getResult(0);
+
+    // Splitting flattens exactly one level, so a nested tuple would leave a
+    // tuple-typed result behind and Shardy would still reject the op.
+    for (mlir::Type elementType : tupleType.getTypes()) {
+      if (mlir::isa<mlir::TupleType>(elementType)) {
+        return op.emitError()
+               << "cannot decompose nested tuple result " << tupleType
+               << " of '" << TTLangTargetName << "'";
+      }
+    }
+
+    for (mlir::Operation *user : oldResult.getUsers()) {
+      if (!mlir::isa<mlir::stablehlo::GetTupleElementOp>(user)) {
+        return op.emitError()
+               << "cannot decompose tuple result of '" << TTLangTargetName
+               << "': expected every user to be a "
+                  "stablehlo.get_tuple_element, but found '"
+               << user->getName() << "'";
+      }
+    }
+
+    if (tupleType.size() == 1 && !op.getOutputOperandAliases().empty()) {
+      return op.emitError()
+             << "cannot decompose single-element tuple result of '"
+             << TTLangTargetName
+             << "' while `output_operand_aliases` is set: the alias indices "
+                "address a tuple that the split removes";
+    }
+
+    rewriter.setInsertionPoint(op);
+
+    // Rebuild with one tensor result per tuple element.
+    auto newCall = rewriter.create<mlir::stablehlo::CustomCallOp>(
+        op.getLoc(), llvm::to_vector(tupleType.getTypes()), op.getOperands(),
+        op.getCallTargetNameAttr(), op.getHasSideEffectAttr(),
+        op.getBackendConfigAttr(), op.getApiVersionAttr(),
+        op.getCalledComputationsAttr(),
+        /*operand_layouts=*/nullptr,
+        /*result_layouts=*/nullptr, op.getOutputOperandAliasesAttr());
+
+    newCall->setDiscardableAttrs(op->getDiscardableAttrDictionary());
+
+    for (OpOperand &use : llvm::make_early_inc_range(oldResult.getUses())) {
+      auto getTupleOp =
+          mlir::cast<mlir::stablehlo::GetTupleElementOp>(use.getOwner());
+      rewriter.replaceOp(getTupleOp, newCall->getResult(getTupleOp.getIndex()));
+    }
+    rewriter.eraseOp(op);
+    return mlir::success();
   }
 };
 } // namespace mlir::tt::stablehlo

--- a/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
@@ -37,6 +37,7 @@
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/TransformUtils.h"
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -447,15 +448,61 @@ mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
     return mlir::failure();
   }
 
+  // Give every DPS "out" init operand its own freshly-allocated device buffer.
+  //
+  // `ttnn.generic` writes each output in place, so distinct outputs must be
+  // backed by distinct buffers; if two outputs share one buffer, the kernel's
+  // writes clobber each other and only the last survives (all such results
+  // read back identical). The operands reaching this pass do NOT satisfy that:
+  // the frontend passes a separate `torch.empty_like()` placeholder per
+  // output, but XLA folds identical uninitialised placeholders into a single
+  // constant, tt-mlir CSE merges the resulting `ttnn.full` / `ttnn.empty` ops
+  // (neither carries a memory effect), and const-eval hoisting then pulls the
+  // shared constant into one `main_const_eval_0` whose `ttcore.load_cached`
+  // call sites the runtime memoises by (function, args) -- so same-shaped
+  // outputs collapse onto one device buffer.
+  //
+  // Rebuild each "out" operand as a fresh `ttnn.empty` here, in the last pass
+  // before flatbuffer emission. `ttnn.empty` is the correct op for a
+  // write-only DPS destination (uninitialised, no wasteful zero-fill), it
+  // carries `TTCoreNonCacheableTrait` so const-eval never hoists/dedupes it,
+  // and creating a separate op per output keeps the buffers distinct with no
+  // later CSE pass to merge them back.
   OpBuilder builder(op);
+  mlir::IRRewriter rewriter(op->getContext());
+  llvm::SmallVector<Value> operands(op.getInputs().begin(),
+                                    op.getInputs().end());
+  for (unsigned r = 0; r < numResults; ++r) {
+    unsigned outIdx = numIns + r;
+    auto outType = mlir::cast<RankedTensorType>(operands[outIdx].getType());
+    auto layoutAttr = mlir::cast<TTNNLayoutAttr>(outType.getEncoding());
+    ShapeAttr shapeAttr = ShapeAttr::get(ctx, outType.getShape());
+
+    Value freshOut;
+    if (isSystemBufferType(layoutAttr.getBufferType())) {
+      // Host-memory destination: EmptyOp requires a device, so fall back to a
+      // ZerosOp (matches the ttir.empty -> ttnn lowering for system buffers).
+      rewriter.setInsertionPoint(op);
+      freshOut = rewriter.create<ZerosOp>(op.getLoc(), outType,
+                                          /*device=*/nullptr, shapeAttr);
+    } else {
+      GetDeviceOp device = utils::getOrInsertDevice(rewriter, op);
+      rewriter.setInsertionPoint(op);
+      freshOut =
+          rewriter.create<EmptyOp>(op.getLoc(), outType, device, shapeAttr);
+    }
+    operands[outIdx] = freshOut;
+  }
+
   // `ttnn.generic` writes in place into its "out" operands and has no
   // results; downstream IR references the out operands directly. Replace
-  // each tt_lang_op result with its tied "out" operand before erasing.
-  builder.create<GenericOp>(op.getLoc(), op.getInputs(),
+  // each tt_lang_op result with its tied (now distinct) "out" operand
+  // before erasing.
+  builder.create<GenericOp>(op.getLoc(), operands,
                             /*additional_args=*/ValueRange{}, program);
 
   for (unsigned r = 0; r < numResults; ++r) {
-    op.getResult(r).replaceAllUsesWith(op.getInputs()[numIns + r]);
+    op.getResult(r).replaceAllUsesWith(operands[numIns + r]);
   }
   op.erase();
   return mlir::success();

--- a/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
@@ -422,7 +422,8 @@ ProgramAttr buildProgramAttr(TTLangOp op, MLIRContext *ctx,
 
 // Lower one `ttnn.tt_lang_op` to a `ttnn.generic`. Returns failure (with
 // a diagnostic already emitted) on a malformed/unset artifact.
-mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
+mlir::LogicalResult
+lowerTTLangOpToGeneric(TTLangOp op, llvm::SmallPtrSetImpl<Value> &claimedOuts) {
   MLIRContext *ctx = op.getContext();
 
   mlir::StringAttr artifactAttr = op.getKernelArtifactAttr();
@@ -449,32 +450,36 @@ mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
     return mlir::failure();
   }
 
-  // Ensure no two DPS "out" init operands share a buffer.
+  // Ensure no DPS "out" init operand is a buffer some other output already
+  // writes to.
   //
-  // `ttnn.generic` writes each output in place, so two results backed by one
-  // buffer clobber each other and only the last write survives -- both then
-  // read back identical, with no diagnostic anywhere. The operands reaching
-  // this pass do not always satisfy that: StableHLOToTTIR synthesizes one
-  // `ttir.empty` init per result, and same-shaped results make those ops
-  // identical and side-effect free, so CSE folds them into a single SSA value
-  // that lands in several "out" slots.
+  // `ttnn.generic` writes each output in place, so two outputs backed by one
+  // buffer clobber each other and only the last write survives, with no
+  // diagnostic anywhere. The operands reaching this pass do not always satisfy
+  // that: StableHLOToTTIR synthesizes one `ttir.empty` init per result, and
+  // same-shaped results make those ops identical and side-effect free, so CSE
+  // folds them into a single SSA value that lands in several "out" slots.
   //
-  // Only the duplicates are rebuilt. The first occurrence of each buffer, and
-  // any init that is already unique, is left alone, so a caller that
-  // deliberately passed a particular destination (a block argument, say) still
-  // gets written in place and DPS semantics are preserved. This is the last
-  // pass before flatbuffer emission, so nothing runs afterwards to merge the
-  // replacements back together, and `ttnn.empty` carries
-  // `TTCoreNonCacheableTrait`, which keeps const-eval from hoisting them into
-  // one shared cached buffer.
+  // CSE folds across the whole module, not just one op, so `claimedOuts` is
+  // carried across every `tt_lang_op` the pass visits. Two chained kernels with
+  // same-shaped outputs otherwise share a destination, and the second one
+  // overwrites the first one's result -- which it may also be reading as an
+  // input.
+  //
+  // Only repeats are rebuilt. The first claimant of a buffer, and any init that
+  // is already unique, is left alone, so a caller that deliberately passed a
+  // particular destination (a block argument, say) still gets written in place
+  // and DPS semantics are preserved. This is the last pass before flatbuffer
+  // emission, so nothing runs afterwards to merge the replacements back
+  // together, and `ttnn.empty` carries `TTCoreNonCacheableTrait`, which keeps
+  // const-eval from hoisting them into one shared cached buffer.
   OpBuilder builder(op);
   mlir::IRRewriter rewriter(op->getContext());
   llvm::SmallVector<Value> operands(op.getInputs().begin(),
                                     op.getInputs().end());
-  llvm::SmallPtrSet<Value, 4> seenOuts;
   for (unsigned r = 0; r < numResults; ++r) {
     unsigned outIdx = numIns + r;
-    if (seenOuts.insert(operands[outIdx]).second) {
+    if (claimedOuts.insert(operands[outIdx]).second) {
       continue;
     }
 
@@ -510,7 +515,7 @@ mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
           rewriter.create<EmptyOp>(op.getLoc(), outType, device, shapeAttr);
     }
     operands[outIdx] = freshOut;
-    seenOuts.insert(freshOut);
+    claimedOuts.insert(freshOut);
   }
 
   // `ttnn.generic` writes in place into its "out" operands and has no
@@ -537,8 +542,9 @@ public:
     llvm::SmallVector<TTLangOp> ops;
     getOperation().walk([&](TTLangOp op) { ops.push_back(op); });
 
+    llvm::SmallPtrSet<Value, 8> claimedOuts;
     for (TTLangOp op : ops) {
-      if (mlir::failed(lowerTTLangOpToGeneric(op))) {
+      if (mlir::failed(lowerTTLangOpToGeneric(op, claimedOuts))) {
         return signalPassFailure();
       }
     }

--- a/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNLowerTTLangToGeneric.cpp
@@ -47,6 +47,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -448,34 +449,51 @@ mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
     return mlir::failure();
   }
 
-  // Give every DPS "out" init operand its own freshly-allocated device buffer.
+  // Ensure no two DPS "out" init operands share a buffer.
   //
-  // `ttnn.generic` writes each output in place, so distinct outputs must be
-  // backed by distinct buffers; if two outputs share one buffer, the kernel's
-  // writes clobber each other and only the last survives (all such results
-  // read back identical). The operands reaching this pass do NOT satisfy that:
-  // the frontend passes a separate `torch.empty_like()` placeholder per
-  // output, but XLA folds identical uninitialised placeholders into a single
-  // constant, tt-mlir CSE merges the resulting `ttnn.full` / `ttnn.empty` ops
-  // (neither carries a memory effect), and const-eval hoisting then pulls the
-  // shared constant into one `main_const_eval_0` whose `ttcore.load_cached`
-  // call sites the runtime memoises by (function, args) -- so same-shaped
-  // outputs collapse onto one device buffer.
+  // `ttnn.generic` writes each output in place, so two results backed by one
+  // buffer clobber each other and only the last write survives -- both then
+  // read back identical, with no diagnostic anywhere. The operands reaching
+  // this pass do not always satisfy that: StableHLOToTTIR synthesizes one
+  // `ttir.empty` init per result, and same-shaped results make those ops
+  // identical and side-effect free, so CSE folds them into a single SSA value
+  // that lands in several "out" slots.
   //
-  // Rebuild each "out" operand as a fresh `ttnn.empty` here, in the last pass
-  // before flatbuffer emission. `ttnn.empty` is the correct op for a
-  // write-only DPS destination (uninitialised, no wasteful zero-fill), it
-  // carries `TTCoreNonCacheableTrait` so const-eval never hoists/dedupes it,
-  // and creating a separate op per output keeps the buffers distinct with no
-  // later CSE pass to merge them back.
+  // Only the duplicates are rebuilt. The first occurrence of each buffer, and
+  // any init that is already unique, is left alone, so a caller that
+  // deliberately passed a particular destination (a block argument, say) still
+  // gets written in place and DPS semantics are preserved. This is the last
+  // pass before flatbuffer emission, so nothing runs afterwards to merge the
+  // replacements back together, and `ttnn.empty` carries
+  // `TTCoreNonCacheableTrait`, which keeps const-eval from hoisting them into
+  // one shared cached buffer.
   OpBuilder builder(op);
   mlir::IRRewriter rewriter(op->getContext());
   llvm::SmallVector<Value> operands(op.getInputs().begin(),
                                     op.getInputs().end());
+  llvm::SmallPtrSet<Value, 4> seenOuts;
   for (unsigned r = 0; r < numResults; ++r) {
     unsigned outIdx = numIns + r;
-    auto outType = mlir::cast<RankedTensorType>(operands[outIdx].getType());
-    auto layoutAttr = mlir::cast<TTNNLayoutAttr>(outType.getEncoding());
+    if (seenOuts.insert(operands[outIdx]).second) {
+      continue;
+    }
+
+    auto outType = mlir::dyn_cast<RankedTensorType>(operands[outIdx].getType());
+    if (!outType) {
+      return op.emitError("ttnn.tt_lang_op \"out\" operand ")
+             << outIdx
+             << " repeats an earlier destination but is not a ranked tensor, "
+                "so a distinct buffer cannot be built for it.";
+    }
+    auto layoutAttr =
+        mlir::dyn_cast_or_null<TTNNLayoutAttr>(outType.getEncoding());
+    if (!layoutAttr) {
+      return op.emitError("ttnn.tt_lang_op \"out\" operand ")
+             << outIdx
+             << " repeats an earlier destination but carries no "
+                "#ttnn.ttnn_layout encoding, so a distinct buffer cannot be "
+                "built for it.";
+    }
     ShapeAttr shapeAttr = ShapeAttr::get(ctx, outType.getShape());
 
     Value freshOut;
@@ -492,6 +510,7 @@ mlir::LogicalResult lowerTTLangOpToGeneric(TTLangOp op) {
           rewriter.create<EmptyOp>(op.getLoc(), outType, device, shapeAttr);
     }
     operands[outIdx] = freshOut;
+    seenOuts.insert(freshOut);
   }
 
   // `ttnn.generic` writes in place into its "out" operands and has no

--- a/test/ttmlir/Dialect/StableHLO/decompose_custom_call_tuples/decompose_custom_call_tuples.mlir
+++ b/test/ttmlir/Dialect/StableHLO/decompose_custom_call_tuples/decompose_custom_call_tuples.mlir
@@ -28,3 +28,117 @@ module @TuplePartialUse {
     return %1 : tensor<4xi32>
   }
 }
+
+// -----
+
+// A tt-lang kernel with two "out" roles arrives as a single tuple-typed result
+// and must become a multi-result custom call, with the frontend attributes that
+// carry the kernel metadata preserved.
+module @TTLangMultiOutput {
+  func.func @main(%arg0: tensor<4x4xf32>, %arg1: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4xf32>) {
+    // CHECK: %[[CALL:.*]]:2 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1)
+    // CHECK-SAME: arg_roles = "in,in,out,out"
+    // CHECK-SAME: kernel_id = "pkg.dual_out::v1"
+    // CHECK-SAME: version_tag = "1.0"
+    // CHECK-SAME: -> (tensor<4x4xf32>, tensor<4xf32>)
+    // CHECK-NOT: stablehlo.get_tuple_element
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0, %arg1) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {
+        arg_roles = "in,in,out,out",
+        kernel_id = "pkg.dual_out::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>, tensor<4x4xf32>) -> tuple<tensor<4x4xf32>, tensor<4xf32>>
+    %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x4xf32>, tensor<4xf32>>) -> tensor<4x4xf32>
+    %2 = stablehlo.get_tuple_element %0[1] : (tuple<tensor<4x4xf32>, tensor<4xf32>>) -> tensor<4xf32>
+    // CHECK: return %[[CALL]]#0, %[[CALL]]#1
+    return %1, %2 : tensor<4x4xf32>, tensor<4xf32>
+  }
+}
+
+// -----
+
+// A single-element tuple is still a tuple as far as Shardy is concerned, so it
+// is split into a one-result custom call rather than left alone.
+module @TTLangSingleElementTuple {
+  func.func @main(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK: %[[CALL:.*]] = stablehlo.custom_call @tt.tt_lang_op(%arg0)
+    // CHECK-SAME: -> tensor<4x4xf32>
+    // CHECK-NOT: tuple
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out",
+        kernel_id = "pkg.single_out::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> tuple<tensor<4x4xf32>>
+    %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x4xf32>>) -> tensor<4x4xf32>
+    // CHECK: return %[[CALL]]
+    return %1 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// Layout attributes are dropped as a pair: stablehlo requires operand_layouts
+// and result_layouts to be set together or not at all, and nothing downstream
+// of this pass consults them on the tt-lang path.
+module @TTLangLayoutsDropped {
+  func.func @main(%arg0: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4xf32>) {
+    // CHECK: stablehlo.custom_call @tt.tt_lang_op
+    // CHECK-NOT: operand_layouts
+    // CHECK-NOT: result_layouts
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      operand_layouts = [dense<[1, 0]> : tensor<2xindex>],
+      result_layouts = [dense<[1, 0]> : tensor<2xindex>, dense<[0]> : tensor<1xindex>],
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out,out",
+        kernel_id = "pkg.layouts::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> tuple<tensor<4x4xf32>, tensor<4xf32>>
+    %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x4xf32>, tensor<4xf32>>) -> tensor<4x4xf32>
+    %2 = stablehlo.get_tuple_element %0[1] : (tuple<tensor<4x4xf32>, tensor<4xf32>>) -> tensor<4xf32>
+    return %1, %2 : tensor<4x4xf32>, tensor<4xf32>
+  }
+}
+
+// -----
+
+// Rewrite 2 is scoped to @tt.tt_lang_op. Other tuple-returning custom calls are
+// unpacked by their own StableHLOToTTIR patterns and must be left untouched.
+module @NonTTLangTupleUntouched {
+  func.func @main(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // CHECK: stablehlo.custom_call @some.other.target
+    // CHECK-SAME: -> tuple<tensor<4x4xf32>, tensor<4xf32>>
+    %0 = stablehlo.custom_call @some.other.target(%arg0) {
+      api_version = 0 : i32
+    } : (tensor<4x4xf32>) -> tuple<tensor<4x4xf32>, tensor<4xf32>>
+    // CHECK: stablehlo.get_tuple_element
+    %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x4xf32>, tensor<4xf32>>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+}
+
+// -----
+
+// A tt-lang call that already uses multi-result form is left as-is.
+module @TTLangAlreadyMultiResult {
+  func.func @main(%arg0: tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4xf32>) {
+    // CHECK: %[[CALL:.*]]:2 = stablehlo.custom_call @tt.tt_lang_op(%arg0)
+    // CHECK-SAME: -> (tensor<4x4xf32>, tensor<4xf32>)
+    %0:2 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out,out",
+        kernel_id = "pkg.dual_out::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> (tensor<4x4xf32>, tensor<4xf32>)
+    // CHECK: return %[[CALL]]#0, %[[CALL]]#1
+    return %0#0, %0#1 : tensor<4x4xf32>, tensor<4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/decompose_custom_call_tuples/decompose_custom_call_tuples_errors.mlir
+++ b/test/ttmlir/Dialect/StableHLO/decompose_custom_call_tuples/decompose_custom_call_tuples_errors.mlir
@@ -1,0 +1,68 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt -split-input-file --decompose-custom-call-tuples --verify-diagnostics %s
+
+// Cases where a tuple-returning `@tt.tt_lang_op` cannot be split faithfully.
+// The pass reports them here rather than leaving a tuple behind for Shardy to
+// reject later with a diagnostic that points at propagation instead of the
+// custom call.
+
+// A user other than get_tuple_element consumes the tuple value itself, which is
+// exactly what Shardy cannot accept, so there is nothing useful to rewire it to.
+module {
+  func.func @non_get_tuple_element_user(%arg0: tensor<4x4xf32>) -> tuple<tensor<4x4xf32>, tensor<4xf32>> {
+    // expected-error @+1 {{expected every user to be a stablehlo.get_tuple_element, but found 'func.return'}}
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out,out",
+        kernel_id = "pkg.dual_out::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> tuple<tensor<4x4xf32>, tensor<4xf32>>
+    return %0 : tuple<tensor<4x4xf32>, tensor<4xf32>>
+  }
+}
+
+// -----
+
+// The split flattens exactly one level, so a nested tuple would leave a
+// tuple-typed result behind.
+module {
+  func.func @nested_tuple(%arg0: tensor<4x4xf32>) -> tensor<4xf32> {
+    // expected-error @+1 {{cannot decompose nested tuple result}}
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out,out",
+        kernel_id = "pkg.nested::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> tuple<tuple<tensor<4x4xf32>>, tensor<4xf32>>
+    %1 = stablehlo.get_tuple_element %0[1] : (tuple<tuple<tensor<4x4xf32>>, tensor<4xf32>>) -> tensor<4xf32>
+    return %1 : tensor<4xf32>
+  }
+}
+
+// -----
+
+// `output_operand_aliases` addresses results through tuple indices. A
+// single-element tuple splits into one plain tensor result, so index [0] no
+// longer resolves and the aliasing contract cannot be carried over.
+module {
+  func.func @single_element_tuple_with_aliases(%arg0: tensor<4x4xf32>) -> tensor<4x4xf32> {
+    // expected-error @+1 {{cannot decompose single-element tuple result}}
+    %0 = stablehlo.custom_call @tt.tt_lang_op(%arg0) {
+      api_version = 0 : i32,
+      output_operand_aliases = [
+        #stablehlo.output_operand_alias<output_tuple_indices = [0], operand_index = 0, operand_tuple_indices = []>
+      ],
+      mhlo.frontend_attributes = {
+        arg_roles = "in,out",
+        kernel_id = "pkg.aliased::v1",
+        version_tag = "1.0"
+      }
+    } : (tensor<4x4xf32>) -> tuple<tensor<4x4xf32>>
+    %1 = stablehlo.get_tuple_element %0[0] : (tuple<tensor<4x4xf32>>) -> tensor<4x4xf32>
+    return %1 : tensor<4x4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/tt_lang_op_flatbuffer.mlir
+++ b/test/ttmlir/Dialect/TTNN/tt_lang_op_flatbuffer.mlir
@@ -85,16 +85,14 @@ module {
       -> tensor<32x32xf32, #dram_layout>
       attributes {tt.function_type = "forward_device"} {
     // The tt_lang_op is gone; lowering produced a ttnn.generic carrying an
-    // inline-source program. Every DPS "out" init is rebuilt as a fresh
-    // ttnn.empty, so the destination is that new buffer rather than the
-    // incoming %arg2, and the result is rewired to it.
+    // inline-source program, and the result was rewired to the "out"
+    // operand (%arg2).
     // CHECK-NOT: ttnn.tt_lang_op
-    // CHECK: %[[OUT:.*]] = "ttnn.empty"
-    // CHECK: "ttnn.generic"(%arg0, %arg1, %[[OUT]])
+    // CHECK: "ttnn.generic"(%arg0, %arg1, %arg2)
     // CHECK-SAME: #ttnn.source_compute_kernel<source = "// compute kernel stub"
     // CHECK-SAME: #ttnn.source_read_kernel<source = "// reader kernel stub"
     // CHECK-SAME: #ttnn.source_write_kernel<source = "// writer kernel stub"
-    // CHECK: return %[[OUT]]
+    // CHECK: return %arg2
     %0 = "ttnn.tt_lang_op"(%arg0, %arg1, %arg2) <{
       kernel_id = "test.add::v1",
       version_tag = "1.0",

--- a/test/ttmlir/Dialect/TTNN/tt_lang_op_flatbuffer.mlir
+++ b/test/ttmlir/Dialect/TTNN/tt_lang_op_flatbuffer.mlir
@@ -85,14 +85,16 @@ module {
       -> tensor<32x32xf32, #dram_layout>
       attributes {tt.function_type = "forward_device"} {
     // The tt_lang_op is gone; lowering produced a ttnn.generic carrying an
-    // inline-source program, and the result was rewired to the "out"
-    // operand (%arg2).
+    // inline-source program. Every DPS "out" init is rebuilt as a fresh
+    // ttnn.empty, so the destination is that new buffer rather than the
+    // incoming %arg2, and the result is rewired to it.
     // CHECK-NOT: ttnn.tt_lang_op
-    // CHECK: "ttnn.generic"(%arg0, %arg1, %arg2)
+    // CHECK: %[[OUT:.*]] = "ttnn.empty"
+    // CHECK: "ttnn.generic"(%arg0, %arg1, %[[OUT]])
     // CHECK-SAME: #ttnn.source_compute_kernel<source = "// compute kernel stub"
     // CHECK-SAME: #ttnn.source_read_kernel<source = "// reader kernel stub"
     // CHECK-SAME: #ttnn.source_write_kernel<source = "// writer kernel stub"
-    // CHECK: return %arg2
+    // CHECK: return %[[OUT]]
     %0 = "ttnn.tt_lang_op"(%arg0, %arg1, %arg2) <{
       kernel_id = "test.add::v1",
       version_tag = "1.0",

--- a/test/ttmlir/Dialect/TTNN/tt_lang_op_multi_output.mlir
+++ b/test/ttmlir/Dialect/TTNN/tt_lang_op_multi_output.mlir
@@ -1,0 +1,83 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-lower-tt-lang-to-generic -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// Covers the multi-output side of `--ttnn-lower-tt-lang-to-generic`, which
+// `tt_lang_op_flatbuffer.mlir` cannot reach because it only has one result.
+//
+// `ttnn.generic` writes each output in place, so two results backed by the
+// same buffer clobber each other and only the last write survives -- both
+// then read back identical, with nothing in the IR to flag it. Identical
+// per-result `ttir.empty` inits are side-effect free, so CSE folds them onto
+// a single SSA value before this pass runs; the pass has to hand the
+// duplicated destinations their own buffers again.
+//
+// Rebuilding is deliberately limited to the duplicates: an init that is
+// already unique belongs to the caller and must keep being written in place,
+// which is what the DPS interface promises.
+//
+// Host-side only, and no flatbuffer RUN line, because the `kernel_artifact`
+// below carries stub kernel bodies. Real on-device coverage lives in tt-xla's
+// `tests/torch/ops/test_tt_lang_kernel_e2e.py`.
+
+#dram = #ttnn.buffer_type<dram>
+
+#dram_layout = #ttnn.ttnn_layout<
+  (d0, d1) -> (d0, d1),
+  <1x1>,
+  memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>
+>
+
+module {
+  // Both "out" operands are the same SSA value, i.e. the post-CSE shape the
+  // frontend's two identical `ttir.empty` placeholders arrive in. The first
+  // keeps %arg2; the second must get a buffer of its own, and result 1 must
+  // follow it.
+  // CHECK-LABEL: func.func @tt_lang_deduped_outs
+  func.func @tt_lang_deduped_outs(%arg0: tensor<32x32xf32, #dram_layout>,
+                                  %arg1: tensor<32x32xf32, #dram_layout>,
+                                  %arg2: tensor<32x32xf32, #dram_layout>)
+      -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+      attributes {tt.function_type = "forward_device"} {
+    // CHECK-NOT: ttnn.tt_lang_op
+    // CHECK: %[[DUP:[0-9a-zA-Z_]+]] = "ttnn.empty"
+    // CHECK: "ttnn.generic"(%arg0, %arg1, %arg2, %[[DUP]])
+    // CHECK-SAME: #ttnn.source_compute_kernel<source = "// compute kernel stub"
+    // CHECK: return %arg2, %[[DUP]]
+    %0, %1 = "ttnn.tt_lang_op"(%arg0, %arg1, %arg2, %arg2) <{
+      kernel_id = "test.dual::v1",
+      version_tag = "1.0",
+      arg_roles = "in,in,out,out",
+      shard_spec = "",
+      kernel_artifact = "{\"format_version\": 1, \"kernels\": [{\"thread_type\": \"compute\", \"cpp_source\": \"// compute kernel stub\", \"tensor_indices\": [0, 1, 2, 3], \"kernel_config\": {\"type\": \"ComputeKernelConfig\", \"math_fidelity\": \"HiFi4\", \"fp32_dest_acc_en\": false, \"dst_full_sync_en\": false, \"bfp8_pack_precise\": false, \"math_approx_mode\": false}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// reader kernel stub\", \"tensor_indices\": [0, 1], \"kernel_config\": {\"type\": \"ReaderKernelConfig\"}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// writer kernel stub\", \"tensor_indices\": [2, 3], \"kernel_config\": {\"type\": \"WriterKernelConfig\"}}], \"core_range\": {\"start\": [0, 0], \"end\": [0, 0]}, \"cb_configs\": [{\"buffer_index\": 0, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 1, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 2, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 3, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}], \"num_tensors\": 4, \"num_pipe_nets\": 0}"
+    }> : (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+          tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+        -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+    return %0, %1 : tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>
+  }
+
+  // The two "out" operands are already distinct, so both are the caller's to
+  // keep: the generic must write straight into %arg2 and %arg3 with no
+  // substitute buffer allocated.
+  // CHECK-LABEL: func.func @tt_lang_distinct_outs
+  func.func @tt_lang_distinct_outs(%arg0: tensor<32x32xf32, #dram_layout>,
+                                   %arg1: tensor<32x32xf32, #dram_layout>,
+                                   %arg2: tensor<32x32xf32, #dram_layout>,
+                                   %arg3: tensor<32x32xf32, #dram_layout>)
+      -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+      attributes {tt.function_type = "forward_device"} {
+    // CHECK-NOT: ttnn.tt_lang_op
+    // CHECK-NOT: ttnn.empty
+    // CHECK: "ttnn.generic"(%arg0, %arg1, %arg2, %arg3)
+    // CHECK: return %arg2, %arg3
+    %0, %1 = "ttnn.tt_lang_op"(%arg0, %arg1, %arg2, %arg3) <{
+      kernel_id = "test.dual::v1",
+      version_tag = "1.0",
+      arg_roles = "in,in,out,out",
+      shard_spec = "",
+      kernel_artifact = "{\"format_version\": 1, \"kernels\": [{\"thread_type\": \"compute\", \"cpp_source\": \"// compute kernel stub\", \"tensor_indices\": [0, 1, 2, 3], \"kernel_config\": {\"type\": \"ComputeKernelConfig\", \"math_fidelity\": \"HiFi4\", \"fp32_dest_acc_en\": false, \"dst_full_sync_en\": false, \"bfp8_pack_precise\": false, \"math_approx_mode\": false}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// reader kernel stub\", \"tensor_indices\": [0, 1], \"kernel_config\": {\"type\": \"ReaderKernelConfig\"}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// writer kernel stub\", \"tensor_indices\": [2, 3], \"kernel_config\": {\"type\": \"WriterKernelConfig\"}}], \"core_range\": {\"start\": [0, 0], \"end\": [0, 0]}, \"cb_configs\": [{\"buffer_index\": 0, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 1, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 2, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 3, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}], \"num_tensors\": 4, \"num_pipe_nets\": 0}"
+    }> : (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+          tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+        -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+    return %0, %1 : tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/tt_lang_op_multi_output.mlir
+++ b/test/ttmlir/Dialect/TTNN/tt_lang_op_multi_output.mlir
@@ -80,4 +80,46 @@ module {
         -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
     return %0, %1 : tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>
   }
+
+  // CSE folds identical `ttir.empty` inits across the whole module, so two
+  // chained kernels with same-shaped outputs reach this pass sharing one
+  // destination for all four "out" slots. Only the very first slot may keep it:
+  // the second kernel writing there would overwrite the first kernel's result,
+  // which it is also reading as its input.
+  // CHECK-LABEL: func.func @tt_lang_chained_shared_out
+  func.func @tt_lang_chained_shared_out(%arg0: tensor<32x32xf32, #dram_layout>,
+                                        %arg1: tensor<32x32xf32, #dram_layout>,
+                                        %arg2: tensor<32x32xf32, #dram_layout>)
+      -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+          tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+      attributes {tt.function_type = "forward_device"} {
+    // CHECK-NOT: ttnn.tt_lang_op
+    // CHECK: %[[E1:[0-9a-zA-Z_]+]] = "ttnn.empty"
+    // CHECK: "ttnn.generic"(%arg0, %arg1, %arg2, %[[E1]])
+    // CHECK: %[[E2:[0-9a-zA-Z_]+]] = "ttnn.empty"
+    // CHECK: %[[E3:[0-9a-zA-Z_]+]] = "ttnn.empty"
+    // The second kernel reads %arg2 and must write somewhere else entirely.
+    // CHECK: "ttnn.generic"(%arg2, %arg1, %[[E2]], %[[E3]])
+    // CHECK: return %arg2, %[[E1]], %[[E2]], %[[E3]]
+    %0, %1 = "ttnn.tt_lang_op"(%arg0, %arg1, %arg2, %arg2) <{
+      kernel_id = "test.dual::v1",
+      version_tag = "1.0",
+      arg_roles = "in,in,out,out",
+      shard_spec = "",
+      kernel_artifact = "{\"format_version\": 1, \"kernels\": [{\"thread_type\": \"compute\", \"cpp_source\": \"// compute kernel stub\", \"tensor_indices\": [0, 1, 2, 3], \"kernel_config\": {\"type\": \"ComputeKernelConfig\", \"math_fidelity\": \"HiFi4\", \"fp32_dest_acc_en\": false, \"dst_full_sync_en\": false, \"bfp8_pack_precise\": false, \"math_approx_mode\": false}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// reader kernel stub\", \"tensor_indices\": [0, 1], \"kernel_config\": {\"type\": \"ReaderKernelConfig\"}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// writer kernel stub\", \"tensor_indices\": [2, 3], \"kernel_config\": {\"type\": \"WriterKernelConfig\"}}], \"core_range\": {\"start\": [0, 0], \"end\": [0, 0]}, \"cb_configs\": [{\"buffer_index\": 0, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 1, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 2, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 3, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}], \"num_tensors\": 4, \"num_pipe_nets\": 0}"
+    }> : (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+          tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+        -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+    %2, %3 = "ttnn.tt_lang_op"(%0, %arg1, %arg2, %arg2) <{
+      kernel_id = "test.dual::v1",
+      version_tag = "1.0",
+      arg_roles = "in,in,out,out",
+      shard_spec = "",
+      kernel_artifact = "{\"format_version\": 1, \"kernels\": [{\"thread_type\": \"compute\", \"cpp_source\": \"// compute kernel stub\", \"tensor_indices\": [0, 1, 2, 3], \"kernel_config\": {\"type\": \"ComputeKernelConfig\", \"math_fidelity\": \"HiFi4\", \"fp32_dest_acc_en\": false, \"dst_full_sync_en\": false, \"bfp8_pack_precise\": false, \"math_approx_mode\": false}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// reader kernel stub\", \"tensor_indices\": [0, 1], \"kernel_config\": {\"type\": \"ReaderKernelConfig\"}}, {\"thread_type\": \"noc\", \"cpp_source\": \"// writer kernel stub\", \"tensor_indices\": [2, 3], \"kernel_config\": {\"type\": \"WriterKernelConfig\"}}], \"core_range\": {\"start\": [0, 0], \"end\": [0, 0]}, \"cb_configs\": [{\"buffer_index\": 0, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 1, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 2, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}, {\"buffer_index\": 3, \"data_format\": \"Float32\", \"page_size\": 4096, \"total_size\": 8192, \"num_tiles\": 2, \"block_count\": 2}], \"num_tensors\": 4, \"num_pipe_nets\": 0}"
+    }> : (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+          tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+        -> (tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>)
+    return %0, %1, %2, %3 : tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>,
+                            tensor<32x32xf32, #dram_layout>, tensor<32x32xf32, #dram_layout>
+  }
 }


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-xla/issues/5740)

### Problem description
A tt-lang kernel with two or more `"out"` roles fails to compile, for two unrelated reasons at opposite ends of the pipeline.

HLO models a multi-output instruction as a single tuple-shaped value, so torch-xla emits such a kernel as a `stablehlo.custom_call @tt.tt_lang_op` whose sole result is a `tuple<...>` which can't be processed by Shardy

```
    error: Shardy propagation doesn't support tuples:
        'tuple<tensor<128x128xf32>, tensor<128x128xf32>>'
```

### What's changed
DecomposeCustomCallTuplesPass expands a tuple-returning stablehlo.custom_call @tt.tt_lang_op into a multi-result custom call so Shardy can propagate through it, and TTNNLowerTTLangToGeneric gives each DPS output its own ttnn.empty buffer when lowering to ttnn.generic.

### Checklist
- [x] New/Existing tests provide coverage for changes

Lit coverage is added for the StableHLO rewrite: positive cases for the multi-output split, a single-element tuple, layout-attribute dropping, and non-tt-lang targets being left alone, plus `--verify-diagnostics` negatives for the three refusals. The `TTNNLowerTTLangToGeneric` change has no dedicated lit test and was validated on silicon with a two-output RMSNorm backward kernel.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem.

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and its impact.

### Checklist
- [ ] New/Existing tests provide coverage for changes
