### PR TITLE
fix(opmodel): ToTensorSpecOp getOpConstraints to 3-arg stateful signature

### DIFF
--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -1908,9 +1908,10 @@ ToLayoutOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 // and typecast ops. It is always decomposed before reaching a backend, so there
 // is no need to model it via the constraint API.
 
-llvm::Expected<op_model::OpConstraints>
-ToTensorSpecOp::getOpConstraints(const std::vector<TTNNLayoutAttr> &inputs,
-                                 const OpConfig &opConfig) {
+llvm::Expected<op_model::OpConstraints> ToTensorSpecOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
   return issueErrorForGetOpConstraints(
       getOperation(), detail::ReasonForLackOfSupport::NoNeedForConstraintAPI);
 }


### PR DESCRIPTION
Unbreaks `main` after #9124's stateful `getOpConstraints` fold collided with #9065's `ToLayoutOp` -> `ToTensorSpecOp` rename.

#9124 was squash-merged on a pre-#9065 base: it converted every `getOpConstraints` to the 3-argument stateful signature, but the `ToTensorSpecOp` block #9065 introduced afterwards kept the 2-argument form. The merge was textually clean, so the semantic conflict slipped through — `main` @ 83a3e2bf52 fails to build:

```
lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp:1912:17: error: out-of-line definition of
'getOpConstraints' does not match any declaration in 'mlir::tt::ttnn::ToTensorSpecOp'
```

(main's own post-merge `release-build` / `debug-build` jobs are red with exactly this.)

Signature-only change; the body still returns `NoNeedForConstraintAPI` as before, and the new `liveRecords` parameter is unused — `to_tensor_spec` is always decomposed before reaching a backend.

Verified locally: `ttmlir-opt` builds clean off `origin/main` + this commit (`TTMLIR_ENABLE_OPMODEL=ON`).