### PR TITLE
Add Shardy sharding rule for tt.sampling

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -1785,6 +1785,8 @@ getArgMaxShardingRule(mlir::stablehlo::CustomCallOp op) {
 static mlir::sdy::OpShardingRuleAttr
 getSamplingShardingRule(mlir::stablehlo::CustomCallOp op) {
   if (op.getNumOperands() != 5 || op.getNumResults() != 1) {
+    op->emitWarning("tt.sampling sharding rule expects 5 operands and 1 "
+                    "result; falling back to replication");
     return mlir::sdy::OpShardingRuleAttr();
   }
 
@@ -1793,22 +1795,38 @@ getSamplingShardingRule(mlir::stablehlo::CustomCallOp op) {
   auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
   if (!valuesType || !resultType || valuesType.getRank() != 2 ||
       resultType.getRank() != 1) {
+    op->emitWarning("tt.sampling sharding rule expects input_values of rank 2 "
+                    "and a result of rank 1; falling back to replication");
     return mlir::sdy::OpShardingRuleAttr();
-  }
-
-  // Operands 1..4 must agree with input_values on the batch dim.
-  for (int64_t i = 1; i < 5; ++i) {
-    auto operandType =
-        llvm::dyn_cast<RankedTensorType>(op.getOperand(i).getType());
-    int64_t expectedRank = (i == 1) ? 2 : 1;
-    if (!operandType || operandType.getRank() != expectedRank ||
-        operandType.getShape()[0] != valuesType.getShape()[0]) {
-      return mlir::sdy::OpShardingRuleAttr();
-    }
   }
 
   int64_t batchSize = valuesType.getShape()[0];
   int64_t candidateSize = valuesType.getShape()[1];
+
+  if (resultType.getShape()[0] != batchSize) {
+    op->emitWarning("tt.sampling sharding rule expects the result batch dim to "
+                    "match input_values; falling back to replication");
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // input_indices must match input_values exactly; k, p and temp must agree on
+  // the batch dim. A mismatch would make the factor sizes below inconsistent
+  // with the operand shapes, which Shardy rejects when verifying the rule.
+  for (unsigned i = 1; i < op.getNumOperands(); ++i) {
+    auto operandType =
+        llvm::dyn_cast<RankedTensorType>(op.getOperand(i).getType());
+    bool shapeOk =
+        operandType && (i == 1 ? operandType.getShape() == valuesType.getShape()
+                               : operandType.getRank() == 1 &&
+                                     operandType.getShape()[0] == batchSize);
+    if (!shapeOk) {
+      op->emitWarning("tt.sampling sharding rule expects operand ")
+          << i
+          << " to match input_values on the batch dim; falling back to "
+             "replication";
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+  }
 
   mlir::sdy::OpShardingRuleBuilder builder(op);
 

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -53,6 +53,8 @@ static constexpr llvm::StringLiteral flashMlaPrefillTargetName =
 static constexpr llvm::StringLiteral indexerScoreDsaTargetName =
     "tt.indexer_score_dsa";
 
+static constexpr llvm::StringLiteral samplingTargetName = "tt.sampling";
+
 static mlir::sdy::OpShardingRuleAttr
 getScatterShardingRule(mlir::stablehlo::ScatterOp scatterOp) {
   mlir::Operation::operand_range inputs = scatterOp.getInputs();
@@ -1766,6 +1768,61 @@ getArgMaxShardingRule(mlir::stablehlo::CustomCallOp op) {
   return builder.build();
 }
 
+// Sharding rule for the `tt.sampling` custom_call.
+//
+// Operands: 0: input_values  [batch, candidates]
+//           1: input_indices [batch, candidates]
+//           2: k             [batch]
+//           3: p             [batch]
+//           4: temp          [batch]
+// Result:                    [batch]
+//
+// Batch dim: kPassThrough, so under data parallelism each device samples its
+//   own rows. The ttnn kernel assigns one Tensix core per user and takes at
+//   most 32 rows per invocation, so the batch must shard rather than gather.
+// Candidate dim: kNeedReplication. A row's candidate set has to stay whole for
+//   softmax, top-k and multinomial.
+static mlir::sdy::OpShardingRuleAttr
+getSamplingShardingRule(mlir::stablehlo::CustomCallOp op) {
+  if (op.getNumOperands() != 5 || op.getNumResults() != 1) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  auto valuesType =
+      llvm::dyn_cast<RankedTensorType>(op.getOperand(0).getType());
+  auto resultType = llvm::dyn_cast<RankedTensorType>(op.getResult(0).getType());
+  if (!valuesType || !resultType || valuesType.getRank() != 2 ||
+      resultType.getRank() != 1) {
+    return mlir::sdy::OpShardingRuleAttr();
+  }
+
+  // Operands 1..4 must agree with input_values on the batch dim.
+  for (int64_t i = 1; i < 5; ++i) {
+    auto operandType =
+        llvm::dyn_cast<RankedTensorType>(op.getOperand(i).getType());
+    int64_t expectedRank = (i == 1) ? 2 : 1;
+    if (!operandType || operandType.getRank() != expectedRank ||
+        operandType.getShape()[0] != valuesType.getShape()[0]) {
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+  }
+
+  int64_t batchSize = valuesType.getShape()[0];
+  int64_t candidateSize = valuesType.getShape()[1];
+
+  mlir::sdy::OpShardingRuleBuilder builder(op);
+
+  builder.addFactor({0, 0, 0, 0, 0}, {0}, batchSize,
+                    mlir::sdy::FactorType::kPassThrough);
+
+  builder.addFactor(
+      {1, 1, mlir::sdy::kNullDim, mlir::sdy::kNullDim, mlir::sdy::kNullDim},
+      {mlir::sdy::kNullDim}, candidateSize,
+      mlir::sdy::FactorType::kNeedReplication);
+
+  return builder.build();
+}
+
 // Sharding rule for RMS norm custom_call (converted from composite).
 //
 // Operands:
@@ -2004,6 +2061,7 @@ private:
           {utils::kTTArgMaxCustomCallTargetName, getArgMaxShardingRule},
           {utils::kTTGatherDimCustomCallTargetName, getGatherDimShardingRule},
           {utils::kTTGatherCustomCallTargetName, getGatherDimShardingRule},
+          {samplingTargetName, getSamplingShardingRule},
       };
 };
 

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/sampling.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/sampling.mlir
@@ -24,5 +24,8 @@ func.func @sampling_candidate_dim_replicated(%arg0: tensor<64x256xbf16> {sdy.sha
 }
 
 // CHECK-LABEL: func.func @sampling_candidate_dim_replicated
+// The candidate dim is gathered back before the op, and only the batch dim
+// stays sharded.
+// CHECK: stablehlo.all_gather
 // CHECK: stablehlo.custom_call @tt.sampling
 // CHECK-SAME: (tensor<32x256xbf16>, tensor<32x256xi32>, tensor<32xi32>, tensor<32xbf16>, tensor<32xbf16>) -> tensor<32xi32>

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/sampling.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/sampling.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+sdy.mesh @mesh = <["batch"=2, "model"=4]>
+
+// Batch dim is pass-through, so the kernel runs on the local rows (64 -> 32)
+// and the result is batch sharded rather than gathered.
+func.func @sampling_batch_sharded(%arg0: tensor<64x256xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}, %arg1: tensor<64x256xi32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}, %arg2: tensor<64xi32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}, %arg3: tensor<64xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}, %arg4: tensor<64xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}) -> tensor<64xi32> {
+  %0 = stablehlo.custom_call @tt.sampling(%arg0, %arg1, %arg2, %arg3, %arg4) {api_version = 0 : i32, mhlo.frontend_attributes = {seed = "0"}} : (tensor<64x256xbf16>, tensor<64x256xi32>, tensor<64xi32>, tensor<64xbf16>, tensor<64xbf16>) -> tensor<64xi32>
+  return %0 : tensor<64xi32>
+}
+
+// CHECK-LABEL: func.func @sampling_batch_sharded
+// CHECK: out_shardings=[<@mesh, [{"batch"}]>]
+// CHECK: stablehlo.custom_call @tt.sampling
+// CHECK-SAME: (tensor<32x256xbf16>, tensor<32x256xi32>, tensor<32xi32>, tensor<32xbf16>, tensor<32xbf16>) -> tensor<32xi32>
+
+// The candidate dim needs replication: a row's candidate set must stay whole
+// for softmax, top-k and multinomial. Sharding it on "model" is undone.
+func.func @sampling_candidate_dim_replicated(%arg0: tensor<64x256xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {"model"}]>}, %arg1: tensor<64x256xi32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {"model"}]>}, %arg2: tensor<64xi32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}, %arg3: tensor<64xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}, %arg4: tensor<64xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}]>}) -> tensor<64xi32> {
+  %0 = stablehlo.custom_call @tt.sampling(%arg0, %arg1, %arg2, %arg3, %arg4) {api_version = 0 : i32, mhlo.frontend_attributes = {seed = "0"}} : (tensor<64x256xbf16>, tensor<64x256xi32>, tensor<64xi32>, tensor<64xbf16>, tensor<64xbf16>) -> tensor<64xi32>
+  return %0 : tensor<64xi32>
+}
+
+// CHECK-LABEL: func.func @sampling_candidate_dim_replicated
+// CHECK: stablehlo.custom_call @tt.sampling
+// CHECK-SAME: (tensor<32x256xbf16>, tensor<32x256xi32>, tensor<32xi32>, tensor<32xbf16>, tensor<32xbf16>) -> tensor<32xi32>


### PR DESCRIPTION
Closes #9136

tenstorrent/tt-xla#5831 depends on this. That PR shards the batch for on-device sampling and needs this rule to be in place, so it cannot land until this one is merged and uplifted.

`tt.sampling` had no entry in the custom call sharding rule registry, so Shardy fell back to replication and the batch dimension was gathered before the op. The ttnn kernel assigns one Tensix core per user and takes at most 32 rows per invocation, so a data parallel batch has to shard rather than gather.

Adds `getSamplingShardingRule`, mirroring the other first party ops in this file. Batch is pass-through so each device samples its own rows, and the candidate dimension is `kNeedReplication` since a row's candidate set has to stay whole for softmax, top-k and multinomial. Returns a null rule, with a warning, for unexpected operand counts, ranks or mismatched shapes.

Testing: new lit test covers both the batch sharded case (64 rows become 32 local) and that a sharded candidate dimension is gathered back before the op. Also validated end to end on an n300 llmbox through tt-xla, mesh 2x4 with a global batch of 64, where the greedy rows match a CPU sampled reference exactly.
