### PR TITLE
[TTNN] Add compute kernel config to SDPA ops, and stop dropping frontend-set pipeline options

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3849,7 +3849,7 @@ def TTNN_LoadTensorOp : TTNN_Op<"load_tensor", [OpModelExempt]> {
 }
 
 
-def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attention_decode", [AttrSizedOperandSegments]> {
+def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attention_decode", [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "A version of scaled dot product attention specifically for decode.";
     let description = [{
       Flash-Decode SDPA for single-query-token decode. Supports MQA and GQA.
@@ -3874,6 +3874,9 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
           sliding_window_size (uint, optional): Restrict attention to the last
               N keys, anchored at the decode position (`cur_pos`, defaulting to
               the last kv position when not provided). Defaults to `None`.
+          compute_config (DeviceComputeKernelConfig, optional): Device compute
+              kernel configuration. Controls math fidelity, approximation mode,
+              and accumulation precision. Defaults to `None` (TTNN decides).
 
       Returns:
           AnyRankedTensor: `[1 x B x Hq x D]` (same type as `query`).
@@ -3888,7 +3891,8 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
                          Optional<AnyRankedTensor>:$attention_sink,
                          OptionalAttr<F32Attr>:$scale,
                          OptionalAttr<UI32Attr>:$sliding_window_size,
-                         OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config);
+                         OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -3901,10 +3905,15 @@ def TTNN_ScaledDotProductAttentionDecodeOp : TTNN_Op<"scaled_dot_product_attenti
     let hasVerifier = 1;
 }
 
-def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_product_attention_decode", [AttrSizedOperandSegments]> {
+def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_product_attention_decode", [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface]> {
   let summary = "Paged scaled dot product attention decode operation.";
   let description = [{
     Paged scaled dot product attention decode operation.
+
+    Args:
+        compute_config (DeviceComputeKernelConfig, optional): Device compute
+            kernel configuration. Controls math fidelity, approximation mode,
+            and accumulation precision. Defaults to `None` (TTNN decides).
   }];
 
   let arguments = (ins AnyRankedTensor:$query,
@@ -3917,7 +3926,8 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
                        Optional<AnyRankedTensor>:$attention_sink,
                        OptionalAttr<F32Attr>:$scale,
                        OptionalAttr<UI32Attr>:$sliding_window_size,
-                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config);
+                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config,
+                       OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -3930,7 +3940,7 @@ def TTNN_PagedScaledDotProductAttentionDecodeOp : TTNN_Op<"paged_scaled_dot_prod
   let hasVerifier = 1;
 }
 
-def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention"> {
+def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_product_attention", [TTNN_ComputeKernelConfigOpInterface]> {
   let summary = "Chunked prefill scaled dot product attention over a paged KV cache.";
   let description = [{
     Chunked-prefill attention. A prefill chunk of `query` attends
@@ -3942,6 +3952,11 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
     table is consumed on device, the op holds no host-side state: it can be
     captured inside a trace and replayed across invocations with a different
     `chunk_start_idx` without recompiling.
+
+    Args:
+        compute_config (DeviceComputeKernelConfig, optional): Device compute
+            kernel configuration. Controls math fidelity, approximation mode,
+            and accumulation precision. Defaults to `None` (TTNN decides).
   }];
 
   let arguments = (ins AnyRankedTensor:$query,
@@ -3950,7 +3965,8 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
                        AnyRankedTensor:$page_table,
                        AnyRankedTensor:$chunk_start_idx,
                        OptionalAttr<F32Attr>:$scale,
-                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config);
+                       OptionalAttr<TTNN_SDPAProgramConfigAttr>:$program_config,
+                       OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -3963,7 +3979,7 @@ def TTNN_ChunkedScaledDotProductAttentionOp : TTNN_Op<"chunked_scaled_dot_produc
   let hasVerifier = 1;
 }
 
-def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments]> {
+def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_latent_attention_decode", [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface]> {
   let summary = "Paged flash multi-latent attention decode operation.";
   let description = [{
     Paged flash Multi-Latent Attention (MLA) for the decode phase. Combines
@@ -3977,6 +3993,11 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
     The key/value cache is laid out as `[max_num_blocks, nkv, block_size,
     head_dim]`. MLA keeps a single compressed latent KV cache shared across all
     query heads, so the number of KV heads `nkv` (dim 1) must be 1.
+
+    Args:
+        compute_config (DeviceComputeKernelConfig, optional): Device compute
+            kernel configuration. Controls math fidelity, approximation mode,
+            and accumulation precision. Defaults to `None` (TTNN decides).
   }];
 
   let arguments = (ins AnyRankedTensor:$query,
@@ -3988,7 +4009,8 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
                        Optional<AnyRankedTensor>:$attention_mask,
                        Optional<AnyRankedTensor>:$cur_pos_tensor,
                        Optional<AnyRankedTensor>:$attention_sink,
-                       OptionalAttr<F32Attr>:$scale);
+                       OptionalAttr<F32Attr>:$scale,
+                       OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
   let results = (outs AnyRankedTensor:$result);
 
@@ -4001,7 +4023,7 @@ def TTNN_PagedFlashMultiLatentAttentionDecodeOp : TTNN_Op<"paged_flash_multi_lat
   let hasVerifier = 1;
 }
 
-def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [AttrSizedOperandSegments]> {
+def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Scaled dot product attention operation.";
     let description = [{
       FlashAttention-2 SDPA. Supports MHA, MQA, and GQA.
@@ -4025,6 +4047,9 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
           attention_sink (AnyRankedTensor, optional): `[1 x Hq x 1 x 1]`, one
               value per query head broadcast across batch and tile dims.
               Defaults to `None`.
+          compute_config (DeviceComputeKernelConfig, optional): Device compute
+              kernel configuration. Controls math fidelity, approximation mode,
+              and accumulation precision. Defaults to `None` (TTNN decides).
 
       Returns:
           AnyRankedTensor: `[B x Hq x Sq x D]` (same type as `query`).
@@ -4037,7 +4062,8 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
                          DefaultValuedAttr<BoolAttr, "true">:$is_causal,
                          OptionalAttr<F32Attr>:$scale,
                          OptionalAttr<UI32Attr>:$sliding_window_size,
-                         Optional<AnyRankedTensor>:$attention_sink);
+                         Optional<AnyRankedTensor>:$attention_sink,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
 
@@ -4050,7 +4076,7 @@ def TTNN_ScaledDotProductAttentionOp : TTNN_Op<"scaled_dot_product_attention", [
     let hasVerifier = 1;
 }
 
-def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegments]> {
+def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegments, TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Flash Multi-head Latent Attention prefill operation.";
     let description = [{
       Multi-head Latent Attention (MLA) prefill. Mirrors
@@ -4072,6 +4098,9 @@ def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegme
           is_causal (bool): Defaults to `true`. Cannot be `true` when
               `attention_mask` is provided.
           scale (float, optional): Softmax scale. Defaults to `1 / sqrt(dh_qk)`.
+          compute_config (DeviceComputeKernelConfig, optional): Device compute
+              kernel configuration. Controls math fidelity, approximation mode,
+              and accumulation precision. Defaults to `None` (TTNN decides).
 
       Returns:
           AnyRankedTensor: `[B x Hq x Sq x head_dim_v]` (same dtype as `query`).
@@ -4083,7 +4112,8 @@ def TTNN_FlashMlaPrefillOp : TTNN_Op<"flash_mla_prefill", [AttrSizedOperandSegme
                          Optional<AnyRankedTensor>:$attention_mask,
                          UI32Attr:$head_dim_v,
                          DefaultValuedAttr<BoolAttr, "true">:$is_causal,
-                         OptionalAttr<F32Attr>:$scale);
+                         OptionalAttr<F32Attr>:$scale,
+                         OptionalAttr<TTNN_DeviceComputeKernelConfig>:$compute_config);
 
     let results = (outs AnyRankedTensor:$result);
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -544,8 +544,7 @@ struct TTIRToTTNNCommonPipelineOptions
                                   "enable-create-d2m-subgraphs to be enabled.");
     }
 
-    if (enableCreateD2MSubgraphs &&
-        enableD2MElementwiseFusion.getNumOccurrences() == 0) {
+    if (enableCreateD2MSubgraphs && !enableD2MElementwiseFusion.hasValue()) {
       enableD2MElementwiseFusion = true;
     }
   }
@@ -559,23 +558,31 @@ struct TTIRToTTNNCommonPipelineOptions
           ". Must be 0, 1, or 2.");
     }
 
-    // Only apply optimization_level if user didn't explicitly set the option.
-    // Use getNumOccurrences() to detect explicit user settings.
-    if (optimizerPassEnabled.getNumOccurrences() == 0) {
+    // Only apply optimization_level if the caller didn't explicitly set the
+    // option.
+    //
+    // Use hasValue(), NOT getNumOccurrences(), to detect that. NumOccurrences
+    // is bumped only by cl::Option::addOccurrence() on the command-line parse
+    // path, so a frontend that assigns an option programmatically
+    // (`options.computeCfgMathFidelity = ...`, as tt-xla's module_builder
+    // does) writes the storage via cl::opt::operator= without ever touching
+    // it, and is indistinguishable from "never set". hasValue() covers both:
+    // MLIR's Option ctor installs a callback that sets optHasValue, and
+    // cl::opt::operator= invokes that callback, while cl::init() does not
+    // (it routes through setInitialValue -> setValue(V, /*initial=*/true)).
+    if (!optimizerPassEnabled.hasValue()) {
       optimizerPassEnabled = (optimizationLevel >= 1);
     }
-    if (enableFusingConv2dWithMultiplyPattern.getNumOccurrences() == 0) {
+    if (!enableFusingConv2dWithMultiplyPattern.hasValue()) {
       enableFusingConv2dWithMultiplyPattern = (optimizationLevel >= 1);
     }
-    if (memoryLayoutAnalysisEnabled.getNumOccurrences() == 0) {
+    if (!memoryLayoutAnalysisEnabled.hasValue()) {
       memoryLayoutAnalysisEnabled = (optimizationLevel >= 2);
     }
-    if (computeCfgMathFidelity.getNumOccurrences() == 0 &&
-        optimizationLevel > 0) {
+    if (!computeCfgMathFidelity.hasValue() && optimizationLevel > 0) {
       computeCfgMathFidelity = OptionalMathFidelity::Undefined;
     }
-    if (computeCfgFp32DestAccEn.getNumOccurrences() == 0 &&
-        optimizationLevel > 0) {
+    if (!computeCfgFp32DestAccEn.hasValue() && optimizationLevel > 0) {
       computeCfgFp32DestAccEn = std::optional<bool>(std::nullopt);
     }
   }

--- a/include/ttmlir/Target/TTNN/operations/transformer.fbs
+++ b/include/ttmlir/Target/TTNN/operations/transformer.fbs
@@ -66,6 +66,7 @@ table ScaledDotProductAttentionDecodeOp {
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
   program_config: tt.target.ttnn.SDPAConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table ScaledDotProductAttentionOp {
@@ -79,6 +80,7 @@ table ScaledDotProductAttentionOp {
   attention_sink: tt.target.ttnn.TensorRef;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table FlashMlaPrefillOp {
@@ -91,6 +93,7 @@ table FlashMlaPrefillOp {
   scale: float = null;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table NLPCreateQKVHeadsDecodeOp {
@@ -132,6 +135,7 @@ table PagedScaledDotProductAttentionDecodeOp {
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
   program_config: tt.target.ttnn.SDPAConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table ChunkedScaledDotProductAttentionOp {
@@ -144,6 +148,7 @@ table ChunkedScaledDotProductAttentionOp {
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
   program_config: tt.target.ttnn.SDPAConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }
 
 table PagedFlashMultiLatentAttentionDecodeOp {
@@ -159,4 +164,5 @@ table PagedFlashMultiLatentAttentionDecodeOp {
   scale: float = null;
   out: tt.target.ttnn.TensorRef;
   memcfg: tt.target.ttnn.MemoryConfig;
+  compute_config: tt.target.ttnn.DeviceComputeKernelConfig;
 }

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -3321,7 +3321,7 @@ public:
         adaptor.getIsCausal(), adaptor.getAttentionMask(),
         adaptor.getCurPosTensor(), adaptor.getAttentionSink(),
         adaptor.getScaleAttr(), /*sliding_window_size=*/IntegerAttr(),
-        /*program_config=*/nullptr);
+        /*program_config=*/nullptr, /*compute_config=*/nullptr);
     return success();
   }
 };
@@ -3344,7 +3344,7 @@ public:
         adaptor.getAttentionMask(), adaptor.getCurPosTensor(),
         adaptor.getAttentionSink(), adaptor.getScaleAttr(),
         adaptor.getSlidingWindowSizeAttr(),
-        /*program_config=*/nullptr);
+        /*program_config=*/nullptr, /*compute_config=*/nullptr);
     return success();
   }
 };
@@ -3365,7 +3365,7 @@ public:
         adaptor.getQuery(), adaptor.getKey(), adaptor.getValue(),
         adaptor.getPageTable(), adaptor.getChunkStartIdx(),
         adaptor.getScaleAttr(),
-        /*program_config=*/nullptr);
+        /*program_config=*/nullptr, /*compute_config=*/nullptr);
     return success();
   }
 };
@@ -3387,7 +3387,7 @@ public:
         static_cast<uint32_t>(adaptor.getHeadDimV()), adaptor.getPageTable(),
         adaptor.getIsCausal(), adaptor.getAttentionMask(),
         adaptor.getCurPosTensor(), adaptor.getAttentionSink(),
-        adaptor.getScaleAttr());
+        adaptor.getScaleAttr(), /*compute_config=*/nullptr);
     return success();
   }
 };
@@ -3528,7 +3528,7 @@ private:
         /*cur_pos_tensor=*/Value(),
         /*attention_sink=*/attentionSink, adaptor.getScaleAttr(),
         adaptor.getSlidingWindowSizeAttr(),
-        /*program_config=*/nullptr);
+        /*program_config=*/nullptr, /*compute_config=*/nullptr);
 
     // Permute result back: [1, B, H, D] -> [B, H, 1, D].
     rewriter.replaceOp(
@@ -3572,7 +3572,8 @@ private:
         op, this->getTypeConverter()->convertType(op.getType()),
         adaptor.getQuery(), adaptor.getKey(), adaptor.getValue(), mask,
         op.getIsCausal(), adaptor.getScaleAttr(),
-        adaptor.getSlidingWindowSizeAttr(), attentionSink);
+        adaptor.getSlidingWindowSizeAttr(), attentionSink,
+        /*compute_config=*/nullptr);
 
     return success();
   }

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3532,6 +3532,8 @@ public:
         emitter.emit(srcOp.getScale()),
         emitter.emit(/*slidingWindowSize=*/std::nullopt),
         emitter.emit(srcOp.getMemoryConfigAttr()),
+        emitter.emit(srcOp.getProgramConfig()),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -3590,7 +3592,7 @@ public:
         emitter.emit(srcOp.getSlidingWindowSize()),
         emitter.emit(srcOp.getMemoryConfig()),
         emitter.emit(srcOp.getProgramConfig()),
-        emitter.emit(/*compute_kernel_config=*/std::nullopt),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -3638,7 +3640,7 @@ public:
         emitter.emit(srcOp.getScale()),
         emitter.emit(srcOp.getMemoryConfig()),
         emitter.emit(srcOp.getProgramConfig()),
-        emitter.emit(/*compute_kernel_config=*/std::nullopt),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -3691,7 +3693,7 @@ public:
         emitter.emit(/*slidingWindowSize=*/std::nullopt),
         emitter.emit(srcOp.getMemoryConfigAttr()),
         emitter.emit(/*program_config=*/std::nullopt),
-        emitter.emit(/*compute_kernel_config=*/std::nullopt),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -3739,6 +3741,8 @@ public:
         emitter.emit(srcOp.getScale()),
         emitter.emit(srcOp.getSlidingWindowSize()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
+        emitter.emit(/*program_config=*/std::nullopt),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -3784,6 +3788,8 @@ public:
         emitter.emit(srcOp.getIsCausal()),
         emitter.emit(srcOp.getScale()),
         emitter.emit(srcOp.getMemoryConfigAttr()),
+        emitter.emit(/*program_config=*/std::nullopt),
+        emitter.emit(srcOp.getComputeConfig()),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4500,7 +4500,7 @@ public:
         emitter.emit(srcOp.getSlidingWindowSize(), "sliding_window_size"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
         emitter.emit(std::nullopt, "program_config"),
-        emitter.emit(std::nullopt, "compute_kernel_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
         emitter.emit(srcOp.getAttentionSink(), "attention_sink"),
     };
 
@@ -4547,6 +4547,7 @@ public:
         emitter.emit(srcOp.getIsCausal(), "is_causal"),
         emitter.emit<float>(srcOp.getScaleAttr(), "scale"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -4598,6 +4599,8 @@ public:
         emitter.emit(srcOp.getScale(), "scale"),
         emitter.emit(std::nullopt, "sliding_window_size"),
         emitter.emit(srcOp.getMemoryConfigAttr(), "memory_config"),
+        emitter.emit(srcOp.getProgramConfig(), "program_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -4651,6 +4654,7 @@ public:
         emitter.emit(srcOp.getSlidingWindowSize(), "sliding_window_size"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
         emitter.emit(srcOp.getProgramConfig(), "program_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -4700,6 +4704,7 @@ public:
         emitter.emit(srcOp.getScale(), "scale"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
         emitter.emit(srcOp.getProgramConfig(), "program_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
@@ -4753,6 +4758,7 @@ public:
         emitter.emit(srcOp.getScale(), "scale"),
         emitter.emit(std::nullopt, "sliding_window_size"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
+        emitter.emit(srcOp.getComputeConfig(), "compute_kernel_config"),
     };
     // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.cpp
@@ -53,7 +53,8 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
             op.getOperation(), op.getLoc(), {qType}, op.getQuery(), op.getKey(),
             op.getValue(), op.getIsCausalAttr(), op.getAttentionMask(),
             op.getCurPosTensor(), op.getAttentionSink(), op.getScaleAttr(),
-            op.getSlidingWindowSizeAttr(), op.getProgramConfigAttr());
+            op.getSlidingWindowSizeAttr(), op.getProgramConfigAttr(),
+            op.getComputeConfigAttr());
 
     if (validationResult.isSuccess()) {
       return failure();
@@ -375,7 +376,8 @@ LogicalResult SDPADecodeDecompositionPattern::matchAndRewrite(
       loc, permutedQuery.getType(), permutedQuery, op.getKey(), op.getValue(),
       scaledMask,
       /*is_causal=*/rewriter.getBoolAttr(false), op.getScaleAttr(),
-      /*sliding_window_size=*/IntegerAttr(), attentionSink);
+      /*sliding_window_size=*/IntegerAttr(), attentionSink,
+      op.getComputeConfigAttr());
 
   // Permute result back from [B, H, 1, D] to [1, B, H, D].
   Value finalResult =

--- a/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.cpp
@@ -101,7 +101,7 @@ SDPADecompositionPattern::matchAndRewrite(ttnn::ScaledDotProductAttentionOp op,
             op.getOperation(), op.getLoc(), {qType}, op.getQuery(), op.getKey(),
             op.getValue(), op.getAttentionMask(), op.getIsCausalAttr(),
             op.getScaleAttr(), op.getSlidingWindowSizeAttr(),
-            op.getAttentionSink());
+            op.getAttentionSink(), op.getComputeConfigAttr());
 
     if (validationResult.isSuccess()) {
       // Op is valid — keep it as-is.

--- a/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -723,7 +723,8 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
             /*is_causal=*/rewriter.getBoolAttr(false), permutedMask,
             /*cur_pos_tensor=*/Value(), c.attentionSink, scaleAttr,
             /*sliding_window_size=*/IntegerAttr(),
-            /*program_config=*/SDPAProgramConfigAttr());
+            /*program_config=*/SDPAProgramConfigAttr(),
+            /*compute_config=*/DeviceComputeKernelConfigAttr());
 
     if (!validationResult.isSuccess()) {
       TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
@@ -738,7 +739,8 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         /*is_causal=*/rewriter.getBoolAttr(false), permutedMask,
         /*cur_pos_tensor=*/Value(), c.attentionSink, scaleAttr,
         /*sliding_window_size=*/IntegerAttr(),
-        /*program_config=*/SDPAProgramConfigAttr());
+        /*program_config=*/SDPAProgramConfigAttr(),
+        /*compute_config=*/DeviceComputeKernelConfigAttr());
 
     Value finalResult = ttir_to_ttnn::utils::generatePermute(
         decodeOp.getResult(),
@@ -754,7 +756,8 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         c.attentionMatmul.getOperation(), c.attentionMatmul.getLoc(),
         {c.query.getType()}, c.query, c.key, c.value, c.mask,
         /*is_causal=*/rewriter.getBoolAttr(false), scaleAttr,
-        /*sliding_window_size=*/IntegerAttr(), c.attentionSink);
+        /*sliding_window_size=*/IntegerAttr(), c.attentionSink,
+        /*compute_config=*/DeviceComputeKernelConfigAttr());
 
     if (!validationResult.isSuccess()) {
       TTMLIR_DEBUG(ttmlir::LogComponent::IsolatedIRValidationWrapper,
@@ -767,7 +770,8 @@ mlir::LogicalResult SDPAFusing::createSDPAOp(mlir::PatternRewriter &rewriter,
         c.attentionMatmul.getLoc(), c.query.getType(), c.query, c.key, c.value,
         c.mask,
         /*is_causal=*/rewriter.getBoolAttr(false), scaleAttr,
-        /*sliding_window_size=*/IntegerAttr(), c.attentionSink);
+        /*sliding_window_size=*/IntegerAttr(), c.attentionSink,
+        /*compute_config=*/DeviceComputeKernelConfigAttr());
 
     Value finalResult =
         squeezeToOriginalRank(sdpaOp.getResult(), originalOutputType, rewriter,

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -164,7 +164,8 @@ static void registerBuiltinComposites() {
             compositeOp.getOperation(), compositeOp.getLoc(), resultTypes,
             args.query, args.key, args.value, args.attentionMask,
             static_cast<uint32_t>(args.headDimV.getValue().getZExtValue()),
-            args.isCausal.getValue(), args.scale);
+            args.isCausal.getValue(), args.scale,
+            /*compute_config=*/nullptr);
       },
       // Build
       [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
@@ -174,7 +175,8 @@ static void registerBuiltinComposites() {
             compositeOp.getLoc(), compositeOp.getResultTypes(), args.query,
             args.key, args.value, args.attentionMask,
             static_cast<uint32_t>(args.headDimV.getValue().getZExtValue()),
-            args.isCausal.getValue(), args.scale);
+            args.isCausal.getValue(), args.scale,
+            /*compute_config=*/nullptr);
       }};
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern.cpp
@@ -71,7 +71,7 @@ LogicalResult PagedScaledDotProductAttentionDecodeProgramConfigRewritePattern::
       srcOp.getValue(), srcOp.getPageTable(), srcOp.getIsCausalAttr(),
       srcOp.getAttentionMask(), srcOp.getCurPosTensor(),
       srcOp.getAttentionSink(), srcOp.getScaleAttr(),
-      srcOp.getSlidingWindowSizeAttr(), desired);
+      srcOp.getSlidingWindowSizeAttr(), desired, srcOp.getComputeConfigAttr());
   return success();
 }
 

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeAttentionSinkRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeAttentionSinkRewritePattern.cpp
@@ -83,7 +83,8 @@ ScaledDotProductAttentionDecodeAttentionSinkRewritePattern::matchAndRewrite(
       srcOp, srcOp.getResult().getType(), srcOp.getQuery(), srcOp.getKey(),
       srcOp.getValue(), srcOp.getIsCausal(), srcOp.getAttentionMask(),
       srcOp.getCurPosTensor(), paddedSink, srcOp.getScaleAttr(),
-      srcOp.getSlidingWindowSizeAttr(), srcOp.getProgramConfigAttr());
+      srcOp.getSlidingWindowSizeAttr(), srcOp.getProgramConfigAttr(),
+      srcOp.getComputeConfigAttr());
 
   return success();
 }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern.cpp
@@ -60,7 +60,8 @@ ScaledDotProductAttentionDecodeBroadcastMaskRewritePattern::matchAndRewrite(
       srcOp, srcOp.getResult().getType(), srcOp.getQuery(), srcOp.getKey(),
       srcOp.getValue(), srcOp.getIsCausal(), broadcastedMask,
       srcOp.getCurPosTensor(), srcOp.getAttentionSink(), srcOp.getScaleAttr(),
-      srcOp.getSlidingWindowSizeAttr(), srcOp.getProgramConfigAttr());
+      srcOp.getSlidingWindowSizeAttr(), srcOp.getProgramConfigAttr(),
+      srcOp.getComputeConfigAttr());
 
   return success();
 }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadTileDimsRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/Decomposition/ScaledDotProductAttentionPadTileDimsRewritePattern.cpp
@@ -108,7 +108,8 @@ ScaledDotProductAttentionPadTileDimsRewritePattern::matchAndRewrite(
   auto sdpaOp = rewriter.create<ScaledDotProductAttentionOp>(
       srcOp.getLoc(), resultType, paddedQuery, paddedKey, paddedValue,
       srcOp.getAttentionMask(), srcOp.getIsCausal(), srcOp.getScaleAttr(),
-      srcOp.getSlidingWindowSizeAttr(), srcOp.getAttentionSink());
+      srcOp.getSlidingWindowSizeAttr(), srcOp.getAttentionSink(),
+      srcOp.getComputeConfigAttr());
 
   // Slice the result back to original head_dim
   Value result = sdpaOp.getResult();

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3336,10 +3336,12 @@ createOp(FlatbufferObjectCache &cache, ScaledDotProductAttentionDecodeOp op) {
   ::flatbuffers::Optional<uint32_t> slidingWindowSize =
       toFlatbuffer(cache, op.getSlidingWindowSize());
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateScaledDotProductAttentionDecodeOp(
       *cache.fbb, query, key, value, isCausal, attentionMask, curPosTensor,
       attentionSink, scale, slidingWindowSize, out, memoryConfig,
-      programConfig.value_or(0));
+      programConfig.value_or(0), computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<
@@ -3384,10 +3386,12 @@ createOp(FlatbufferObjectCache &cache,
   std::optional<::flatbuffers::Offset<::tt::target::ttnn::SDPAConfig>>
       programConfig = toFlatbuffer(cache, op.getProgramConfig());
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreatePagedScaledDotProductAttentionDecodeOp(
       *cache.fbb, query, key, value, pageTable, isCausal, attentionMask,
       curPosTensor, attentionSink, scale, slidingWindowSize, out, memoryConfig,
-      programConfig.value_or(0));
+      programConfig.value_or(0), computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ChunkedScaledDotProductAttentionOp>
@@ -3418,9 +3422,11 @@ createOp(FlatbufferObjectCache &cache, ChunkedScaledDotProductAttentionOp op) {
       programConfig = toFlatbuffer(cache, op.getProgramConfig());
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateChunkedScaledDotProductAttentionOp(
       *cache.fbb, query, key, value, pageTable, chunkStartIdx, scale, out,
-      memoryConfig, programConfig.value_or(0));
+      memoryConfig, programConfig.value_or(0), computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<
@@ -3465,9 +3471,12 @@ createOp(FlatbufferObjectCache &cache,
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
                                   /*local_shape*/ std::nullopt);
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreatePagedFlashMultiLatentAttentionDecodeOp(
       *cache.fbb, query, key, value, headDimV, pageTable, isCausal,
-      attentionMask, curPosTensor, attentionSink, scale, out, memoryConfig);
+      attentionMask, curPosTensor, attentionSink, scale, out, memoryConfig,
+      computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ScaledDotProductAttentionOp>
@@ -3505,10 +3514,13 @@ createOp(FlatbufferObjectCache &cache, ScaledDotProductAttentionOp op) {
                                  getOperandThroughDPSOps(op.getAttentionSink()))
                            : 0;
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   // NOLINTEND(clang-analyzer-cplusplus.NewDelete)
   return ::tt::target::ttnn::CreateScaledDotProductAttentionOp(
       *cache.fbb, query, key, value, isCausal, attentionMask, scale,
-      slidingWindowSize, attentionSink, out, memoryConfig);
+      slidingWindowSize, attentionSink, out, memoryConfig,
+      computeConfig.value_or(0));
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::FlashMlaPrefillOp>
@@ -3540,9 +3552,11 @@ createOp(FlatbufferObjectCache &cache, FlashMlaPrefillOp op) {
       cache.getOrCreateNoSharding(op.getResult(), tensorValueToFlatbuffer,
                                   /*local_shape*/ std::nullopt);
 
+  auto computeConfig = toFlatbuffer(cache, op.getComputeConfig());
+
   return ::tt::target::ttnn::CreateFlashMlaPrefillOp(
       *cache.fbb, query, key, value, attentionMask, headDimV, isCausal, scale,
-      out, memoryConfig);
+      out, memoryConfig, computeConfig.value_or(0));
 }
 
 std::vector<::flatbuffers::Offset<::tt::target::ttnn::KernelArg>>

--- a/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/chunked_scaled_dot_product_attention.cpp
@@ -39,12 +39,18 @@ static void runChunkedScaledDotProductAttentionOp(
     programConfig = utils::createSDPAProgramConfig(op->program_config());
   }
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out =
       ::ttnn::transformer::chunked_scaled_dot_product_attention(
           query, key, value, pageTable, chunkStartIdx, scale,
           outputMemoryConfig,
           /*program_config=*/programConfig,
-          /*compute_kernel_config=*/std::nullopt);
+          /*compute_kernel_config=*/computeConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/flash_mla_prefill.cpp
+++ b/runtime/lib/ttnn/operations/transformer/flash_mla_prefill.cpp
@@ -35,11 +35,17 @@ runFlashMlaPrefillOp(const ::tt::target::ttnn::FlashMlaPrefillOp *op,
   bool isCausal = op->is_causal();
   std::optional<float> scale = op->scale();
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out = ::ttnn::transformer::flash_mla_prefill(
       query, key, headDimV, value, attentionMask, isCausal, scale,
       outputMemoryConfig,
       /*program_config=*/std::nullopt,
-      /*compute_kernel_config=*/std::nullopt);
+      /*compute_kernel_config=*/computeConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/paged_flash_multi_latent_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_flash_multi_latent_attention_decode.cpp
@@ -4,6 +4,7 @@
 
 #include "operations/transformer/paged_flash_multi_latent_attention_decode.h"
 
+#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::transformer {
@@ -55,13 +56,19 @@ static void runPagedFlashMultiLatentAttentionDecodeOp(
   programConfig->compute_with_storage_grid_size =
       query.device()->compute_with_storage_grid_size();
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out =
       ::ttnn::transformer::paged_flash_multi_latent_attention_decode(
           query, key, value, headDimV, pageTable, isCausal, attentionMask,
           curPosTensor, attentionSink, scale, slidingWindowSize,
           outputMemoryConfig,
           /*program_config=*/programConfig,
-          /*compute_kernel_config=*/std::nullopt);
+          /*compute_kernel_config=*/computeConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/paged_scaled_dot_product_attention_decode.cpp
@@ -52,12 +52,18 @@ static void runPagedScaledDotProductAttentionDecodeOp(
     programConfig = utils::createSDPAProgramConfig(op->program_config());
   }
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out =
       ::ttnn::transformer::paged_scaled_dot_product_attention_decode(
           query, key, value, pageTable, isCausal, attentionMask, curPosTensor,
           attentionSink, scale, slidingWindowSize, outputMemoryConfig,
           /*program_config=*/programConfig,
-          /*compute_kernel_config=*/std::nullopt);
+          /*compute_kernel_config=*/computeConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention.cpp
@@ -38,11 +38,17 @@ static void runScaledDotProductAttentionOp(
                 tensorPool.getTTNNTensorAndValidate(op->attention_sink()))
           : std::nullopt;
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   ::ttnn::Tensor out = ::ttnn::transformer::scaled_dot_product_attention(
       query, key, value, attentionMask, isCausal, scale, slidingWindowSize,
       outputMemoryConfig,
       /*program_config=*/std::nullopt,
-      /*compute_kernel_config=*/std::nullopt, attentionSink);
+      /*compute_kernel_config=*/computeConfig, attentionSink);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
+++ b/runtime/lib/ttnn/operations/transformer/scaled_dot_product_attention_decode.cpp
@@ -50,6 +50,12 @@ static void runScaledDotProductAttentionDecodeOp(
     programConfig = utils::createSDPAProgramConfig(op->program_config());
   }
 
+  std::optional<::ttnn::DeviceComputeKernelConfig> computeConfig = std::nullopt;
+  if (op->compute_config()) {
+    computeConfig =
+        utils::createDeviceComputeKernelConfig(op->compute_config());
+  }
+
   // The current position information is required for this op. It can either be
   // passed as a tensor or as a uint vector. The uint vector is not wrapped in a
   // std::optional so we must pass an empty vector.
@@ -58,7 +64,7 @@ static void runScaledDotProductAttentionDecodeOp(
       query, key, value, isCausal, attentionMask, curPosEmpty, curPosTensor,
       attentionSink, scale, slidingWindowSize, outputMemoryConfig,
       programConfig,
-      /*compute_kernel_config=*/std::nullopt);
+      /*compute_kernel_config=*/computeConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/sdpa_preserve_existing.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/sdpa_preserve_existing.mlir
@@ -1,0 +1,32 @@
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=lofi fp32-dest-acc-en=true packer-l1-acc=false" %s | FileCheck %s
+// Tri-state handling on SDPA ops:
+//   - math_fidelity is already hifi4 on the op, so the lofi override must not win.
+//   - fp32_dest_acc_en is unset on the op, so the override (true) is applied.
+//   - packer_l1_acc is already true on the op, so the false override must not win.
+
+// CHECK-LABEL: func @test_sdpa_preserve_existing
+func.func @test_sdpa_preserve_existing(%query: tensor<1x8x64x64xbf16>, %key: tensor<1x8x64x64xbf16>, %value: tensor<1x8x64x64xbf16>) -> tensor<1x8x64x64xbf16> {
+  // CHECK: "ttnn.scaled_dot_product_attention"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, fp32_dest_acc_en = true, packer_l1_acc = true>
+  // CHECK-NOT: math_fidelity = lofi
+  %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
+    is_causal = true,
+    compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, packer_l1_acc = true>
+  }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>) -> tensor<1x8x64x64xbf16>
+  return %result : tensor<1x8x64x64xbf16>
+}
+
+// An explicit `false` from the pipeline is a real value, so it is applied to the
+// knobs the op leaves unset while math_fidelity stays at the op's hifi4.
+// CHECK-LABEL: func @test_sdpa_decode_merge_with_existing
+func.func @test_sdpa_decode_merge_with_existing(%query: tensor<1x32x8x128xbf16>, %key: tensor<32x8x256x128xbf16>, %value: tensor<32x8x256x128xbf16>, %cur_pos: tensor<32xi32>) -> tensor<1x32x8x128xbf16> {
+  // CHECK: "ttnn.scaled_dot_product_attention_decode"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, fp32_dest_acc_en = true, packer_l1_acc = false>
+  %result = "ttnn.scaled_dot_product_attention_decode"(%query, %key, %value, %cur_pos) <{
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 1, 0>,
+    is_causal = true,
+    compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4>
+  }> : (tensor<1x32x8x128xbf16>, tensor<32x8x256x128xbf16>, tensor<32x8x256x128xbf16>, tensor<32xi32>) -> tensor<1x32x8x128xbf16>
+  return %result : tensor<1x32x8x128xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/sdpa_set_compute_config.mlir
+++ b/test/ttmlir/Dialect/TTNN/set_compute_kernel_config/sdpa_set_compute_config.mlir
@@ -1,0 +1,68 @@
+// RUN: ttmlir-opt --ttnn-set-compute-kernel-config="math-fidelity=hifi2 fp32-dest-acc-en=true packer-l1-acc=true" %s | FileCheck %s
+// Test that the pass applies the global compute-kernel-config override to the
+// SDPA family of ops, all of which forward compute_config to ttnn.
+
+// CHECK-LABEL: func @test_sdpa
+func.func @test_sdpa(%query: tensor<1x8x64x64xbf16>, %key: tensor<1x8x64x64xbf16>, %value: tensor<1x8x64x64xbf16>) -> tensor<1x8x64x64xbf16> {
+  // CHECK: "ttnn.scaled_dot_product_attention"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.scaled_dot_product_attention"(%query, %key, %value) <{
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 0>,
+    is_causal = true
+  }> : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>) -> tensor<1x8x64x64xbf16>
+  return %result : tensor<1x8x64x64xbf16>
+}
+
+// CHECK-LABEL: func @test_sdpa_decode
+func.func @test_sdpa_decode(%query: tensor<1x32x8x128xbf16>, %key: tensor<32x8x256x128xbf16>, %value: tensor<32x8x256x128xbf16>, %cur_pos: tensor<32xi32>) -> tensor<1x32x8x128xbf16> {
+  // CHECK: "ttnn.scaled_dot_product_attention_decode"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.scaled_dot_product_attention_decode"(%query, %key, %value, %cur_pos) <{
+    operandSegmentSizes = array<i32: 1, 1, 1, 0, 1, 0>,
+    is_causal = true
+  }> : (tensor<1x32x8x128xbf16>, tensor<32x8x256x128xbf16>, tensor<32x8x256x128xbf16>, tensor<32xi32>) -> tensor<1x32x8x128xbf16>
+  return %result : tensor<1x32x8x128xbf16>
+}
+
+// CHECK-LABEL: func @test_paged_sdpa_decode
+func.func @test_paged_sdpa_decode(%query: tensor<1x32x8x128xbf16>, %key: tensor<64x8x32x128xbf16>, %value: tensor<64x8x32x128xbf16>, %page_table: tensor<32x2xi32>, %cur_pos: tensor<32xi32>) -> tensor<1x32x8x128xbf16> {
+  // CHECK: "ttnn.paged_scaled_dot_product_attention_decode"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.paged_scaled_dot_product_attention_decode"(%query, %key, %value, %page_table, %cur_pos) <{
+    operandSegmentSizes = array<i32: 1, 1, 1, 1, 0, 1, 0>,
+    is_causal = true
+  }> : (tensor<1x32x8x128xbf16>, tensor<64x8x32x128xbf16>, tensor<64x8x32x128xbf16>, tensor<32x2xi32>, tensor<32xi32>) -> tensor<1x32x8x128xbf16>
+  return %result : tensor<1x32x8x128xbf16>
+}
+
+// CHECK-LABEL: func @test_chunked_sdpa
+func.func @test_chunked_sdpa(%query: tensor<1x8x64x64xbf16>, %key: tensor<64x8x32x64xbf16>, %value: tensor<64x8x32x64xbf16>, %page_table: tensor<1x2xi32>, %chunk_start_idx: tensor<1xi32>) -> tensor<1x8x64x64xbf16> {
+  // CHECK: "ttnn.chunked_scaled_dot_product_attention"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.chunked_scaled_dot_product_attention"(%query, %key, %value, %page_table, %chunk_start_idx) : (tensor<1x8x64x64xbf16>, tensor<64x8x32x64xbf16>, tensor<64x8x32x64xbf16>, tensor<1x2xi32>, tensor<1xi32>) -> tensor<1x8x64x64xbf16>
+  return %result : tensor<1x8x64x64xbf16>
+}
+
+// CHECK-LABEL: func @test_flash_mla_prefill
+func.func @test_flash_mla_prefill(%query: tensor<1x8x64x192xbf16>, %key: tensor<1x1x64x192xbf16>) -> tensor<1x8x64x128xbf16> {
+  // CHECK: "ttnn.flash_mla_prefill"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.flash_mla_prefill"(%query, %key) <{
+    operandSegmentSizes = array<i32: 1, 1, 0, 0>,
+    head_dim_v = 128 : ui32,
+    is_causal = true
+  }> : (tensor<1x8x64x192xbf16>, tensor<1x1x64x192xbf16>) -> tensor<1x8x64x128xbf16>
+  return %result : tensor<1x8x64x128xbf16>
+}
+
+// CHECK-LABEL: func @test_paged_flash_mla_decode
+func.func @test_paged_flash_mla_decode(%query: tensor<1x32x8x192xbf16>, %key: tensor<64x1x32x192xbf16>, %page_table: tensor<32x2xi32>, %cur_pos: tensor<32xi32>) -> tensor<1x32x8x128xbf16> {
+  // CHECK: "ttnn.paged_flash_multi_latent_attention_decode"
+  // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi2, fp32_dest_acc_en = true, packer_l1_acc = true>
+  %result = "ttnn.paged_flash_multi_latent_attention_decode"(%query, %key, %page_table, %cur_pos) <{
+    operandSegmentSizes = array<i32: 1, 1, 0, 1, 0, 1, 0>,
+    head_dim_v = 128 : ui32,
+    is_causal = true
+  }> : (tensor<1x32x8x192xbf16>, tensor<64x1x32x192xbf16>, tensor<32x2xi32>, tensor<32xi32>) -> tensor<1x32x8x128xbf16>
+  return %result : tensor<1x32x8x128xbf16>
+}

--- a/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
+++ b/test/ttmlir/Dialect/TTNN/transformer/chunked_scaled_dot_product_attention.mlir
@@ -11,7 +11,9 @@ module attributes {} {
     // CHECK-DAG: %[[CHUNK_START:.*]] = "ttnn.to_layout"(%arg4){{.*}} -> tensor<1xsi32, #[[CHUNK_START_RM_LAYOUT]]>
     // CHECK: "ttnn.chunked_scaled_dot_product_attention"
     // CHECK-SAME: %[[PAGE_TABLE]], %[[CHUNK_START]]
-    // CHECK-SAME: <{scale = 1.250000e-01 : f32}>
+    // The pipeline's default compute-kernel-config is applied to the op.
+    // CHECK-SAME: compute_config = #ttnn.device_compute_kernel_config<math_fidelity = hifi4, fp32_dest_acc_en = true>
+    // CHECK-SAME: scale = 1.250000e-01 : f32
     %0 = ttir.empty() : tensor<1x12x64x64xf32>
     %1 = "ttir.chunked_scaled_dot_product_attention"(%arg0, %arg1, %arg2, %arg3, %arg4, %0) <{scale = 1.250000e-01 : f32}> : (tensor<1x12x64x64xf32>, tensor<128x12x32x64xf32>, tensor<128x12x32x64xf32>, tensor<1x4xi32>, tensor<1xi32>, tensor<1x12x64x64xf32>) -> tensor<1x12x64x64xf32>
     return %1 : tensor<1x12x64x64xf32>

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -2024,7 +2024,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionDecodeOpInterface) {
       /*attention_sink=*/nullptr,
       /*scale=*/nullptr,
       /*sliding_window_size=*/nullptr,
-      /*program_config=*/nullptr);
+      /*program_config=*/nullptr,
+      /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(
@@ -2108,7 +2109,8 @@ TEST_F(OpModelBase,
       /*attention_mask=*/attentionMask,
       /*cur_pos_tensor=*/curPos, /*attention_sink=*/nullptr,
       /*scale=*/nullptr, /*sliding_window_size=*/nullptr,
-      /*program_config=*/nullptr);
+      /*program_config=*/nullptr,
+      /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(
@@ -2200,7 +2202,8 @@ TEST_F(OpModelBase, DISABLED_PagedScaledDotProductAttentionDecodeOpInterface) {
           /*attention_sink=*/nullptr,
           /*scale=*/builder.getF32FloatAttr(0.125f),
           /*sliding_window_size=*/nullptr,
-          /*program_config=*/nullptr);
+          /*program_config=*/nullptr,
+          /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttentionDecode.getOperation());
   auto constraintsExp = backend.getOpConstraints(
@@ -2291,7 +2294,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterface) {
       /*is_causal=*/false,
       /*scale=*/nullptr,
       /*sliding_window_size=*/nullptr,
-      /*attention_sink=*/Value());
+      /*attention_sink=*/Value(),
+      /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttention.getOperation());
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
@@ -2371,7 +2375,8 @@ TEST_F(OpModelBase, ScaledDotProductAttentionOpInterfaceWithAttentionSink) {
       /*is_causal=*/false,
       /*scale=*/nullptr,
       /*sliding_window_size=*/nullptr,
-      /*attention_sink=*/attentionSink);
+      /*attention_sink=*/attentionSink,
+      /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(sdpAttention.getOperation());
   auto constraintsExp = backend.getOpConstraints(getInputLayouts(sdpAttention),
@@ -2457,7 +2462,8 @@ TEST_F(OpModelBase, ChunkedScaledDotProductAttentionOpInterface) {
       builder.getUnknownLoc(), outputType, query, key, value, pageTable,
       chunkStartIdx,
       /*scale=*/builder.getF32FloatAttr(0.125f),
-      /*program_config=*/nullptr);
+      /*program_config=*/nullptr,
+      /*compute_config=*/nullptr);
 
   OpModel backend = dyn_cast<OpModel>(chunkedSdpAttention.getOperation());
   auto constraintsExp = backend.getOpConstraints(
@@ -6790,7 +6796,8 @@ TEST_F(OpModelBase, PagedFlashMultiLatentAttentionDecodeOpInterface) {
       /*attention_mask=*/nullptr,
       /*cur_pos_tensor=*/curPos,
       /*attention_sink=*/nullptr,
-      /*scale=*/builder.getF32FloatAttr(headDim * 1.0f));
+      /*scale=*/builder.getF32FloatAttr(headDim * 1.0f),
+      /*compute_config=*/nullptr);
 
   mlaOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
@@ -6887,7 +6894,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterface) {
                                                  /*attention_mask=*/nullptr,
                                                  /*head_dim_v=*/s.headDimV,
                                                  /*is_causal=*/true,
-                                                 /*scale=*/nullptr);
+                                                 /*scale=*/nullptr,
+                                                 /*compute_config=*/nullptr);
 
   mlaOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
@@ -6947,7 +6955,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithValue) {
                                                  /*attention_mask=*/nullptr,
                                                  /*head_dim_v=*/s.headDimV,
                                                  /*is_causal=*/true,
-                                                 /*scale=*/nullptr);
+                                                 /*scale=*/nullptr,
+                                                 /*compute_config=*/nullptr);
 
   mlaOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 
@@ -7008,7 +7017,8 @@ TEST_F(OpModelBase, FlashMlaPrefillOpInterfaceWithMask) {
       /*attention_mask=*/attentionMask,
       /*head_dim_v=*/s.headDimV,
       /*is_causal=*/false,
-      /*scale=*/nullptr);
+      /*scale=*/nullptr,
+      /*compute_config=*/nullptr);
 
   mlaOp->setAttr(ttcore::DeviceAttr::name, getFakeDeviceAttr());
 

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -32,6 +32,17 @@ if (TTMLIR_ENABLE_OPMODEL)
     )
 endif()
 
+add_mlir_unittest(PipelineOptionsResolutionTests
+    TestPipelineOptionsResolution.cpp
+    PARTIAL_SOURCES_INTENDED
+)
+
+target_link_libraries(PipelineOptionsResolutionTests
+    PRIVATE
+    MLIRTTNNDialect
+    MLIRTTNNPipelines
+)
+
 add_mlir_unittest(L1SpillManagementTests
     TestL1SpillManagement.cpp
     PARTIAL_SOURCES_INTENDED

--- a/test/unittests/Optimizer/TestPipelineOptionsResolution.cpp
+++ b/test/unittests/Optimizer/TestPipelineOptionsResolution.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
+
+#include "llvm/Support/CommandLine.h"
+
+#include "gtest/gtest.h"
+
+#include <optional>
+
+using namespace mlir::tt::ttnn;
+
+// resolveOptimizationLevelOptions() must distinguish "the caller explicitly
+// asked for this value" from "nobody touched it, it is still the cl::init
+// default". Frontends such as tt-xla assign the options programmatically
+// (options.computeCfgMathFidelity = ...), which does NOT bump
+// cl::Option::NumOccurrences -- only command-line parsing does. Detecting
+// explicit settings via getNumOccurrences() therefore silently discarded every
+// programmatically supplied value; hasValue() covers both paths.
+//
+// These tests exercise the programmatic path specifically, since the lit tests
+// only ever reach the options through the command line.
+namespace {
+
+// EXPECT_EQ on the Option wrapper itself compares the wrapper, not the value;
+// pull the value out explicitly.
+OptionalMathFidelity mf(const TTIRToTTNNCommonPipelineOptions &o) {
+  return o.computeCfgMathFidelity.getValue();
+}
+std::optional<bool> fp32(const TTIRToTTNNCommonPipelineOptions &o) {
+  return o.computeCfgFp32DestAccEn.getValue();
+}
+
+class PipelineOptionsResolutionTest : public ::testing::Test {
+protected:
+  TTIRToTTNNCommonPipelineOptions options;
+};
+
+// Nothing set: the cl::init defaults (HiFi4 / true) survive at optimization
+// level 0, so ops exposing a compute kernel config get the accuracy-oriented
+// defaults.
+TEST_F(PipelineOptionsResolutionTest, DefaultsSurviveAtOptLevelZero) {
+  options.optimizationLevel = 0;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_EQ(mf(options), OptionalMathFidelity::HiFi4);
+  EXPECT_EQ(fp32(options), std::optional<bool>(true));
+}
+
+// Nothing set: at optimization level > 0 the defaults are cleared so TTNN picks
+// per-op defaults. This is the pre-existing behaviour and must not regress.
+TEST_F(PipelineOptionsResolutionTest, DefaultsClearedAboveOptLevelZero) {
+  options.optimizationLevel = 1;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_EQ(mf(options), OptionalMathFidelity::Undefined);
+  EXPECT_EQ(fp32(options), std::optional<bool>(std::nullopt));
+}
+
+// The regression this fixes: a programmatically assigned value must survive at
+// optimization level > 0.
+TEST_F(PipelineOptionsResolutionTest, ProgrammaticComputeCfgSurvivesOptLevel) {
+  options.optimizationLevel = 1;
+  options.computeCfgMathFidelity = OptionalMathFidelity::HiFi4;
+  options.computeCfgFp32DestAccEn = std::optional<bool>(true);
+
+  // Precondition: assignment must not look like a command-line occurrence,
+  // otherwise this test would pass for the wrong reason.
+  ASSERT_EQ(options.computeCfgMathFidelity.getNumOccurrences(), 0u);
+  ASSERT_EQ(options.computeCfgFp32DestAccEn.getNumOccurrences(), 0u);
+
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_EQ(mf(options), OptionalMathFidelity::HiFi4);
+  EXPECT_EQ(fp32(options), std::optional<bool>(true));
+}
+
+// A frontend must be able to force a knob OFF, distinct from leaving it unset.
+TEST_F(PipelineOptionsResolutionTest, ProgrammaticFalseIsNotTreatedAsUnset) {
+  options.optimizationLevel = 2;
+  options.computeCfgFp32DestAccEn = std::optional<bool>(false);
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_EQ(fp32(options), std::optional<bool>(false));
+}
+
+// "ttnn_default" maps onto Undefined, which is still an explicit request to not
+// override; it must survive rather than be re-derived from the opt level.
+TEST_F(PipelineOptionsResolutionTest, ProgrammaticUndefinedSurvives) {
+  options.optimizationLevel = 1;
+  options.computeCfgMathFidelity = OptionalMathFidelity::Undefined;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_EQ(mf(options), OptionalMathFidelity::Undefined);
+}
+
+// The same predicate guards the non-compute-config options. tt-xla also sets
+// enableFusingConv2dWithMultiplyPattern, and that one had no
+// `optimizationLevel > 0` guard at all, so it was overridden at every level.
+TEST_F(PipelineOptionsResolutionTest, ProgrammaticFusingFlagSurvives) {
+  options.optimizationLevel = 1;
+  options.enableFusingConv2dWithMultiplyPattern = false;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_FALSE(options.enableFusingConv2dWithMultiplyPattern);
+}
+
+// ... while an untouched flag is still derived from the optimization level.
+TEST_F(PipelineOptionsResolutionTest, UntouchedFlagsFollowOptLevel) {
+  options.optimizationLevel = 2;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_TRUE(options.optimizerPassEnabled);
+  EXPECT_TRUE(options.enableFusingConv2dWithMultiplyPattern);
+  EXPECT_TRUE(options.memoryLayoutAnalysisEnabled);
+}
+
+TEST_F(PipelineOptionsResolutionTest,
+       ProgrammaticOptimizerPassEnabledSurvives) {
+  options.optimizationLevel = 2;
+  options.optimizerPassEnabled = false;
+  options.resolveOptimizationLevelOptions();
+
+  EXPECT_FALSE(options.optimizerPassEnabled);
+}
+
+} // namespace


### PR DESCRIPTION
### Ticket
Context: tenstorrent/tt-inference-server#4752

### Problem description
The SDPA ops take a `DeviceComputeKernelConfig` on the tt-metal side, but the TTNN dialect had no way to express it: the runtime always passed `std::nullopt` and `TTNNSetComputeKernelConfig` skipped these ops entirely.

Separately, `resolveOptimizationLevelOptions()` used `getNumOccurrences() == 0` to detect "the caller explicitly set this option". That is only bumped by command-line parsing, so options a frontend assigns programmatically (tt-xla's `math_fidelity` / `fp32_dest_acc_en`) looked unset and were discarded at `optimization_level > 0`.

Together: fidelity overrides never reached SDPA. On the Falcon3-7B decode graph, 0 of 28 SDPA ops carried a compute config.

### What's changed
- Add optional `compute_config` + `TTNN_ComputeKernelConfigOpInterface` to the six SDPA ops (`scaled_dot_product_attention`, `..._decode`, `paged_..._decode`, `chunked_...`, `flash_mla_prefill`, `paged_flash_multi_latent_attention_decode`), plumbed through flatbuffer schema/serialization, runtime, EmitC and EmitPy. Rewrite patterns that recreate an SDPA op now forward the attribute instead of dropping it. EmitC additionally needed `program_config` emitted for three of the ops, since the C++ arguments are positional.
- Replace `getNumOccurrences() == 0` with `!hasValue()` in `resolveOptimizationLevelOptions()` and `resolveCreateD2MSubgraphsOptions()`. MLIR's `Option` ctor installs a callback that `cl::opt::operator=` fires and `cl::init()` does not, so `hasValue()` covers the command-line and programmatic paths alike. No tt-xla change needed.

Behaviour is unchanged when no knob is set. Two side effects worth review: an explicit `fp32_dest_acc_en=false` now actually reaches the passes at `optimization_level > 0` (tt-xla #5116 hazard, previously latent), and `enableFusingConv2dWithMultiplyPattern` — which has no optimization-level guard — is no longer overridden at every level.

### Checklist
- [x] New/Existing tests provide coverage for changes