### PR TITLE
TTMetal: reuse immutable D2M inputs across submissions

### DIFF
--- a/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
+++ b/runtime/include/tt/runtime/detail/ttmetal/ttmetal.h
@@ -88,6 +88,9 @@ HostBuffer getHostBuffer(::tt::runtime::Tensor tensor);
 DistributedHostBuffer getDistributedHostBuffer(::tt::runtime::Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
+bool getTensorReusable(Tensor tensor);
+void setTensorReusable(Tensor &tensor, bool reusable);
+TensorReuseStats getTensorReuseStats(Tensor tensor);
 
 tt::target::Arch getArch();
 

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -148,6 +148,22 @@ TensorDesc getTensorDesc(Tensor tensor);
 bool getTensorRetain(Tensor tensor);
 void setTensorRetain(Tensor tensor, bool retain);
 
+// Marks a tensor as an immutable input whose device representation may be
+// reused by compatible program submissions. The first submission uploads the
+// tensor normally. Later submissions of the same Tensor bind the retained
+// device buffer directly. Clearing the flag invalidates all retained device
+// representations for the tensor.
+//
+// Callers must not modify the tensor's host storage or submit it to a program
+// that writes or aliases the corresponding device input while reuse is
+// enabled. The Tensor and its copies must also remain alive until all using
+// submissions have completed. Clearing the flag is also forbidden while a
+// using submission is in flight. Currently implemented for single-device
+// programs in the local TTMetal runtime.
+bool getTensorReusable(Tensor tensor);
+void setTensorReusable(Tensor &tensor, bool reusable);
+TensorReuseStats getTensorReuseStats(Tensor tensor);
+
 tt::target::Arch getArch();
 
 size_t getNumAvailableDevices();

--- a/runtime/include/tt/runtime/types.h
+++ b/runtime/include/tt/runtime/types.h
@@ -10,6 +10,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -417,6 +418,27 @@ struct Event : public detail::RuntimeCheckedObjectImpl {
   using detail::RuntimeCheckedObjectImpl::RuntimeCheckedObjectImpl;
 };
 
+struct TensorReuseStats {
+  // Hits and misses count reusable program-input destinations, not submit
+  // calls. One logical input may feed more than one destination.
+  std::uint64_t cacheHits = 0;
+  std::uint64_t cacheMisses = 0;
+  // Counts the device-buffer bytes uploaded while populating cache entries.
+  std::uint64_t uploadedBytes = 0;
+  std::uint64_t deviceBufferCount = 0;
+};
+
+struct TensorMetadata {
+  // Reusable inputs keep backend-owned device representations across program
+  // submissions. Tensor allocates this metadata only when reuse is enabled,
+  // then copies share it so the cache lifetime follows the logical tensor.
+  // The reusable-input API requires that a sharing Tensor outlive every
+  // submission that uses the retained device representations.
+  mutable std::mutex mutex;
+  bool reusable = false;
+  std::shared_ptr<void> reusableInputCache;
+};
+
 struct Tensor : public detail::RuntimeCheckedObjectImpl {
   std::shared_ptr<void> data;
   Event event;
@@ -430,6 +452,8 @@ struct Tensor : public detail::RuntimeCheckedObjectImpl {
 
   void setGlobalId(std::uint64_t id) { globalId = id; }
   std::uint64_t getGlobalId() const { return globalId; }
+
+  std::shared_ptr<TensorMetadata> metadata;
 
 private:
   std::uint64_t nextTensorGlobalId();

--- a/runtime/lib/runtime.cpp
+++ b/runtime/lib/runtime.cpp
@@ -616,6 +616,52 @@ void setTensorRetain(Tensor tensor, bool retain) {
       [&]() { ::tt::runtime::distributed::setTensorRetain(tensor, retain); });
 }
 
+bool getTensorReusable(Tensor tensor) {
+  using RetType = bool;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getTensorReusable", DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorReusable(tensor);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getTensorReusable",
+                                    HostRuntime::Distributed);
+      });
+}
+
+void setTensorReusable(Tensor &tensor, bool reusable) {
+  using RetType = void;
+  DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() {
+        detail::fatalNotImplemented("setTensorReusable", DeviceRuntime::TTNN);
+      },
+      [&]() { ::tt::runtime::ttmetal::setTensorReusable(tensor, reusable); },
+      [&]() {
+        detail::fatalNotImplemented("setTensorReusable",
+                                    HostRuntime::Distributed);
+      });
+}
+
+TensorReuseStats getTensorReuseStats(Tensor tensor) {
+  using RetType = TensorReuseStats;
+  return DISPATCH_TO_CURRENT_RUNTIME(
+      RetType,
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getTensorReuseStats", DeviceRuntime::TTNN);
+      },
+      [&]() -> RetType {
+        return ::tt::runtime::ttmetal::getTensorReuseStats(tensor);
+      },
+      [&]() -> RetType {
+        detail::fatalNotImplemented("getTensorReuseStats",
+                                    HostRuntime::Distributed);
+      });
+}
+
 tt::target::Arch getArch() {
   using RetType = tt::target::Arch;
   return DISPATCH_TO_CURRENT_RUNTIME(

--- a/runtime/lib/ttmetal/arguments.h
+++ b/runtime/lib/ttmetal/arguments.h
@@ -74,7 +74,9 @@ std::vector<std::uint32_t> processKernelArgs(
                  target::metal::BufferDetail::MetalBuffer);
       const target::metal::MetalBuffer *metalBuffer =
           bufferDesc->buffer_detail_as_MetalBuffer();
-      argsVec.push_back(deviceAddressValidator(buffer->address(),
+      const tt_metal::Buffer *liveBuffer =
+          meshBuffers.at(buffer->global_id())->get_reference_buffer();
+      argsVec.push_back(deviceAddressValidator(liveBuffer->address(),
                                                metalBuffer->buffer_type()));
       break;
     }

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -31,8 +31,11 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace tt::runtime::ttmetal {
 
@@ -82,6 +85,196 @@ bool hasDynamicCompileTimeBindings(
   return false;
 }
 
+struct ReusableInputKey {
+  std::uint32_t deviceId;
+  std::uint64_t binaryId;
+  std::uint32_t programIndex;
+  std::uint32_t deviceProgramIndex;
+  std::uint32_t inputIndex;
+  std::uint32_t destinationGlobalId;
+
+  bool operator==(const ReusableInputKey &other) const = default;
+};
+
+struct ReusableInputKeyHash {
+  std::size_t operator()(const ReusableInputKey &key) const {
+    std::size_t hash = std::hash<std::uint32_t>{}(key.deviceId);
+    auto combine = [&hash](auto value) {
+      hash ^= std::hash<decltype(value)>{}(value) + 0x9e3779b9 + (hash << 6) +
+              (hash >> 2);
+    };
+    combine(key.binaryId);
+    combine(key.programIndex);
+    combine(key.deviceProgramIndex);
+    combine(key.inputIndex);
+    combine(key.destinationGlobalId);
+    return hash;
+  }
+};
+
+struct ReusableInputCache {
+  std::mutex mutex;
+  std::unordered_map<ReusableInputKey, MeshBuffer, ReusableInputKeyHash>
+      buffers;
+  std::uint64_t hits = 0;
+  std::uint64_t misses = 0;
+  std::uint64_t uploadedBytes = 0;
+};
+
+std::uint64_t bufferSpanPerBank(const tt_metal::Buffer *buffer) {
+  const auto &distribution = buffer->buffer_distribution_spec();
+  if (distribution) {
+    return distribution->max_num_dev_pages_per_core() *
+           buffer->aligned_page_size();
+  }
+  return buffer->aligned_size_per_bank();
+}
+
+std::optional<tt_metal::CoreRangeSet>
+getBufferCoreRangeSet(const tt_metal::Buffer *buffer) {
+  if (buffer->buffer_distribution_spec()) {
+    return tt_metal::CoreRangeSet(
+        buffer->buffer_distribution_spec()->cores_with_data());
+  }
+  if (buffer->has_shard_spec()) {
+    return buffer->shard_spec().grid();
+  }
+  return std::nullopt;
+}
+
+bool buffersOverlap(const MeshBuffer &lhs, const MeshBuffer &rhs) {
+  const tt_metal::Buffer *lhsBuffer = lhs->get_reference_buffer();
+  const tt_metal::Buffer *rhsBuffer = rhs->get_reference_buffer();
+  if (lhsBuffer->buffer_type() != rhsBuffer->buffer_type()) {
+    return false;
+  }
+
+  const std::uint64_t lhsBegin = lhsBuffer->address();
+  const std::uint64_t lhsEnd = lhsBegin + bufferSpanPerBank(lhsBuffer);
+  const std::uint64_t rhsBegin = rhsBuffer->address();
+  const std::uint64_t rhsEnd = rhsBegin + bufferSpanPerBank(rhsBuffer);
+  if (lhsBegin >= rhsEnd || rhsBegin >= lhsEnd) {
+    return false;
+  }
+
+  // L1 addresses are core-local. Equal ranges on disjoint shard grids do not
+  // overlap, while an unsharded L1 buffer is conservatively treated as using
+  // every participating core.
+  if (lhsBuffer->is_l1()) {
+    const auto lhsCores = getBufferCoreRangeSet(lhsBuffer);
+    const auto rhsCores = getBufferCoreRangeSet(rhsBuffer);
+    if (lhsCores && rhsCores) {
+      return lhsCores->intersects(*rhsCores);
+    }
+  }
+  return true;
+}
+
+class ReusableInputRegistry {
+public:
+  static ReusableInputRegistry &instance() {
+    static ReusableInputRegistry registry;
+    return registry;
+  }
+
+  void insert(std::uint32_t deviceId, const MeshBuffer &buffer,
+              const std::shared_ptr<ReusableInputCache> &cache) {
+    std::lock_guard<std::mutex> lock(mutex);
+    auto &deviceBuffers = buffers[deviceId];
+    for (auto it = deviceBuffers.begin(); it != deviceBuffers.end();) {
+      auto existing = it->lock();
+      if (!existing) {
+        it = deviceBuffers.erase(it);
+        continue;
+      }
+      if (existing.get() == buffer.get()) {
+        return;
+      }
+      ++it;
+    }
+    deviceBuffers.push_back(buffer);
+
+    auto &deviceCaches = caches[deviceId];
+    for (auto it = deviceCaches.begin(); it != deviceCaches.end();) {
+      auto existing = it->lock();
+      if (!existing) {
+        it = deviceCaches.erase(it);
+        continue;
+      }
+      if (existing.get() == cache.get()) {
+        return;
+      }
+      ++it;
+    }
+    deviceCaches.push_back(cache);
+  }
+
+  void assertNoOverlap(std::uint32_t deviceId, const MeshBuffer &buffer) {
+    std::lock_guard<std::mutex> lock(mutex);
+    auto deviceIt = buffers.find(deviceId);
+    if (deviceIt == buffers.end()) {
+      return;
+    }
+
+    for (auto it = deviceIt->second.begin(); it != deviceIt->second.end();) {
+      auto reusable = it->lock();
+      if (!reusable) {
+        it = deviceIt->second.erase(it);
+        continue;
+      }
+      LOG_ASSERT(reusable.get() == buffer.get() ||
+                     !buffersOverlap(reusable, buffer),
+                 "D2M transient allocation overlaps a reusable input buffer; "
+                 "the compiled memory plan does not leave enough device "
+                 "memory for input reuse");
+      ++it;
+    }
+  }
+
+  void clearDevice(std::uint32_t deviceId) {
+    std::vector<std::shared_ptr<ReusableInputCache>> liveCaches;
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      auto cacheIt = caches.find(deviceId);
+      if (cacheIt != caches.end()) {
+        liveCaches.reserve(cacheIt->second.size());
+        for (const auto &cache : cacheIt->second) {
+          if (auto liveCache = cache.lock()) {
+            liveCaches.push_back(std::move(liveCache));
+          }
+        }
+        caches.erase(cacheIt);
+      }
+      buffers.erase(deviceId);
+    }
+
+    for (const auto &cache : liveCaches) {
+      std::lock_guard<std::mutex> lock(cache->mutex);
+      for (auto it = cache->buffers.begin(); it != cache->buffers.end();) {
+        if (it->first.deviceId == deviceId) {
+          it = cache->buffers.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+  }
+
+private:
+  std::mutex mutex;
+  std::unordered_map<std::uint32_t,
+                     std::vector<std::weak_ptr<distributed::MeshBuffer>>>
+      buffers;
+  std::unordered_map<std::uint32_t,
+                     std::vector<std::weak_ptr<ReusableInputCache>>>
+      caches;
+};
+
+struct ProgramInputProvenance {
+  std::uint32_t inputIndex;
+  std::shared_ptr<ReusableInputCache> cache;
+};
+
 class MCQExecutor {
 public:
   MCQExecutor(
@@ -89,14 +282,15 @@ public:
       const flatbuffers::Vector<
           flatbuffers::Offset<tt::target::metal::BufferRef>> *programInputs,
       const std::vector<Tensor> &inputs, common::DylibManager &&dylibManager,
-      bool blockingCQ, std::uint64_t binaryId, std::uint32_t programIndex,
-      std::uint32_t deviceProgramIndex);
+      bool blockingCQ, std::uint32_t deviceId, std::uint64_t binaryId,
+      std::uint32_t programIndex, std::uint32_t deviceProgramIndex);
 
   const std::vector<Tensor> &getOutputs() const { return outputs; }
 
   void execute(const target::metal::CommandQueue *commandQueue);
 
 private:
+  void analyzeReusableInputs(const target::metal::CommandQueue *commandQueue);
   void execute(const target::metal::Command *command);
   void execute(const target::metal::HostAllocCommand *command);
   void execute(const target::metal::ReturnCommand *command);
@@ -126,6 +320,13 @@ private:
   void enqueueMeshWorkload(distributed::MeshWorkload &workload,
                            const char *loc);
 
+  ReusableInputKey
+  createReusableInputKey(const ProgramInputProvenance &input,
+                         std::uint32_t destinationGlobalId) const;
+  void
+  bindReusableInput(const target::metal::EnqueueWriteBufferCommand *command,
+                    const ProgramInputProvenance &input);
+
   std::uint64_t generateUniqueProgramRuntimeId() {
     return nextProgramRuntimeId++;
   }
@@ -144,6 +345,16 @@ private:
 
   // Buffers that live on the host. Indexed by global_id.
   std::unordered_map<std::uint32_t, Tensor> hostBuffers;
+  // Maps host buffers and their derived memref views back to program inputs.
+  std::unordered_map<std::uint32_t, ProgramInputProvenance>
+      hostBufferInputProvenance;
+  // Host buffers and copies that are unnecessary once every device write for
+  // their immutable source input has a reusable cache entry.
+  std::unordered_set<std::uint32_t> skippedHostBufferIds;
+  std::unordered_set<std::uint32_t> skippedHostCopyInputIndices;
+  // Destination aliases that refer to tensor-owned reusable buffers. Their
+  // scheduled deallocation removes the alias without freeing the cache entry.
+  std::unordered_set<std::uint32_t> reusableBufferAliases;
   std::unordered_map<std::uint32_t, std::shared_ptr<distributed::MeshEvent>>
       meshEvents;
   std::vector<Tensor> outputs;
@@ -152,6 +363,7 @@ private:
   const char *currentProgramName;
   DeviceAddressValidator deviceAddressValidator;
   common::DylibManager dylibManager;
+  std::uint32_t deviceId;
   std::uint64_t binaryId;
   std::uint32_t programIndex;
   std::uint32_t deviceProgramIndex;
@@ -160,22 +372,44 @@ private:
 };
 } // namespace
 
+std::shared_ptr<void> createReusableInputCache() {
+  return std::make_shared<ReusableInputCache>();
+}
+
+TensorReuseStats
+getReusableInputCacheStats(const std::shared_ptr<void> &reusableInputCache) {
+  if (!reusableInputCache) {
+    return {};
+  }
+
+  auto cache = std::static_pointer_cast<ReusableInputCache>(reusableInputCache);
+  std::lock_guard<std::mutex> lock(cache->mutex);
+  return TensorReuseStats{cache->hits, cache->misses, cache->uploadedBytes,
+                          static_cast<std::uint64_t>(cache->buffers.size())};
+}
+
+void clearReusableInputCachesForDevice(std::uint32_t deviceId) {
+  ReusableInputRegistry::instance().clearDevice(deviceId);
+}
+
 MCQExecutor::MCQExecutor(
     distributed::MeshDevice *meshDevice,
     const flatbuffers::Vector<flatbuffers::Offset<tt::target::metal::BufferRef>>
         *programInputs,
     const std::vector<Tensor> &inputs, common::DylibManager &&dylibManager,
-    bool blockingCQ, std::uint64_t binaryId, std::uint32_t programIndex,
-    std::uint32_t deviceProgramIndex)
+    bool blockingCQ, std::uint32_t deviceId, std::uint64_t binaryId,
+    std::uint32_t programIndex, std::uint32_t deviceProgramIndex)
     : meshDevice(meshDevice), blockingCQ(blockingCQ),
       deviceAddressValidator(meshDevice->get_devices().at(0)),
-      dylibManager(std::move(dylibManager)), binaryId(binaryId),
-      programIndex(programIndex), deviceProgramIndex(deviceProgramIndex) {
+      dylibManager(std::move(dylibManager)), deviceId(deviceId),
+      binaryId(binaryId), programIndex(programIndex),
+      deviceProgramIndex(deviceProgramIndex) {
   initMeshEvents.reserve(inputs.size());
 
   std::uint32_t inputIndex = 0;
   for (const Tensor &input : inputs) {
-    const target::metal::BufferRef *ref = programInputs->Get(inputIndex++);
+    const std::uint32_t currentInputIndex = inputIndex++;
+    const target::metal::BufferRef *ref = programInputs->Get(currentInputIndex);
     std::visit(utils::overloaded{
                    [&](const std::uint32_t &) {
                      auto [_, inserted] =
@@ -205,6 +439,27 @@ MCQExecutor::MCQExecutor(
                },
                input.as<MetalTensor>(DeviceRuntime::TTMetal));
 
+    std::shared_ptr<ReusableInputCache> reusableInputCache;
+    if (input.metadata) {
+      std::lock_guard<std::mutex> lock(input.metadata->mutex);
+      if (input.metadata->reusable) {
+        LOG_ASSERT(input.metadata->reusableInputCache,
+                   "Reusable tensor cache is not initialized");
+        reusableInputCache = std::static_pointer_cast<ReusableInputCache>(
+            input.metadata->reusableInputCache);
+      }
+    }
+    if (reusableInputCache &&
+        hostBuffers.find(ref->global_id()) != hostBuffers.end()) {
+      LOG_ASSERT(meshDevice->num_devices() == 1,
+                 "Reusable D2M inputs currently require a single-device "
+                 "program");
+      hostBufferInputProvenance.try_emplace(
+          ref->global_id(),
+          ProgramInputProvenance{currentInputIndex,
+                                 std::move(reusableInputCache)});
+    }
+
     auto meshEvent =
         input.event.asSharedPtr<distributed::MeshEvent>(DeviceRuntime::TTMetal);
     if (meshEvent) {
@@ -213,9 +468,131 @@ MCQExecutor::MCQExecutor(
   }
 }
 
+void MCQExecutor::analyzeReusableInputs(
+    const target::metal::CommandQueue *commandQueue) {
+  struct ReusePlan {
+    ProgramInputProvenance input;
+    std::unordered_set<std::uint32_t> destinationGlobalIds;
+    std::unordered_set<std::uint32_t> derivedHostBufferIds;
+    bool requiresHostMaterialization = false;
+  };
+
+  auto provenance = hostBufferInputProvenance;
+  std::unordered_map<std::uint32_t, ReusePlan> plans;
+  for (const auto &[globalId, input] : provenance) {
+    plans.try_emplace(input.inputIndex, ReusePlan{input, {}, {}, false});
+  }
+
+  auto markHostUse = [&](const target::metal::BufferRef *ref) {
+    auto source = provenance.find(ref->global_id());
+    if (source != provenance.end()) {
+      plans.at(source->second.inputIndex).requiresHostMaterialization = true;
+    }
+  };
+
+  for (const target::metal::Command *command : *commandQueue->commands()) {
+    switch (command->type_type()) {
+    case target::metal::CommandType::HostAllocCommand: {
+      provenance.erase(command->type_as_HostAllocCommand()->dst()->global_id());
+      break;
+    }
+    case target::metal::CommandType::MemrefCopyCommand: {
+      const auto *copy = command->type_as_MemrefCopyCommand();
+      auto source = provenance.find(copy->src()->global_id());
+      if (source == provenance.end()) {
+        provenance.erase(copy->dst()->global_id());
+        break;
+      }
+      provenance.insert_or_assign(copy->dst()->global_id(), source->second);
+      plans.at(source->second.inputIndex)
+          .derivedHostBufferIds.insert(copy->dst()->global_id());
+      break;
+    }
+    case target::metal::CommandType::EnqueueWriteBufferCommand: {
+      const auto *write = command->type_as_EnqueueWriteBufferCommand();
+      auto source = provenance.find(write->src()->global_id());
+      if (source != provenance.end()) {
+        plans.at(source->second.inputIndex)
+            .destinationGlobalIds.insert(write->dst()->global_id());
+      }
+      break;
+    }
+    case target::metal::CommandType::EnqueueReadBufferCommand: {
+      const auto *read = command->type_as_EnqueueReadBufferCommand();
+      markHostUse(read->dst());
+      provenance.erase(read->dst()->global_id());
+      break;
+    }
+    case target::metal::CommandType::CpuCommand: {
+      const auto *cpu = command->type_as_CpuCommand();
+      for (const target::metal::BufferRef *input : *cpu->ins()) {
+        markHostUse(input);
+      }
+      for (const target::metal::BufferRef *output : *cpu->outs()) {
+        provenance.erase(output->global_id());
+      }
+      break;
+    }
+    case target::metal::CommandType::MeshShardCommand: {
+      const auto *meshShard = command->type_as_MeshShardCommand();
+      markHostUse(meshShard->src());
+      provenance.erase(meshShard->dst()->global_id());
+      break;
+    }
+    case target::metal::CommandType::ReturnCommand: {
+      for (const target::metal::BufferRef *result :
+           *command->type_as_ReturnCommand()->results()) {
+        markHostUse(result);
+      }
+      break;
+    }
+    default:
+      break;
+    }
+  }
+
+  for (const auto &[inputIndex, plan] : plans) {
+    if (!plan.input.cache || plan.requiresHostMaterialization ||
+        plan.destinationGlobalIds.empty()) {
+      continue;
+    }
+
+    const auto &cache = plan.input.cache;
+    std::lock_guard<std::mutex> lock(cache->mutex);
+    const bool fullyCached = std::all_of(
+        plan.destinationGlobalIds.begin(), plan.destinationGlobalIds.end(),
+        [&](std::uint32_t destination) {
+          return cache->buffers.contains(
+              createReusableInputKey(plan.input, destination));
+        });
+    if (!fullyCached) {
+      continue;
+    }
+
+    // Bind cache hits before command execution so the corresponding
+    // CreateBufferCommand becomes a no-op. Otherwise every reuse would still
+    // allocate and immediately release the compiled transient destination
+    // before EnqueueWriteBufferCommand replaced it with the cached buffer.
+    for (std::uint32_t destination : plan.destinationGlobalIds) {
+      const MeshBuffer &buffer =
+          cache->buffers.at(createReusableInputKey(plan.input, destination));
+      auto [existing, inserted] = meshBuffers.try_emplace(destination, buffer);
+      LOG_ASSERT(inserted || existing->second.get() == buffer.get(),
+                 "Reusable input destination is already bound to a different "
+                 "device buffer");
+      reusableBufferAliases.insert(destination);
+    }
+
+    skippedHostCopyInputIndices.insert(inputIndex);
+    skippedHostBufferIds.insert(plan.derivedHostBufferIds.begin(),
+                                plan.derivedHostBufferIds.end());
+  }
+}
+
 void MCQExecutor::execute(const target::metal::CommandQueue *commandQueue) {
   currentProgramName = commandQueue->name()->c_str();
   mcq = &meshDevice->mesh_command_queue(commandQueue->queue_id());
+  analyzeReusableInputs(commandQueue);
 
   for (const auto &mesh_event : initMeshEvents) {
     distributed::EventSynchronize(*mesh_event);
@@ -309,6 +686,10 @@ void MCQExecutor::execute(const target::metal::Command *command) {
 }
 
 void MCQExecutor::execute(const target::metal::HostAllocCommand *command) {
+  if (skippedHostBufferIds.contains(command->dst()->global_id())) {
+    return;
+  }
+
   LOG_ASSERT(command->dst()->address() == 0);
   const auto *bufferDesc = command->dst()->desc();
 
@@ -687,9 +1068,81 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
   }
 }
 
+ReusableInputKey
+MCQExecutor::createReusableInputKey(const ProgramInputProvenance &input,
+                                    std::uint32_t destinationGlobalId) const {
+  return ReusableInputKey{deviceId,         binaryId,
+                          programIndex,     deviceProgramIndex,
+                          input.inputIndex, destinationGlobalId};
+}
+
+void MCQExecutor::bindReusableInput(
+    const target::metal::EnqueueWriteBufferCommand *command,
+    const ProgramInputProvenance &input) {
+  LOG_ASSERT(input.cache, "Expected reusable input cache");
+  const auto &cache = input.cache;
+
+  const ReusableInputKey key =
+      createReusableInputKey(input, command->dst()->global_id());
+  MeshBuffer reusableBuffer;
+  bool cacheHit = false;
+  {
+    std::lock_guard<std::mutex> lock(cache->mutex);
+    auto cached = cache->buffers.find(key);
+    if (cached != cache->buffers.end()) {
+      reusableBuffer = cached->second;
+      ++cache->hits;
+      cacheHit = true;
+    } else {
+      reusableBuffer = createOwnedMeshBufferFromBufferRef(
+          meshDevice, command->dst(), deviceAddressValidator);
+
+      // Owned reusable allocations and D2M's explicit-address plan are managed
+      // by different allocators. Check all currently-live transient buffers
+      // before publishing the cache entry, then check every future transient
+      // allocation through ReusableInputRegistry.
+      for (const auto &[globalId, liveBuffer] : meshBuffers) {
+        LOG_ASSERT(!buffersOverlap(reusableBuffer, liveBuffer),
+                   "Reusable input allocation overlaps live D2M buffer ",
+                   globalId,
+                   "; the compiled memory plan does not leave "
+                   "enough device memory for input reuse");
+      }
+
+      auto &hostInput = hostBuffers.at(command->src()->global_id());
+      checkHostTensorSizeMatchWithMeshBufferSize(hostInput, reusableBuffer);
+      writeHostTensorToMeshBuffer(mcq, hostInput, reusableBuffer, blockingCQ);
+
+      cache->uploadedBytes += reusableBuffer->size();
+      ++cache->misses;
+      cache->buffers.emplace(key, reusableBuffer);
+      ReusableInputRegistry::instance().insert(deviceId, reusableBuffer, cache);
+    }
+  }
+
+  auto destination = meshBuffers.find(command->dst()->global_id());
+  LOG_ASSERT(destination != meshBuffers.end(),
+             "Reusable input destination was not allocated");
+  destination->second = reusableBuffer;
+  reusableBufferAliases.insert(command->dst()->global_id());
+
+  LOG_DEBUG(logger::LogRuntimeTTMetalBufferCreation, "D2M reusable input ",
+            input.inputIndex, cacheHit ? " cache hit" : " cache miss",
+            ", destination buffer ", command->dst()->global_id(), ", ",
+            reusableBuffer->size(), " bytes at ",
+            logger::Address(reusableBuffer->address()));
+}
+
 void MCQExecutor::execute(
     const target::metal::EnqueueWriteBufferCommand *command) {
   ZoneScopedN("EnqueueWriteBufferCommand");
+
+  const auto provenance =
+      hostBufferInputProvenance.find(command->src()->global_id());
+  if (provenance != hostBufferInputProvenance.end()) {
+    bindReusableInput(command, provenance->second);
+    return;
+  }
 
   auto &input = hostBuffers.at(command->src()->global_id());
   auto meshBuffer = meshBuffers.at(command->dst()->global_id());
@@ -710,8 +1163,10 @@ void MCQExecutor::execute(
 void MCQExecutor::execute(const target::metal::CreateBufferCommand *command) {
   ZoneScopedN("CreateBufferCommand");
   if (meshBuffers.find(command->ref()->global_id()) == meshBuffers.end()) {
-    meshBuffers[command->ref()->global_id()] = createMeshBufferFromBufferRef(
-        meshDevice, command->ref(), deviceAddressValidator);
+    auto meshBuffer = createMeshBufferFromBufferRef(meshDevice, command->ref(),
+                                                    deviceAddressValidator);
+    ReusableInputRegistry::instance().assertNoOverlap(deviceId, meshBuffer);
+    meshBuffers[command->ref()->global_id()] = std::move(meshBuffer);
   }
 }
 
@@ -721,6 +1176,10 @@ void MCQExecutor::execute(
   auto meshBufferIter = meshBuffers.find(command->ref()->global_id());
   LOG_ASSERT(meshBufferIter != meshBuffers.end(), "Buffer not allocated");
   LOG_ASSERT(meshBufferIter->second != nullptr, "Buffer already deallocated");
+  if (reusableBufferAliases.erase(command->ref()->global_id()) != 0) {
+    meshBuffers.erase(meshBufferIter);
+    return;
+  }
   auto meshBuffer = meshBufferIter->second;
   meshBuffer->deallocate();
   meshBuffers.erase(meshBufferIter);
@@ -748,6 +1207,15 @@ void MCQExecutor::execute(
 }
 
 void MCQExecutor::execute(const target::metal::MemrefCopyCommand *command) {
+  const auto input =
+      hostBufferInputProvenance.find(command->src()->global_id());
+  if (input != hostBufferInputProvenance.end() &&
+      skippedHostCopyInputIndices.contains(input->second.inputIndex)) {
+    hostBufferInputProvenance.insert_or_assign(command->dst()->global_id(),
+                                               input->second);
+    return;
+  }
+
   auto srcIt = hostBuffers.find(command->src()->global_id());
   LOG_ASSERT(srcIt != hostBuffers.end());
   auto dstIt = hostBuffers.find(command->dst()->global_id());
@@ -755,6 +1223,13 @@ void MCQExecutor::execute(const target::metal::MemrefCopyCommand *command) {
   ttmetal::memcpy(
       dstIt->second, createTensorDescFromBufferDesc(command->dst()->desc()),
       srcIt->second, createTensorDescFromBufferDesc(command->src()->desc()));
+
+  if (input == hostBufferInputProvenance.end()) {
+    hostBufferInputProvenance.erase(command->dst()->global_id());
+  } else {
+    hostBufferInputProvenance.insert_or_assign(command->dst()->global_id(),
+                                               input->second);
+  }
 }
 
 void MCQExecutor::execute(const target::metal::CpuCommand *command) {
@@ -855,14 +1330,14 @@ std::vector<Tensor>
 executeMeshDeviceProgram(distributed::MeshDevice *meshDevice,
                          const target::metal::DeviceProgram *program,
                          const std::vector<Tensor> &inputs,
-                         common::DylibManager &&dylibs, std::uint64_t binaryId,
-                         std::uint32_t programIndex,
+                         common::DylibManager &&dylibs, std::uint32_t deviceId,
+                         std::uint64_t binaryId, std::uint32_t programIndex,
                          std::uint32_t deviceProgramIndex) {
   LOG_ASSERT(program->command_queues()->size() == 1, "Only one MCQ supported");
 
   MCQExecutor executor(meshDevice, program->inputs(), inputs, std::move(dylibs),
-                       debug::Env::get().blockingCQ, binaryId, programIndex,
-                       deviceProgramIndex);
+                       debug::Env::get().blockingCQ, deviceId, binaryId,
+                       programIndex, deviceProgramIndex);
   for (const target::metal::CommandQueue *cq : *program->command_queues()) {
     FrameMark;
     ZoneScoped;

--- a/runtime/lib/ttmetal/executor.h
+++ b/runtime/lib/ttmetal/executor.h
@@ -21,12 +21,17 @@ namespace target = ::tt::target;
 namespace tt_metal = ::tt::tt_metal;
 namespace distributed = ::tt::tt_metal::distributed;
 
+std::shared_ptr<void> createReusableInputCache();
+TensorReuseStats
+getReusableInputCacheStats(const std::shared_ptr<void> &reusableInputCache);
+void clearReusableInputCachesForDevice(std::uint32_t deviceId);
+
 std::vector<Tensor>
 executeMeshDeviceProgram(::tt::tt_metal::distributed::MeshDevice *meshDevice,
                          const ::tt::target::metal::DeviceProgram *program,
                          const std::vector<Tensor> &inputs,
-                         common::DylibManager &&dylibs, std::uint64_t binaryId,
-                         std::uint32_t programIndex,
+                         common::DylibManager &&dylibs, std::uint32_t deviceId,
+                         std::uint64_t binaryId, std::uint32_t programIndex,
                          std::uint32_t deviceProgramIndex);
 
 } // namespace tt::runtime::ttmetal

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -107,10 +107,11 @@ private:
 
 inline std::shared_ptr<distributed::MeshBuffer>
 createMeshBufferForShardedMetalBuffer(
-    distributed::MeshDevice *meshDevice, uint64_t refAddress,
+    distributed::MeshDevice *meshDevice, std::optional<uint64_t> refAddress,
     const target::metal::ShardedBufferConfig *shardedBufferConfig,
     target::BufferType bufferType,
-    const DeviceAddressValidator &deviceAddressValidator) {
+    const DeviceAddressValidator &deviceAddressValidator,
+    std::optional<bool> bottomUp = std::nullopt) {
   const target::metal::ShardSpecBuffer *shardSpecBuffer =
       shardedBufferConfig->shard_spec_buffer();
   const target::metal::ShardSpec *shardSpec = shardSpecBuffer->shard_spec();
@@ -139,7 +140,10 @@ createMeshBufferForShardedMetalBuffer(
   tt_metal::BufferType metalBufferType = bufferType == target::BufferType::DRAM
                                              ? tt_metal::BufferType::DRAM
                                              : tt_metal::BufferType::L1;
-  uint32_t address = deviceAddressValidator(refAddress, bufferType);
+  std::optional<uint32_t> address;
+  if (refAddress) {
+    address = deviceAddressValidator(*refAddress, bufferType);
+  }
 
   // BufferShardingArgs describes buffer distribution across worker cores within
   // each device.
@@ -170,6 +174,13 @@ createMeshBufferForShardedMetalBuffer(
     tt_metal::BufferDistributionSpec metalDistributionSpec(
         toShape(distributionSpec->tensor_shape_in_pages()),
         toShape(distributionSpec->shard_shape_in_pages()), std::move(cores));
+    if (!refAddress) {
+      // An owning allocation must be sized from the distribution spec. When
+      // both forms are present, Metal's allocation path currently prioritizes
+      // the legacy shard spec, which describes only one shard per core and can
+      // under-allocate buffers that place multiple shards on each core.
+      return tt_metal::BufferShardingArgs(std::move(metalDistributionSpec));
+    }
     return tt_metal::BufferShardingArgs(
         std::move(metalDistributionSpec), metalShardSpecBuffer,
         tt_metal::TensorMemoryLayout::BLOCK_SHARDED);
@@ -181,7 +192,7 @@ createMeshBufferForShardedMetalBuffer(
       .page_size = shardedBufferConfig->page_size(),
       .buffer_type = metalBufferType,
       .sharding_args = std::move(bufferShardingArgs),
-      .bottom_up = std::nullopt,
+      .bottom_up = bottomUp,
       .sub_device_id = std::nullopt};
 
   // ShardedBufferConfig describes buffer distribution across mesh devices.
@@ -222,9 +233,10 @@ createMeshBufferForShardedMetalBuffer(
 
 inline std::shared_ptr<distributed::MeshBuffer>
 createMeshBufferForInterleavedMetalBuffer(
-    distributed::MeshDevice *meshDevice, uint64_t refAddress,
+    distributed::MeshDevice *meshDevice, std::optional<uint64_t> refAddress,
     const target::metal::InterleavedBufferConfig *interleavedBufferConfig,
-    const DeviceAddressValidator &deviceAddressValidator) {
+    const DeviceAddressValidator &deviceAddressValidator,
+    std::optional<bool> bottomUp = std::nullopt) {
 
   auto metalInterleavedBufferConfig = distributed::ShardedBufferConfig{
       .global_size = interleavedBufferConfig->size(),
@@ -241,10 +253,12 @@ createMeshBufferForInterleavedMetalBuffer(
       .page_size = interleavedBufferConfig->page_size(),
       .buffer_type = tt_metal::BufferType::DRAM,
       .sharding_args = std::move(bufferShardingArgs),
-      .bottom_up = std::nullopt};
+      .bottom_up = bottomUp};
 
-  uint32_t address =
-      deviceAddressValidator(refAddress, target::BufferType::DRAM);
+  std::optional<uint32_t> address;
+  if (refAddress) {
+    address = deviceAddressValidator(*refAddress, target::BufferType::DRAM);
+  }
   return distributed::MeshBuffer::create(
       metalInterleavedBufferConfig, localBufferConfig, meshDevice, address);
 }
@@ -286,6 +300,39 @@ inline std::shared_ptr<distributed::MeshBuffer> createMeshBufferFromBufferRef(
         metalBuffer->buffer_config_as_InterleavedBufferConfig(),
         deviceAddressValidator);
   }
+}
+
+inline std::shared_ptr<distributed::MeshBuffer>
+createOwnedMeshBufferFromBufferRef(
+    distributed::MeshDevice *meshDevice,
+    const target::metal::BufferRef *bufferRef,
+    const DeviceAddressValidator &deviceAddressValidator) {
+  const target::metal::BufferDesc *bufferDesc = bufferRef->desc();
+  LOG_ASSERT(bufferDesc->buffer_detail_type() ==
+             target::metal::BufferDetail::MetalBuffer);
+  const target::metal::MetalBuffer *metalBuffer =
+      bufferDesc->buffer_detail_as_MetalBuffer();
+
+  // D2M's static allocation plan grows from the unreserved base address.
+  // Reusable inputs are allocator-owned and grow down from the opposite end,
+  // keeping the transient plan intact while making overlap detectable.
+  constexpr bool bottomUp = false;
+  if (metalBuffer->buffer_config_type() ==
+      target::metal::BufferConfig::ShardedBufferConfig) {
+    return createMeshBufferForShardedMetalBuffer(
+        meshDevice, std::nullopt,
+        metalBuffer->buffer_config_as_ShardedBufferConfig(),
+        metalBuffer->buffer_type(), deviceAddressValidator, bottomUp);
+  }
+
+  LOG_ASSERT(meshDevice->num_rows() == 1 && meshDevice->num_cols() == 1,
+             "Interleaved buffers are only supported for single device");
+  LOG_ASSERT(metalBuffer->buffer_type() == target::BufferType::DRAM,
+             "Interleaved buffers are only supported for DRAM");
+  return createMeshBufferForInterleavedMetalBuffer(
+      meshDevice, std::nullopt,
+      metalBuffer->buffer_config_as_InterleavedBufferConfig(),
+      deviceAddressValidator, bottomUp);
 }
 #pragma clang diagnostic pop
 

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <optional>
 #include <variant>
 
@@ -271,6 +272,55 @@ void setTensorRetain(Tensor tensor, bool retain) {
   LOG_FATAL("setTensorRetain not implemented for metal runtime");
 }
 
+bool getTensorReusable(Tensor tensor) {
+  tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
+  if (!tensor.metadata) {
+    return false;
+  }
+  std::lock_guard<std::mutex> lock(tensor.metadata->mutex);
+  return tensor.metadata->reusable;
+}
+
+TensorReuseStats getTensorReuseStats(Tensor tensor) {
+  tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
+  if (!tensor.metadata) {
+    return {};
+  }
+  std::shared_ptr<void> reusableInputCache;
+  {
+    std::lock_guard<std::mutex> lock(tensor.metadata->mutex);
+    reusableInputCache = tensor.metadata->reusableInputCache;
+  }
+  return getReusableInputCacheStats(reusableInputCache);
+}
+
+void setTensorReusable(Tensor &tensor, bool reusable) {
+  const MetalTensor &metalTensor =
+      tensor.as<MetalTensor>(DeviceRuntime::TTMetal);
+  if (!tensor.metadata) {
+    if (!reusable) {
+      return;
+    }
+    tensor.metadata = std::make_shared<TensorMetadata>();
+  }
+  std::lock_guard<std::mutex> lock(tensor.metadata->mutex);
+  LOG_ASSERT(!reusable || !std::holds_alternative<MeshBuffer>(metalTensor),
+             "Device-resident TTMetal tensors are already reusable and must "
+             "not use the host-input reuse cache");
+  LOG_ASSERT(!reusable || !std::holds_alternative<std::uint32_t>(metalTensor),
+             "Scalar TTMetal inputs do not support device-buffer reuse");
+
+  if (tensor.metadata->reusable == reusable) {
+    return;
+  }
+
+  // Releasing the backend cache owns invalidation. Cached MeshBuffers remain
+  // alive until any in-flight executor aliases have also released them.
+  tensor.metadata->reusableInputCache =
+      reusable ? createReusableInputCache() : nullptr;
+  tensor.metadata->reusable = reusable;
+}
+
 tt::target::Arch getArch() {
   return ::tt::runtime::common::toTargetArch(::tt::tt_metal::hal::get_arch());
 }
@@ -342,6 +392,7 @@ void closeMeshDevice(Device parentMesh) {
   ::tt::tt_metal::ReadMeshDeviceProfilerResults(metalMeshDevice);
 #endif
 
+  clearReusableInputCachesForDevice(parentMesh.getGlobalId());
   metalMeshDevice.close();
 }
 
@@ -377,6 +428,7 @@ void releaseSubMeshDevice(Device subMesh) {
   LOG_ASSERT(!metalMeshDevice.is_parent_mesh(),
              "Mesh device must be a submesh");
 
+  clearReusableInputCachesForDevice(subMesh.getGlobalId());
   metalMeshDevice.close();
   subMesh.handle.reset();
 }
@@ -387,6 +439,7 @@ void reshapeMeshDevice(Device meshDevice,
       meshDevice.as<::tt::tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
 
+  clearReusableInputCachesForDevice(meshDevice.getGlobalId());
   metalMeshDevice.reshape(
       ::tt::tt_metal::distributed::MeshShape(meshShape[0], meshShape[1]));
 }
@@ -1045,6 +1098,10 @@ std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
   tt_metal::distributed::MeshDevice &meshDevice =
       deviceHandle.as<tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
+  const bool hasReusableInput =
+      std::any_of(inputs.begin(), inputs.end(), getTensorReusable);
+  LOG_ASSERT(!hasReusableInput || meshDevice.num_devices() == 1,
+             "Reusable D2M inputs currently require a single-device handle");
   if (meshDevice.num_rows() != 1 || meshDevice.num_cols() != 1) {
     LOG_WARNING("D2M runtime multi-device support is experimental. mesh = [",
                 meshDevice.num_rows(), ", ", meshDevice.num_cols(), "]");
@@ -1089,10 +1146,10 @@ std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::to_string(deviceProgramMeshDevice[i]->id());
     ZoneName(zoneName.c_str(), zoneName.size());
 
-    outputs = executeMeshDeviceProgram(deviceProgramMeshDevice[i].get(),
-                                       deviceProgram, inputs,
-                                       common::DylibManager(fbb.dylibs()),
-                                       executableHandle.id(), programIndex, i);
+    outputs = executeMeshDeviceProgram(
+        deviceProgramMeshDevice[i].get(), deviceProgram, inputs,
+        common::DylibManager(fbb.dylibs()), deviceHandle.getGlobalId(),
+        executableHandle.id(), programIndex, i);
 
     LOG_ASSERT(outputs.size() == program->outputs()->size(),
                "Outputs size mismatch");

--- a/runtime/python/runtime/runtime.cpp
+++ b/runtime/python/runtime/runtime.cpp
@@ -216,6 +216,25 @@ void registerRuntimeBindings(nb::module_ &m) {
            [](tt::runtime::Tensor self, bool retain) {
              tt::runtime::setTensorRetain(self, retain);
            })
+      .def("get_reusable",
+           [](tt::runtime::Tensor self) {
+             return tt::runtime::getTensorReusable(self);
+           })
+      .def("set_reusable",
+           [](tt::runtime::Tensor &self, bool reusable) {
+             tt::runtime::setTensorReusable(self, reusable);
+           })
+      .def("get_reuse_stats",
+           [](tt::runtime::Tensor self) {
+             const tt::runtime::TensorReuseStats stats =
+                 tt::runtime::getTensorReuseStats(self);
+             return std::unordered_map<std::string, std::uint64_t>{
+                 {"cache_hits", stats.cacheHits},
+                 {"cache_misses", stats.cacheMisses},
+                 {"uploaded_bytes", stats.uploadedBytes},
+                 {"device_buffer_count", stats.deviceBufferCount},
+             };
+           })
       .def("get_shape",
            [](tt::runtime::Tensor self) {
              return tt::runtime::getTensorShape(self);

--- a/runtime/python/runtime/stubs_macos.cpp
+++ b/runtime/python/runtime/stubs_macos.cpp
@@ -249,6 +249,8 @@ tt::target::DataType getTensorDataType(Tensor tensor) { __builtin_trap(); }
 TensorDesc getTensorDesc(Tensor tensor) { __builtin_trap(); }
 std::uint32_t getTensorElementSize(Tensor tensor) { __builtin_trap(); }
 bool getTensorRetain(Tensor tensor) { __builtin_trap(); }
+bool getTensorReusable(Tensor tensor) { __builtin_trap(); }
+TensorReuseStats getTensorReuseStats(Tensor tensor) { __builtin_trap(); }
 std::vector<std::uint32_t> getTensorShape(Tensor tensor) { __builtin_trap(); }
 std::vector<std::uint32_t> getTensorStride(Tensor tensor) { __builtin_trap(); }
 std::uint32_t getTensorVolume(Tensor tensor) { __builtin_trap(); }
@@ -281,6 +283,7 @@ void setCurrentDeviceRuntime(const DeviceRuntime &runtime) { __builtin_trap(); }
 void setCurrentHostRuntime(const HostRuntime &runtime) { __builtin_trap(); }
 void setFabricConfig(FabricConfig config) { __builtin_trap(); }
 void setTensorRetain(Tensor tensor, bool retain) { __builtin_trap(); }
+void setTensorReusable(Tensor &tensor, bool reusable) { __builtin_trap(); }
 void shutdownDistributedRuntime() { __builtin_trap(); }
 std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
   __builtin_trap();

--- a/test/python/golden/d2m/test_input_reuse.py
+++ b/test/python/golden/d2m/test_input_reuse.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Optional
+
+import pytest
+import torch
+
+import _ttmlir_runtime as tt_runtime
+from builder.base.builder_apis import compile_ttir_to_flatbuffer
+from builder.base.builder_runtime import (
+    convert_input_layouts,
+    create_tensor,
+    program_outputs_as_dict,
+    runtime_dtype_to_torch_dtype,
+    runtime_str_dtype_to_torch_dtype,
+)
+from builder.base.builder_utils import Operand, Shape
+from builder.ttir.ttir_builder import TTIRBuilder
+
+pytestmark = pytest.mark.frontend("ttir")
+
+
+def _read_output(fbb, device, runtime_output) -> torch.Tensor:
+    output_desc = program_outputs_as_dict(fbb, 0)[0]["desc"]
+    output = torch.empty(
+        output_desc["shape"],
+        dtype=runtime_str_dtype_to_torch_dtype(
+            output_desc["layout"]["memory_desc"]["data_type"]
+        ),
+    )
+    output_tensor = create_tensor({0: output}, device.get_mesh_shape())
+    output_shards = tt_runtime.runtime.to_host(runtime_output, untilize=True)
+    assert len(output_shards) == 1
+    tt_runtime.runtime.memcpy(output_tensor, output_shards[0])
+    data = torch.frombuffer(
+        bytearray(output_tensor.get_data_buffer()),
+        dtype=runtime_dtype_to_torch_dtype(output_tensor.get_dtype()),
+    ).reshape(output_tensor.get_shape())
+    tt_runtime.runtime.deallocate_tensor(runtime_output, force=True)
+    return data.clone()
+
+
+def _submit_add(fbb, device, lhs, rhs: torch.Tensor) -> torch.Tensor:
+    rhs_runtime = create_tensor({0: rhs}, device.get_mesh_shape())
+    rhs_layout = tt_runtime.runtime.get_layout(fbb, 0, 1)
+    rhs_runtime = tt_runtime.runtime.to_layout(rhs_runtime, device, rhs_layout, True)
+    outputs = tt_runtime.runtime.submit(device, fbb, 0, [lhs, rhs_runtime])
+    tt_runtime.runtime.wait(outputs)
+    assert len(outputs) == 1
+    return _read_output(fbb, device, outputs[0])
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_reusable_input_is_uploaded_once_and_preserves_output(
+    target: str, request, device
+):
+    shape: Shape = (64, 64)
+    dtype = torch.float32
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, shape], [dtype, dtype])
+        def add(
+            in0: Operand,
+            in1: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            return builder.add(in0, in1, unit_attrs=unit_attrs)
+
+    _, capsule, _, _ = compile_ttir_to_flatbuffer(
+        module,
+        system_desc_path=request.config.getoption("--sys-desc"),
+        target=target,
+    )
+    fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+    tt_runtime.runtime.set_compatible_device_runtime(fbb)
+
+    lhs = torch.linspace(-1.0, 1.0, shape[0] * shape[1], dtype=dtype).reshape(shape)
+    lhs_runtime = create_tensor({0: lhs}, device.get_mesh_shape())
+    lhs_runtime = convert_input_layouts(
+        device, [lhs_runtime], fbb=fbb, program_index=0
+    )[0]
+    assert not lhs_runtime.get_reusable()
+    assert lhs_runtime.get_reuse_stats() == {
+        "cache_hits": 0,
+        "cache_misses": 0,
+        "uploaded_bytes": 0,
+        "device_buffer_count": 0,
+    }
+    lhs_runtime.set_reusable(True)
+    assert lhs_runtime.get_reusable()
+
+    first_rhs = torch.full(shape, 0.25, dtype=dtype)
+    first_output = _submit_add(fbb, device, lhs_runtime, first_rhs)
+    torch.testing.assert_close(first_output, lhs + first_rhs, atol=0.005, rtol=0.01)
+    assert lhs_runtime.get_reuse_stats() == {
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "uploaded_bytes": lhs.numel() * lhs.element_size(),
+        "device_buffer_count": 1,
+    }
+
+    second_rhs = torch.full(shape, -0.5, dtype=dtype)
+    second_output = _submit_add(fbb, device, lhs_runtime, second_rhs)
+    torch.testing.assert_close(second_output, lhs + second_rhs, atol=0.005, rtol=0.01)
+    assert lhs_runtime.get_reuse_stats()["cache_hits"] == 1
+
+    # A separately loaded binary has its own compiled allocation plan. It must
+    # populate a distinct cache entry even when the flatbuffer bytes and input
+    # destination global IDs are identical.
+    second_fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+    binary_scoped_rhs = torch.full(shape, 0.75, dtype=dtype)
+    binary_scoped_output = _submit_add(
+        second_fbb, device, lhs_runtime, binary_scoped_rhs
+    )
+    torch.testing.assert_close(
+        binary_scoped_output, lhs + binary_scoped_rhs, atol=0.005, rtol=0.01
+    )
+    assert lhs_runtime.get_reuse_stats() == {
+        "cache_hits": 1,
+        "cache_misses": 2,
+        "uploaded_bytes": 2 * lhs.numel() * lhs.element_size(),
+        "device_buffer_count": 2,
+    }
+
+    # Clearing reuse is explicit invalidation: all retained buffers and stats
+    # are released. Re-enabling it causes the next submit to upload again.
+    lhs_runtime.set_reusable(False)
+    assert not lhs_runtime.get_reusable()
+    lhs.add_(2.0)
+    lhs_runtime.set_reusable(True)
+    third_rhs = torch.full(shape, 1.0, dtype=dtype)
+    third_output = _submit_add(fbb, device, lhs_runtime, third_rhs)
+    torch.testing.assert_close(third_output, lhs + third_rhs, atol=0.005, rtol=0.01)
+    assert lhs_runtime.get_reuse_stats() == {
+        "cache_hits": 0,
+        "cache_misses": 1,
+        "uploaded_bytes": lhs.numel() * lhs.element_size(),
+        "device_buffer_count": 1,
+    }


### PR DESCRIPTION
## Summary

Add an explicit reusable-input contract for immutable host-backed D2M tensors. The first compatible submission materializes and uploads each input destination normally; later submissions bind tensor-owned device buffers and skip redundant derived host-layout copies and H2D writes.

The cache key includes device, binary, program, device-program, input, and destination identity. Reusable buffers are allocator-owned from the opposite end of memory from D2M's explicit transient plan, with overlap checks against live and future transient allocations. Cached TT-Metal programs refresh runtime arguments from the live buffer addresses.

The API is opt-in through `Tensor.set_reusable(bool)`, with retention statistics exposed for validation. Device close/release/reshape invalidates entries. The initial implementation intentionally supports only single-device local TTMetal execution.

This PR is stacked on #9096 because reuse must coexist with cached programs whose runtime buffer addresses can change.

## Contract

While reuse is enabled, the caller must not mutate the tensor's host storage or submit it to a program that writes or aliases the corresponding device input. The tensor must outlive all using submissions, and reuse must not be cleared while a submission is in flight.

## Validation

- `pre-commit` passes for all 12 changed files.
- Debug `_ttmlir_runtime` build passes with runtime, StableHLO, runtime tests, TTNN JIT, and perf trace enabled.
- Focused device tests pass: input reuse, program cache, and scalar runtime args (`4 passed`).
- Exact Llama 3 8B prefill decoder block, batch 32 / sequence 18:
  - Every retained D2M tensor recorded one miss followed by eight hits.
  - Reused output is bitwise identical to two uncached D2M executions for all three outputs.
  - D2M/TTNN validation passes: cache PCCs 0.999865 and 0.999855; hidden-state PCC 0.996717; untouched cache suffixes are bitwise preserved.

## Steady-state experiment

The selected immutable inputs are 436,224,128 logical bytes per invocation (436,736,000 scheduled destination bytes in D2M).

| condition | median wall time |
| --- | ---: |
| D2M, all inputs materialized/uploaded per invocation | 863.73 ms |
| D2M, immutable inputs retained | 385.92 ms |
| D2M retained, reversed backend order repeat | 391.42 ms |
| compiler TTNN, prepared immutable handles | 272.28 ms |
| compiler TTNN prepared, reversed order repeat | 270.93 ms |

The D2M no-reuse delta is 477.80 ms, almost entirely deferred into submit/wait. TTNN's analogous no-prepared-handle path is not a raw-transfer control: new tensor-wrapper versions miss six `LoadCachedOp` global tensor-cache entries and re-run const-eval subprograms containing CPU/typecast, layout, and device-transfer work. The retained/prepared condition is therefore the semantically matched steady-state comparison.
