### PR TITLE
[TTIR] Accept ttir.constant splat as SDPA scale

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -122,13 +122,32 @@ std::optional<float> extractConstant(Value v) {
     break;
   }
 
-  auto fullOp = v.getDefiningOp<FullOp>();
-  if (!fullOp) {
+  // ttir.full carries the scalar directly as its fill value.
+  if (auto fullOp = v.getDefiningOp<FullOp>()) {
+    if (auto attr = mlir::dyn_cast<FloatAttr>(fullOp.getFillValue())) {
+      return attr.getValue().convertToFloat();
+    }
     return std::nullopt;
   }
-  if (auto attr = mlir::dyn_cast<FloatAttr>(fullOp.getFillValue())) {
-    return attr.getValue().convertToFloat();
+
+  // ttir.constant with a splat dense attribute. This is the form
+  // framework-traced models arrive in: a splat `stablehlo.constant` lowers to
+  // ttir.constant, never to ttir.full, so accepting only FullOp above silently
+  // declined the scale peel for every StableHLO-sourced attention (the
+  // ttir.full form is what hand-written tests use). Mirrors
+  // getSplatConstantValue in TTIRFusing.cpp; kept local because
+  // extractConstant is deliberately a narrow, one-direction look-through.
+  if (auto constOp = v.getDefiningOp<ConstantOp>()) {
+    auto elements = mlir::dyn_cast<mlir::ElementsAttr>(constOp.getValue());
+    if (!elements || !elements.isSplat() ||
+        !mlir::isa<mlir::FloatType>(elements.getElementType())) {
+      return std::nullopt;
+    }
+    // Safe for bf16/f16/f32 splats: every one of those semantics is
+    // representable by IEEEsingle, which is what convertToFloat requires.
+    return elements.getSplatValue<mlir::APFloat>().convertToFloat();
   }
+
   return std::nullopt;
 }
 

--- a/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa_from_dot_general.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa_from_dot_general.mlir
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Faithful reproduction of the CogVideoX-5b DiT attention chain as it actually
+// enters the TTIR pipeline from StableHLO. Unlike sdpa.mlir, this does NOT
+// start from a pre-fused ttir.softmax / ttir.matmul -- it starts from
+// ttir.dot_general plus the raw numerically-stable softmax decomposition, which
+// is what a framework-traced model presents, and runs the same pass order the
+// real pipeline uses (fusing -> decomposition -> canonicalize -> fusing).
+//
+// Op-for-op transcription of the real graph (shapes reduced from
+// 2x12x17776x{64,17776} so the test is cheap; structure identical):
+//   scale : ttir.constant(splat) -> reshape -> broadcast -> multiply on Q
+//   Kᵀ    : ttir.permute [0, 1, 3, 2]
+//   scores: ttir.dot_general batch=[0,1] contract=lhs[3]/rhs[2]
+//   softmax: max(keep_dim=false) -> reshape -> broadcast -> subtract -> exp
+//            -> sum(keep_dim=false) -> reshape -> broadcast -> div
+//   out   : ttir.dot_general batch=[0,1] contract=lhs[3]/rhs[2]
+
+// RUN: ttmlir-opt --ttir-fusing --ttir-to-ttir-decomposition --canonicalize --ttir-fusing %s | FileCheck %s
+
+module {
+  func.func @sdpa_from_dot_general_real_form(
+      %q: tensor<2x12x128x64xbf16>,
+      %k: tensor<2x12x128x64xbf16>,
+      %v: tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16> {
+    // CHECK-LABEL: @sdpa_from_dot_general_real_form
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-NOT: ttir.matmul
+    // CHECK-NOT: ttir.softmax
+
+    // Q * (64 ** -0.5), scale as a splat ttir.constant broadcast to full shape.
+    %c = "ttir.constant"() <{value = dense<1.250000e-01> : tensor<bf16>}> : () -> tensor<bf16>
+    %cr = "ttir.reshape"(%c) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<bf16>) -> tensor<1x1x1x1xbf16>
+    %cb = "ttir.broadcast"(%cr) <{broadcast_dimensions = array<i64: 2, 12, 128, 64>}> : (tensor<1x1x1x1xbf16>) -> tensor<2x12x128x64xbf16>
+    %qs = "ttir.multiply"(%q, %cb) : (tensor<2x12x128x64xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+
+    // Kᵀ
+    %kt = "ttir.permute"(%k) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<2x12x128x64xbf16>) -> tensor<2x12x64x128xbf16>
+
+    // scores = Q·Kᵀ
+    %scores = "ttir.dot_general"(%qs, %kt) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<2x12x128x64xbf16>, tensor<2x12x64x128xbf16>) -> tensor<2x12x128x128xbf16>
+
+    // numerically-stable softmax, fully decomposed
+    %mx = "ttir.max"(%scores) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128xbf16>
+    %mxr = "ttir.reshape"(%mx) <{shape = [2 : i32, 12 : i32, 128 : i32, 1 : i32]}> : (tensor<2x12x128xbf16>) -> tensor<2x12x128x1xbf16>
+    %mxb = "ttir.broadcast"(%mxr) <{broadcast_dimensions = array<i64: 1, 1, 1, 128>}> : (tensor<2x12x128x1xbf16>) -> tensor<2x12x128x128xbf16>
+    %sub = "ttir.subtract"(%scores, %mxb) : (tensor<2x12x128x128xbf16>, tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %ex = "ttir.exp"(%sub) : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %sm = "ttir.sum"(%ex) <{dim_arg = [3 : i32], keep_dim = false}> : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128xbf16>
+    %smr = "ttir.reshape"(%sm) <{shape = [2 : i32, 12 : i32, 128 : i32, 1 : i32]}> : (tensor<2x12x128xbf16>) -> tensor<2x12x128x1xbf16>
+    %smb = "ttir.broadcast"(%smr) <{broadcast_dimensions = array<i64: 1, 1, 1, 128>}> : (tensor<2x12x128x1xbf16>) -> tensor<2x12x128x128xbf16>
+    %probs = "ttir.div"(%ex, %smb) : (tensor<2x12x128x128xbf16>, tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+
+    // out = probs·V
+    %out = "ttir.dot_general"(%probs, %v) <{batch_dims_lhs = array<i64: 0, 1>, batch_dims_rhs = array<i64: 0, 1>, contract_dims_lhs = array<i64: 3>, contract_dims_rhs = array<i64: 2>}> : (tensor<2x12x128x128xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+    return %out : tensor<2x12x128x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa_scale_from_constant.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa_scale_from_constant.mlir
@@ -1,0 +1,76 @@
+// Reproduces the CogVideoX-5b DiT attention chain as it actually reaches
+// TTIRFusing: the scale arrives as ttir.constant (dense splat) + reshape +
+// broadcast, which is what StableHLO-sourced models produce, rather than the
+// ttir.full the existing sdpa_fusing tests all use.
+//
+// Shapes are the per-device (TP=4) CogVideoX ones scaled down so the test is
+// cheap; the structure is identical.
+
+// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+
+// Case A: scale as ttir.constant -> reshape -> broadcast, pre-scale on Q.
+// This is the real-model form and the one that currently fails.
+module {
+  func.func @sdpa_scale_from_constant_prescale_q(
+      %q: tensor<2x12x128x64xbf16>,
+      %k: tensor<2x12x128x64xbf16>,
+      %v: tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16> {
+    // CHECK-LABEL: @sdpa_scale_from_constant_prescale_q
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: scale = 1.250000e-01
+    // CHECK-NOT: ttir.matmul
+    %c = "ttir.constant"() <{value = dense<1.250000e-01> : tensor<bf16>}> : () -> tensor<bf16>
+    %r = "ttir.reshape"(%c) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<bf16>) -> tensor<1x1x1x1xbf16>
+    %b = "ttir.broadcast"(%r) <{broadcast_dimensions = array<i64: 2, 12, 128, 64>}> : (tensor<1x1x1x1xbf16>) -> tensor<2x12x128x64xbf16>
+    %qs = "ttir.multiply"(%q, %b) : (tensor<2x12x128x64xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+    // Kᵀ as ttir.permute on the last two dims (the dot_general-decomposition form).
+    %kt = "ttir.permute"(%k) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<2x12x128x64xbf16>) -> tensor<2x12x64x128xbf16>
+    %s = "ttir.matmul"(%qs, %kt) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x64xbf16>, tensor<2x12x64x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %p = "ttir.softmax"(%s) <{dimension = -1 : si32, numericStable = true}> : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %o = "ttir.matmul"(%p, %v) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x128xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+    return %o : tensor<2x12x128x64xbf16>
+  }
+}
+
+// Case B: same, but the scale is applied post-matmul on the score tensor.
+// This is the form the chain takes after later broadcast/commute passes.
+module {
+  func.func @sdpa_scale_from_constant_postscale(
+      %q: tensor<2x12x128x64xbf16>,
+      %k: tensor<2x12x128x64xbf16>,
+      %v: tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16> {
+    // CHECK-LABEL: @sdpa_scale_from_constant_postscale
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: scale = 1.250000e-01
+    // CHECK-NOT: ttir.matmul
+    %c = "ttir.constant"() <{value = dense<1.250000e-01> : tensor<bf16>}> : () -> tensor<bf16>
+    %r = "ttir.reshape"(%c) <{shape = [1 : i32, 1 : i32, 1 : i32, 1 : i32]}> : (tensor<bf16>) -> tensor<1x1x1x1xbf16>
+    %b = "ttir.broadcast"(%r) <{broadcast_dimensions = array<i64: 2, 12, 128, 128>}> : (tensor<1x1x1x1xbf16>) -> tensor<2x12x128x128xbf16>
+    %kt = "ttir.permute"(%k) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<2x12x128x64xbf16>) -> tensor<2x12x64x128xbf16>
+    %s = "ttir.matmul"(%q, %kt) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x64xbf16>, tensor<2x12x64x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %ss = "ttir.multiply"(%s, %b) : (tensor<2x12x128x128xbf16>, tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %p = "ttir.softmax"(%ss) <{dimension = -1 : si32, numericStable = true}> : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %o = "ttir.matmul"(%p, %v) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x128xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+    return %o : tensor<2x12x128x64xbf16>
+  }
+}
+
+// Case C: control -- identical to A but with ttir.full. Must already pass.
+module {
+  func.func @sdpa_scale_from_full_control(
+      %q: tensor<2x12x128x64xbf16>,
+      %k: tensor<2x12x128x64xbf16>,
+      %v: tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16> {
+    // CHECK-LABEL: @sdpa_scale_from_full_control
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: scale = 1.250000e-01
+    // CHECK-NOT: ttir.matmul
+    %f = "ttir.full"() <{fill_value = 1.250000e-01 : f32, shape = array<i32: 1, 1, 1, 1>}> : () -> tensor<1x1x1x1xbf16>
+    %qs = "ttir.multiply"(%q, %f) : (tensor<2x12x128x64xbf16>, tensor<1x1x1x1xbf16>) -> tensor<2x12x128x64xbf16>
+    %kt = "ttir.permute"(%k) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<2x12x128x64xbf16>) -> tensor<2x12x64x128xbf16>
+    %s = "ttir.matmul"(%qs, %kt) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x64xbf16>, tensor<2x12x64x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %p = "ttir.softmax"(%s) <{dimension = -1 : si32, numericStable = true}> : (tensor<2x12x128x128xbf16>) -> tensor<2x12x128x128xbf16>
+    %o = "ttir.matmul"(%p, %v) <{transpose_a = false, transpose_b = false}> : (tensor<2x12x128x128xbf16>, tensor<2x12x128x64xbf16>) -> tensor<2x12x128x64xbf16>
+    return %o : tensor<2x12x128x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
[#5841](https://github.com/tenstorrent/tt-xla/issues/5841)

### Problem description
CogVideoX pipeline test does not fuse attention: the DiT's 42 attention blocks each keep an explicit` matmul → multiply → softmax → matmul` chain, leaving the [B, H, S, S] score matrix materialized ([2, 48, 17776, 17776] at 49 frames).

SDPAFusingPattern extracts the softmax scale via peelScale → extractConstant. extractConstant walks through TypecastOp/BroadcastOp/ReshapeOp and then requires the producer to be a ttir.full — its own comment states the assumption: "the constant may be produced as a scalar ttir.full". That holds for the hand-written tests in sdpa.mlir, which build the scale with ttir.full, but not for framework-traced models: a splat stablehlo.constant lowers to ttir.constant, never to ttir.full, so extractConstant returned std::nullopt for every StableHLO-sourced attention.

Losing the scale attribute is not the whole cost. peelScale returns the value unchanged when extraction fails:

`return {v, std::nullopt};   // SDPAFusingPattern.cpp:173`

and the score-matmul matcher then does:


```
auto [stripped, postScale] = peelScale(candidate);
auto matmul = stripped.getDefiningOp<MatmulOp>();
if (!matmul || matmul == c.attentionMatmul) {
  return false;                            // SDPAFusingPattern.cpp:473-477
}
```
When the scale sits post-matmul on the score tensor — the form the chain takes once the broadcast/commute passes have run, and the form CogVideoX presents — the unpeeled stripped is still the ttir.multiply, so getDefiningOp<MatmulOp>() is null and the match aborts. The fatal part is that this is not a degraded fusion with a missing scale; it is no fusion at all, and the score matrix stays materialized.

### What's changed

- In SDPAFusingPattern.cpp, extractConstant now recognizes ttir.constant in addition to ttir.full. The FullOp lookup becomes one of two branches rather than a hard requirement:


```
// was: bail out on anything that is not ttir.full
auto fullOp = v.getDefiningOp<FullOp>();
if (!fullOp) {
  return std::nullopt;                     // ttir.constant landed here
}
```
The new branch accepts a ttir.constant whose value is a splat dense attribute of float element type, mirroring getSplatConstantValue in TTIRFusing.cpp:

```
if (auto constOp = v.getDefiningOp<ConstantOp>()) {
  auto elements = mlir::dyn_cast<mlir::ElementsAttr>(constOp.getValue());
  if (!elements || !elements.isSplat() ||
      !mlir::isa<mlir::FloatType>(elements.getElementType())) {
    return std::nullopt;
  }
  return elements.getSplatValue<mlir::APFloat>().convertToFloat();
}
```
Restricted to splat float elements; convertToFloat is safe for bf16/f16/f32 because each of those semantics is representable by IEEEsingle. Non-splat and integer constants still return std::nullopt, so nothing new is peeled that shouldn't be. The look-through walk, peelScale, the pre-scale path, mask handling, and the shape/transpose validation are otherwise unchanged — this widens what counts as a recognizable scalar constant and nothing else.

Two lit tests cover the real-model forms sdpa.mlir does not: sdpa_scale_from_constant.mlir (ttir.constant → reshape → broadcast, both pre-scale on Q and post-scale on the score tensor) and sdpa_from_dot_general.mlir (starts from ttir.dot_general plus the raw numerically-stable softmax decomposition, run through the real pass order fusing → decomposition → canonicalize → fusing). The existing ttir.full cases in sdpa.mlir still fuse. Post this fix the post-scale ttir.constant chain fuses to ttir.scaled_dot_product_attention with scale = 1.250000e-01 and no residual ttir.matmul.

### Checklist

- [x] Verify the changes through local testing in N150