### PR TITLE
Uplift third_party/tt-metal to 5beed318d0f0d1c6212e605947fb0be80c9e0a1d 2026-07-31

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "d4e579756ad716062b96cc7af3b4a0057acf35ce")
+set(TT_METAL_VERSION "5beed318d0f0d1c6212e605947fb0be80c9e0a1d")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 5beed318d0f0d1c6212e605947fb0be80c9e0a1d



### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/30629929653
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/30629936450
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):