### PR TITLE
[OpModel] Add stateful CCL and DistributedRMSNorm op constraints support

### DIFF
--- a/docs/src/ttnn-op-constraints.md
+++ b/docs/src/ttnn-op-constraints.md
@@ -488,6 +488,38 @@ Migrating a blocked op later means adding the `initialState` parameter at the
 op-model layer first, then switching the body to `detail::constraintsDispatch`.
 That changes nothing for stateless callers.
 
+### Multi-device ops, and building resources inside the capture
+
+Multi-device ops are stateful like any other: `DistributedTensorSpec` arguments
+materialize identically under both flavours, and the with-state query's mock-device
+requirement is satisfied by construction, since the op-model device always uses the
+canned mock for a multi-chip mesh. `AllGatherOp`, `ReduceScatterOp`, `AllReduceOp`
+and `MeshPartitionOp` follow the plain recipe above.
+
+`DistributedRMSNormOp` is the one to copy when an op must **construct a device
+resource inside the graph capture**. It calls
+`::ttnn::graph::query_op_constraints_with_optional_state` directly (rather than via
+`QUERY_OP_CONSTRAINTS_WITH_STATE`) so it can keep an inner lambda that creates its
+`GlobalSemaphore` within the capture scope. Keep that inner-lambda shape when
+porting such an op — do not hoist the resource out:
+
+* stateless (`NO_DISPATCH`): `GraphTracker`'s `hook_allocate` /
+  `hook_write_to_device` intercept the semaphore's L1 allocation and its
+  initial-value write, so no real device state is mutated and the trace still
+  accounts for the allocation;
+* stateful (phase 2, `NORMAL`): the semaphore is allocated for real through the
+  mock allocator alongside the op's own buffers — which is what the live-record
+  accounting wants.
+
+Either way the resource must be created inside the capture, so the same lambda
+serves both flavours.
+
+Finally, remember what the stateful path is for: it reports **fit and output
+placement**, not peak CB/L1 bytes. It models buffer allocation against the live
+set; circular-buffer pressure is not part of that model for any op. Peak CB/L1
+numbers come from the stateless path, and the peak-byte check in validation is
+enforced only there (see above).
+
 ### How the L1 spill pass uses it
 
 `MockAllocatorL1Tracker::validate` (`lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp`,

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -229,6 +229,7 @@ def TTCore_SystemDescAttr : TTCore_Attr<"SystemDesc", "system_desc"> {
 
   let extraClassDeclaration = [{
     static SystemDescAttr getDefault(MLIRContext *context, Arch arch = Arch::WormholeB0, const llvm::SmallVector<int64_t> &meshShape = {1});
+    static SystemDescAttr getDefault(MLIRContext *context, Arch arch, const llvm::SmallVector<int64_t> &meshShape, const llvm::SmallVector<int64_t> &chipGrid);
     static FailureOr<SystemDescAttr> getFromPath(MLIRContext *context, StringRef path, llvm::function_ref<mlir::InFlightDiagnostic()> diagFn);
     static FailureOr<SystemDescAttr> getFromBuffer(MLIRContext *context, void *systemDesc, llvm::function_ref<mlir::InFlightDiagnostic()> diagFn);
     ChipDescAttr getChipDesc(unsigned chipIndex) const;

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2723,7 +2723,7 @@ def TTNN_AdamWOp : TTNN_InplaceOp<"adamw", [OpModelExempt]> {
 }
 
 def TTNN_DistributedRMSNormOp : TTNN_Op<"distributed_rms_norm",
-    [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface, TTNN_DistributedOpInterface, OpModelExempt]> {
+    [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface, TTNN_DistributedOpInterface]> {
     let summary = "Distributed RMS normalization with all-gather op.";
     let description = [{
       Fused distributed RMS normalization operation across mesh devices.
@@ -3328,7 +3328,7 @@ def TTNN_GatherOp : TTNN_Op<"gather"> {
     }];
 }
 
-def TTNN_AllGatherOp: TTNN_Op<"all_gather", [OpModelExempt]> {
+def TTNN_AllGatherOp: TTNN_Op<"all_gather", []> {
     let summary = "All gather op.";
     let description = [{
         Tensor All Gather operation
@@ -3349,7 +3349,7 @@ def TTNN_AllGatherOp: TTNN_Op<"all_gather", [OpModelExempt]> {
 }
 
 def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
-    [TTNN_ComputeKernelConfigOpInterface, OpModelExempt]> {
+    [TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Reduce scatter op.";
     let description = [{
         Tensor Reduce Scatter operation
@@ -3371,7 +3371,7 @@ def TTNN_ReduceScatterOp: TTNN_Op<"reduce_scatter",
     let hasFolder = 1;
 }
 
-def TTNN_AllReduceOp: TTNN_Op<"all_reduce", [OpModelExempt]> {
+def TTNN_AllReduceOp: TTNN_Op<"all_reduce", []> {
     let summary = "All reduce op.";
     let description = [{
         Tensor All Reduce operation

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -32,10 +32,14 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 }
 } // namespace ttnn::graph::detail
 
+#include "ttnn/global_semaphore.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/ccl/all_gather/all_gather.hpp"
+#include "ttnn/operations/ccl/all_reduce/all_reduce.hpp"
 #include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
+#include "ttnn/operations/ccl/reduce_scatter/reduce_scatter.hpp"
 #include "ttnn/operations/conv/conv1d/conv1d.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
@@ -65,6 +69,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/embedding/embedding.hpp"
 #include "ttnn/operations/embedding_backward/embedding_backward.hpp"
 #include "ttnn/operations/experimental/ccl/all_reduce_async/all_reduce_async.hpp"
+#include "ttnn/operations/experimental/ccl/rms_allgather/rms_allgather.hpp"
 #include "ttnn/operations/experimental/conv3d/conv3d.hpp"
 #include "ttnn/operations/experimental/conv3d/prepare_conv3d_weights.hpp"
 #include "ttnn/operations/experimental/dropout/dropout.hpp"
@@ -81,6 +86,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/normalization/batch_norm/batch_norm.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm.hpp"
+#include "ttnn/operations/normalization/layernorm/device/layernorm_types.hpp"
 #include "ttnn/operations/normalization/layernorm/layernorm.hpp"
 #include "ttnn/operations/normalization/layernorm_distributed/layernorm_post_all_gather.hpp"
 #include "ttnn/operations/normalization/layernorm_distributed/layernorm_pre_all_gather.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2277,5 +2277,113 @@ struct OpModel<MeshPartitionOp> {
                TTNNLayoutAttr outputLayout);
 };
 
+//===----------------------------------------------------------------------===//
+// AllGatherOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<AllGatherOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t allGatherDim, uint32_t clusterAxis,
+      std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+      std::optional<ttcore::Topology> topology, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      int32_t allGatherDim, uint32_t clusterAxis,
+      std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+      std::optional<ttcore::Topology> topology, TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
+// ReduceScatterOp
+//===----------------------------------------------------------------------===//
+
+// Note: reduce_type is not forwarded — ttnn::reduce_scatter always performs
+// sum reduction (no reduce_type C++ API parameter).
+template <>
+struct OpModel<ReduceScatterOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout, int32_t scatterDim,
+                   uint32_t clusterAxis, std::optional<uint32_t> subDeviceId,
+                   std::optional<uint32_t> numLinks,
+                   std::optional<ttcore::Topology> topology,
+                   std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+                   TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               int32_t scatterDim, uint32_t clusterAxis,
+               std::optional<uint32_t> subDeviceId,
+               std::optional<uint32_t> numLinks,
+               std::optional<ttcore::Topology> topology,
+               std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
+// AllReduceOp
+//===----------------------------------------------------------------------===//
+// Note: reduce_type is not forwarded — ttnn::all_reduce always performs sum
+// and the C++ API has no reduce_type parameter.
+template <>
+struct OpModel<AllReduceOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      uint32_t clusterAxis, std::optional<uint32_t> subDeviceId,
+      std::optional<uint32_t> numLinks,
+      std::optional<ttcore::Topology> topology, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               uint32_t clusterAxis, std::optional<uint32_t> subDeviceId,
+               std::optional<uint32_t> numLinks,
+               std::optional<ttcore::Topology> topology,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
+// DistributedRMSNormOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<DistributedRMSNormOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualShape,
+      std::optional<TTNNLayoutAttr> residualLayout,
+      std::optional<llvm::ArrayRef<int64_t>> statsShape,
+      std::optional<TTNNLayoutAttr> statsLayout, uint32_t clusterAxis,
+      llvm::APFloat epsilon, std::optional<uint32_t> subDeviceId,
+      std::optional<uint32_t> numLinks,
+      std::optional<ttcore::Topology> topology,
+      std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>> weightShape,
+      std::optional<TTNNLayoutAttr> weightLayout,
+      std::optional<llvm::ArrayRef<int64_t>> residualShape,
+      std::optional<TTNNLayoutAttr> residualLayout,
+      std::optional<llvm::ArrayRef<int64_t>> statsShape,
+      std::optional<TTNNLayoutAttr> statsLayout, uint32_t clusterAxis,
+      llvm::APFloat epsilon, std::optional<uint32_t> subDeviceId,
+      std::optional<uint32_t> numLinks,
+      std::optional<ttcore::Topology> topology,
+      std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+      TTNNLayoutAttr outputLayout);
+};
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -66,7 +66,8 @@ createDefaultQuasarSystemDesc(mlir::MLIRContext *context,
 }
 
 SystemDescAttr createDefaultBlackholeSystemDesc(
-    mlir::MLIRContext *context, const ::llvm::SmallVector<int64_t> &meshShape) {
+    mlir::MLIRContext *context, const ::llvm::SmallVector<int64_t> &meshShape,
+    const ::llvm::SmallVector<int64_t> &chipGrid = {10, 11}) {
   // Set default values
   constexpr auto l1Size = 1572864;
   constexpr auto numDramChannels = 8;
@@ -89,7 +90,8 @@ SystemDescAttr createDefaultBlackholeSystemDesc(
                       std::multiplies<int64_t>());
 
   // Populate dummy values for single chip or multi chip config.
-  llvm::SmallVector<std::int64_t> gridShape = {10, 13};
+  // Blackhole's compute-with-storage worker grid defaults to 10 rows x 11 cols.
+  llvm::SmallVector<std::int64_t> gridShape(chipGrid.begin(), chipGrid.end());
   llvm::SmallVector<std::int64_t> dramGridShape = {1, 8};
 
   // Captured from a p150 device. Blackhole's optimal mapping is identical
@@ -188,9 +190,9 @@ SystemDescAttr createDefaultBlackholeSystemDesc(
       chipChannelList);
 }
 
-SystemDescAttr
-createDefaultWormholeSystemDesc(mlir::MLIRContext *context,
-                                const ::llvm::SmallVector<int64_t> &meshShape) {
+SystemDescAttr createDefaultWormholeSystemDesc(
+    mlir::MLIRContext *context, const ::llvm::SmallVector<int64_t> &meshShape,
+    const ::llvm::SmallVector<int64_t> &chipGrid = {8, 8}) {
   // Set default values
   constexpr auto l1Size = 1499136;
   constexpr auto numDramChannels = 12;
@@ -213,7 +215,7 @@ createDefaultWormholeSystemDesc(mlir::MLIRContext *context,
                       std::multiplies<int64_t>());
 
   // Populate dummy values for single chip or multi chip config.
-  llvm::SmallVector<std::int64_t> gridShape = {8, 8};
+  llvm::SmallVector<std::int64_t> gridShape(chipGrid.begin(), chipGrid.end());
   llvm::SmallVector<std::int64_t> dramGridShape = {1, 12};
 
   // Captured from an n150 device. Wormhole's optimal mapping is identical
@@ -324,6 +326,22 @@ SystemDescAttr::getDefault(MLIRContext *context, Arch arch,
   case Arch::Blackhole:
     return createDefaultBlackholeSystemDesc(context, meshShape);
   case Arch::Quasar:
+    return createDefaultQuasarSystemDesc(context, meshShape);
+  }
+}
+
+SystemDescAttr
+SystemDescAttr::getDefault(MLIRContext *context, Arch arch,
+                           const ::llvm::SmallVector<int64_t> &meshShape,
+                           const ::llvm::SmallVector<int64_t> &chipGrid) {
+  switch (arch) {
+  case Arch::WormholeB0:
+    return createDefaultWormholeSystemDesc(context, meshShape, chipGrid);
+  case Arch::Blackhole:
+    return createDefaultBlackholeSystemDesc(context, meshShape, chipGrid);
+  case Arch::Quasar:
+    // Quasar has no chipGrid-aware default descriptor yet; use its built-in
+    // grid.
     return createDefaultQuasarSystemDesc(context, meshShape);
   }
 }

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4355,6 +4355,83 @@ RMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// DistributedRMSNormOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> DistributedRMSNormOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() >= 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  // Unpack optional tensor shapes/layouts from the inputs vector.
+  // Inputs follow operand order: input(0), weight(1?), residual(2?), stats(3?)
+  size_t idx = 1;
+  std::optional<llvm::ArrayRef<int64_t>> weightShape;
+  std::optional<TTNNLayoutAttr> weightLayout;
+  if (getWeight() && inputs.size() > idx) {
+    weightShape = getWeight().getType().getShape();
+    weightLayout = inputs[idx++];
+  }
+  std::optional<llvm::ArrayRef<int64_t>> residualShape;
+  std::optional<TTNNLayoutAttr> residualLayout;
+  if (getResidual() && inputs.size() > idx) {
+    residualShape = getResidual().getType().getShape();
+    residualLayout = inputs[idx++];
+  }
+  std::optional<llvm::ArrayRef<int64_t>> statsShape;
+  std::optional<TTNNLayoutAttr> statsLayout;
+  if (getStats() && inputs.size() > idx) {
+    statsShape = getStats().getType().getShape();
+    statsLayout = inputs[idx++];
+  }
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], weightShape, weightLayout,
+      residualShape, residualLayout, statsShape, statsLayout, getClusterAxis(),
+      getEpsilon(), getSubDeviceId(), getNumLinks(), getTopology(),
+      getComputeConfig(), getProgramConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+DistributedRMSNormOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                   const OpConfig &opConfig) {
+  assert(inputs.size() >= 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  // Unpack optional tensor shapes/layouts (same as getOpConstraints).
+  size_t idx = 1;
+  std::optional<llvm::ArrayRef<int64_t>> weightShape;
+  std::optional<TTNNLayoutAttr> weightLayout;
+  if (getWeight() && inputs.size() > idx) {
+    weightShape = getWeight().getType().getShape();
+    weightLayout = inputs[idx++];
+  }
+  std::optional<llvm::ArrayRef<int64_t>> residualShape;
+  std::optional<TTNNLayoutAttr> residualLayout;
+  if (getResidual() && inputs.size() > idx) {
+    residualShape = getResidual().getType().getShape();
+    residualLayout = inputs[idx++];
+  }
+  std::optional<llvm::ArrayRef<int64_t>> statsShape;
+  std::optional<TTNNLayoutAttr> statsLayout;
+  if (getStats() && inputs.size() > idx) {
+    statsShape = getStats().getType().getShape();
+    statsLayout = inputs[idx++];
+  }
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<DistributedRMSNormOp>::getOpRuntime, *this, inputShape,
+      inputs[0], weightShape, weightLayout, residualShape, residualLayout,
+      statsShape, statsLayout, getClusterAxis(), getEpsilon(), getSubDeviceId(),
+      getNumLinks(), getTopology(), getComputeConfig(), getProgramConfig(),
+      opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // RMSNormPreAllGatherOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -4984,6 +5061,68 @@ FullOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// AllGatherOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> AllGatherOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return detail::constraintsDispatch(*this, liveRecords, inputShape, inputs[0],
+                                     getAllGatherDim(), getClusterAxis(),
+                                     getSubDeviceId(), getNumLinks(),
+                                     getTopology(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+AllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<AllGatherOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getAllGatherDim(), getClusterAxis(), getSubDeviceId(),
+      getNumLinks(), getTopology(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
+// ReduceScatterOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+// Note: reduce_type is always SUM in ttnn::reduce_scatter (no API parameter).
+llvm::Expected<op_model::OpConstraints> ReduceScatterOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], getScatterDim(),
+      getClusterAxis(), getSubDeviceId(), getNumLinks(), getTopology(),
+      getComputeConfig(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+ReduceScatterOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                              const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<ReduceScatterOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getScatterDim(), getClusterAxis(), getSubDeviceId(),
+      getNumLinks(), getTopology(), getComputeConfig(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // MeshPartitionOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 
@@ -5010,6 +5149,36 @@ MeshPartitionOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<MeshPartitionOp>::getOpRuntime, *this, inputShape,
       inputs[0], getDim(), getClusterAxis(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
+// AllReduceOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> AllReduceOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, inputShape, inputs[0], getClusterAxis(),
+      getSubDeviceId(), getNumLinks(), getTopology(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+AllReduceOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                          const OpConfig &opConfig) {
+  assert(inputs.size() == 1);
+
+  const auto inputShape = getInput().getType().getShape();
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<AllReduceOp>::getOpRuntime, *this, inputShape,
+      inputs[0], getClusterAxis(), getSubDeviceId(), getNumLinks(),
+      getTopology(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
@@ -5,6 +5,7 @@
 #ifdef TTMLIR_ENABLE_OPMODEL
 
 #include "ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -55,7 +56,20 @@ public:
     } else {
       op_model::SingletonDeviceContext::setSystemDesc(
           ttcore::getCurrentScopeSystemDesc(getOperation()));
-      op_model::SingletonDeviceContext::getInstance().openMockDevice();
+      // Read mesh shape from the DeviceAttr registered by
+      // TTCoreRegisterDevicePass (which always runs before this wrapper).
+      // Multi-chip shapes (rows*cols > 1) trigger fabric initialization
+      // required for CCL op constraint queries.
+      std::optional<std::pair<size_t, size_t>> devMeshShape = std::nullopt;
+      if (auto deviceOp = ttcore::lookupDeviceOp(getOperation())) {
+        auto shape = deviceOp.getDeviceAttr().getMeshShape();
+        if (shape.size() >= 2) {
+          devMeshShape = {static_cast<size_t>(shape[0]),
+                          static_cast<size_t>(shape[1])};
+        }
+      }
+      op_model::SingletonDeviceContext::getInstance().openMockDevice(
+          ::tt::constants::opModelDefaultTraceRegionSize, devMeshShape);
     }
 
     // Set tensorL1UsageCap as a module attribute so it's accessible to nested

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/RowMajorLayoutPropagation.cpp
@@ -279,14 +279,23 @@ private:
           continue;
         }
 
+        bool requiresTiledFixup = false;
         llvm::Expected<TTNNLayoutAttr> rmOutputLayout =
-            opStopsRowMajorPropagation(user, use.getOperandNumber());
+            opStopsRowMajorPropagation(user, use.getOperandNumber(),
+                                       requiresTiledFixup);
 
         if (!rmOutputLayout) {
           llvm::consumeError(rmOutputLayout.takeError());
-          // TODO(rpavlovicTT): Remove when
-          // https://github.com/tenstorrent/tt-mlir/pull/8413 is merged.
-          if (user->hasTrait<OpModelExempt>()) {
+          // The op stops RowMajor propagation. If it rejects the RowMajor
+          // operand outright (op-model reports an error — e.g. it needs a Tiled
+          // input, or is a multi-device CCL op whose constraints can't be
+          // queried on this single-device op-model context), reconcile the
+          // already-RM operand by inserting a corrective to_layout back to
+          // Tiled on just this use. If instead the op accepts the RM operand
+          // and merely produces a Tiled result (requiresTiledFixup == false),
+          // leave the operand RowMajor (the integer-input fast path feeding,
+          // e.g., an eltwise op that consumes RowMajor directly).
+          if (requiresTiledFixup) {
             insertTiledFixup(rewriter, use, current);
           }
           continue;
@@ -320,7 +329,11 @@ private:
   // operation is not valid with RowMajor layout on given operand, returns an
   // error. Returns the RowMajor output layout if operation is valid.
   llvm::Expected<TTNNLayoutAttr>
-  opStopsRowMajorPropagation(Operation *op, unsigned operandIdx) {
+  opStopsRowMajorPropagation(Operation *op, unsigned operandIdx,
+                             bool &requiresTiledFixup) {
+    // Default: stopping does not require reconciling the operand back to Tiled.
+    // Only set when the op rejects the RowMajor operand (op-model error).
+    requiresTiledFixup = false;
     if (auto toTensorSpecOp = mlir::dyn_cast<ttnn::ToTensorSpecOp>(op)) {
       TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
                    "Stopping RM propagation at ToTensorSpecOp {}",
@@ -360,6 +373,10 @@ private:
     op_constraint_validation::ValidationResult result =
         op_constraint_validation::validateOperation(op, inputLayouts, config);
     if (result.isError()) {
+      // The op cannot accept a RowMajor operand (constraints failed, or could
+      // not be queried). The already-RM operand must be reconciled back to
+      // Tiled before this op — signal the caller to insert the fixup.
+      requiresTiledFixup = true;
       TTMLIR_DEBUG(ttmlir::LogComponent::RMPropagation,
                    "Stopping RM propagation at op {} as it fails validation "
                    "with RM layout on operand {},\n\t input layout: {}",

--- a/lib/OpModel/TTNN/SingletonDeviceContext.cpp
+++ b/lib/OpModel/TTNN/SingletonDeviceContext.cpp
@@ -14,6 +14,7 @@
 
 #include <tt-metalium/dispatch_core_common.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 #include <tt-metalium/experimental/mock_device.hpp>
 
 #include <umd/device/cluster.hpp>
@@ -22,6 +23,7 @@
 #include <cstdlib>
 #include <exception>
 #include <filesystem>
+#include <limits>
 #include <optional>
 #include <string>
 
@@ -60,8 +62,12 @@ ttcore::Arch fromMetalArch(::tt::ARCH arch) {
 
 // Build a MetalEnvDescriptor for the requested device. Mock mode loads the
 // per-(arch, numChips) mock cluster descriptor; silicon uses the default.
-// Fabric is left DISABLED: multi-chip mock CCL fabric setup is blocked on
-// tt-metal-side work (https://github.com/tenstorrent/tt-metal/issues/44748).
+// For multi-chip mock we enable 1D fabric in the descriptor so CCL
+// op-constraint queries (AllGather/ReduceScatter/AllReduce/DistributedRMSNorm)
+// can build routing across the mock mesh. The mock-fabric routing path was
+// fixed in tt-metal#46133; external callers enable it by passing a
+// FabricConfigDescriptor in the MetalEnvDescriptor. Single-chip mock and
+// silicon need no fabric here.
 ::tt::tt_metal::MetalEnvDescriptor
 makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
   if (!isMock) {
@@ -97,7 +103,20 @@ makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
     }
   }();
 
-  if (discovered && discovered->arch == toMetalArch(arch) &&
+  // Prefer the live descriptor only for a single-chip op-model device. For a
+  // multi-chip device we must use the canned mock instead. The discovered
+  // descriptor is the live machine's real cluster desc (serialized), which
+  // carries that chip's harvested/inactive eth cores. Even though the resulting
+  // device is still a mock (MetalEnvDescriptor::is_mock_device() is true and
+  // physical fabric bring-up is skipped), multi-chip CCL/DistributedRMSNorm
+  // op-model queries compute fabric routing during metal graph-capture and read
+  // that topology, fataling when a fabric-router eth core is inactive ("Logical
+  // eth core N is not an active eth core on chip M") — which happens on a real
+  // multi-chip host such as an n300/n300-llmbox CI runner. The canned mock has
+  // a clean topology, so the query traces cleanly and portably; single-chip
+  // queries have no fabric routing, so discovery is safe there.
+  // See https://github.com/tenstorrent/tt-mlir/issues/9035.
+  if (numChips == 1 && discovered && discovered->arch == toMetalArch(arch) &&
       discovered->numChips == numChips) {
     return ::tt::tt_metal::MetalEnvDescriptor{discovered->path};
   }
@@ -109,7 +128,16 @@ makeEnvDescriptor(bool isMock, ttcore::Arch arch, uint32_t numChips) {
     llvm::report_fatal_error(
         "Unsupported (arch, numChips) for mock cluster descriptor");
   }
-  return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath};
+  if (numChips <= 1) {
+    return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath};
+  }
+  ::tt::tt_metal::FabricConfigDescriptor fabricDesc{};
+  fabricDesc.fabric_config = ::tt::tt_fabric::FabricConfig::FABRIC_1D;
+  fabricDesc.reliability_mode =
+      ::tt::tt_fabric::FabricReliabilityMode::RELAXED_SYSTEM_HEALTH_SETUP_MODE;
+  fabricDesc.num_routing_planes = std::numeric_limits<uint8_t>::max();
+  return ::tt::tt_metal::MetalEnvDescriptor{*mockClusterPath,
+                                            std::move(fabricDesc)};
 }
 
 // Pick the dispatch core type for a device opened on this env. When every
@@ -264,21 +292,30 @@ void SingletonDeviceContext::openDevice(
   assert(m_env == nullptr && "MetalEnv must be torn down before opening.");
 
   ttcore::Arch arch = ttcore::Arch::WormholeB0;
-  uint32_t numChips = 1;
   if (isMock) {
     assert(m_systemDesc && "System desc must be set for mock device mode");
     arch = m_systemDesc.getChipDesc(0).getArch().getValue();
-    numChips = m_systemDesc.getChipDescIndices().size();
   }
+
+  ::tt::tt_metal::distributed::MeshShape shape{
+      meshShape ? static_cast<unsigned int>(meshShape->first) : 1,
+      meshShape ? static_cast<unsigned int>(meshShape->second) : 1};
+
+  // Size the mock env (and thus its fabric enablement) to the mesh we actually
+  // open, not the system descriptor's chip count. makeEnvDescriptor enables 1D
+  // fabric for a multi-chip env; opening a mesh smaller than a fabric-enabled
+  // env launches fabric on a device subset, which tt-metal rejects with a fatal
+  // ("Device N is not active"). Callers that need a multi-device op-model
+  // device (DevicePassesWrapper, reshapeMeshDevice) pass the full meshShape;
+  // the default (no meshShape) opens a single-device env with no fabric, and
+  // CCL op-model queries on it fall back gracefully (see
+  // requireMultiDeviceMesh).
+  uint32_t numChips = static_cast<uint32_t>(shape.mesh_size());
 
   // Build into locals; commit to members only on success so a throw leaves
   // m_env/m_device null and the context reusable.
   auto env = std::make_unique<::tt::tt_metal::MetalEnv>(
       makeEnvDescriptor(isMock, arch, numChips));
-
-  ::tt::tt_metal::distributed::MeshShape shape{
-      meshShape ? static_cast<unsigned int>(meshShape->first) : 1,
-      meshShape ? static_cast<unsigned int>(meshShape->second) : 1};
 
   // create_mesh_device registers a process-global MetalContext before it
   // validates the mesh size and does not unwind it if the size check fails,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -28,6 +28,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <type_traits>
 #include <vector>
@@ -342,6 +343,25 @@ convertToTensorSpec(::tt::tt_metal::distributed::MeshDevice *device,
 
   return llvm::createStringError(
       "Unable to create TensorSpec out of given shape and layout");
+}
+
+// Multi-device CCL ops (all_gather/reduce_scatter/all_reduce/rms_allgather)
+// launch fabric across the mesh. Optimizer passes open a single-device (1x1)
+// mock op-model device via ScopedSingletonDeviceGuard, on which such a query
+// makes metal attempt to launch fabric on a device subset and abort with an
+// uncatchable TT_FATAL ("Device N is not active"). Refuse up front with a
+// graceful error so callers (e.g. TTNNRowMajorLayoutPropagation) fall back
+// instead of crashing. Multi-device contexts — the mock-device unit tests,
+// which reshape to the op's mesh, or an external mesh device — satisfy this and
+// proceed to a real query.
+llvm::Error
+requireMultiDeviceMesh(const ::tt::tt_metal::distributed::MeshDevice *device) {
+  if (device->shape().mesh_size() <= 1) {
+    return llvm::createStringError(
+        "CCL op-model constraints require a multi-device mesh; the op-model "
+        "device is single-device");
+  }
+  return llvm::Error::success();
 }
 
 std::optional<::tt::tt_metal::TensorSpec>
@@ -676,6 +696,38 @@ inline bool programCarriesFusedActivation(
         return false;
       },
       *pc);
+}
+
+std::optional<::tt::tt_metal::SubDeviceId>
+convertSubDeviceId(std::optional<uint32_t> subDeviceId) {
+  if (!subDeviceId) {
+    return std::nullopt;
+  }
+  // SubDeviceId is StrongType<uint8_t>; reject values that would silently
+  // wrap when narrowed.
+  assert(*subDeviceId <= std::numeric_limits<uint8_t>::max() &&
+         "sub_device_id exceeds uint8_t range");
+  return ::tt::tt_metal::SubDeviceId{static_cast<uint8_t>(*subDeviceId)};
+}
+
+std::optional<::ttnn::ccl::Topology>
+convertTopology(std::optional<ttcore::Topology> topology) {
+  if (!topology) {
+    return std::nullopt;
+  }
+  switch (*topology) {
+  case ttcore::Topology::Ring:
+    return ::ttnn::ccl::Topology::Ring;
+  case ttcore::Topology::Linear:
+    return ::ttnn::ccl::Topology::Linear;
+  case ttcore::Topology::Mesh:
+    return ::ttnn::ccl::Topology::Mesh;
+  case ttcore::Topology::Torus:
+    return ::ttnn::ccl::Topology::Torus;
+  case ttcore::Topology::Disabled:
+    return std::nullopt;
+  }
+  llvm_unreachable("Unknown ttcore::Topology");
 }
 
 } // namespace detail
@@ -9129,6 +9181,9 @@ llvm::Expected<OpConstraints> OpModel<MeshPartitionOp>::getOpConstraints(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
 
   // Convert input tensor to TensorSpec
   ASSIGN_OR_RETURN(
@@ -9159,6 +9214,9 @@ llvm::Expected<size_t> OpModel<MeshPartitionOp>::getOpRuntime(
 #ifdef TTMLIR_ENABLE_OPMODEL
   ::tt::tt_metal::distributed::MeshDevice *device =
       SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
 
   // Convert input tensor to TensorSpec
   ASSIGN_OR_RETURN(
@@ -9173,6 +9231,524 @@ llvm::Expected<size_t> OpModel<MeshPartitionOp>::getOpRuntime(
   };
 
   return operation::getOpRuntime(meshPartitionOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// AllGatherOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<AllGatherOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t allGatherDim, uint32_t clusterAxis,
+    std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+    std::optional<ttcore::Topology> topology, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::all_gather, device, initialStateOpt, distInput, allGatherDim,
+        std::optional<uint32_t>(clusterAxis),
+        detail::getNullableMemoryConfig(outputLayout),
+        /*persistent_output_tensor=*/std::optional<::ttnn::Tensor>{},
+        metalSubDeviceId,
+        /*sub_core_grid=*/std::optional<::tt::tt_metal::CoreRangeSet>{},
+        numLinks, fabricTopology);
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<AllGatherOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t allGatherDim, uint32_t clusterAxis,
+    std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+    std::optional<ttcore::Topology> topology, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+
+  auto query = [=]() {
+    return QUERY_OP_RUNTIME(
+        ::ttnn::all_gather, device, distInput, allGatherDim,
+        std::optional<uint32_t>(clusterAxis),
+        detail::getNullableMemoryConfig(outputLayout),
+        /*persistent_output_tensor=*/std::optional<::ttnn::Tensor>{},
+        metalSubDeviceId,
+        /*sub_core_grid=*/std::optional<::tt::tt_metal::CoreRangeSet>{},
+        numLinks, fabricTopology);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// ReduceScatterOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<ReduceScatterOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t scatterDim, uint32_t clusterAxis,
+    std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+    std::optional<ttcore::Topology> topology,
+    std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+  auto metalComputeConfig =
+      conversion::getDeviceComputeKernelConfig(computeConfig);
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  // Param order matches runtime/lib/ttnn/operations/ccl/reduce_scatter.cpp.
+  auto query = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::reduce_scatter, device, initialStateOpt, distInput, scatterDim,
+        std::optional<uint32_t>(clusterAxis), metalSubDeviceId,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*intermediate_memory_config=*/std::optional<::ttnn::MemoryConfig>{},
+        /*optional_output_tensor=*/std::optional<::ttnn::Tensor>{}, numLinks,
+        fabricTopology,
+        /*chunks_per_sync=*/std::optional<uint32_t>{},
+        /*num_workers_per_link=*/std::optional<uint32_t>{},
+        /*num_buffers_per_channel=*/std::optional<uint32_t>{},
+        metalComputeConfig);
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<ReduceScatterOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    int32_t scatterDim, uint32_t clusterAxis,
+    std::optional<uint32_t> subDeviceId, std::optional<uint32_t> numLinks,
+    std::optional<ttcore::Topology> topology,
+    std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+  auto metalComputeConfig =
+      conversion::getDeviceComputeKernelConfig(computeConfig);
+
+  auto query = [=]() {
+    return QUERY_OP_RUNTIME(
+        ::ttnn::reduce_scatter, device, distInput, scatterDim,
+        std::optional<uint32_t>(clusterAxis), metalSubDeviceId,
+        detail::getNullableMemoryConfig(outputLayout),
+        /*intermediate_memory_config=*/std::optional<::ttnn::MemoryConfig>{},
+        /*optional_output_tensor=*/std::optional<::ttnn::Tensor>{}, numLinks,
+        fabricTopology,
+        /*chunks_per_sync=*/std::optional<uint32_t>{},
+        /*num_workers_per_link=*/std::optional<uint32_t>{},
+        /*num_buffers_per_channel=*/std::optional<uint32_t>{},
+        metalComputeConfig);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// AllReduceOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<AllReduceOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t clusterAxis, std::optional<uint32_t> subDeviceId,
+    std::optional<uint32_t> numLinks, std::optional<ttcore::Topology> topology,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto query = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttnn::all_reduce, device, initialStateOpt, distInput,
+        std::optional<uint32_t>(clusterAxis), metalSubDeviceId,
+        detail::getNullableMemoryConfig(outputLayout), numLinks,
+        fabricTopology);
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<AllReduceOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    uint32_t clusterAxis, std::optional<uint32_t> subDeviceId,
+    std::optional<uint32_t> numLinks, std::optional<ttcore::Topology> topology,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+
+  ::tt::tt_metal::TensorTopology shardedTopology =
+      ::tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
+          device->shape(), static_cast<int>(clusterAxis));
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 shardedTopology};
+
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto fabricTopology = detail::convertTopology(topology);
+
+  auto query = [=]() {
+    return QUERY_OP_RUNTIME(::ttnn::all_reduce, device, distInput,
+                            std::optional<uint32_t>(clusterAxis),
+                            metalSubDeviceId,
+                            detail::getNullableMemoryConfig(outputLayout),
+                            numLinks, fabricTopology);
+  };
+
+  return operation::getOpRuntime(query);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// DistributedRMSNormOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<DistributedRMSNormOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualShape,
+    std::optional<TTNNLayoutAttr> residualLayout,
+    std::optional<llvm::ArrayRef<int64_t>> statsShape,
+    std::optional<TTNNLayoutAttr> statsLayout, uint32_t clusterAxis,
+    llvm::APFloat epsilon, std::optional<uint32_t> subDeviceId,
+    std::optional<uint32_t> numLinks, std::optional<ttcore::Topology> topology,
+    std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  // Input: replicated topology — each device holds its own local copy of the
+  // tensor (whatever its layout) and runs the RMS computation locally; only
+  // statistics are communicated across devices via all-gather.
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto replicatedTopology =
+      ::tt::tt_metal::TensorTopology::create_fully_replicated_tensor_topology(
+          device->shape());
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 replicatedTopology};
+
+  // Optional tensors (weight, residual, stats) passed as TensorSpec.
+  std::optional<::tt::tt_metal::TensorSpec> weightSpec =
+      detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
+  std::optional<::tt::tt_metal::TensorSpec> residualSpec =
+      detail::convertToOptionalTensorSpec(device, residualShape,
+                                          residualLayout);
+  std::optional<::tt::tt_metal::TensorSpec> statsSpec =
+      detail::convertToOptionalTensorSpec(device, statsShape, statsLayout);
+
+  // Build LayerNormProgramConfig (variant).
+  ::ttnn::prim::LayerNormProgramConfig metalProgramConfig;
+  if (programConfig) {
+    auto gridCoord = programConfig->getComputeWithStorageGridSize();
+    metalProgramConfig = ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig{
+        .compute_with_storage_grid_size =
+            ::tt::tt_metal::CoreCoord{static_cast<size_t>(gridCoord.getX()),
+                                      static_cast<size_t>(gridCoord.getY())},
+        .subblock_w = programConfig->getSubblockW(),
+        .block_h = programConfig->getBlockH(),
+        .block_w = programConfig->getBlockW(),
+        .inplace = programConfig->getInplace()};
+  }
+
+  // fused_rms_minimal requires a sharded input layout (carries the
+  // core_range_set used for the global semaphore). Reject gracefully if the
+  // input isn't sharded; the op verifier doesn't currently enforce this.
+  if (!inputLayout.getCoreRangeSet()) {
+    return llvm::createStringError(
+        "DistributedRMSNormOp requires a sharded input layout");
+  }
+  auto coreRangeSet = conversion::getCoreRangeSet(inputLayout);
+  auto cclTopology =
+      detail::convertTopology(topology).value_or(::ttnn::ccl::Topology::Linear);
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto metalComputeConfig =
+      conversion::getDeviceComputeKernelConfig(computeConfig);
+  std::optional<size_t> metalNumLinks =
+      numLinks ? std::optional<size_t>(*numLinks) : std::nullopt;
+  auto outputMemCfg = detail::getNullableMemoryConfig(outputLayout);
+  float epsilonF = static_cast<float>(epsilon.convertToDouble());
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  // Inner-lambda form so the GlobalSemaphore is created INSIDE the
+  // ScopedGraphCapture. Stateless (NO_DISPATCH): GraphTracker's hook_allocate
+  // and hook_write_to_device return true, so the semaphore's L1 allocation and
+  // initial-value EnqueueWriteMeshBuffer are both intercepted — no real device
+  // state is mutated, and the trace records the would-be allocation so
+  // peakL1MemorySize includes the semaphore. Stateful (NORMAL, phase 2): the
+  // semaphore is allocated for real through the mock allocator alongside the
+  // op's own buffers, which is exactly what the live-record accounting wants.
+  // Either way the semaphore must be built inside the capture, so this stays an
+  // inner lambda rather than a hoisted value.
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_constraints_with_optional_state(
+        [device, coreRangeSet, metalProgramConfig, clusterAxis, cclTopology,
+         metalSubDeviceId, metalComputeConfig, metalNumLinks, outputMemCfg,
+         epsilonF](auto &&input, auto &&weight, auto &&residual, auto &&stats) {
+          auto semaphore = ::ttnn::global_semaphore::create_global_semaphore(
+              device, coreRangeSet, /*initial_value=*/0);
+          return ::ttnn::fused_rms_minimal(
+              input, metalProgramConfig, clusterAxis, *device, semaphore,
+              /*persistent_output_tensor=*/std::optional<::ttnn::Tensor>{},
+              metalNumLinks, cclTopology, metalSubDeviceId,
+              /*dtype=*/std::optional<::ttnn::DataType>{}, metalComputeConfig,
+              outputMemCfg, std::forward<decltype(residual)>(residual),
+              epsilonF, std::forward<decltype(weight)>(weight),
+              std::forward<decltype(stats)>(stats),
+              /*use_noc1_only=*/false);
+        },
+        device, initialStateOpt, distInput, weightSpec, residualSpec,
+        statsSpec);
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
+#else
+  return OpConstraints{};
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<DistributedRMSNormOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    std::optional<llvm::ArrayRef<int64_t>> weightShape,
+    std::optional<TTNNLayoutAttr> weightLayout,
+    std::optional<llvm::ArrayRef<int64_t>> residualShape,
+    std::optional<TTNNLayoutAttr> residualLayout,
+    std::optional<llvm::ArrayRef<int64_t>> statsShape,
+    std::optional<TTNNLayoutAttr> statsLayout, uint32_t clusterAxis,
+    llvm::APFloat epsilon, std::optional<uint32_t> subDeviceId,
+    std::optional<uint32_t> numLinks, std::optional<ttcore::Topology> topology,
+    std::optional<DeviceComputeKernelConfigAttr> computeConfig,
+    std::optional<LayerNormShardedMultiCoreProgramConfigAttr> programConfig,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+  if (llvm::Error err = detail::requireMultiDeviceMesh(device)) {
+    return std::move(err);
+  }
+
+  auto inputSpecExp =
+      detail::convertToTensorSpec(device, inputShape, inputLayout);
+  if (!inputSpecExp) {
+    return inputSpecExp.takeError();
+  }
+  auto replicatedTopology =
+      ::tt::tt_metal::TensorTopology::create_fully_replicated_tensor_topology(
+          device->shape());
+  ::ttnn::graph::DistributedTensorSpec distInput{inputSpecExp.get(),
+                                                 replicatedTopology};
+
+  std::optional<::tt::tt_metal::TensorSpec> weightSpec =
+      detail::convertToOptionalTensorSpec(device, weightShape, weightLayout);
+  std::optional<::tt::tt_metal::TensorSpec> residualSpec =
+      detail::convertToOptionalTensorSpec(device, residualShape,
+                                          residualLayout);
+  std::optional<::tt::tt_metal::TensorSpec> statsSpec =
+      detail::convertToOptionalTensorSpec(device, statsShape, statsLayout);
+
+  ::ttnn::prim::LayerNormProgramConfig metalProgramConfig;
+  if (programConfig) {
+    auto gridCoord = programConfig->getComputeWithStorageGridSize();
+    metalProgramConfig = ::ttnn::prim::LayerNormShardedMultiCoreProgramConfig{
+        .compute_with_storage_grid_size =
+            ::tt::tt_metal::CoreCoord{static_cast<size_t>(gridCoord.getX()),
+                                      static_cast<size_t>(gridCoord.getY())},
+        .subblock_w = programConfig->getSubblockW(),
+        .block_h = programConfig->getBlockH(),
+        .block_w = programConfig->getBlockW(),
+        .inplace = programConfig->getInplace()};
+  }
+
+  // fused_rms_minimal requires a sharded input layout (carries the
+  // core_range_set used for the global semaphore). Reject gracefully if the
+  // input isn't sharded; the op verifier doesn't currently enforce this.
+  if (!inputLayout.getCoreRangeSet()) {
+    return llvm::createStringError(
+        "DistributedRMSNormOp requires a sharded input layout");
+  }
+  auto coreRangeSet = conversion::getCoreRangeSet(inputLayout);
+  auto cclTopology =
+      detail::convertTopology(topology).value_or(::ttnn::ccl::Topology::Linear);
+  auto metalSubDeviceId = detail::convertSubDeviceId(subDeviceId);
+  auto metalComputeConfig =
+      conversion::getDeviceComputeKernelConfig(computeConfig);
+  std::optional<size_t> metalNumLinks =
+      numLinks ? std::optional<size_t>(*numLinks) : std::nullopt;
+  auto outputMemCfg = detail::getNullableMemoryConfig(outputLayout);
+  float epsilonF = static_cast<float>(epsilon.convertToDouble());
+
+  // Runtime path uses ScopedGraphCapture(NORMAL) — create_global_semaphore
+  // cannot run inside trace capture (writes L1 via EnqueueWriteMeshBuffer
+  // which is not replayable). Semaphore is allocated for real here.
+  auto semaphore = ::ttnn::global_semaphore::create_global_semaphore(
+      device, coreRangeSet, /*initial_value=*/0);
+
+  auto query = [=]() {
+    return ::ttnn::graph::query_op_runtime(
+        [device, semaphore, metalProgramConfig, clusterAxis, cclTopology,
+         metalSubDeviceId, metalComputeConfig, metalNumLinks, outputMemCfg,
+         epsilonF](auto &&input, auto &&weight, auto &&residual, auto &&stats) {
+          return ::ttnn::fused_rms_minimal(
+              input, metalProgramConfig, clusterAxis, *device, semaphore,
+              /*persistent_output_tensor=*/std::optional<::ttnn::Tensor>{},
+              metalNumLinks, cclTopology, metalSubDeviceId,
+              /*dtype=*/std::optional<::ttnn::DataType>{}, metalComputeConfig,
+              outputMemCfg, std::forward<decltype(residual)>(residual),
+              epsilonF, std::forward<decltype(weight)>(weight),
+              std::forward<decltype(stats)>(stats),
+              /*use_noc1_only=*/false);
+        },
+        device, distInput, weightSpec, residualSpec, statsSpec);
+  };
+
+  return operation::getOpRuntime(query);
 #else
   return llvm::createStringError("Not Implemented");
 #endif // TTMLIR_ENABLE_OPMODEL

--- a/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
@@ -28,16 +28,16 @@ module {
 
   // CHECK-BH-NO-TA-LABEL: func.func @tensor_accessor_vgm
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x12>
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 3x4>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
   // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x6>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
 
   // CHECK-BH-TA-LABEL: func.func @tensor_accessor_vgm
-  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
-  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x12>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x4>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-BH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
   // CHECK-BH-TA: const uint32_t page_id_{{[0-9]+}}

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
@@ -3,9 +3,9 @@
 
 module {
   // CHECK-LABEL: func.func @slice_f32_virtual_grid_host_transfers
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_virtual_grid_host_transfers(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
@@ -4,8 +4,8 @@
 module {
   // CHECK-LABEL: func.func @slice_f32_cb_page_compatible
   // CHECK-NOT: memref<8x8x384x4xf32
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_cb_page_compatible(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
+++ b/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
@@ -24,7 +24,7 @@
 // RUN: cat %t.dir/trace.json | FileCheck %s
 
 // Llama 3.1 8B single decoder layer on Blackhole. Different hardware
-// constants than n150 (512 GB/s DRAM, 1.35 GHz, 130 Tensix cores) so the
+// constants than n150 (512 GB/s DRAM, 1.35 GHz, 110 Tensix cores) so the
 // roofline shrinks vs the Wormhole companion test even though the model
 // is the same. At default opt level SDPA is not fused, so 6 dram-bound
 // weight matmuls + 2 skipped activation@activation matmuls. (The third,
@@ -38,7 +38,7 @@
 // CHECK: "dram_bandwidth_bytes_per_sec": 512000000000
 // CHECK: "dram_bound_ops": 6
 // CHECK: "num_chips": 1
-// CHECK: "num_tensix_cores": 130
+// CHECK: "num_tensix_cores": 110
 // CHECK: "params_count": 743440384
 // CHECK: "params_memory_bytes": 789905408
 // CHECK: "roofline_ms": 1.542784

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLibMockDevice.cpp
@@ -15,6 +15,7 @@
 #include "OpModelFixture.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
@@ -25,28 +26,87 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace mlir::tt::ttnn::op_model {
+
+// Arches exercised by the mock-device tests. Multi-chip mock cluster
+// descriptors exist for both Wormhole and Blackhole; see
+// get_mock_cluster_desc_name() in tt-metal for the supported (arch, num_chips)
+// combinations. The 32-chip Galaxy 6U mesh is Wormhole-only (no Blackhole
+// 32-chip mock cluster descriptor exists yet).
+//
+// NOTE: the 32-chip Galaxy 6U (WH 4x8) cases need a tt-metal build where the
+// mock 6u fabric setup is fixed. Root cause: the UMD 6u cluster descriptor
+// (the one shipped in packaged tt-metal) lacks the chip->bus_id mapping, so
+// get_ubb_id() can't derive the rack tray positions; galaxy corner-pinning then
+// fatals with "Failed to add pinning constraints" (tt-umd#2896). It passes
+// locally only because the dev tree also exposes tt-metal's custom 6u
+// descriptor (which has chip_to_bus_id) on the search path. Fixed by either
+// tt-umd#2896 (add chip_to_bus_id to the UMD 6u desc) or tt-metal#47731 (skip
+// galaxy corner-pinning for mock clusters). These cases are kept here ready;
+// they pass once tt-mlir's pinned tt-metal includes one of those fixes.
+inline std::string archName(ttcore::Arch arch) {
+  switch (arch) {
+  case ttcore::Arch::WormholeB0:
+    return "WormholeB0";
+  case ttcore::Arch::Blackhole:
+    return "Blackhole";
+  default:
+    return "UnknownArch";
+  }
+}
 
 // Base fixture for mock device lib tests. Op-agnostic — sets up MLIR context
 // and reshapes the mock device. Per-op test classes inherit from this and add
 // their own WithParamInterface.
 class OpModelLibMockDeviceBase : public OpModelFixture {
 public:
-  void setupMockDevice(size_t meshRows, size_t meshCols) {
+  void setupMockDevice(ttcore::Arch arch, size_t meshRows, size_t meshCols) {
     // Initialize MLIR context and module.
     context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
     context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
     module = mlir::ModuleOp::create(builder.getUnknownLoc());
     builder.setInsertionPointToStart(&module->getBodyRegion().front());
 
-    // Update system desc and reshape the mock device for this test's topology.
+    SingletonDeviceContext &ctx = SingletonDeviceContext::getInstance();
+
+    // reshapeMeshDevice keeps the arch of the currently open env, so to target
+    // a specific arch we (re)open a fresh single-chip device of that arch
+    // first. A single-chip mock reports the canonical worker grid for the arch,
+    // which matches the default system descriptor for that arch, so the
+    // open-time grid validation passes. We then reshape to the requested
+    // topology below.
+    if (ctx.isDeviceInitialized()) {
+      SingletonDeviceContext::closeInstance();
+    }
+    SingletonDeviceContext::setSystemDesc(
+        ttcore::SystemDescAttr::getDefault(&context, arch, {1}));
+    ctx.openMockDevice(
+        /*traceRegionSize=*/0,
+        std::make_pair(static_cast<size_t>(1), static_cast<size_t>(1)));
+
+    // Clear the bootstrap descriptor before reshaping: the device grid is
+    // topology-dependent (different mock cluster descriptors report different
+    // worker grids), and reshapeMeshDevice validates the new device grid
+    // against the registered descriptor. We register a fresh descriptor built
+    // from the reshaped device grid below.
+    SingletonDeviceContext::setSystemDesc(ttcore::SystemDescAttr());
+
+    // Reshape to the requested topology so getComputeGridShape() reflects the
+    // actual hardware grid (which depends on the cluster descriptor's
+    // harvesting masks).
+    ctx.reshapeMeshDevice({meshRows, meshCols});
+
+    // Build system desc from the actual device grid so the registered MLIR
+    // device attribute matches the grid the open device reports.
+    llvm::SmallVector<int64_t> gridShape =
+        llvm::to_vector(ctx.getComputeGridShape());
     auto systemDesc = ttcore::SystemDescAttr::getDefault(
-        &context, ttcore::Arch::WormholeB0,
-        {static_cast<int>(meshRows), static_cast<int>(meshCols)});
+        &context, arch,
+        {static_cast<int>(meshRows), static_cast<int>(meshCols)}, gridShape);
     SingletonDeviceContext::setSystemDesc(systemDesc);
-    SingletonDeviceContext::getInstance().reshapeMeshDevice(
-        {meshRows, meshCols});
 
     mlir::tt::ttcore::registerDevice(module.get());
   }
@@ -66,8 +126,9 @@ public:
 
 // --- MeshPartitionOp tests ---
 
-// Param: {meshRows, meshCols, dim, clusterAxis}
+// Param: {arch, meshRows, meshCols, dim, clusterAxis}
 struct MeshPartitionParam {
+  ttcore::Arch arch;
   size_t meshRows;
   size_t meshCols;
   int32_t dim;
@@ -80,9 +141,17 @@ class MeshPartitionLibMockDeviceTest
 public:
   void SetUp() override {
     const auto &p = GetParam();
-    setupMockDevice(p.meshRows, p.meshCols);
+    setupMockDevice(p.arch, p.meshRows, p.meshCols);
   }
 };
+
+static std::string
+meshPartitionName(const ::testing::TestParamInfo<MeshPartitionParam> &info) {
+  const auto &p = info.param;
+  return archName(p.arch) + "_" + std::to_string(p.meshRows) + "x" +
+         std::to_string(p.meshCols) + "_dim" + std::to_string(p.dim) + "_axis" +
+         std::to_string(p.clusterAxis);
+}
 
 TEST_P(MeshPartitionLibMockDeviceTest, MeshPartitionOp) {
   const auto &p = GetParam();
@@ -128,38 +197,756 @@ TEST_P(MeshPartitionLibMockDeviceTest, MeshPartitionOp) {
   }
 }
 
+static std::vector<MeshPartitionParam> meshPartitionParams() {
+  // {meshRows, meshCols, dim, clusterAxis}; chips = rows*cols.
+  struct Topo {
+    size_t rows, cols;
+    int32_t dim;
+    uint32_t axis;
+  };
+  // Topologies with <= 8 chips run on both Wormhole and Blackhole.
+  const Topo common[] = {
+      {1, 8, 0, 1}, {1, 8, 1, 1}, // T3K
+      {2, 4, 0, 0}, {2, 4, 0, 1}, {2, 4, 1, 0}, {2, 4, 1, 1},
+      {4, 2, 0, 0}, {4, 2, 0, 1}, {4, 2, 1, 0}, {4, 2, 1, 1},
+      {1, 2, 0, 1}, {1, 2, 1, 1}, // N300
+      {2, 1, 0, 0}, {2, 1, 1, 0}, {1, 4, 0, 1}, {1, 4, 1, 1},
+      {4, 1, 0, 0}, {4, 1, 1, 0},
+  };
+  // 32-chip Galaxy 6U: Wormhole only (no Blackhole 32-chip mock descriptor).
+  // Needs the 6u mock fix (tt-umd#2896 / tt-metal#47731); see file header.
+  const Topo whOnly[] = {{4, 8, 0, 0}, {4, 8, 1, 1}};
+  std::vector<MeshPartitionParam> params;
+  for (ttcore::Arch arch :
+       {ttcore::Arch::WormholeB0, ttcore::Arch::Blackhole}) {
+    for (const Topo &t : common) {
+      params.push_back({arch, t.rows, t.cols, t.dim, t.axis});
+    }
+  }
+  for (const Topo &t : whOnly) {
+    params.push_back({ttcore::Arch::WormholeB0, t.rows, t.cols, t.dim, t.axis});
+  }
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(MeshPartition, MeshPartitionLibMockDeviceTest,
+                         ::testing::ValuesIn(meshPartitionParams()),
+                         meshPartitionName);
+
+// --- AllGatherOp tests ---
+
+struct AllGatherParam {
+  ttcore::Arch arch;
+  size_t meshRows;
+  size_t meshCols;
+  int32_t allGatherDim;
+  uint32_t clusterAxis;
+};
+
+class AllGatherLibMockDeviceTest
+    : public OpModelLibMockDeviceBase,
+      public ::testing::WithParamInterface<AllGatherParam> {
+public:
+  void SetUp() override {
+    const auto &p = GetParam();
+    setupMockDevice(p.arch, p.meshRows, p.meshCols);
+  }
+};
+
+static std::string
+allGatherName(const ::testing::TestParamInfo<AllGatherParam> &info) {
+  const auto &p = info.param;
+  return archName(p.arch) + "_" + std::to_string(p.meshRows) + "x" +
+         std::to_string(p.meshCols) + "_dim" + std::to_string(p.allGatherDim) +
+         "_axis" + std::to_string(p.clusterAxis);
+}
+
+TEST_P(AllGatherLibMockDeviceTest, AllGatherOp) {
+  const auto &p = GetParam();
+
+  // Interleaved DRAM tiled input: [1, 1, 32, 128] — each device holds 1 shard.
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<AllGatherOp>::getOpConstraints(
+      inputShape, layoutDRAMTiled, p.allGatherDim, p.clusterAxis,
+      /*subDeviceId=*/std::nullopt,
+      /*numLinks=*/std::optional<uint32_t>(1),
+      /*topology=*/std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+      layoutDRAMTiled);
+
+  bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    GTEST_LOG_(INFO) << "all_gather constraints error: "
+                     << llvm::toString(constraintsExp.takeError());
+  } else {
+    GTEST_LOG_(INFO) << "all_gather constraints ok: cbPeak="
+                     << constraintsExp->cbL1PeakSize;
+  }
+  EXPECT_TRUE(ok);
+}
+
+static std::vector<AllGatherParam> allGatherParams() {
+  struct Topo {
+    size_t rows, cols;
+    int32_t dim;
+    uint32_t axis;
+  };
+  // <= 8 chips: run on both Wormhole and Blackhole.
+  const Topo common[] = {
+      {1, 2, 3, 1}, // N300: gather last dim on axis 1
+      {1, 2, 2, 1}, // N300: gather dim 2 on axis 1
+      {2, 1, 3, 0}, // gather last dim on axis 0
+      {1, 8, 3, 1}, // T3K: gather last dim on col axis
+  };
+  // 32-chip Galaxy 6U: Wormhole only (needs the 6u mock fix; see file header).
+  const Topo whOnly[] = {
+      {4, 8, 3, 1}, // gather last dim on col axis
+      {4, 8, 3, 0}, // gather last dim on row axis
+  };
+  std::vector<AllGatherParam> params;
+  for (ttcore::Arch arch :
+       {ttcore::Arch::WormholeB0, ttcore::Arch::Blackhole}) {
+    for (const Topo &t : common) {
+      params.push_back({arch, t.rows, t.cols, t.dim, t.axis});
+    }
+  }
+  for (const Topo &t : whOnly) {
+    params.push_back({ttcore::Arch::WormholeB0, t.rows, t.cols, t.dim, t.axis});
+  }
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllGather, AllGatherLibMockDeviceTest,
+                         ::testing::ValuesIn(allGatherParams()), allGatherName);
+
+// --- ReduceScatterOp tests ---
+
+struct ReduceScatterParam {
+  ttcore::Arch arch;
+  size_t meshRows;
+  size_t meshCols;
+  int32_t scatterDim;
+  uint32_t clusterAxis;
+};
+
+class ReduceScatterLibMockDeviceTest
+    : public OpModelLibMockDeviceBase,
+      public ::testing::WithParamInterface<ReduceScatterParam> {
+public:
+  void SetUp() override {
+    const auto &p = GetParam();
+    setupMockDevice(p.arch, p.meshRows, p.meshCols);
+  }
+};
+
+static std::string
+reduceScatterName(const ::testing::TestParamInfo<ReduceScatterParam> &info) {
+  const auto &p = info.param;
+  return archName(p.arch) + "_" + std::to_string(p.meshRows) + "x" +
+         std::to_string(p.meshCols) + "_dim" + std::to_string(p.scatterDim) +
+         "_axis" + std::to_string(p.clusterAxis);
+}
+
+TEST_P(ReduceScatterLibMockDeviceTest, ReduceScatterOp) {
+  const auto &p = GetParam();
+
+  // Interleaved DRAM tiled input: [1, 1, 32, 256] — scatter halves each dim.
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 256};
+  const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<ReduceScatterOp>::getOpConstraints(
+      inputShape, layoutDRAMTiled, p.scatterDim, p.clusterAxis,
+      /*subDeviceId=*/std::nullopt,
+      /*numLinks=*/std::optional<uint32_t>(1),
+      /*topology=*/std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+      /*computeConfig=*/std::nullopt, layoutDRAMTiled);
+
+  bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    GTEST_LOG_(INFO) << "reduce_scatter constraints error: "
+                     << llvm::toString(constraintsExp.takeError());
+  } else {
+    GTEST_LOG_(INFO) << "reduce_scatter constraints ok: cbPeak="
+                     << constraintsExp->cbL1PeakSize;
+  }
+  EXPECT_TRUE(ok);
+}
+
+static std::vector<ReduceScatterParam> reduceScatterParams() {
+  struct Topo {
+    size_t rows, cols;
+    int32_t dim;
+    uint32_t axis;
+  };
+  // <= 8 chips: run on both Wormhole and Blackhole.
+  const Topo common[] = {
+      {1, 2, 3, 1}, // N300: scatter last dim on axis 1
+      {1, 2, 2, 1}, // N300: scatter dim 2 on axis 1
+      {2, 1, 3, 0}, // scatter last dim on axis 0
+      {1, 8, 3, 1}, // T3K: scatter last dim on col axis
+  };
+  // 32-chip Galaxy 6U: Wormhole only (needs the 6u mock fix; see file header).
+  const Topo whOnly[] = {
+      {4, 8, 3, 1}, // scatter last dim on col axis
+      {4, 8, 3, 0}, // scatter last dim on row axis
+  };
+  std::vector<ReduceScatterParam> params;
+  for (ttcore::Arch arch :
+       {ttcore::Arch::WormholeB0, ttcore::Arch::Blackhole}) {
+    for (const Topo &t : common) {
+      params.push_back({arch, t.rows, t.cols, t.dim, t.axis});
+    }
+  }
+  for (const Topo &t : whOnly) {
+    params.push_back({ttcore::Arch::WormholeB0, t.rows, t.cols, t.dim, t.axis});
+  }
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(ReduceScatter, ReduceScatterLibMockDeviceTest,
+                         ::testing::ValuesIn(reduceScatterParams()),
+                         reduceScatterName);
+
+// --- AllReduceOp tests ---
+
+struct AllReduceParam {
+  ttcore::Arch arch;
+  size_t meshRows;
+  size_t meshCols;
+  uint32_t clusterAxis;
+};
+
+class AllReduceLibMockDeviceTest
+    : public OpModelLibMockDeviceBase,
+      public ::testing::WithParamInterface<AllReduceParam> {
+public:
+  void SetUp() override {
+    const auto &p = GetParam();
+    setupMockDevice(p.arch, p.meshRows, p.meshCols);
+  }
+};
+
+static std::string
+allReduceName(const ::testing::TestParamInfo<AllReduceParam> &info) {
+  const auto &p = info.param;
+  return archName(p.arch) + "_" + std::to_string(p.meshRows) + "x" +
+         std::to_string(p.meshCols) + "_axis" + std::to_string(p.clusterAxis);
+}
+
+TEST_P(AllReduceLibMockDeviceTest, AllReduceOp) {
+  const auto &p = GetParam();
+
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 128};
+  const TTNNLayoutAttr layoutDRAMTiled = CreateTiledLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<AllReduceOp>::getOpConstraints(
+      inputShape, layoutDRAMTiled, p.clusterAxis,
+      /*subDeviceId=*/std::nullopt,
+      /*numLinks=*/std::optional<uint32_t>(1),
+      /*topology=*/std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+      layoutDRAMTiled);
+
+  bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    GTEST_LOG_(INFO) << "all_reduce constraints error: "
+                     << llvm::toString(constraintsExp.takeError());
+  } else {
+    GTEST_LOG_(INFO) << "all_reduce constraints ok: cbPeak="
+                     << constraintsExp->cbL1PeakSize;
+  }
+  EXPECT_TRUE(ok);
+}
+
+static std::vector<AllReduceParam> allReduceParams() {
+  struct Topo {
+    size_t rows, cols;
+    uint32_t axis;
+  };
+  // <= 8 chips: run on both Wormhole and Blackhole.
+  const Topo common[] = {
+      {1, 2, 1}, // N300: reduce on col axis
+      {1, 8, 1}, // T3K: reduce on col axis
+  };
+  // 32-chip Galaxy 6U: Wormhole only (needs the 6u mock fix; see file header).
+  const Topo whOnly[] = {
+      {4, 8, 1}, // reduce on col axis
+      {4, 8, 0}, // reduce on row axis
+  };
+  std::vector<AllReduceParam> params;
+  for (ttcore::Arch arch :
+       {ttcore::Arch::WormholeB0, ttcore::Arch::Blackhole}) {
+    for (const Topo &t : common) {
+      params.push_back({arch, t.rows, t.cols, t.axis});
+    }
+  }
+  for (const Topo &t : whOnly) {
+    params.push_back({ttcore::Arch::WormholeB0, t.rows, t.cols, t.axis});
+  }
+  return params;
+}
+
+INSTANTIATE_TEST_SUITE_P(AllReduce, AllReduceLibMockDeviceTest,
+                         ::testing::ValuesIn(allReduceParams()), allReduceName);
+
+// --- CCL L1-sharded output coverage ---
+//
+// The collective tests above only exercise DRAM-interleaved outputs. These
+// tests pin down that the op-model constraint queries also accept L1 outputs —
+// interleaved and width/height/block sharded — and that an output memory config
+// the op cannot satisfy is rejected *gracefully* (a returned error, not an
+// abort). The graceful-error contract is what TTNNRowMajorLayoutPropagation
+// relies on to fall back instead of crashing. Fixed on a 1x8 Wormhole (T3K)
+// mesh; L1 sharding is over each chip's worker grid, independent of the mesh.
+namespace {
+// The op accepts this output config: for an L1 output the reported output
+// buffer must live in L1 (non-zero), and peak L1 (CB + buffers) is non-zero.
+void expectAccepted(llvm::Expected<OpConstraints> &exp,
+                    const std::string &label, BufferType buf) {
+  if (!exp) {
+    ADD_FAILURE() << label << " was unexpectedly rejected: "
+                  << llvm::toString(exp.takeError());
+    return;
+  }
+  if (buf == BufferType::L1) {
+    EXPECT_GT(exp->outputL1BufferSize, 0u) << label << ": output not in L1";
+  }
+  EXPECT_GT(exp->peakL1MemorySize, 0u) << label << ": no L1 usage reported";
+}
+
+// The op cannot satisfy this output config and must say so gracefully — a
+// returned error, never an abort. Consume the error.
+void expectGracefulReject(llvm::Expected<OpConstraints> &exp,
+                          const std::string &label) {
+  if (exp) {
+    ADD_FAILURE() << label << " was expected to be rejected but was accepted";
+    return;
+  }
+  llvm::consumeError(exp.takeError());
+}
+} // namespace
+
+class CCLShardedOutputTest : public OpModelLibMockDeviceBase {};
+
+TEST_F(CCLShardedOutputTest, AllGatherOutputLayouts) {
+  setupMockDevice(ttcore::Arch::WormholeB0, /*meshRows=*/1, /*meshCols=*/8);
+  // gather last dim on axis 1: [1,1,32,128] -> [1,1,32,1024].
+  const llvm::SmallVector<int64_t> in = {1, 1, 32, 128};
+  const llvm::SmallVector<int64_t> out = {1, 1, 32, 1024};
+  const TTNNLayoutAttr inL =
+      CreateTiledLayout(in, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  auto query = [&](BufferType buf, TensorMemoryLayout mem) {
+    return OpModel<AllGatherOp>::getOpConstraints(
+        in, inL, /*allGatherDim=*/3, /*clusterAxis=*/1,
+        /*subDeviceId=*/std::nullopt, /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+        CreateTiledLayout(out, buf, mem));
+  };
+  auto dram = query(BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  expectAccepted(dram, "all_gather DRAM-interleaved", BufferType::DRAM);
+  auto l1i = query(BufferType::L1, TensorMemoryLayout::Interleaved);
+  expectAccepted(l1i, "all_gather L1-interleaved", BufferType::L1);
+  auto ws = query(BufferType::L1, TensorMemoryLayout::WidthSharded);
+  expectAccepted(ws, "all_gather L1-width-sharded", BufferType::L1);
+  auto hs = query(BufferType::L1, TensorMemoryLayout::HeightSharded);
+  expectAccepted(hs, "all_gather L1-height-sharded", BufferType::L1);
+  auto bs = query(BufferType::L1, TensorMemoryLayout::BlockSharded);
+  expectAccepted(bs, "all_gather L1-block-sharded", BufferType::L1);
+}
+
+TEST_F(CCLShardedOutputTest, ReduceScatterOutputLayouts) {
+  setupMockDevice(ttcore::Arch::WormholeB0, /*meshRows=*/1, /*meshCols=*/8);
+  // scatter last dim on axis 1: [1,1,32,256] -> [1,1,32,32].
+  const llvm::SmallVector<int64_t> in = {1, 1, 32, 256};
+  const llvm::SmallVector<int64_t> out = {1, 1, 32, 32};
+  const TTNNLayoutAttr inL =
+      CreateTiledLayout(in, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  auto query = [&](BufferType buf, TensorMemoryLayout mem) {
+    return OpModel<ReduceScatterOp>::getOpConstraints(
+        in, inL, /*scatterDim=*/3, /*clusterAxis=*/1,
+        /*subDeviceId=*/std::nullopt, /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+        /*computeConfig=*/std::nullopt, CreateTiledLayout(out, buf, mem));
+  };
+  auto dram = query(BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  expectAccepted(dram, "reduce_scatter DRAM-interleaved", BufferType::DRAM);
+  auto l1i = query(BufferType::L1, TensorMemoryLayout::Interleaved);
+  expectAccepted(l1i, "reduce_scatter L1-interleaved", BufferType::L1);
+  auto ws = query(BufferType::L1, TensorMemoryLayout::WidthSharded);
+  expectAccepted(ws, "reduce_scatter L1-width-sharded", BufferType::L1);
+  auto hs = query(BufferType::L1, TensorMemoryLayout::HeightSharded);
+  expectAccepted(hs, "reduce_scatter L1-height-sharded", BufferType::L1);
+  auto bs = query(BufferType::L1, TensorMemoryLayout::BlockSharded);
+  expectAccepted(bs, "reduce_scatter L1-block-sharded", BufferType::L1);
+}
+
+TEST_F(CCLShardedOutputTest, AllReduceOutputLayouts) {
+  setupMockDevice(ttcore::Arch::WormholeB0, /*meshRows=*/1, /*meshCols=*/8);
+  // all_reduce preserves shape: [1,1,32,128].
+  const llvm::SmallVector<int64_t> shape = {1, 1, 32, 128};
+  const TTNNLayoutAttr inL = CreateTiledLayout(shape, BufferType::DRAM,
+                                               TensorMemoryLayout::Interleaved);
+  auto query = [&](BufferType buf, TensorMemoryLayout mem) {
+    return OpModel<AllReduceOp>::getOpConstraints(
+        shape, inL, /*clusterAxis=*/1, /*subDeviceId=*/std::nullopt,
+        /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+        CreateTiledLayout(shape, buf, mem));
+  };
+  auto dram = query(BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  expectAccepted(dram, "all_reduce DRAM-interleaved", BufferType::DRAM);
+  auto l1i = query(BufferType::L1, TensorMemoryLayout::Interleaved);
+  expectAccepted(l1i, "all_reduce L1-interleaved", BufferType::L1);
+  auto hs = query(BufferType::L1, TensorMemoryLayout::HeightSharded);
+  expectAccepted(hs, "all_reduce L1-height-sharded", BufferType::L1);
+  // A 1x4-tile output cannot tile-fit a width/block shard grid over the worker
+  // cores; the query must reject gracefully rather than abort.
+  auto ws = query(BufferType::L1, TensorMemoryLayout::WidthSharded);
+  expectGracefulReject(ws, "all_reduce L1-width-sharded (too small)");
+  auto bs = query(BufferType::L1, TensorMemoryLayout::BlockSharded);
+  expectGracefulReject(bs, "all_reduce L1-block-sharded (too small)");
+}
+
+// --- DistributedRMSNormOp tests ---
+//
+// fused_rms_minimal constraints (from the tt-metal test):
+//   8 cores × 2 tiles (N=512) on a 1×8 mesh.
+//   input: (1,1,32,512) WIDTH_SHARDED L1, each core holds (32,64).
+//   weight: (1,1,16,32) ROW_MAJOR L1.
+//   stats: (1,1,32,512) WIDTH_SHARDED L1, all on core (0,0).
+
+class DistributedRMSNormLibMockDeviceTest
+    : public OpModelLibMockDeviceBase,
+      public ::testing::WithParamInterface<ttcore::Arch> {
+public:
+  static constexpr uint32_t kNumCores = 8;
+  static constexpr uint32_t kTilesPerCore = 2;
+  static constexpr uint32_t kTileSize = 32;
+  static constexpr uint32_t kN = kNumCores * kTilesPerCore * kTileSize; // 512
+
+  // 1x8 mesh (8 chips) is available as a mock cluster descriptor on both
+  // Wormhole (t3k) and Blackhole (8xP150).
+  void SetUp() override { setupMockDevice(GetParam(), 1, kNumCores); }
+};
+
+TEST_P(DistributedRMSNormLibMockDeviceTest, FusedRmsMinimal1x8) {
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, kTileSize, kN};
+
+  // WIDTH_SHARDED tiled input: virtualGrid {1, 8} → each core gets (32,64).
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, BufferType::L1, TensorMemoryLayout::WidthSharded,
+      /*virtualGrid=*/llvm::SmallVector<int64_t>{1, kNumCores});
+
+  // Weight: ROW_MAJOR, shape (N/32, 32).
+  const llvm::SmallVector<int64_t> weightShape = {1, 1, kN / kTileSize,
+                                                  kTileSize};
+  const TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
+      weightShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  // Stats: WIDTH_SHARDED on 1 core only (aggregation point).
+  const llvm::SmallVector<int64_t> statsShape = {1, 1, kTileSize, kN};
+  const TTNNLayoutAttr statsLayout = CreateTiledLayout(
+      statsShape, BufferType::L1, TensorMemoryLayout::WidthSharded,
+      /*virtualGrid=*/llvm::SmallVector<int64_t>{1, 1});
+
+  // program_config: grid (x=8, y=1), block_w=2 tiles per core.
+  auto gridCoord =
+      mlir::tt::ttnn::CoreCoordAttr::get(&context, kNumCores, /*y=*/1);
+  auto programConfig = LayerNormShardedMultiCoreProgramConfigAttr::get(
+      &context, gridCoord, /*subblock_w=*/1, /*block_h=*/1,
+      /*block_w=*/kTilesPerCore, /*inplace=*/false);
+
+  auto constraintsExp = OpModel<DistributedRMSNormOp>::getOpConstraints(
+      inputShape, inputLayout,
+      std::optional<llvm::ArrayRef<int64_t>>(weightShape),
+      std::optional<TTNNLayoutAttr>(weightLayout),
+      /*residualShape=*/std::nullopt, /*residualLayout=*/std::nullopt,
+      std::optional<llvm::ArrayRef<int64_t>>(statsShape),
+      std::optional<TTNNLayoutAttr>(statsLayout),
+      /*clusterAxis=*/1u, llvm::APFloat(1e-5f),
+      /*subDeviceId=*/std::nullopt,
+      /*numLinks=*/std::optional<uint32_t>(1),
+      std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+      /*computeConfig=*/std::nullopt,
+      std::optional<LayerNormShardedMultiCoreProgramConfigAttr>(programConfig),
+      inputLayout);
+
+  bool ok = static_cast<bool>(constraintsExp);
+  if (!ok) {
+    GTEST_LOG_(INFO) << "distributed_rms_norm constraints error: "
+                     << llvm::toString(constraintsExp.takeError());
+  } else {
+    GTEST_LOG_(INFO) << "distributed_rms_norm constraints ok: cbPeak="
+                     << constraintsExp->cbL1PeakSize
+                     << " tensorPeak=" << constraintsExp->tensorL1PeakSize
+                     << " peakL1=" << constraintsExp->peakL1MemorySize
+                     << " outputBuf=" << constraintsExp->outputL1BufferSize;
+  }
+  EXPECT_TRUE(ok);
+}
+
 INSTANTIATE_TEST_SUITE_P(
-    MeshPartition, MeshPartitionLibMockDeviceTest,
-    ::testing::Values(
-        // {1,8} mesh: axis 0=1, axis 1=8. Only axis 1 splits.
-        MeshPartitionParam{1, 8, 0, 1}, // split dim 0 on axis 1
-        MeshPartitionParam{1, 8, 1, 1}, // split dim 1 on axis 1
-        // {8,1} mesh: axis 0=8, axis 1=1. Only axis 0 splits.
-        MeshPartitionParam{8, 1, 0, 0}, // split dim 0 on axis 0
-        MeshPartitionParam{8, 1, 1, 0}, // split dim 1 on axis 0
-        // {2,4} mesh: both axes split (axis 0=2, axis 1=4).
-        MeshPartitionParam{2, 4, 0, 0}, // split dim 0 on axis 0
-        MeshPartitionParam{2, 4, 0, 1}, // split dim 0 on axis 1
-        MeshPartitionParam{2, 4, 1, 0}, // split dim 1 on axis 0
-        MeshPartitionParam{2, 4, 1, 1}, // split dim 1 on axis 1
-        // {4,2} mesh: both axes split (axis 0=4, axis 1=2).
-        MeshPartitionParam{4, 2, 0, 0}, // split dim 0 on axis 0
-        MeshPartitionParam{4, 2, 0, 1}, // split dim 0 on axis 1
-        MeshPartitionParam{4, 2, 1, 0}, // split dim 1 on axis 0
-        MeshPartitionParam{4, 2, 1, 1}, // split dim 1 on axis 1
-        // {1,2} mesh: axis 0=1, axis 1=2. Only axis 1 splits.
-        MeshPartitionParam{1, 2, 0, 1}, // split dim 0 on axis 1
-        MeshPartitionParam{1, 2, 1, 1}, // split dim 1 on axis 1
-        // {2,1} mesh: axis 0=2, axis 1=1. Only axis 0 splits.
-        MeshPartitionParam{2, 1, 0, 0}, // split dim 0 on axis 0
-        MeshPartitionParam{2, 1, 1, 0}, // split dim 1 on axis 0
-        // {1,4} mesh: axis 0=1, axis 1=4. Only axis 1 splits.
-        MeshPartitionParam{1, 4, 0, 1}, // split dim 0 on axis 1
-        MeshPartitionParam{1, 4, 1, 1}, // split dim 1 on axis 1
-        // {4,1} mesh: axis 0=4, axis 1=1. Only axis 0 splits.
-        MeshPartitionParam{4, 1, 0, 0}, // split dim 0 on axis 0
-        MeshPartitionParam{4, 1, 1, 0}  // split dim 1 on axis 0
-        ));
+    DistributedRMSNorm, DistributedRMSNormLibMockDeviceTest,
+    ::testing::Values(ttcore::Arch::WormholeB0, ttcore::Arch::Blackhole),
+    [](const ::testing::TestParamInfo<ttcore::Arch> &info) {
+      return archName(info.param);
+    });
+
+// --- CCL / DistributedRMSNorm stateful-constraint tests ---
+//
+// The multi-device ops go through the same stateful getOpConstraints entry as
+// every other migrated op: a null initialState takes the cached stateless query
+// (nothing allocated, no outputAllocations), a non-null one takes the
+// allocator-backed query that really runs the op and reports where its output
+// landed. These tests pin that branch per op, and pin the success/failure
+// contract the stateful path exists to provide: the op succeeds when it fits on
+// top of the live set and reports a graceful error when it does not.
+//
+// Note the stateful path deliberately does NOT report peak CB / L1 usage --
+// that is the stateless path's job. Its product is fit (success/failure) plus
+// the output's placement, which is what the L1 spill pass consumes.
+
+namespace {
+// Pins one op's stateless-vs-stateful branch. `query` runs the op's constraint
+// query with the given initial state (nullptr = stateless). Returns the live
+// record the stateful query reported, so callers can re-seed it.
+template <typename QueryFn>
+OpModelAllocationRecord expectStatefulBranch(QueryFn query,
+                                             const std::string &label) {
+  // Stateless: no state to apply, so no output allocations are reported.
+  auto statelessExp = query(/*initialState=*/nullptr);
+  if (!statelessExp) {
+    ADD_FAILURE() << label << " stateless query failed: "
+                  << llvm::toString(statelessExp.takeError());
+    return {};
+  }
+  EXPECT_TRUE(statelessExp->outputAllocations.empty())
+      << label << ": stateless query must not report allocations";
+
+  // Stateful: an empty live set is still a non-null state, which selects the
+  // with-initial-state query and its allocating capture.
+  std::shared_ptr<MockAllocatorState> state = buildInitialState({});
+  EXPECT_NE(state, nullptr);
+  auto statefulExp = query(state.get());
+  if (!statefulExp) {
+    ADD_FAILURE() << label << " stateful query failed: "
+                  << llvm::toString(statefulExp.takeError());
+    return {};
+  }
+  EXPECT_EQ(statefulExp->outputAllocations.size(), 1u)
+      << label << ": stateful query must report the output's allocation";
+  if (statefulExp->outputAllocations.empty()) {
+    return {};
+  }
+  EXPECT_EQ(statefulExp->outputAllocations[0].bufferType, BufferType::L1)
+      << label << ": L1 output must yield an L1 record";
+  return statefulExp->outputAllocations[0];
+}
+
+// Pins that the live set actually reaches the allocator: re-running the query
+// with `base` already live must move the output somewhere else.
+template <typename QueryFn>
+void expectLiveRecordShiftsPlacement(QueryFn query,
+                                     const OpModelAllocationRecord &base,
+                                     const std::string &label) {
+  ASSERT_GT(base.sizePerBank, 0u) << label << ": no baseline record to seed";
+  std::shared_ptr<MockAllocatorState> seeded = buildInitialState({base});
+  ASSERT_NE(seeded, nullptr);
+  auto seededExp = query(seeded.get());
+  ASSERT_TRUE(static_cast<bool>(seededExp))
+      << label
+      << " seeded query failed: " << llvm::toString(seededExp.takeError());
+  ASSERT_EQ(seededExp->outputAllocations.size(), 1u);
+  EXPECT_NE(seededExp->outputAllocations[0].address, base.address)
+      << label << ": seeded live record did not shift the output's placement";
+}
+} // namespace
+
+class CCLStatefulTest : public OpModelLibMockDeviceBase {
+public:
+  void SetUp() override {
+    setupMockDevice(ttcore::Arch::WormholeB0, /*meshRows=*/1, /*meshCols=*/8);
+  }
+};
+
+TEST_F(CCLStatefulTest, AllGatherReportsOutputAllocation) {
+  // gather last dim on axis 1: [1,1,32,128] -> [1,1,32,1024].
+  const llvm::SmallVector<int64_t> in = {1, 1, 32, 128};
+  const llvm::SmallVector<int64_t> out = {1, 1, 32, 1024};
+  const TTNNLayoutAttr inL =
+      CreateTiledLayout(in, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outL =
+      CreateTiledLayout(out, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto query = [&](const MockAllocatorState *state) {
+    return OpModel<AllGatherOp>::getOpConstraints(
+        in, inL, /*allGatherDim=*/3, /*clusterAxis=*/1,
+        /*subDeviceId=*/std::nullopt, /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear), outL, state);
+  };
+
+  OpModelAllocationRecord record = expectStatefulBranch(query, "all_gather");
+  expectLiveRecordShiftsPlacement(query, record, "all_gather");
+}
+
+TEST_F(CCLStatefulTest, ReduceScatterReportsOutputAllocation) {
+  // scatter last dim on axis 1: [1,1,32,256] -> [1,1,32,32].
+  const llvm::SmallVector<int64_t> in = {1, 1, 32, 256};
+  const llvm::SmallVector<int64_t> out = {1, 1, 32, 32};
+  const TTNNLayoutAttr inL =
+      CreateTiledLayout(in, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outL =
+      CreateTiledLayout(out, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto query = [&](const MockAllocatorState *state) {
+    return OpModel<ReduceScatterOp>::getOpConstraints(
+        in, inL, /*scatterDim=*/3, /*clusterAxis=*/1,
+        /*subDeviceId=*/std::nullopt, /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+        /*computeConfig=*/std::nullopt, outL, state);
+  };
+
+  OpModelAllocationRecord record =
+      expectStatefulBranch(query, "reduce_scatter");
+  expectLiveRecordShiftsPlacement(query, record, "reduce_scatter");
+}
+
+TEST_F(CCLStatefulTest, AllReduceReportsOutputAllocation) {
+  // all_reduce preserves shape: [1,1,32,128].
+  const llvm::SmallVector<int64_t> shape = {1, 1, 32, 128};
+  const TTNNLayoutAttr inL = CreateTiledLayout(shape, BufferType::DRAM,
+                                               TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outL =
+      CreateTiledLayout(shape, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto query = [&](const MockAllocatorState *state) {
+    return OpModel<AllReduceOp>::getOpConstraints(
+        shape, inL, /*clusterAxis=*/1, /*subDeviceId=*/std::nullopt,
+        /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear), outL, state);
+  };
+
+  OpModelAllocationRecord record = expectStatefulBranch(query, "all_reduce");
+  expectLiveRecordShiftsPlacement(query, record, "all_reduce");
+}
+
+// Same fused_rms_minimal config as FusedRmsMinimal1x8. The GlobalSemaphore is
+// built inside the graph capture; under the stateful path that capture runs in
+// NORMAL mode, so the semaphore is allocated for real through the mock
+// allocator alongside the op's own buffers. This pins that that works.
+TEST_F(CCLStatefulTest, DistributedRMSNormReportsOutputAllocation) {
+  constexpr uint32_t kNumCores = 8;
+  constexpr uint32_t kTilesPerCore = 2;
+  constexpr uint32_t kTileSize = 32;
+  constexpr uint32_t kN = kNumCores * kTilesPerCore * kTileSize; // 512
+
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, kTileSize, kN};
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, BufferType::L1, TensorMemoryLayout::WidthSharded,
+      /*virtualGrid=*/llvm::SmallVector<int64_t>{1, kNumCores});
+
+  const llvm::SmallVector<int64_t> weightShape = {1, 1, kN / kTileSize,
+                                                  kTileSize};
+  const TTNNLayoutAttr weightLayout = CreateRowMajorLayout(
+      weightShape, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  const llvm::SmallVector<int64_t> statsShape = {1, 1, kTileSize, kN};
+  const TTNNLayoutAttr statsLayout = CreateTiledLayout(
+      statsShape, BufferType::L1, TensorMemoryLayout::WidthSharded,
+      /*virtualGrid=*/llvm::SmallVector<int64_t>{1, 1});
+
+  auto gridCoord =
+      mlir::tt::ttnn::CoreCoordAttr::get(&context, kNumCores, /*y=*/1);
+  auto programConfig = LayerNormShardedMultiCoreProgramConfigAttr::get(
+      &context, gridCoord, /*subblock_w=*/1, /*block_h=*/1,
+      /*block_w=*/kTilesPerCore, /*inplace=*/false);
+
+  auto query = [&](const MockAllocatorState *state) {
+    return OpModel<DistributedRMSNormOp>::getOpConstraints(
+        inputShape, inputLayout,
+        std::optional<llvm::ArrayRef<int64_t>>(weightShape),
+        std::optional<TTNNLayoutAttr>(weightLayout),
+        /*residualShape=*/std::nullopt, /*residualLayout=*/std::nullopt,
+        std::optional<llvm::ArrayRef<int64_t>>(statsShape),
+        std::optional<TTNNLayoutAttr>(statsLayout),
+        /*clusterAxis=*/1u, llvm::APFloat(1e-5f),
+        /*subDeviceId=*/std::nullopt,
+        /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear),
+        /*computeConfig=*/std::nullopt,
+        std::optional<LayerNormShardedMultiCoreProgramConfigAttr>(
+            programConfig),
+        inputLayout, state);
+  };
+
+  expectStatefulBranch(query, "distributed_rms_norm");
+}
+
+// The live set really drives placement: with all of L1 below the top slot
+// already live, the op still succeeds and puts its output in exactly the gap
+// that is left. This is the success/failure signal the L1 spill pass consumes
+// -- the stateful path reports fit and placement, not peak CB/L1 usage (that
+// stays the stateless path's job, which is why cbL1PeakSize is not asserted
+// here).
+//
+// Scope note, measured on this mock: the stateful path models *buffer*
+// allocation against the live set, not circular-buffer pressure. Seeding L1 so
+// that only the output fits still succeeds even for an op whose CBs cannot fit,
+// and seeding L1 to full exhaustion returns a wrapped address rather than an
+// error. Both behaviors are identical for a plain ReluOp control on this same
+// mock, so they are properties of the stateful query as it exists today (see
+// #9124), not of the multi-device ops -- which is precisely the bar for this
+// port: the CCL ops behave like every other stateful op.
+TEST_F(CCLStatefulTest, AllGatherPlacesOutputInGapLeftByLiveSet) {
+  const llvm::SmallVector<int64_t> in = {1, 1, 32, 128};
+  const llvm::SmallVector<int64_t> out = {1, 1, 32, 1024};
+  const TTNNLayoutAttr inL =
+      CreateTiledLayout(in, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr outL =
+      CreateTiledLayout(out, BufferType::L1, TensorMemoryLayout::Interleaved);
+
+  auto query = [&](const MockAllocatorState *state) {
+    return OpModel<AllGatherOp>::getOpConstraints(
+        in, inL, /*allGatherDim=*/3, /*clusterAxis=*/1,
+        /*subDeviceId=*/std::nullopt, /*numLinks=*/std::optional<uint32_t>(1),
+        std::optional<ttcore::Topology>(ttcore::Topology::Linear), outL, state);
+  };
+
+  // Calibrate off the empty-state placement rather than hardcoding L1 geometry:
+  // the output's own record tells us where its slot is.
+  std::shared_ptr<MockAllocatorState> empty = buildInitialState({});
+  ASSERT_NE(empty, nullptr);
+  auto fitsExp = query(empty.get());
+  ASSERT_TRUE(static_cast<bool>(fitsExp))
+      << "all_gather must fit on an empty live set: "
+      << llvm::toString(fitsExp.takeError());
+  ASSERT_EQ(fitsExp->outputAllocations.size(), 1u);
+  const OpModelAllocationRecord fit = fitsExp->outputAllocations[0];
+
+  ttcore::SystemDescAttr systemDesc =
+      ttcore::getCurrentScopeSystemDesc(module.get());
+  ASSERT_TRUE(static_cast<bool>(systemDesc));
+  ASSERT_FALSE(systemDesc.getChipDescs().empty());
+  const uint64_t l1Base = systemDesc.getChipDescs()[0].getL1UnreservedBase();
+  ASSERT_LT(l1Base, fit.address);
+
+  // Occupy everything below the slot the output used, leaving exactly that
+  // slot.
+  const OpModelAllocationRecord below{BufferType::L1, /*address=*/l1Base,
+                                      /*sizePerBank=*/fit.address - l1Base};
+  std::shared_ptr<MockAllocatorState> seeded = buildInitialState({below});
+  ASSERT_NE(seeded, nullptr);
+  auto seededExp = query(seeded.get());
+  ASSERT_TRUE(static_cast<bool>(seededExp))
+      << "all_gather must still fit in the gap the live set leaves: "
+      << llvm::toString(seededExp.takeError());
+  ASSERT_EQ(seededExp->outputAllocations.size(), 1u);
+  EXPECT_EQ(seededExp->outputAllocations[0].address, fit.address);
+  EXPECT_EQ(seededExp->outputAllocations[0].sizePerBank, fit.sizePerBank);
+}
 
 // --- IndexerScoreDsaOp stateful-constraint test ---
 
@@ -169,74 +956,11 @@ INSTANTIATE_TEST_SUITE_P(
 // singleton on Blackhole would poison every later test in this binary.
 class IndexerScoreDsaLibMockDeviceTest : public OpModelLibMockDeviceBase {
 public:
-  void SetUp() override {
-    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
-    context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
-    module = mlir::ModuleOp::create(builder.getUnknownLoc());
-    builder.setInsertionPointToStart(&module->getBodyRegion().front());
-
-    reopenMockDevice(ttcore::Arch::Blackhole, {1, 1});
-    mlir::tt::ttcore::registerDevice(module.get());
-  }
+  void SetUp() override { setupMockDevice(ttcore::Arch::Blackhole, 1, 1); }
 
   void TearDown() override {
-    // Restore the topology MockDeviceEnvironment established for this binary.
-    reopenMockDevice(ttcore::Arch::WormholeB0, {1, maxMockChips});
-  }
-
-private:
-  // SystemDescAttr::getDefault's Blackhole worker grid (TTCoreOpsTypes.cpp) is
-  // 13 wide, but tt-metal's mock blackhole_P150.yaml is 2-column harvested and
-  // its device reports 11. SingletonDeviceContext::openDevice validates the two
-  // against each other and hard-errors on a mismatch, so give this test a desc
-  // whose grid matches the mock device it opens. Only the grid differs from the
-  // default; the shared default is deliberately left alone, since it is the
-  // fallback for every Blackhole compile and correcting it is a separate change
-  // with its own golden churn.
-  static constexpr int64_t mockBlackholeGridX = 11;
-
-  static ttcore::SystemDescAttr
-  withGridMatchingMockDevice(mlir::MLIRContext *ctx,
-                             ttcore::SystemDescAttr desc) {
-    llvm::SmallVector<ttcore::ChipDescAttr> chipDescs;
-    for (ttcore::ChipDescAttr chip : desc.getChipDescs()) {
-      llvm::SmallVector<int64_t> grid(chip.getGrid());
-      assert(grid.size() == 2 && "expected a 2D worker grid");
-      grid[1] = mockBlackholeGridX;
-      chipDescs.push_back(ttcore::ChipDescAttr::get(
-          ctx, chip.getArch(), grid, chip.getCoordTranslationOffsets(),
-          chip.getL1Size(), chip.getNumDramChannels(),
-          chip.getDramChannelSize(), chip.getNocL1AddressAlignBytes(),
-          chip.getPcieAddressAlignBytes(), chip.getNocDRAMAddressAlignBytes(),
-          chip.getL1UnreservedBase(), chip.getEriscL1UnreservedBase(),
-          chip.getDramUnreservedBase(), chip.getDramUnreservedEnd(),
-          chip.getSupportedDataTypes(), chip.getSupportedTileSizes(),
-          chip.getDstPhysicalSizeTiles(), chip.getNumCBs(),
-          chip.getNumComputeThreads(), chip.getNumDatamovementThreads(),
-          chip.getDramGrid(), chip.getDramBankToLogicalWorkerNoc0(),
-          chip.getDramBankToLogicalWorkerNoc1()));
-    }
-    return ttcore::SystemDescAttr::get(
-        ctx, desc.getCpuDescs(), chipDescs, desc.getChipDescIndices(),
-        desc.getChipCapabilities(), desc.getChipCoords(),
-        desc.getChipChannels());
-  }
-
-  void reopenMockDevice(ttcore::Arch arch,
-                        const std::pair<size_t, size_t> &meshShape) {
-    mlir::MLIRContext tmpCtx;
-    tmpCtx.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
-    ttcore::SystemDescAttr desc = ttcore::SystemDescAttr::getDefault(
-        &tmpCtx, arch,
-        {static_cast<int>(meshShape.first),
-         static_cast<int>(meshShape.second)});
-    if (arch == ttcore::Arch::Blackhole) {
-      desc = withGridMatchingMockDevice(&tmpCtx, desc);
-    }
-    SingletonDeviceContext::closeInstance();
-    SingletonDeviceContext::setSystemDesc(desc);
-    SingletonDeviceContext::getInstance().openMockDevice(
-        /*traceRegionSize=*/0, meshShape);
+    // Restore the arch MockDeviceEnvironment established for this binary.
+    setupMockDevice(ttcore::Arch::WormholeB0, 1, 1);
   }
 };
 

--- a/test/unittests/OpModel/TTNN/MockDeviceFixture.h
+++ b/test/unittests/OpModel/TTNN/MockDeviceFixture.h
@@ -36,11 +36,10 @@
 #include <cstddef>
 #include <utility>
 
-// Maximum number of mock chips configured once per binary.
-// Individual tests can reshape to any topology whose volume <= maxMockChips.
-static constexpr size_t maxMockChips = 8;
-
-// Configures mock mode once for the entire test binary.
+// Opens a single-chip mock device once per binary as a bootstrap. Individual
+// tests reshape to their target sub-topology — N300 (1×2), T3K (1×8),
+// Galaxy (4×8), etc. — via reshapeMeshDevice(); each reshape builds a fresh
+// MetalEnv (and a fresh per-topology system descriptor).
 // Register via ::testing::AddGlobalTestEnvironment(new MockDeviceEnvironment())
 // in main().
 class MockDeviceEnvironment : public ::testing::Environment {
@@ -48,15 +47,21 @@ public:
   void SetUp() override {
     mlir::MLIRContext tmpCtx;
     tmpCtx.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    // Bootstrap a single-chip mock device. Its 8x8 Wormhole worker grid matches
+    // the default system descriptor, so the grid validation in openDevice
+    // passes. Each test fixture reshapes to its target topology in SetUp(),
+    // rebuilding the system descriptor from the reshaped device's grid (the
+    // worker grid is topology-dependent: e.g. the 6u mock reports 9x8). With
+    // MetalEnv every reshape builds a fresh env, so there is no need to
+    // pre-size the base mesh here.
     auto systemDesc = mlir::tt::ttcore::SystemDescAttr::getDefault(
-        &tmpCtx, mlir::tt::ttcore::Arch::WormholeB0,
-        {1, static_cast<int>(maxMockChips)});
+        &tmpCtx, mlir::tt::ttcore::Arch::WormholeB0, {1});
     mlir::tt::ttnn::op_model::SingletonDeviceContext::setSystemDesc(systemDesc);
     mlir::tt::ttnn::op_model::SingletonDeviceContext::getInstance()
         .openMockDevice(
             /*traceRegionSize=*/0,
             /*meshShape=*/
-            std::make_pair(static_cast<size_t>(1), maxMockChips));
+            std::make_pair(static_cast<size_t>(1), static_cast<size_t>(1)));
   }
 
   void TearDown() override {

--- a/test/unittests/OpModel/TTNN/OpModelFixture.h
+++ b/test/unittests/OpModel/TTNN/OpModelFixture.h
@@ -55,8 +55,9 @@ public:
   }
 
   static llvm::SmallVector<int64_t> GetPhysicalGridSize() {
-    llvm::SmallVector<int64_t> grid = {gridShapeHwN300[0], gridShapeHwN300[1]};
-    return grid;
+    return llvm::to_vector(
+        mlir::tt::ttnn::op_model::SingletonDeviceContext::getInstance()
+            .getComputeGridShape());
   }
 
   // helper function to get virtual grid shape based on tensor shape and

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -73,6 +73,8 @@ set(TTMETAL_INCLUDE_DIRS
   ${TTMETAL_SOURCE_DIR}
   ${TTMETAL_SOURCE_DIR}/tt_metal
   ${TTMETAL_SOURCE_DIR}/tt_metal/api
+  ${TTMETAL_SOURCE_DIR}/tt_metal/api/tt-metalium
+  ${TTMETAL_SOURCE_DIR}/tt_metal/include
   ${TTMETAL_SOURCE_DIR}/tt_metal/hostdevcommon/api
   ${TTMETAL_SOURCE_DIR}/tt_metal/third_party/umd
   ${TTMETAL_SOURCE_DIR}/tt_metal/third_party/umd/device/api


### PR DESCRIPTION
## Change

Successor to #8413 — same CCL + `DistributedRMSNorm` op-model constraints, rebased onto #9124's folded
stateful `getOpConstraints` and **ported to the stateful (allocator-backed) path**.

#8413's branch `rpavlovic/ccl-opmodel-constraints` is **retained untouched as a backup**; this PR ships on
the new branch `rpavlovic/ccl-opmodel-stateful`.

Base is #9124's branch (`rpavlovic/op-model-stateful-constraints-v2`) so the diff shows only the CCL delta.
GitHub will retarget this to `main` automatically when #9124 merges.

### OpModel constraints for multi-device ops

- **AllGatherOp, ReduceScatterOp, AllReduceOp** — via `DistributedTensorSpec` with sharded topology; input
  shards distributed along `clusterAxis` of the mesh.
- **DistributedRMSNormOp** — via `DistributedTensorSpec` with replicated topology (each device runs RMS
  locally; only stats are all-gathered); uses `fused_rms_minimal` with a `GlobalSemaphore` created from the
  input shard spec.

All four are now **stateful**: they take the trailing `initialState` / `liveRecords` argument and route
through `query_op_constraints_with_optional_state`, so they behave like every other migrated op — a null
state takes the cached stateless query, a non-null one (even from an empty live set) takes the
allocator-backed query and reports where the output landed.

`DistributedRMSNormOp` keeps its inner-lambda form so the `GlobalSemaphore` is still built *inside* the
graph capture. That works under both flavours: stateless (`NO_DISPATCH`) intercepts the semaphore's L1
allocation and initial-value write via `GraphTracker`; stateful (phase 2, `NORMAL`) allocates it for real
through the mock allocator alongside the op's own buffers. Verified on both Wormhole and Blackhole mocks.

Note the stateful path reports **fit and output placement**, not peak CB/L1 bytes — peak numbers remain the
stateless path's job. `docs/src/ttnn-op-constraints.md` gains a short subsection covering multi-device ops
and the build-a-resource-inside-the-capture pattern.

### Also in this PR

- **Blackhole default worker grid corrected `{10,13}` → `{10,11}`**, with the golden churn that entails
  (`llama_3_1_8b_blackhole.mlir`, two `D2MToTTMetal/virtual_grid*` re-factorizations, and
  `D2MToTTMetal/tensor_accessor_vgm.mlir` — the last one added by #9002 after this work's original base, so
  its `CHECK-BH-*` blocks now match the `CHECK-WH-*` shape: a 12-wide virtual grid no longer fits 11 columns
  and re-factorizes to `3x4` with a virtual-grid mapping, exactly as Wormhole already did). This also makes
  #9124's indexer-test local grid override redundant, so `withGridMatchingMockDevice` + `mockBlackholeGridX`
  are **deleted** in favour of the base fixture's `setupMockDevice()`. Net code removal.
- **`ttnn::all_gather` migrated off the deprecated legacy argument order** (that overload's removal date was
  2026-08-01 and it already failed under `-Werror`) to
  `(input_tensor, dim, cluster_axis, memory_config, persistent_output_tensor, subdevice_id, sub_core_grid, num_links, topology)`.
- Infrastructure: `SingletonDeviceContext` fabric lifecycle + `getComputeGridShape()`;
  `SystemDescAttr::getDefault` overload accepting `chipGrid`; `DevicePassesWrapper` passing the registered
  mesh shape to `openMockDevice`; `MockDeviceFixture` covering all sub-meshes (N300, T3K, Galaxy 6U) in one
  binary; `OpModelFixture::GetPhysicalGridSize` querying the live device.

### Known limitation — single-axis `DistributedTensorSpec`

`TTNNLayoutAttr` describes only the single-device tensor layout and the MLIR CCL ops carry only one
`cluster_axis`, so the query builds `create_sharded_tensor_topology` along that single axis even when the
runtime tensor is sharded on two mesh axes. For tensors that fit comfortably in L1 this does not change the
outcome; for tight fits the per-device size estimate may differ from reality. Under the stateful path a wrong
per-device size also propagates — the op runs on that input, so the output size written into the live-record
set is wrong for later ops in the spill window.

## Testing

`TestOpModelLibMockDevice` — **75/75 PASS**, including the 32-chip WH 4×8 Galaxy 6U CCL cases and #9124's
indexer stateful test after the workaround deletion. Pure mock; no device required.

New `CCLStatefulTest` suite (5 tests) adds the branch oracle per op — null state → no `outputAllocations`;
non-null state → exactly one L1 record; a seeded live record shifts placement — plus a fit test pinning that
with all of L1 below the output's slot live, the op still succeeds and places its output in exactly the gap
left.

Scope note, measured and documented on that test: the stateful path models **buffer** allocation against the
live set, not circular-buffer pressure — seeding L1 so only the output fits still succeeds even when the op's
CBs cannot fit, and total exhaustion returns a wrapped address rather than an error. A plain `ReluOp` control
on the same mock behaves **identically** in both regimes, so these are properties of the stateful query as it
exists today (#9124), not of the multi-device ops.

`check-ttmlir`: 1644 passed / 549 unsupported. The only remaining local failures are environmental to this
build config — two `StableHLO/ComplexDataTypeConversion` tests that need `TTMLIR_ENABLE_STABLEHLO=ON` (the
pass does not exist otherwise) and one `Silicon/TTNN/n150` conv3d test that needs real hardware.
Real-device / multi-chip-hardware suites deferred to CI.

Predecessor: #8413.
