### PR TITLE
[TTIR] Canonicalize reshape->permute->reshape patterns with unit-dims at any position

### DIFF
--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2810,19 +2810,58 @@ static mlir::OpFoldResult constFoldReshape(mlir::tt::ttir::ReshapeOp op,
   return nullptr;
 }
 
+// Match `outShape` against `inShape` with unit dimensions deleted. Returns, for
+// each position of `inShape`, its index in `outShape`, or -1 when that position
+// is one of the deleted unit dims; std::nullopt when `outShape` cannot be
+// obtained from `inShape` by deleting unit dims alone.
+//
+// Non-unit dims must correspond in order, so the greedy walk is forced there.
+// Adjacent unit dims are ambiguous -- which of the two was deleted? -- but
+// interchangeable: an extent-1 dim holds no data and contributes nothing to a
+// linear index, so either reading describes the same rewrite.
+static std::optional<llvm::SmallVector<int64_t>>
+matchShapeByDeletingUnitDims(llvm::ArrayRef<int64_t> inShape,
+                             llvm::ArrayRef<int64_t> outShape) {
+  llvm::SmallVector<int64_t> inToOut(inShape.size(), -1);
+  size_t outDim = 0;
+  for (size_t inDim = 0; inDim < inShape.size(); ++inDim) {
+    if (outDim < outShape.size() && inShape[inDim] == outShape[outDim]) {
+      inToOut[inDim] = outDim++;
+      continue;
+    }
+    if (inShape[inDim] != 1) {
+      return std::nullopt;
+    }
+  }
+  if (outDim != outShape.size()) {
+    return std::nullopt;
+  }
+  return inToOut;
+}
+
 // ReshapeOp canonicalization
 //
 // Fold Reshape(Permute(Reshape(x))) → Permute(Reshape(x)) when the trailing
-// reshape only removes leading unit dimensions. The permutation is adjusted to
-// operate at the lower rank.
+// reshape does nothing but delete unit dimensions from the permute's result,
+// wherever in the shape they sit. The permutation is rebuilt over the surviving
+// dims and the leading reshape is retargeted, so the rewrite never adds an op.
 //
-// Example:
-//   reshape: 256x32 → 1x1x256x32
-//   permute [0,1,3,2]: 1x1x256x32 → 1x1x32x256
-//   reshape: 1x1x32x256 → 1x32x256
+// This matters because tt-mlir tiles the last two dimensions at 32x32, so a
+// unit dim in either of those positions is padded out to a whole tile: a result
+// typed 32x4096x128x1x1 carries 32 MiB of bf16 in a 32 GiB buffer, a 1024x
+// amplification that exhausts a device rather than merely wasting space. XLA
+// emits precisely this shape when canonicalizing dot_general operands -- it
+// inserts degenerate dims, then picks a non-default result layout that makes
+// the transpose a bitcast, an intent StableHLO has no way to carry -- so the
+// sandwich turns up in any graph lowered from einsum.
+//
+// Example (DeepSeek-V3.2 MLA Q absorption, the 1024x case above):
+//   reshape: 4096x32x128 → 1x4096x32x1x128
+//   permute [2,1,4,0,3]: → 32x4096x128x1x1
+//   reshape: → 32x4096x128
 // Becomes:
-//   reshape: 256x32 → 1x256x32
-//   permute [0,2,1]: 1x256x32 → 1x32x256
+//   reshape: 4096x32x128 → 4096x32x128    (identity, folds away)
+//   permute [1,0,2]: → 32x4096x128
 //
 void mlir::tt::ttir::ReshapeOp::getCanonicalizationPatterns(
     mlir::RewritePatternSet &patterns, mlir::MLIRContext *context) {
@@ -2840,60 +2879,75 @@ void mlir::tt::ttir::ReshapeOp::getCanonicalizationPatterns(
       return failure();
     }
 
-    // Check that the trailing reshape only removes leading 1s.
-    auto permuteOutShape = permuteOp.getType().getShape();
-    auto outShape = trailingReshape.getType().getShape();
+    llvm::ArrayRef<int64_t> permuteOutShape = permuteOp.getType().getShape();
+    llvm::ArrayRef<int64_t> outShape = trailingReshape.getType().getShape();
     if (outShape.size() >= permuteOutShape.size()) {
       return failure();
     }
-    int64_t n = permuteOutShape.size() - outShape.size();
-    if (!llvm::all_of(permuteOutShape.take_front(n),
-                      [](int64_t d) { return d == 1; })) {
-      return failure();
-    }
-    if (permuteOutShape.drop_front(n) != outShape) {
+
+    std::optional<llvm::SmallVector<int64_t>> resultToOut =
+        matchShapeByDeletingUnitDims(permuteOutShape, outShape);
+    if (!resultToOut) {
       return failure();
     }
 
-    // Check that the first n permuted dims come from the first n input dims
-    // (all unit dims mapping to unit dims).
-    auto perm = permuteOp.getPermutation();
-    for (int64_t i = 0; i < n; ++i) {
-      if (perm[i] >= n) {
+    // Deleting a result dim deletes its source dim from the permute too. That
+    // source is necessarily a unit dim as well: a permutation moves extents
+    // around without changing them.
+    llvm::ArrayRef<int64_t> perm = permuteOp.getPermutation();
+    llvm::SmallVector<bool> dropped(perm.size(), false);
+    for (size_t dim = 0; dim < perm.size(); ++dim) {
+      if ((*resultToOut)[dim] < 0) {
+        dropped[perm[dim]] = true;
+      }
+    }
+
+    // The surviving operand dims, in order, form the new permute's operand.
+    RankedTensorType permuteInType = permuteOp.getInput().getType();
+    llvm::ArrayRef<int64_t> permuteInShape = permuteInType.getShape();
+    llvm::SmallVector<int64_t> newInShape;
+    llvm::SmallVector<int64_t> operandToNew(permuteInShape.size(), -1);
+    for (size_t dim = 0; dim < permuteInShape.size(); ++dim) {
+      if (!dropped[dim]) {
+        operandToNew[dim] = newInShape.size();
+        newInShape.push_back(permuteInShape[dim]);
+      }
+    }
+    if (newInShape.size() != outShape.size()) {
+      return failure();
+    }
+
+    // Rebuild the permutation over the survivors, indexed by result position.
+    llvm::SmallVector<int64_t> newPerm(outShape.size(), -1);
+    for (size_t dim = 0; dim < perm.size(); ++dim) {
+      int64_t outPos = (*resultToOut)[dim];
+      if (outPos >= 0) {
+        newPerm[outPos] = operandToNew[perm[dim]];
+      }
+    }
+
+    // The rebuilt permutation has to be total, and applying it to the new
+    // operand shape has to reproduce the result type being replaced. Both hold
+    // for a well-formed permutation; check rather than assume, since failing
+    // here just declines the rewrite whereas building the op would not verify.
+    for (size_t outPos = 0; outPos < newPerm.size(); ++outPos) {
+      if (newPerm[outPos] < 0 ||
+          newInShape[newPerm[outPos]] != outShape[outPos]) {
         return failure();
       }
     }
 
-    // Build the new lower-rank permutation.
-    SmallVector<int64_t> newPerm;
-    for (int64_t i = n; i < static_cast<int64_t>(perm.size()); ++i) {
-      newPerm.push_back(perm[i] - n);
-    }
-
-    // Build the new input reshape shape (drop leading 1s from permute input).
-    auto permuteInType = permuteOp.getInput().getType();
-    auto permuteInShape = permuteInType.getShape();
-    SmallVector<int64_t> newMidShape(permuteInShape.drop_front(n));
-
-    // Create new reshape: original input → reduced rank.
-    auto newMidType =
-        RankedTensorType::get(newMidShape, permuteInType.getElementType(),
-                              permuteInType.getEncoding());
-    SmallVector<int32_t> midShapeAttr(newMidShape.begin(), newMidShape.end());
+    llvm::SmallVector<int32_t> newInShapeAttr(newInShape.begin(),
+                                              newInShape.end());
     auto newReshape = rewriter.create<mlir::tt::ttir::ReshapeOp>(
-        leadingReshape.getLoc(), newMidType, leadingReshape.getInput(),
-        rewriter.getI32ArrayAttr(midShapeAttr));
+        leadingReshape.getLoc(),
+        RankedTensorType::get(newInShape, permuteInType.getElementType(),
+                              permuteInType.getEncoding()),
+        leadingReshape.getInput(), rewriter.getI32ArrayAttr(newInShapeAttr));
 
-    // Create new permute at reduced rank.
-    SmallVector<int64_t> newOutShape;
-    for (int64_t i : newPerm) {
-      newOutShape.push_back(newMidShape[i]);
-    }
-    auto trailingType = trailingReshape.getType();
-    auto newOutType = RankedTensorType::get(
-        newOutShape, trailingType.getElementType(), trailingType.getEncoding());
     auto newPermute = rewriter.create<mlir::tt::ttir::PermuteOp>(
-        permuteOp.getLoc(), newOutType, newReshape.getResult(), newPerm);
+        permuteOp.getLoc(), trailingReshape.getType(), newReshape.getResult(),
+        newPerm);
 
     rewriter.replaceOp(trailingReshape, newPermute.getResult());
     return success();

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -2815,13 +2815,17 @@ static mlir::OpFoldResult constFoldReshape(mlir::tt::ttir::ReshapeOp op,
 // is one of the deleted unit dims; std::nullopt when `outShape` cannot be
 // obtained from `inShape` by deleting unit dims alone.
 //
-// Non-unit dims must correspond in order, so the greedy walk is forced there.
-// Adjacent unit dims are ambiguous -- which of the two was deleted? -- but
-// interchangeable: an extent-1 dim holds no data and contributes nothing to a
-// linear index, so either reading describes the same rewrite.
+// Example: inShape = [1, 4, 1, 1, 5], outShape = [4, 5]
+//   inDim 0 (extent 1) doesn't match outShape[0]=4, so it's a deleted unit dim
+//     -> inToOut[0] = -1
+//   inDim 1 (extent 4) matches outShape[0]=4 -> inToOut[1] = 0
+//   inDim 2 (extent 1) doesn't match outShape[1]=5, deleted -> inToOut[2] = -1
+//   inDim 3 (extent 1) doesn't match outShape[1]=5, deleted -> inToOut[3] = -1
+//   inDim 4 (extent 5) matches outShape[1]=5 -> inToOut[4] = 1
+// Result: inToOut = [-1, 0, -1, -1, 1]
 static std::optional<llvm::SmallVector<int64_t>>
-matchShapeByDeletingUnitDims(llvm::ArrayRef<int64_t> inShape,
-                             llvm::ArrayRef<int64_t> outShape) {
+matchShapeByDeletingUnitDims(const llvm::ArrayRef<int64_t> &inShape,
+                             const llvm::ArrayRef<int64_t> &outShape) {
   llvm::SmallVector<int64_t> inToOut(inShape.size(), -1);
   size_t outDim = 0;
   for (size_t inDim = 0; inDim < inShape.size(); ++inDim) {
@@ -2846,16 +2850,7 @@ matchShapeByDeletingUnitDims(llvm::ArrayRef<int64_t> inShape,
 // wherever in the shape they sit. The permutation is rebuilt over the surviving
 // dims and the leading reshape is retargeted, so the rewrite never adds an op.
 //
-// This matters because tt-mlir tiles the last two dimensions at 32x32, so a
-// unit dim in either of those positions is padded out to a whole tile: a result
-// typed 32x4096x128x1x1 carries 32 MiB of bf16 in a 32 GiB buffer, a 1024x
-// amplification that exhausts a device rather than merely wasting space. XLA
-// emits precisely this shape when canonicalizing dot_general operands -- it
-// inserts degenerate dims, then picks a non-default result layout that makes
-// the transpose a bitcast, an intent StableHLO has no way to carry -- so the
-// sandwich turns up in any graph lowered from einsum.
-//
-// Example (DeepSeek-V3.2 MLA Q absorption, the 1024x case above):
+// Example:
 //   reshape: 4096x32x128 → 1x4096x32x1x128
 //   permute [2,1,4,0,3]: → 32x4096x128x1x1
 //   reshape: → 32x4096x128

--- a/test/ttmlir/Dialect/TTIR/canonicalize/reshape_permute_reshape_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/reshape_permute_reshape_canonicalize_tests.mlir
@@ -44,14 +44,58 @@ module {
     return %2 : tensor<3x2xbf16>
   }
 
-  // Pattern should NOT match: permute shuffles non-unit dim into leading position.
-  func.func @reshape_permute_reshape_no_match_perm_mixes(%arg0: tensor<6x4xbf16>) -> tensor<4x6xbf16> {
-    // CHECK-LABEL: @reshape_permute_reshape_no_match_perm_mixes
+  // Interior unit dim. The permutation moves a non-unit dim past the unit dim,
+  // which the leading-unit-dims-only version of this pattern rejected; deleting
+  // dim 1 of 4x1x6 is still nothing but a unit-dim deletion, and the rewrite to
+  // permute[1,0] moves the same data.
+  func.func @reshape_permute_reshape_interior_unit_dim(%arg0: tensor<6x4xbf16>) -> tensor<4x6xbf16> {
+    // CHECK-LABEL: @reshape_permute_reshape_interior_unit_dim
+    // CHECK-NOT: "ttir.reshape"
     // CHECK: "ttir.permute"
-    // CHECK-SAME: permutation = array<i64: 2, 0, 1>
+    // CHECK-SAME: permutation = array<i64: 1, 0>
     %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 6 : i32, 4 : i32]}> : (tensor<6x4xbf16>) -> tensor<1x6x4xbf16>
     %1 = "ttir.permute"(%0) <{permutation = array<i64: 2, 0, 1>}> : (tensor<1x6x4xbf16>) -> tensor<4x1x6xbf16>
     %2 = "ttir.reshape"(%1) <{shape = [4 : i32, 6 : i32]}> : (tensor<4x1x6xbf16>) -> tensor<4x6xbf16>
     return %2 : tensor<4x6xbf16>
+  }
+
+  // The DeepSeek-V3.2 MLA Q-absorption sandwich, which is what motivated
+  // generalizing this pattern. XLA emits it while canonicalizing dot_general
+  // operands. The two TRAILING unit dims are the expensive part: tiling the last
+  // two dims at 32x32 pads 32x4096x128x1x1 from 32 MiB to 32 GiB.
+  func.func @reshape_permute_reshape_mla_q_absorption(%arg0: tensor<4096x32x128xbf16>) -> tensor<32x4096x128xbf16> {
+    // CHECK-LABEL: @reshape_permute_reshape_mla_q_absorption
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK-NOT: x1x1xbf16
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 0, 2>
+    %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 4096 : i32, 32 : i32, 1 : i32, 128 : i32]}> : (tensor<4096x32x128xbf16>) -> tensor<1x4096x32x1x128xbf16>
+    %1 = "ttir.permute"(%0) <{permutation = array<i64: 2, 1, 4, 0, 3>}> : (tensor<1x4096x32x1x128xbf16>) -> tensor<32x4096x128x1x1xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [32 : i32, 4096 : i32, 128 : i32]}> : (tensor<32x4096x128x1x1xbf16>) -> tensor<32x4096x128xbf16>
+    return %2 : tensor<32x4096x128xbf16>
+  }
+
+  // Pattern must NOT match: the trailing reshape merges 2x3 into 6, which is
+  // real data movement rather than a unit-dim deletion.
+  func.func @reshape_permute_reshape_no_match_merges_dims(%arg0: tensor<4x2x3xbf16>) -> tensor<6x4xbf16> {
+    // CHECK-LABEL: @reshape_permute_reshape_no_match_merges_dims
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 1, 2, 0>
+    %0 = "ttir.reshape"(%arg0) <{shape = [4 : i32, 2 : i32, 3 : i32]}> : (tensor<4x2x3xbf16>) -> tensor<4x2x3xbf16>
+    %1 = "ttir.permute"(%0) <{permutation = array<i64: 1, 2, 0>}> : (tensor<4x2x3xbf16>) -> tensor<2x3x4xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [6 : i32, 4 : i32]}> : (tensor<2x3x4xbf16>) -> tensor<6x4xbf16>
+    return %2 : tensor<6x4xbf16>
+  }
+
+  // Pattern must NOT match: the permute has a second consumer, so rewriting it
+  // would leave the original alive and duplicate the work.
+  func.func @reshape_permute_reshape_no_match_multi_use(%arg0: tensor<8x8xbf16>) -> (tensor<8x8xbf16>, tensor<1x1x8x8xbf16>) {
+    // CHECK-LABEL: @reshape_permute_reshape_no_match_multi_use
+    // CHECK: "ttir.permute"
+    // CHECK-SAME: permutation = array<i64: 0, 1, 3, 2>
+    %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 8 : i32, 8 : i32]}> : (tensor<8x8xbf16>) -> tensor<1x1x8x8xbf16>
+    %1 = "ttir.permute"(%0) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<1x1x8x8xbf16>) -> tensor<1x1x8x8xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [8 : i32, 8 : i32]}> : (tensor<1x1x8x8xbf16>) -> tensor<8x8xbf16>
+    return %2, %1 : tensor<8x8xbf16>, tensor<1x1x8x8xbf16>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/reshape_permute_reshape_canonicalize_tests.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/reshape_permute_reshape_canonicalize_tests.mlir
@@ -44,10 +44,7 @@ module {
     return %2 : tensor<3x2xbf16>
   }
 
-  // Interior unit dim. The permutation moves a non-unit dim past the unit dim,
-  // which the leading-unit-dims-only version of this pattern rejected; deleting
-  // dim 1 of 4x1x6 is still nothing but a unit-dim deletion, and the rewrite to
-  // permute[1,0] moves the same data.
+  // Interior unit dim. The permutation moves a non-unit dim past the unit dim.
   func.func @reshape_permute_reshape_interior_unit_dim(%arg0: tensor<6x4xbf16>) -> tensor<4x6xbf16> {
     // CHECK-LABEL: @reshape_permute_reshape_interior_unit_dim
     // CHECK-NOT: "ttir.reshape"
@@ -59,10 +56,7 @@ module {
     return %2 : tensor<4x6xbf16>
   }
 
-  // The DeepSeek-V3.2 MLA Q-absorption sandwich, which is what motivated
-  // generalizing this pattern. XLA emits it while canonicalizing dot_general
-  // operands. The two TRAILING unit dims are the expensive part: tiling the last
-  // two dims at 32x32 pads 32x4096x128x1x1 from 32 MiB to 32 GiB.
+  // MLA Q-absorption pattern emitted by XLA.
   func.func @reshape_permute_reshape_mla_q_absorption(%arg0: tensor<4096x32x128xbf16>) -> tensor<32x4096x128xbf16> {
     // CHECK-LABEL: @reshape_permute_reshape_mla_q_absorption
     // CHECK-NOT: "ttir.reshape"


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ReshapeOp already canonicalized Reshape(Permute(Reshape(x))) into a single lower-rank permute, but only when the trailing reshape stripped LEADING unit dims.

Certain graphs with unit-dims in other positions weren't getting canonicalized. Ex: during tt-xla MLA Q absorption the following pattern emerged:

  reshape:             4096x32x128 -> 1x4096x32x1x128
  permute [2,1,4,0,3]:             -> 32x4096x128x1x1
  reshape:                         -> 32x4096x128

Since the unit-dims weren't all leading, the canonicalization did not apply, and the 32x4096x128x1x1 shaped tensor would blow up memory usage 1024x times (due to the trailing 1x1 dims getting padded to 32x32).

### What's changed
- Generalize the reshape->permute->reshape canonicalization to apply to all cases with unit sized dims

### Checklist
- [x] New/Existing tests provide coverage for changes
