### PR TITLE
Use portable bash shebangs

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/alchemist.sh
+++ b/.github/build_scripts/alchemist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/emitc.sh
+++ b/.github/build_scripts/emitc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/explorer.sh
+++ b/.github/build_scripts/explorer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/test-install.sh
+++ b/.github/build_scripts/test-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/ttnn-jit.sh
+++ b/.github/build_scripts/ttnn-jit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/build_scripts/ttnn-standalone.sh
+++ b/.github/build_scripts/ttnn-standalone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/gcov_for_clang.sh
+++ b/.github/gcov_for_clang.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/scripts/bash/get_test_summary.sh
+++ b/.github/scripts/bash/get_test_summary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/alchemist.sh
+++ b/.github/test_scripts/alchemist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/builder.sh
+++ b/.github/test_scripts/builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/chisel.sh
+++ b/.github/test_scripts/chisel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/emitc.sh
+++ b/.github/test_scripts/emitc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/op_model.sh
+++ b/.github/test_scripts/op_model.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/op_model_ttrt.sh
+++ b/.github/test_scripts/op_model_ttrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/pykernel.sh
+++ b/.github/test_scripts/pykernel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/pytest.sh
+++ b/.github/test_scripts/pytest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/runtime_debug.sh
+++ b/.github/test_scripts/runtime_debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/test-ttrt.sh
+++ b/.github/test_scripts/test-ttrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/ttnn_jit.sh
+++ b/.github/test_scripts/ttnn_jit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/ttnn_runtime.sh
+++ b/.github/test_scripts/ttnn_runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/ttnn_standalone.sh
+++ b/.github/test_scripts/ttnn_standalone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/.github/test_scripts/ttrt.sh
+++ b/.github/test_scripts/ttrt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/env/init_venv.sh
+++ b/env/init_venv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/env/install-tt-triage.sh
+++ b/env/install-tt-triage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/explorer/hosted/docker-entrypoint.sh
+++ b/tools/explorer/hosted/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/explorer/hosted/explorer-setup.sh
+++ b/tools/explorer/hosted/explorer-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/scripts/ttsysjson
+++ b/tools/scripts/ttsysjson
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Simple JSON/FlatBuffer converter
 # Automatically detects conversion direction based on input file extension

--- a/tools/scripts/update_llm_perf_tests.sh
+++ b/tools/scripts/update_llm_perf_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tools/tt-alchemist/templates/cpp/local/run
+++ b/tools/tt-alchemist/templates/cpp/local/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e

--- a/tools/tt-alchemist/templates/python/local/run
+++ b/tools/tt-alchemist/templates/python/local/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Parse command line arguments
 TRACY_MODE=false

--- a/tools/ttnn-standalone/run
+++ b/tools/ttnn-standalone/run
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e


### PR DESCRIPTION
  ### Ticket
  N/A

  ### Problem description
  Some development environments, such as NixOS, do not provide bash at `/bin/bash`.

  ### What's changed
  Updated shell script shebangs to use a more portable bash lookup via `/usr/bin/env bash`.

  ### Checklist
  - [ ] New/Existing tests provide coverage for changes