### PR TITLE
[TTIR] Skip the SDPA NaN-safety select when there is no mask

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -317,6 +317,30 @@ bool validateMask(Value mask, ArrayRef<int64_t> qShape, int64_t kSeqLen) {
 
 } // namespace
 
+// True if `v` transitively reads a tensor shaped like the score matrix. torch's
+// NaN guard builds its predicate from the scores; a caller-supplied row mask
+// does not. Only the former can be reasoned about from the absence of a mask.
+static bool readsScoreShape(Value v, Value scores) {
+  ArrayRef<int64_t> shape =
+      mlir::cast<RankedTensorType>(scores.getType()).getShape();
+  SmallVector<Value> worklist{v};
+  llvm::SmallPtrSet<Operation *, 16> seen;
+  while (!worklist.empty()) {
+    Value current = worklist.pop_back_val();
+    if (auto type = mlir::dyn_cast<RankedTensorType>(current.getType())) {
+      if (type.getShape() == shape) {
+        return true;
+      }
+    }
+    Operation *def = current.getDefiningOp();
+    if (!def || !seen.insert(def).second) {
+      continue;
+    }
+    worklist.append(def->getOperands().begin(), def->getOperands().end());
+  }
+  return false;
+}
+
 mlir::LogicalResult
 SDPAFusingPattern::matchAndRewrite(MatmulOp srcOp,
                                    mlir::PatternRewriter &rewriter) const {
@@ -598,6 +622,16 @@ SDPAFusingPattern::matchAndRewrite(MatmulOp srcOp,
       /*attention_sink=*/attentionSink);
 
   Value result = newOp.getResult();
+
+  // Only a mask can introduce -inf, so with no mask a score-derived predicate
+  // is uniformly false and the select is an identity. Dropping it frees the
+  // score matmul it is the last reader of. A caller-supplied predicate is
+  // preserved.
+  if (nanSafeRowCond && !c.mask &&
+      readsScoreShape(nanSafeRowCond, c.softmax.getInput())) {
+    nanSafeRowCond = nullptr;
+  }
+
   if (nanSafeRowCond) {
     // Re-apply the NaN-safety select on the SDPA output. Zeroing whole rows of
     // the attention weights equals zeroing the same output rows (the matmul

--- a/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa.mlir
@@ -637,3 +637,30 @@ module {
     return %o : tensor<2x8x1x64xf32>
   }
 }
+
+// Same guard, but with the predicate derived from the scores (as torch's
+// _safe_softmax lowers). With no mask nothing introduces -inf, so it cannot
+// fire: the select must be dropped, or its predicate pins the QK^T matmul.
+module {
+  func.func @sdpa_mha_nan_safe_where_score_derived(
+      %q: tensor<1x8x128x64xbf16>,
+      %k: tensor<1x8x128x64xbf16>,
+      %v: tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64xbf16> {
+    // CHECK-LABEL: @sdpa_mha_nan_safe_where_score_derived
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-NOT: ttir.where
+    // CHECK-NOT: ttir.matmul
+    // CHECK-NOT: ttir.eq
+    %kt = "ttir.permute"(%k) <{permutation = array<i64: 0, 1, 3, 2>}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x64x128xbf16>
+    %qk = "ttir.matmul"(%q, %kt) <{transpose_a = false, transpose_b = false}> : (tensor<1x8x128x64xbf16>, tensor<1x8x64x128xbf16>) -> tensor<1x8x128x128xbf16>
+    %smx = "ttir.softmax"(%qk) <{dimension = -1 : si32, numericStable = false}> : (tensor<1x8x128x128xbf16>) -> tensor<1x8x128x128xbf16>
+    %neginf = "ttir.full"() <{fill_value = 0xFF800000 : f32, shape = array<i32: 1, 8, 128, 128>}> : () -> tensor<1x8x128x128xbf16>
+    %masked = "ttir.eq"(%qk, %neginf) : (tensor<1x8x128x128xbf16>, tensor<1x8x128x128xbf16>) -> tensor<1x8x128x128xi1>
+    %rowdead = "ttir.min"(%masked) <{dim_arg = [3 : i32], keep_dim = true}> : (tensor<1x8x128x128xi1>) -> tensor<1x8x128x1xi1>
+    %cond = "ttir.broadcast"(%rowdead) <{broadcast_dimensions = array<i64: 1, 1, 1, 128>}> : (tensor<1x8x128x1xi1>) -> tensor<1x8x128x128xi1>
+    %zeros = "ttir.zeros"() <{shape = array<i32: 1, 8, 128, 128>}> : () -> tensor<1x8x128x128xbf16>
+    %safe = "ttir.where"(%cond, %zeros, %smx) : (tensor<1x8x128x128xi1>, tensor<1x8x128x128xbf16>, tensor<1x8x128x128xbf16>) -> tensor<1x8x128x128xbf16>
+    %o = "ttir.matmul"(%safe, %v) <{transpose_a = false, transpose_b = false}> : (tensor<1x8x128x128xbf16>, tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64xbf16>
+    return %o : tensor<1x8x128x64xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket

https://github.com/tenstorrent/tt-xla/issues/5863

### Problem description

`SDPAFusing` peels the NaN-safety select a model wraps around attention (`where(row_all_masked, 0, softmax)`), fuses the core, then re-applies the select to the fused output. For the predicate it prefers a mask-derived one, which is equivalent but does not read `QK^T` — so the score matmul becomes dead. That preference is gated on a mask being present; with no mask it falls back to the model's score-derived predicate.

A score-derived predicate reads every element of the score matrix, so it becomes the matmul's last consumer and pins it. In Mochi's transformer that is 12.18 GB of f32 scores plus a 6.09 GB bf16 compare per device — 18.27 GB — to evaluate a condition that is uniformly false, since the op has no mask and `is_causal=false` so nothing can introduce `-inf`. It OOMs at 6,090,129,408 B.

For more context, checkout https://github.com/tenstorrent/tt-xla/issues/5863#issuecomment-5178695824

### What's changed
Skip re-applying the select when it provably cannot fire: no mask, and a predicate derived from the scores. Both conditions are needed — a caller-supplied predicate says nothing about the scores and must be preserved (covered by the existing `sdpa_mha_nan_safe_where`), so `readsScoreShape` walks back from the predicate to confirm it reads a score-shaped tensor.

Dropping the select removes the score matmul's last reader, so the `eq`, the reduction and the matmul are all DCE'd.

Measured on a standalone repro of Mochi's attention block (24 heads sharded to 6/device on a 1x4 mesh, seq 22516, bf16):

| | before | after |
|---|---|---|
| `ttnn.eq` / `ttnn.min` over `1x6x22516x22516` | 3 / 3 | 0 / 0 |
| any TTNN op on `22516x22516` | yes | none |
| `ttnn.scaled_dot_product_attention` | 1 per graph | 1 per graph |
| peak device DRAM | 18.44 GB | 0.243 GB |

The attention still fuses to a single hardware op; only the dead guard and the score matmul it pinned are gone.

In the full Mochi transformer the guard OOM is gone and the run progresses much further — 45 fused SDPA ops instead of 4, no `ttnn.eq` and no TTNN op on `22516x22516`. It now fails later at `untilize_with_unpadding` on a 547,061,760 B allocation with 33.34 GB resident, which is a separate memory issue tracked outside this PR.

### Checklist
- [x] Verify the changes through local testing in quitebox

### Logs

- [aug4_sdpa_mc_before_fix.log](https://github.com/user-attachments/files/30703222/aug4_sdpa_mc_before_fix.log)
- [aug4_sdpa_mc_after_fix.log](https://github.com/user-attachments/files/30703221/aug4_sdpa_mc_after_fix_z2.log)
- [aug4_mochi_transformer_before_fix.log](https://github.com/user-attachments/files/30703219/aug4_mochi_transformer_before_fix.log)
- [aug4_mochi_transformer_after_fix.log.zip](https://github.com/user-attachments/files/30703218/aug4_mochi_transformer_after_fix_z.log.zip)