### PR TITLE
[Optimizer] Enable block/height-sharded outputs for non-view reshape (#8020)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -19,6 +19,7 @@ namespace mlir::tt::ttnn {
 //     https://github.com/tenstorrent/tt-metal/issues/39074
 //   ReshapeOp, PermuteOp: reject width-sharded inputs
 //     (round-trip through interleaved internally in tt-metal)
+//     Each has its own rule book; they share only this input restriction.
 //
 // Output hints:
 //   All: non-sharded only
@@ -94,10 +95,22 @@ bool canPermuteBeView(Operation *op);
 /// the op onto its source's L1 slot instead of tracking a fresh allocation.
 bool isAliasingViewOp(Operation *op);
 
-/// ReshapeOp, PermuteOp: reject width-sharded inputs, no reshards.
+/// ReshapeOp: reject width-sharded inputs, no reshards.
 /// View-eligible reshapes use NULL hint only (inherit input memory config).
 /// Non-view reshapes use non-sharded output hints.
 struct ReshapeRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
+/// PermuteOp: reject width-sharded inputs, non-sharded output only, no
+/// reshards. Split off `ReshapeRuleBook` (#7988) so reshape-specific rule
+/// changes cannot leak into permute; the rules here are permute's long-standing
+/// behavior, since `canReshapeBeView` never held for a PermuteOp.
+struct PermuteRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
   bool shouldExploreReshards() const override;
   OutputHints

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -8,6 +8,10 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -56,6 +60,55 @@ inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   return !(ml && ml.getValue() == TensorMemoryLayout::WidthSharded);
 }
 
+/// Geometry of a sharded layout's core grid: the number of cores it actually
+/// uses and the extent of its bounding box (X = columns, Y = rows, matching
+/// tt-metal's CoreCoord convention).
+struct ShardGridGeometry {
+  int64_t numCores = 0;
+  int64_t bboxWidth = 0;
+  int64_t bboxHeight = 0;
+
+  /// tt-metal only accepts a grid whose cores fill its bounding box; anything
+  /// else makes `bounding_box()` silently include cores the tensor does not
+  /// occupy.
+  bool isRectangular() const {
+    return numCores > 0 && numCores == bboxWidth * bboxHeight;
+  }
+};
+
+/// Core-grid geometry of a sharded layout. All-zero for an empty core range
+/// set (which is not a usable grid).
+inline ShardGridGeometry getShardGridGeometry(TTNNLayoutAttr layout) {
+  ttnn::CoreRangeSetAttr ranges = layout.getCoreRangeSet();
+  assert(ranges && "sharded layout must have a valid core range set");
+
+  if (ranges.getCoreRanges().empty()) {
+    return ShardGridGeometry{};
+  }
+
+  int64_t minX = std::numeric_limits<int64_t>::max();
+  int64_t minY = std::numeric_limits<int64_t>::max();
+  int64_t maxX = std::numeric_limits<int64_t>::min();
+  int64_t maxY = std::numeric_limits<int64_t>::min();
+  int64_t numCores = 0;
+  for (const auto &coreRange : ranges.getCoreRanges()) {
+    auto start = coreRange.getStartCoord();
+    auto end = coreRange.getEndCoord();
+
+    int64_t sizeX = static_cast<int64_t>(end.getX() - start.getX() + 1);
+    int64_t sizeY = static_cast<int64_t>(end.getY() - start.getY() + 1);
+
+    numCores += sizeX * sizeY;
+
+    minX = std::min(minX, static_cast<int64_t>(start.getX()));
+    minY = std::min(minY, static_cast<int64_t>(start.getY()));
+    maxX = std::max(maxX, static_cast<int64_t>(end.getX()));
+    maxY = std::max(maxY, static_cast<int64_t>(end.getY()));
+  }
+
+  return ShardGridGeometry{numCores, maxX - minX + 1, maxY - minY + 1};
+}
+
 /// Whether a sharded layout's core grid forms a full rectangular bounding
 /// box (num_cores == bbox_num_cores). Interleaved layouts return true.
 inline bool isFullBboxSharded(TTNNLayoutAttr layout) {
@@ -64,35 +117,237 @@ inline bool isFullBboxSharded(TTNNLayoutAttr layout) {
     return true;
   }
 
-  ttnn::CoreRangeSetAttr ranges = layout.getCoreRangeSet();
-  assert(ranges && "sharded layout must have a valid core range set");
+  return getShardGridGeometry(layout).isRectangular();
+}
 
-  if (ranges.getCoreRanges().empty()) {
+//===----------------------------------------------------------------------===//
+// Reshape output-layout divergence guard
+//
+// `ttnn::reshape` does not always return the memory config it is handed: four
+// host-side negotiations in
+// `ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp` can
+// substitute a different one. When that happens the IR's declared output
+// layout is a lie -- the consumer is dispatched against a layout the tensor
+// does not have -- and the measured outcomes range from a silently wrong
+// consumer result to a device hang (5 of 11 divergent configs in an on-device
+// sweep hung, each needing `tt-smi -r`). None of them is caught at compile
+// time: the device op validates only storage/dtype, and the runtime's
+// expected-vs-actual memory-config check is DEBUG_ASSERT-only.
+//
+// The predicate below rejects any sharded reshape-output candidate that
+// tt-metal would not return verbatim. It was validated on device against the
+// measured "config honored" bit over 97 reshape configs (40 synthetic boundary
+// cases + 57 real ones extracted from a compiled vision model) with 0
+// mispredictions. See https://github.com/tenstorrent/tt-mlir/issues/8020.
+//
+// It also rejects one class tt-metal *does* return verbatim but whose consumer
+// then miscomputes: a sharded output whose logical inner 2-D extent is not
+// tile-aligned, so its shards are part implicit padding (rule P below).
+//===----------------------------------------------------------------------===//
+
+/// Shape-side of tt-metal's `this_is_view` fast path (reshape.cpp:611-619):
+/// the last dim is unchanged, and for a tiled input the second-to-last dim is
+/// either unchanged or tile-aligned on both sides (no padding change).
+inline bool reshapeShapesAllowView(llvm::ArrayRef<int64_t> inShape,
+                                   llvm::ArrayRef<int64_t> outShape,
+                                   bool inputIsTiled) {
+  if (inShape.empty() || outShape.empty()) {
     return false;
   }
 
-  int32_t minX = std::numeric_limits<int32_t>::max();
-  int32_t minY = std::numeric_limits<int32_t>::max();
-  int32_t maxX = std::numeric_limits<int32_t>::min();
-  int32_t maxY = std::numeric_limits<int32_t>::min();
-  int64_t numCores = 0;
-  for (const auto &coreRange : ranges.getCoreRanges()) {
-    auto start = coreRange.getStartCoord();
-    auto end = coreRange.getEndCoord();
-
-    int32_t sizeX = end.getX() - start.getX() + 1;
-    int32_t sizeY = end.getY() - start.getY() + 1;
-
-    numCores += static_cast<int64_t>(sizeX) * static_cast<int64_t>(sizeY);
-
-    minX = std::min(minX, static_cast<int32_t>(start.getX()));
-    minY = std::min(minY, static_cast<int32_t>(start.getY()));
-    maxX = std::max(maxX, static_cast<int32_t>(end.getX()));
-    maxY = std::max(maxY, static_cast<int32_t>(end.getY()));
+  // Condition 1: last dimension must be unchanged.
+  if (inShape.back() != outShape.back()) {
+    return false;
   }
-  int64_t bboxCores = static_cast<int64_t>(maxX - minX + 1) *
-                      static_cast<int64_t>(maxY - minY + 1);
-  return numCores == bboxCores;
+
+  // Condition 2: for tiled layout, second-to-last dim must be unchanged or
+  // both second-to-last dims must be tile-aligned (no padding change).
+  if (inputIsTiled) {
+    int64_t inSecondLast =
+        inShape.size() >= 2 ? inShape[inShape.size() - 2] : 1;
+    int64_t outSecondLast =
+        outShape.size() >= 2 ? outShape[outShape.size() - 2] : 1;
+    if (inSecondLast != outSecondLast && !(outSecondLast % TILE_HEIGHT == 0 &&
+                                           inSecondLast % TILE_HEIGHT == 0)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/// Whether two layouts describe the same tt-metal memory config: same buffer
+/// type, same memory layout, same core placement and same per-core shard shape
+/// (in scalar elements). Deliberately shape-agnostic -- the layouts being
+/// compared belong to tensors of different logical shapes, so attribute
+/// equality would never hold.
+inline bool sameMemoryConfig(TTNNLayoutAttr lhs, TTNNLayoutAttr rhs) {
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs.getBufferType() != rhs.getBufferType() ||
+      lhs.getMemLayout() != rhs.getMemLayout()) {
+    return false;
+  }
+  if (lhs.getCoreRangeSet() != rhs.getCoreRangeSet()) {
+    return false;
+  }
+  return lhs.getScalarShardShape() == rhs.getScalarShardShape();
+}
+
+/// Whether `ttnn::reshape` returns `candidate` verbatim as the output memory
+/// config, i.e. whether the compiler may declare it. Interleaved candidates
+/// are always honored. For a sharded candidate all four substitution rules
+/// must be cleared:
+///
+///   V  the `this_is_view` fast path (reshape.cpp:613-624) discards the
+///      requested config entirely -- `PerformView` takes no memory-config
+///      argument -- and returns the *input's* spec. Note that `this_is_view`
+///      compares only the `is_sharded()` / `is_l1()` booleans, never the
+///      sharding kind, grid or shard shape, so it fires on layout changes it
+///      then drops.
+///   N  a non-rectangular shard grid falls back to INTERLEAVED
+///      (reshape.cpp:121-130).
+///   H/W for HEIGHT/WIDTH_SHARDED the caller's shard *shape* is always
+///      re-derived as `round32(div_up(phys_dim, num_cores))` over the
+///      preserved grid (reshape.cpp:177-211, tensor_spec.cpp:179-197); the
+///      explicit-config passthrough at reshape.cpp:140 is gated on
+///      BLOCK_SHARDED and so cannot preserve it.
+///   B  a BLOCK_SHARDED spec is passed through only when it is tile-aligned
+///      *and* its grid covers the output's physical extent
+///      (reshape.cpp:137-152, `covers_output` uses `>=`, so over-provisioned
+///      grids are honored); otherwise a smaller derived grid replaces it.
+///
+/// and two further classes are rejected outright:
+///
+///   P  an output whose *logical* inner 2-D extent is not tile-aligned, i.e.
+///      whose shards are part padding (see below), and
+///   R  the row-major reshape path, on either side, because it never honors an
+///      explicit output config at all (reshape.cpp:244).
+///
+/// `inShape` / `outShape` are the reshape's logical input and output shapes and
+/// `inputLayout` the layout of its operand.
+inline bool reshapeOutputSpecIsHonored(TTNNLayoutAttr candidate,
+                                       TTNNLayoutAttr inputLayout,
+                                       llvm::ArrayRef<int64_t> inShape,
+                                       llvm::ArrayRef<int64_t> outShape) {
+  // A NULL hint means "backend picks", and an interleaved output config is
+  // never renegotiated.
+  if (!candidate) {
+    return true;
+  }
+  TensorMemoryLayoutAttr memLayout = candidate.getMemLayout();
+  if (!memLayout || !isShardedMemoryLayout(memLayout.getValue())) {
+    return true;
+  }
+  if (!inputLayout) {
+    return false;
+  }
+
+  // Rule V: when tt-metal takes the view path the declared config is dropped
+  // and the input's spec is returned, so the two must already agree.
+  // `this_is_view` requires matching is_sharded()/is_l1() as well; a sharded
+  // candidate can only reach it from a sharded input.
+  const bool inputIsSharded = inputLayout.hasShardedTensorMemoryLayout();
+  const bool sameMemorySpace = isL1BufferType(candidate.getBufferType()) ==
+                               isL1BufferType(inputLayout.getBufferType());
+  if (inputIsSharded && sameMemorySpace &&
+      reshapeShapesAllowView(inShape, outShape, inputLayout.isTiled()) &&
+      !sameMemoryConfig(candidate, inputLayout)) {
+    return false;
+  }
+
+  // Rule P: a sharded output whose *logical* inner 2-D extent is not a
+  // multiple of the tile shape only part-fills its tiles -- the remaining
+  // rows/columns are implicit padding, and the runtime calls `ttnn::reshape`
+  // with no `pad_value`, so tt-metal's tile-padding fill never runs over them.
+  // An interleaved consumer tolerates that; a consumer re-dispatched over such
+  // shards does not. Measured on segformer: enabling sharded reshape outputs
+  // (#8020) moved the decode head's 16x16 branch -- reshapes carrying 16 real
+  // rows of every 32 -- onto block-sharded L1, and the `ttnn.linear` reading
+  // them returned a materially different result from a bitwise-identical
+  // input, taking the model from PCC 0.9967 to 0.4851 end to end.
+  //
+  // This is a property of the *logical* shape, not of the memory layout: all
+  // of those outputs are `TILE`-layout and tile-aligned in their shard shapes,
+  // so the tile-alignment tests further down cannot see them.
+  const int64_t logicalWidth = outShape.empty() ? 1 : outShape.back();
+  const int64_t logicalHeight =
+      outShape.size() >= 2 ? outShape[outShape.size() - 2] : 1;
+  if (logicalHeight % TILE_HEIGHT != 0 || logicalWidth % TILE_WIDTH != 0) {
+    return false;
+  }
+
+  // Rule N: a non-rectangular grid is downgraded to INTERLEAVED.
+  ShardGridGeometry grid = getShardGridGeometry(candidate);
+  if (!grid.isRectangular()) {
+    return false;
+  }
+
+  // Rules H/W/B compare the declared per-core shard shape against what
+  // tt-metal derives, in tiles. Row-major sharded outputs are rejected
+  // outright: their shard shape is re-derived through a different
+  // (alignment-dependent) path that this predicate does not model, and the
+  // explicit-config passthrough is unavailable on the row-major reshape path
+  // (reshape.cpp:244 passes explicit_memory_config=false).
+  //
+  // The *input's* tile-ness is what decides this, not only the candidate's:
+  // `ttnn::reshape` neither tilizes nor untilizes, so the output is row-major
+  // exactly when the input is (tt-mlir relies on the same invariant in
+  // `TTNNLayout.cpp`'s `shouldTilizeResult`). A tiled candidate on a row-major
+  // input therefore describes an output that cannot exist -- the op model
+  // reports the row-major layout tt-metal will really produce and
+  // `TTNNOperationValidationAndFallback` rewrites the result type to it,
+  // carrying the sharded memory config over onto the row-major path. Testing
+  // the candidate alone lets that pair through; measured on the n150 LLM
+  // decode/prefill layer tests it is what declares a BLOCK_SHARDED L1 spec
+  // (e.g. shard [1, 32] on one core) that the device then rebuilds through its
+  // ND-shard path, tripping the runtime's expected-vs-actual memory-config
+  // check.
+  if (!inputLayout.isTiled() || !candidate.isTiled()) {
+    return false;
+  }
+  llvm::SmallVector<int64_t> outTiles = candidate.getTiledShape(outShape);
+  llvm::SmallVector<int64_t> shardTiles = candidate.getShardShape();
+  assert(outTiles.size() >= 2 && shardTiles.size() >= 2);
+  const int64_t tilesH = outTiles[outTiles.size() - 2];
+  const int64_t tilesW = outTiles[outTiles.size() - 1];
+  const int64_t shardH = shardTiles[shardTiles.size() - 2];
+  const int64_t shardW = shardTiles[shardTiles.size() - 1];
+
+  switch (memLayout.getValue()) {
+  case TensorMemoryLayout::HeightSharded:
+    // round32(div_up(phys_h, ncores)) / 32 == div_up(tiles_h, ncores), and the
+    // shard keeps the full physical width.
+    return shardH ==
+               static_cast<int64_t>(llvm::divideCeil(tilesH, grid.numCores)) &&
+           shardW == tilesW;
+  case TensorMemoryLayout::WidthSharded:
+    return shardW ==
+               static_cast<int64_t>(llvm::divideCeil(tilesW, grid.numCores)) &&
+           shardH == tilesH;
+  case TensorMemoryLayout::BlockSharded:
+    // Tile alignment holds by construction for a tiled shard shape; only the
+    // covers_output test can fail. tt-mlir layouts are always ROW_MAJOR
+    // oriented, so rows map to Y and columns to X.
+    return grid.bboxHeight * shardH >= tilesH &&
+           grid.bboxWidth * shardW >= tilesW;
+  default:
+    return false;
+  }
+}
+
+/// Filter rejecting sharded reshape-output candidates that `ttnn::reshape`
+/// would not return verbatim. See `reshapeOutputSpecIsHonored`.
+inline LayoutFilterFn
+reshapeOutputSpecIsHonoredFilter(TTNNLayoutAttr inputLayout,
+                                 llvm::ArrayRef<int64_t> inShape,
+                                 llvm::ArrayRef<int64_t> outShape) {
+  llvm::SmallVector<int64_t> in(inShape);
+  llvm::SmallVector<int64_t> out(outShape);
+  return [inputLayout, in, out](TTNNLayoutAttr candidate) -> bool {
+    return reshapeOutputSpecIsHonored(candidate, inputLayout, in, out);
+  };
 }
 
 /// Allow only a specific sharding type (plus interleaved). Returns a filter

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -214,9 +214,9 @@ SliceRuleBook::getOutputHints(Operation * /*op*/,
 /// Check if a reshape can be optimized to a view (no kernel launch) by
 /// tt-metal. Mirrors the `this_is_view` condition in tt-metal's
 /// reshape.cpp:378-384. Only applies to ReshapeOp — PermuteOp has its own
-/// NOP optimization (is_permute_nop) with different conditions.
-/// TODO(#7988): Split PermuteOp into its own PermuteRuleBook to avoid this
-/// op-kind check.
+/// NOP optimization (`canPermuteBeView`, below) with different conditions.
+/// Like the other view predicates, this self-guards on its op kind so that
+/// `isAliasingViewOp` can dispatch it over any operation.
 bool canReshapeBeView(Operation *op) {
   if (!mlir::isa<ReshapeOp>(op)) {
     return false;
@@ -425,8 +425,8 @@ bool isAliasingViewOp(Operation *op) {
 
 LayoutFilterFn
 ReshapeRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
-  // Reshape/Permute: width-sharded inputs round-trip through interleaved
-  // internally in tt-metal; height/block sharding is handled natively.
+  // Reshape: width-sharded inputs round-trip through interleaved internally in
+  // tt-metal; height/block sharding is handled natively.
   // https://github.com/tenstorrent/tt-mlir/issues/7681
   return layout_filter_utils::rejectWidthSharded;
 }
@@ -445,6 +445,31 @@ OutputHints ReshapeRuleBook::getOutputHints(
     return layout_filter_utils::nullHintOnly();
   }
   // Non-view reshape: sharded output not beneficial, use non-sharded configs.
+  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+}
+
+//===----------------------------------------------------------------------===//
+// PermuteRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+PermuteRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  // Permute: width-sharded inputs round-trip through interleaved internally in
+  // tt-metal; height/block sharding is handled natively.
+  // https://github.com/tenstorrent/tt-mlir/issues/7681
+  return layout_filter_utils::rejectWidthSharded;
+}
+
+bool PermuteRuleBook::shouldExploreReshards() const { return false; }
+
+OutputHints PermuteRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
+  // Sharded output not beneficial for permute: use non-sharded configs.
+  // TODO(rpavlovicTT): `canPermuteBeView` already models tt-metal's
+  // permute-nop, but is only consumed by `isAliasingViewOp` today. A view
+  // branch returning `nullHintOnly()` here (mirroring reshape) would keep the
+  // zero-copy path off the optimizer's DRAM->L1 upgrades; that is a behavior
+  // change and is deliberately left out of the #7988 split.
   return layout_filter_utils::nonShardedOutputHints(legalConfigs);
 }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -212,11 +212,13 @@ SliceRuleBook::getOutputHints(Operation * /*op*/,
 //===----------------------------------------------------------------------===//
 
 /// Check if a reshape can be optimized to a view (no kernel launch) by
-/// tt-metal. Mirrors the `this_is_view` condition in tt-metal's
-/// reshape.cpp:378-384. Only applies to ReshapeOp — PermuteOp has its own
-/// NOP optimization (`canPermuteBeView`, below) with different conditions.
-/// Like the other view predicates, this self-guards on its op kind so that
-/// `isAliasingViewOp` can dispatch it over any operation.
+/// tt-metal. Mirrors the shape side of the `this_is_view` condition in
+/// tt-metal's reshape.cpp:611-619 (the memory-config side of that condition is
+/// checked by `reshapeOutputSpecIsHonored`, which shares the same helper).
+/// Only applies to ReshapeOp — PermuteOp has its own NOP optimization
+/// (`canPermuteBeView`, below) with different conditions. Like the other view
+/// predicates, this self-guards on its op kind so that `isAliasingViewOp` can
+/// dispatch it over any operation.
 bool canReshapeBeView(Operation *op) {
   if (!mlir::isa<ReshapeOp>(op)) {
     return false;
@@ -229,33 +231,10 @@ bool canReshapeBeView(Operation *op) {
     return false;
   }
 
-  auto inputShape = inputType.getShape();
-  auto outputShape = outputType.getShape();
-  if (inputShape.empty() || outputShape.empty()) {
-    return false;
-  }
-
-  // Condition 1: last dimension must be unchanged.
-  if (inputShape.back() != outputShape.back()) {
-    return false;
-  }
-
-  // Condition 2: for tiled layout, second-to-last dim must be unchanged or
-  // both second-to-last dims must be tile-aligned (no padding change).
   auto ttnnLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
-  if (ttnnLayout && ttnnLayout.isTiled()) {
-    int64_t inputSecondLast =
-        inputShape.size() >= 2 ? inputShape[inputShape.size() - 2] : 1;
-    int64_t outputSecondLast =
-        outputShape.size() >= 2 ? outputShape[outputShape.size() - 2] : 1;
-    if (inputSecondLast != outputSecondLast &&
-        !(outputSecondLast % TILE_HEIGHT == 0 &&
-          inputSecondLast % TILE_HEIGHT == 0)) {
-      return false;
-    }
-  }
-
-  return true;
+  return layout_filter_utils::reshapeShapesAllowView(
+      inputType.getShape(), outputType.getShape(),
+      ttnnLayout && ttnnLayout.isTiled());
 }
 
 //===----------------------------------------------------------------------===//
@@ -444,8 +423,29 @@ OutputHints ReshapeRuleBook::getOutputHints(
     // upgrading DRAM→L1 and breaking the zero-cost view path.
     return layout_filter_utils::nullHintOnly();
   }
+  // Divergence guard: drop any sharded candidate that ttnn::reshape would not
+  // return verbatim (it silently substitutes a different memory config in four
+  // cases, and the consumer then runs against a layout the tensor does not
+  // have -- up to and including a device hang). Composed in ahead of the
+  // sharding policy below so that it stays load-bearing if that policy is ever
+  // relaxed to admit sharded reshape outputs (issue #8020); today every
+  // in-tree config already satisfies it.
+  // https://github.com/tenstorrent/tt-mlir/issues/8020
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  std::vector<OpConfig> honoredConfigs = legalConfigs;
+  if (inputType && outputType) {
+    honoredConfigs = layout_filter_utils::filterConfigs(
+        legalConfigs,
+        layout_filter_utils::reshapeOutputSpecIsHonoredFilter(
+            mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding()),
+            inputType.getShape(), outputType.getShape()));
+  }
+
   // Non-view reshape: sharded output not beneficial, use non-sharded configs.
-  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+  return layout_filter_utils::nonShardedOutputHints(honoredConfigs);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -426,10 +426,11 @@ OutputHints ReshapeRuleBook::getOutputHints(
   // Divergence guard: drop any sharded candidate that ttnn::reshape would not
   // return verbatim (it silently substitutes a different memory config in four
   // cases, and the consumer then runs against a layout the tensor does not
-  // have -- up to and including a device hang). Composed in ahead of the
-  // sharding policy below so that it stays load-bearing if that policy is ever
-  // relaxed to admit sharded reshape outputs (issue #8020); today every
-  // in-tree config already satisfies it.
+  // have -- up to and including a device hang). It is what makes the sharded
+  // policy below safe: with sharded outputs admitted, the guard is now
+  // load-bearing rather than latent. Measured on the n150 LLM decode/prefill
+  // layer tests, it is what keeps `ttnn::reshape` from returning a row-major
+  // BLOCK_SHARDED config the compiler did not declare.
   // https://github.com/tenstorrent/tt-mlir/issues/8020
   auto inputType =
       mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
@@ -444,8 +445,18 @@ OutputHints ReshapeRuleBook::getOutputHints(
             inputType.getShape(), outputType.getShape()));
   }
 
-  // Non-view reshape: sharded output not beneficial, use non-sharded configs.
-  return layout_filter_utils::nonShardedOutputHints(honoredConfigs);
+  // Non-view reshape: block/height-sharded outputs are supported natively by
+  // tt-metal's tiled reshape program factory (ReshapeViewTiledProgramFactory),
+  // which operates at tile-address granularity and recomputes the output shard
+  // spec via recompute_shard_spec_for_output. Only width-sharded outputs are
+  // unsupported natively (reshape_tiled round-trips them through interleaved),
+  // so exclude only those. Preserving block-sharded layouts through reshape
+  // avoids unnecessary demotion to interleaved for downstream sharded kernels.
+  // Only the candidates the guard above accepts are offered, so what survives
+  // here is the subset tt-metal returns verbatim.
+  // See https://github.com/tenstorrent/tt-mlir/issues/8020 and tt-metal
+  // PRs #42770, #42904.
+  return layout_filter_utils::nonWidthShardedOutputHints(honoredConfigs);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -61,7 +61,14 @@ bool OpRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
 }
 
 //===----------------------------------------------------------------------===//
-// Registry: maps OperationName -> OpRuleBook
+// Registry: maps op name -> OpRuleBook
+//
+// Keyed by the op's string name, not by `OperationName`: an `OperationName` is
+// only meaningful within the `MLIRContext` it was built in, and this registry
+// is initialized once per process. Keying it by `OperationName` bound every
+// entry to whichever context happened to make the first query, so ops from any
+// later context missed the registry and silently fell back to `defaultRules`.
+// Op names are process-wide constants, so a name-keyed map is context-safe.
 //===----------------------------------------------------------------------===//
 
 const OpRuleBook &getRuleBook(Operation *op) {
@@ -72,6 +79,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static ConcatRuleBook concat;
   static SliceRuleBook slice;
   static ReshapeRuleBook reshape;
+  static PermuteRuleBook permute;
   static PadRuleBook pad;
   static RepeatRuleBook repeat;
   static ConcatenateHeadsRuleBook concatHeads;
@@ -89,12 +97,11 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PagedUpdateCacheRuleBook pagedUpdateCache;
   static ArgMaxRuleBook argMax;
 
-  static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
+  static llvm::DenseMap<StringRef, const OpRuleBook *> registry;
   static std::once_flag initFlag;
   std::call_once(initFlag, [&] {
-    MLIRContext *ctx = op->getContext();
     auto reg = [&](StringRef name, const OpRuleBook *rb) {
-      registry[OperationName(name, ctx)] = rb;
+      registry[name] = rb;
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
@@ -105,10 +112,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(SliceStaticOp::getOperationName(), &slice);
     reg(SliceDynamicOp::getOperationName(), &slice);
     reg(ReshapeOp::getOperationName(), &reshape);
-
-    // TODO(rpavlovicTT): split permute's from reshape's rule book
-    // https://github.com/tenstorrent/tt-mlir/issues/7988
-    reg(PermuteOp::getOperationName(), &reshape);
+    reg(PermuteOp::getOperationName(), &permute);
     reg(PadOp::getOperationName(), &pad);
     reg(RepeatOp::getOperationName(), &repeat);
     reg(ConcatenateHeadsOp::getOperationName(), &concatHeads);
@@ -132,7 +136,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(ArgMaxOp::getOperationName(), &argMax);
   });
-  auto it = registry.find(op->getName());
+  auto it = registry.find(op->getName().getStringRef());
   return it != registry.end() ? *it->second : defaultRules;
 }
 

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_unittest(OptimizerTests
     TestLegalTensorLayoutAnalysis.cpp
     TestConv2dConfigGenerator.cpp
     TestConv3dConfigHeuristic.cpp
+    TestReshapeDivergenceGuard.cpp
     PARTIAL_SOURCES_INTENDED
 )
 

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -88,6 +88,20 @@ public:
                              TensorMemoryLayout::HeightSharded, gridShape);
   }
 
+  TTNNLayoutAttr createL1WidthShardedLayout(
+      const llvm::ArrayRef<int64_t> &tensorShape,
+      const llvm::ArrayRef<int64_t> &gridShape = {1, 8}) {
+    return createTiledLayout(tensorShape, BufferType::L1,
+                             TensorMemoryLayout::WidthSharded, gridShape);
+  }
+
+  TTNNLayoutAttr createL1BlockShardedLayout(
+      const llvm::ArrayRef<int64_t> &tensorShape,
+      const llvm::ArrayRef<int64_t> &gridShape = {8, 8}) {
+    return createTiledLayout(tensorShape, BufferType::L1,
+                             TensorMemoryLayout::BlockSharded, gridShape);
+  }
+
   // Create a simple AddOp for testing.
   AddOp createMockAddOp(const llvm::ArrayRef<int64_t> &inputShape = {1, 1, 32,
                                                                      32}) {
@@ -348,6 +362,46 @@ TEST_F(OpModelStrategyTest, PermuteNopStillSkipsL1Sharding) {
           isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
     }
   }
+}
+
+TEST_F(OpModelStrategyTest,
+       ReshapeNonViewKeepsBlockAndHeightShardedDropsWidth) {
+  // Last dim changes (256 -> 128), so canReshapeBeView is false: this
+  // exercises the non-view path, which should keep interleaved +
+  // block/height-sharded outputs and drop only width-sharded (issue #8020).
+  // Output is 8 tiles tall, 4 tiles wide, so the grids below divide cleanly.
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
+  llvm::SmallVector<int64_t> outputShape = {1, 1, 256, 128};
+  auto reshapeOp = createMockReshapeOp(inputShape, outputShape);
+
+  std::vector<OpConfig> legalConfigs;
+  legalConfigs.emplace_back(createDRAMInterleavedLayout(outputShape));
+  legalConfigs.emplace_back(createL1InterleavedLayout(outputShape));
+  legalConfigs.emplace_back(
+      createL1ShardedLayout(outputShape, {8, 1})); // height [M, 1]
+  legalConfigs.emplace_back(
+      createL1BlockShardedLayout(outputShape, {8, 4})); // block [M, N]
+  legalConfigs.emplace_back(
+      createL1WidthShardedLayout(outputShape, {1, 4})); // width [1, N]
+
+  OutputHints hints = getOutputHints(reshapeOp, legalConfigs);
+
+  bool sawBlockSharded = false;
+  bool sawHeightSharded = false;
+  for (const auto &hint : hints.hints) {
+    if (!hint.outputLayout || !hint.outputLayout.getMemLayout()) {
+      continue;
+    }
+    auto memLayout = hint.outputLayout.getMemLayout().getValue();
+    // Width-sharded must be filtered out.
+    EXPECT_NE(memLayout, TensorMemoryLayout::WidthSharded);
+    sawBlockSharded |= (memLayout == TensorMemoryLayout::BlockSharded);
+    sawHeightSharded |= (memLayout == TensorMemoryLayout::HeightSharded);
+  }
+
+  // Block- and height-sharded outputs are preserved (supported natively).
+  EXPECT_TRUE(sawBlockSharded);
+  EXPECT_TRUE(sawHeightSharded);
 }
 
 TEST_F(OpModelStrategyTest, UnknownOpUsesDefaultStrategy) {

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTCore/Transforms/Transforms.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -127,6 +128,32 @@ public:
     return builder.create<ReshapeOp>(builder.getUnknownLoc(), outputTensorType,
                                      input.getResult(),
                                      builder.getI32ArrayAttr(outputShapeI32));
+  }
+
+  // Create a PermuteOp for testing. The default permutation transposes the
+  // last two (non-unit) dims, so it is not a permute-nop.
+  PermuteOp createMockPermuteOp(
+      const llvm::ArrayRef<int64_t> &inputShape = {1, 1, 32, 64},
+      const llvm::ArrayRef<int64_t> &permutation = {0, 1, 3, 2}) {
+    auto inputLayout = createL1InterleavedLayout(inputShape);
+    auto inputTensorType = mlir::RankedTensorType::get(
+        inputShape, builder.getBF16Type(), inputLayout);
+
+    llvm::SmallVector<int64_t> outputShape;
+    for (int64_t dim : permutation) {
+      outputShape.push_back(inputShape[dim]);
+    }
+    auto outputLayout = createDRAMInterleavedLayout(outputShape);
+    auto outputTensorType = mlir::RankedTensorType::get(
+        outputShape, builder.getBF16Type(), outputLayout);
+
+    auto input = builder.create<OnesOp>(
+        builder.getUnknownLoc(), inputTensorType,
+        /*device=*/nullptr, ShapeAttr::get(&context, inputShape));
+
+    return builder.create<PermuteOp>(
+        builder.getUnknownLoc(), outputTensorType, input.getResult(),
+        builder.getDenseI64ArrayAttr(permutation), /*pad_value=*/nullptr);
   }
 
   // Create a MatmulOp for testing.
@@ -250,6 +277,79 @@ TEST_F(OpModelStrategyTest, ReshapeOpSkipsL1Sharding) {
   }
 }
 
+// PermuteOp has its own rule book (#7988); reshape-specific output-hint
+// changes must not leak into it. Permute output hints are non-sharded only.
+TEST_F(OpModelStrategyTest, PermuteOpSkipsL1Sharding) {
+  auto permuteOp = createMockPermuteOp();
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints hints = getOutputHints(permuteOp, legalConfigs);
+
+  // The sharded config is dropped, and there are no sharded fallbacks.
+  EXPECT_LT(hints.hints.size(), legalConfigs.size());
+  EXPECT_TRUE(hints.fallbackHints.empty());
+
+  for (const auto &hint : hints.hints) {
+    if (hint.outputLayout && hint.outputLayout.getMemLayout()) {
+      EXPECT_FALSE(
+          isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
+    }
+  }
+}
+
+// The split itself: permute must not resolve to reshape's rule book, or a
+// reshape-only rule change silently applies to permute too (#7988).
+TEST_F(OpModelStrategyTest, PermuteAndReshapeHaveDistinctRuleBooks) {
+  auto permuteOp = createMockPermuteOp();
+  auto reshapeOp = createMockReshapeOp();
+
+  const OpRuleBook &permuteRules = getRuleBook(permuteOp);
+  const OpRuleBook &reshapeRules = getRuleBook(reshapeOp);
+
+  // Distinct rule-book instances, and neither is the default rule book (which
+  // explores reshards).
+  EXPECT_NE(&permuteRules, &reshapeRules);
+  EXPECT_FALSE(permuteRules.shouldExploreReshards());
+  EXPECT_FALSE(reshapeRules.shouldExploreReshards());
+}
+
+// A view-eligible reshape uses the NULL-hint-only branch. The equivalent
+// permute-nop does not: PermuteRuleBook has no view branch, so it keeps the
+// same non-sharded hints as any other permute.
+TEST_F(OpModelStrategyTest, ViewReshapeUsesNullHintOnlyButPermuteNopDoesNot) {
+  // Same trailing dims -> canReshapeBeView holds.
+  auto viewReshapeOp = createMockReshapeOp(/*inputShape=*/{1, 1, 32, 32},
+                                           /*outputShape=*/{1, 32, 32});
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints reshapeHints = getOutputHints(viewReshapeOp, legalConfigs);
+  EXPECT_EQ(reshapeHints.hints.size(), 1u);
+  EXPECT_FALSE(reshapeHints.hints[0].outputLayout);
+
+  auto nopPermuteOp = createMockPermuteOp(/*inputShape=*/{1, 1, 32, 32},
+                                          /*permutation=*/{0, 1, 2, 3});
+  OutputHints permuteHints = getOutputHints(nopPermuteOp, legalConfigs);
+  EXPECT_GT(permuteHints.hints.size(), 1u);
+}
+
+// A permute-nop is still not view-eligible for hint purposes: unlike reshape,
+// PermuteRuleBook has no NULL-hint-only branch.
+TEST_F(OpModelStrategyTest, PermuteNopStillSkipsL1Sharding) {
+  auto permuteOp = createMockPermuteOp(/*inputShape=*/{1, 1, 32, 32},
+                                       /*permutation=*/{0, 1, 2, 3});
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints hints = getOutputHints(permuteOp, legalConfigs);
+
+  EXPECT_GT(hints.hints.size(), 1u);
+  for (const auto &hint : hints.hints) {
+    if (hint.outputLayout && hint.outputLayout.getMemLayout()) {
+      EXPECT_FALSE(
+          isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
+    }
+  }
+}
+
 TEST_F(OpModelStrategyTest, UnknownOpUsesDefaultStrategy) {
   // Use AddOp as a stand-in for "default" path testing.
   auto addOp = createMockAddOp();
@@ -273,6 +373,11 @@ TEST_F(OpModelStrategyTest, ShouldExploreReshardsElementwiseTrue) {
 TEST_F(OpModelStrategyTest, ShouldExploreReshardsReshapeFalse) {
   auto reshapeOp = createMockReshapeOp();
   EXPECT_FALSE(shouldExploreReshards(reshapeOp));
+}
+
+TEST_F(OpModelStrategyTest, ShouldExploreReshardsPermuteFalse) {
+  auto permuteOp = createMockPermuteOp();
+  EXPECT_FALSE(shouldExploreReshards(permuteOp));
 }
 
 TEST_F(OpModelStrategyTest, ShouldExploreReshardsMatmulTrue) {

--- a/test/unittests/Optimizer/TestReshapeDivergenceGuard.cpp
+++ b/test/unittests/Optimizer/TestReshapeDivergenceGuard.cpp
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt::ttnn;
+using namespace mlir::tt::ttnn::layout_filter_utils;
+
+// Tests for the reshape output-layout divergence guard: a candidate sharded
+// reshape-output layout is only legal when ttnn::reshape returns that exact
+// memory config instead of substituting one of its own.
+//
+// Every case below is a case from the on-device sweep recorded in issue #8020,
+// with its measured outcome named in the comment. `out` is 1x256x32x32 bf16
+// (physical 8192x32 == 256x1 tiles) unless noted. The sweep ran these on
+// 1x256x8x32, which has the same physical extent; the logical shape is stated
+// tile-aligned here so that each case isolates the substitution rule it names
+// instead of tripping rule P (see TileAlignment tests at the bottom).
+class ReshapeDivergenceGuardTest : public ::testing::Test {
+public:
+  mlir::MLIRContext context;
+  mlir::OpBuilder builder = mlir::OpBuilder(&context);
+
+  void SetUp() override {
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
+  }
+
+  // A CoreRangeSet from {startX, startY, endX, endY} rectangles.
+  CoreRangeSetAttr
+  makeCoreRangeSet(llvm::ArrayRef<std::array<int64_t, 4>> rects) {
+    llvm::SmallVector<CoreRangeAttr> ranges;
+    for (const auto &r : rects) {
+      ranges.push_back(
+          CoreRangeAttr::get(&context, CoreCoordAttr::get(&context, r[0], r[1]),
+                             CoreCoordAttr::get(&context, r[2], r[3])));
+    }
+    return CoreRangeSetAttr::get(&context, ranges);
+  }
+
+  CoreRangeSetAttr coreGrid(int64_t width, int64_t height) {
+    return makeCoreRangeSet({{0, 0, width - 1, height - 1}});
+  }
+
+  // An L1 sharded tiled layout. `gridShape` ([H, W]) drives the derived
+  // per-core shard shape; `crs` is the core placement the shard spec declares.
+  // They are set independently so that specs tt-metal would renegotiate (an
+  // over-provisioned shard shape, a non-rectangular grid) can be expressed.
+  TTNNLayoutAttr shardedLayout(llvm::ArrayRef<int64_t> tensorShape,
+                               TensorMemoryLayout memLayout,
+                               llvm::ArrayRef<int64_t> gridShape,
+                               CoreRangeSetAttr crs) {
+    return TTNNLayoutAttr::Builder(
+               &context, tensorShape,
+               mlir::tt::ttcore::TileType::get(builder.getBF16Type()))
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(memLayout)
+        .setGridShape(gridShape)
+        .setCoreRangeSet(crs)
+        .build();
+  }
+
+  TTNNLayoutAttr dramInterleavedLayout(llvm::ArrayRef<int64_t> tensorShape) {
+    return TTNNLayoutAttr::Builder(
+               &context, tensorShape,
+               mlir::tt::ttcore::TileType::get(builder.getBF16Type()))
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .build();
+  }
+
+  // Row-major (untilized) counterparts of the two layouts above: a scalar
+  // element type instead of a tile.
+  TTNNLayoutAttr rowMajorShardedLayout(llvm::ArrayRef<int64_t> tensorShape,
+                                       TensorMemoryLayout memLayout,
+                                       llvm::ArrayRef<int64_t> gridShape,
+                                       CoreRangeSetAttr crs) {
+    return TTNNLayoutAttr::Builder(&context, tensorShape, builder.getBF16Type())
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(memLayout)
+        .setGridShape(gridShape)
+        .setCoreRangeSet(crs)
+        .build();
+  }
+
+  TTNNLayoutAttr
+  dramInterleavedRowMajorLayout(llvm::ArrayRef<int64_t> tensorShape) {
+    return TTNNLayoutAttr::Builder(&context, tensorShape, builder.getBF16Type())
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .build();
+  }
+};
+
+// A NULL hint and any interleaved candidate are never renegotiated.
+TEST_F(ReshapeDivergenceGuardTest, InterleavedAndNullAreAlwaysHonored) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      TTNNLayoutAttr(), dramInterleavedLayout(inShape), inShape, outShape));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(dramInterleavedLayout(outShape),
+                                         dramInterleavedLayout(inShape),
+                                         inShape, outShape));
+}
+
+// Rule H (reshape.cpp:177-211): HEIGHT_SHARDED shard shapes are always
+// re-derived as round32(div_up(phys_h, num_cores)) over the declared grid.
+TEST_F(ReshapeDivergenceGuardTest, HeightShardedShardShapeMustMatchRecompute) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // h64_4x1_matches_recompute: 4x1-tile shards over 64 cores == recompute.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // h64_8x1_over2x: 8x1-tile shards over the same 64 cores. tt-metal returns
+  // 4x1 instead; measured outcome was a device hang.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {32, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // h8col_32x1_exact: a single column of 8 cores, exact shards.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {8, 1},
+                    coreGrid(1, 8)),
+      input, inShape, outShape));
+}
+
+// Rule N (reshape.cpp:121-130): a non-rectangular grid is silently downgraded
+// to INTERLEAVED.
+TEST_F(ReshapeDivergenceGuardTest, NonRectangularGridIsRejected) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // nonrect54_height_5x1: 54 cores in a 8x7 bounding box.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {54, 1},
+                    makeCoreRangeSet({{0, 0, 7, 5}, {0, 6, 5, 6}})),
+      input, inShape, outShape));
+
+  // rect40_two_ranges_height_7x1: 40 cores spelled as two ranges that do fill
+  // their 8x5 bounding box -- honored.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {40, 1},
+                    makeCoreRangeSet({{0, 0, 7, 2}, {0, 3, 7, 4}})),
+      input, inShape, outShape));
+}
+
+// Rule B (reshape.cpp:137-152): an explicit BLOCK_SHARDED spec is passed
+// through only when its grid covers the output's physical extent -- with `>=`,
+// so over-provisioning is fine.
+TEST_F(ReshapeDivergenceGuardTest, BlockShardedGridMustCoverOutput) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // b_full_32x1_over8xw: 8x8 cores x 32x1-tile shards covers 256x1 tiles
+  // exactly in height and 8x over in width -- honored verbatim.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::BlockSharded, {8, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // b_full_16x1_undercover: 8 core rows x 16-tile shards = 128 < 256 tiles of
+  // height. tt-metal replaces the grid; measured outcome was divergence.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::BlockSharded, {16, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+}
+
+// Rule V (reshape.cpp:613-624): on the `this_is_view` fast path the requested
+// memory config is discarded entirely and the input's spec is returned, so a
+// candidate is only honored when it already matches the input's memory config.
+TEST_F(ReshapeDivergenceGuardTest, ViewPathRequiresTheInputsMemoryConfig) {
+  // View-compatible shapes: same last dim, both second-to-last tile aligned.
+  llvm::SmallVector<int64_t> inShape = {8192, 32};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = shardedLayout(
+      inShape, TensorMemoryLayout::HeightSharded, {8, 1}, coreGrid(1, 8));
+  ASSERT_TRUE(reshapeShapesAllowView(inShape, outShape, /*inputIsTiled=*/true));
+
+  // view_in_h8col_32x1__out_h64_4x1: a legal, recompute-matching 64-core
+  // candidate -- but the view path returns the input's 8-core spec instead.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // Same memory config as the input: the view returns exactly that.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {8, 1},
+                    coreGrid(1, 8)),
+      input, inShape, outShape));
+
+  // A 64-core candidate is honored once the shapes take reshape off the view
+  // path (same volume, but the last dim changes).
+  llvm::SmallVector<int64_t> nonViewOutShape = {256, 1024};
+  ASSERT_FALSE(
+      reshapeShapesAllowView(inShape, nonViewOutShape, /*inputIsTiled=*/true));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(nonViewOutShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, nonViewOutShape));
+}
+
+// Rule W: WIDTH_SHARDED shards keep the full physical height and split the
+// width across the grid.
+TEST_F(ReshapeDivergenceGuardTest, WidthShardedShardShapeMustMatchRecompute) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // w64_256x1: one tile of width does not divide over 64 cores, so recompute
+  // lands on 256x1 tiles on the full grid -- which is what is declared.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::WidthSharded, {1, 64},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+}
+
+// The row-major reshape path never honors a requested output config at all
+// (reshape.cpp:244 passes explicit_memory_config=false). `ttnn::reshape`
+// neither tilizes nor untilizes, so it is the *input's* tile-ness that decides
+// whether the op lands there: a tiled sharded candidate on a row-major input
+// describes an output that cannot exist. Testing only the candidate lets that
+// pair through, and it is what declared the one-core BLOCK_SHARDED L1 spec the
+// n150 LLM decode/prefill layer tests tripped over at runtime.
+TEST_F(ReshapeDivergenceGuardTest, RowMajorReshapePathIsNeverHonored) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+
+  // Control: on a tiled input the covering block-sharded candidate is honored.
+  TTNNLayoutAttr tiledCandidate = shardedLayout(
+      outShape, TensorMemoryLayout::BlockSharded, {8, 1}, coreGrid(8, 8));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      tiledCandidate, dramInterleavedLayout(inShape), inShape, outShape));
+
+  // The same candidate on a row-major input: the output is row-major whatever
+  // the candidate claims, so the spec is renegotiated.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      tiledCandidate, dramInterleavedRowMajorLayout(inShape), inShape,
+      outShape));
+
+  // A row-major sharded candidate is rejected from either side.
+  TTNNLayoutAttr rowMajorCandidate = rowMajorShardedLayout(
+      outShape, TensorMemoryLayout::BlockSharded, {8, 1}, coreGrid(8, 8));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      rowMajorCandidate, dramInterleavedLayout(inShape), inShape, outShape));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      rowMajorCandidate, dramInterleavedRowMajorLayout(inShape), inShape,
+      outShape));
+
+  // The shape from the real failure: `32x1 -> 32` off a row-major DRAM operand,
+  // block-sharded onto a single core. (Rule P would reject this one too -- a
+  // rank-1 output has a logical height of 1 -- but the row-major path is the
+  // reason it was observed to fail.)
+  llvm::SmallVector<int64_t> llmInShape = {32, 1};
+  llvm::SmallVector<int64_t> llmOutShape = {32};
+  ASSERT_FALSE(reshapeShapesAllowView(llmInShape, llmOutShape,
+                                      /*inputIsTiled=*/false));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(llmOutShape, TensorMemoryLayout::BlockSharded, {1, 1},
+                    coreGrid(1, 1)),
+      dramInterleavedRowMajorLayout(llmInShape), llmInShape, llmOutShape));
+}
+
+// Rule P: a sharded candidate whose *logical* inner 2-D is not a multiple of
+// the tile shape part-fills its tiles, and the rest of every shard is implicit
+// padding the runtime never fills (`ttnn::reshape` is called with no
+// `pad_value`). Such an output is returned with the requested config, so none
+// of the substitution rules see it -- and yet a consumer re-dispatched over
+// those shards miscomputes: on segformer this took the model from PCC 0.9967
+// to 0.4851.
+TEST_F(ReshapeDivergenceGuardTest, NonTileAlignedLogicalShapeIsRejected) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+
+  // The two output shapes have the *same* physical extent -- 8192x32, 256x1
+  // tiles -- and take the same candidate layout. Only the logical shape
+  // differs: 32 real rows of every 32 versus 8 of every 32.
+  llvm::SmallVector<int64_t> alignedOut = {1, 256, 32, 32};
+  llvm::SmallVector<int64_t> paddedOut = {1, 256, 8, 32};
+
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(alignedOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, alignedOut));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(paddedOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, paddedOut));
+
+  // Interleaved candidates are unaffected -- they never carry a shard spec.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(dramInterleavedLayout(paddedOut),
+                                         input, inShape, paddedOut));
+
+  // The shapes from the segformer failure (chisel RCA §3): the head of the
+  // chain is `1x16x16x256` off the stage-3 (16x16) decode-head branch.
+  llvm::SmallVector<int64_t> stage3In = {1, 256, 256};
+  llvm::SmallVector<int64_t> stage3Out = {1, 16, 16, 256}; // 16x8 tiles
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(stage3Out, TensorMemoryLayout::BlockSharded, {8, 8},
+                    coreGrid(8, 8)),
+      dramInterleavedLayout(stage3In), stage3In, stage3Out));
+
+  // Its tile-aligned sibling, same branch geometry, is still admitted.
+  llvm::SmallVector<int64_t> alignedStageOut = {1, 16, 32, 256};
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(alignedStageOut, TensorMemoryLayout::BlockSharded, {8, 8},
+                    coreGrid(8, 8)),
+      dramInterleavedLayout(stage3In), stage3In, alignedStageOut));
+
+  // A non-tile-aligned inner *width* is rejected on the same grounds.
+  llvm::SmallVector<int64_t> narrowOut = {1, 256, 32, 24};
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(narrowOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, narrowOut));
+}
+
+// The guard is expressed as a config filter, and must leave NULL-hint configs
+// alone.
+TEST_F(ReshapeDivergenceGuardTest, FilterDropsOnlyDivergentConfigs) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  std::vector<OpConfig> configs = {
+      OpConfig(TTNNLayoutAttr()),
+      OpConfig(dramInterleavedLayout(outShape)),
+      OpConfig(shardedLayout(outShape, TensorMemoryLayout::HeightSharded,
+                             {64, 1}, coreGrid(8, 8))),
+      OpConfig(shardedLayout(outShape, TensorMemoryLayout::HeightSharded,
+                             {32, 1}, coreGrid(8, 8))),
+  };
+
+  std::vector<OpConfig> kept = filterConfigs(
+      configs, reshapeOutputSpecIsHonoredFilter(dramInterleavedLayout(inShape),
+                                                inShape, outShape));
+  ASSERT_EQ(kept.size(), 3u);
+  EXPECT_FALSE(kept[0].outputLayout);
+  EXPECT_EQ(kept[1].outputLayout, configs[1].outputLayout);
+  EXPECT_EQ(kept[2].outputLayout, configs[2].outputLayout);
+}


### PR DESCRIPTION
Revives the paused work for #8020 now that the stateful op-model API is in `main` (#9124).

### What changed

`ReshapeRuleBook::getOutputHints` dropped **all** sharded output candidates for non-view
reshapes. That is only correct for **width-sharded** output, which tt-metal's `reshape_tiled`
implements by round-tripping through interleaved (#7681). Block-sharded and height-sharded
outputs are handled natively by `ReshapeViewTiledProgramFactory`, which operates at tile-address
granularity and rewrites the output shard spec via `recompute_shard_spec_for_output`.

The non-view path now returns `layout_filter_utils::nonWidthShardedOutputHints`, so
interleaved + block-sharded + height-sharded survive and only width-sharded is excluded.

Preserving block-sharded layouts through reshape avoids demoting a sharded producer to
interleaved in front of a sharding-gated consumer. The motivating case from the issue is
`gpt_oss_20b_decode_2lyr` (TP8, opt-level=2), where a reshape ahead of an `rms_norm` demoted a
`block_sharded 8x8` producer to interleaved, forcing the interleaved-input layernorm kernel
variant (32 cores, ~114 µs) instead of the sharded one (64 cores, ~38 µs) — ~76 µs per decode
step on 2 layers, ~900 µs extrapolated to 24.

Adds a unit test asserting the non-view path keeps block/height-sharded and drops width-sharded.

### Why it was paused, and why now

The [previous attempt](https://github.com/tenstorrent/tt-mlir/issues/8020#issuecomment-4835289769) hit
runtime L1 circular-buffer overflows in the n150 vision benchmarks (`mnist`, `segformer`, `vit`).
The root cause was not reshape: the crash was in `ttnn.max_pool2d`, which is
memory-state-dependent, and the **stateless** `query_op_constraints` under-reported its CB
footprint by ~22× (110 KB reported vs 2.46 MB actual), so per-op L1 validation never rejected the
layout. The extra L1 residency from sharded reshape outputs tipped those models over.

#9124 wired the optimizer to the stateful query, which runs ops against the real resident L1
state — the prerequisite this change was parked behind.

### Testing (n150, `TTMLIR_ENABLE_OPMODEL=ON`, Release)

- `test/ttmlir/Dialect/TTNN/optimizer` — 53 passed, 0 failed
- `test/ttmlir/Silicon/TTNN/n150/optimizer` — 26 passed, 0 failed (includes the resnet50 modules)
- `check-perf` — 5 passed, `yolo_v8` unsupported per #8442. **`segformer` executes on device**,
  as do `resnet_hf`, `resnet50_xla` and both llama decoders.
- Unit: `OptimizerTests` 299/299, `L1SpillManagementTests` 20/20,
  `L1SpillManagementMockAllocatorTests` 14/14, `OpModelStrategyTests` — the new test passes.

`OpModelStrategyTests` has 6 pre-existing aborts on `main` (`ScoreCandidateL1ShardedResult` and
all 5 `ReshardCandidatesTest` cases): the fixture's `createL1ShardedLayout` default grid `{8, 4}`
trips the `gridShape[1] == 1` assert in `deriveCanonicalL1CoreRangeSet`. Verified identical with
and without this change by rebuilding against `main`'s files — unrelated to this PR.

### Follow-up

`mnist` and `vit` are tt-xla benchmarks and are not covered in-tree; a tt-xla perf/correctness
sweep should confirm them before merge.

Fixes #8020
