### PR TITLE
[L1SpillManagement] Spill Typecast inputs before DRAM demote (fixes #9094)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/L1SpillManagement.h
@@ -465,6 +465,17 @@ protected:
   /// Build schedule, last-use positions, death schedule, and position map.
   ScheduleData buildScheduleData();
 
+  /// Before demoting `op` to DRAM Interleaved, spill any L1-sharded operands
+  /// to DRAM Interleaved so layout-constrained ops (notably TypecastOp) keep
+  /// matching input/output memory layouts. Without this, demoteToDram leaves
+  /// Typecast with BLOCK_SHARDED in / INTERLEAVED out, which tt-metal rejects
+  /// (tt-mlir#9094).
+  ///
+  /// Live operands go through `evictValue` (tracker-safe). Non-live L1
+  /// sharded operands get a ToMemoryConfig inserted just before `op`.
+  void prepareOperandsForDramDemotion(Operation *op, int64_t pos,
+                                      ScheduleData &data);
+
   /// Insert a reshard op into the schedule at consumerPos (shifting the
   /// consumer and all later ops by +1), updating positionMap, lastUsePositions,
   /// and deathSchedule so the forward sweep processes the reshard naturally.
@@ -588,6 +599,7 @@ protected:
   using Base::markEvictedAndRebuild;
   using Base::memoryTracker;
   using Base::observer_;
+  using Base::prepareOperandsForDramDemotion;
   using Base::spillToDram;
 
   // Strategy hooks (address-sim implementations).
@@ -620,6 +632,10 @@ protected:
   void evictForCBOverlap(uint64_t cushionedCBUsage, int64_t pos,
                          ScheduleData &data);
   void evictForDramCBGrowth(Operation *op, int64_t pos, ScheduleData &data);
+
+  /// Spill matching-layout operands if needed, demote `op` to DRAM, then
+  /// run the DRAM-output CB growth check (address-sim path only).
+  void demoteOpToDramChecked(Operation *op, int64_t pos, ScheduleData &data);
 };
 
 extern template class AddressSimSpillManagement<SumL1MemoryTracker>;

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -729,9 +729,12 @@ void AddressSimSpillManagement<MemoryTracker>::handleOOM(
     // Stage 3: Op exceeds L1 budget even with no other live tensors — the op
     // itself is too large for the configured cap. Demote its output to DRAM.
     // No evictForDramCBGrowth needed: evictUntil already drained the live set.
+    // Still prepare Typecast operands (tt-mlir#9094): they may be L1-sharded
+    // in IR even when not present in the live set.
     observer_->onSelfSpill(op, pos);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    DEMOTE SELF: op exceeds budget alone");
+    prepareOperandsForDramDemotion(op, pos, data);
     demoteToDram(op);
   }
 }
@@ -1187,8 +1190,7 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(
     return 0;
   }
   if (!fitsAfterEviction) {
-    demoteToDram(op);
-    evictForDramCBGrowth(op, pos, data);
+    demoteOpToDramChecked(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    NO_FIT: eviction exhausted, demoting to DRAM");
     return 0;
@@ -1210,8 +1212,7 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleNoFit(
     return freshL1;
   }
 
-  demoteToDram(op);
-  evictForDramCBGrowth(op, pos, data);
+  demoteOpToDramChecked(op, pos, data);
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    NO_FIT: validation failed after eviction, demoting to "
                "DRAM");
@@ -1250,8 +1251,7 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
   // Eviction was exhausted (op's own output won't fit / CB still overlaps).
   // Demote this op's output to DRAM rather than ship a clashing layout.
   if (!fitsAfterEviction) {
-    demoteToDram(op);
-    evictForDramCBGrowth(op, pos, data);
+    demoteOpToDramChecked(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "    FRAG_DEMOTE: eviction exhausted, output to DRAM");
     return 0;
@@ -1326,8 +1326,7 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     }
   }
 
-  demoteToDram(op);
-  evictForDramCBGrowth(op, pos, data);
+  demoteOpToDramChecked(op, pos, data);
   TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                "    FRAG_DEMOTE: output to DRAM");
   return 0;
@@ -1608,6 +1607,7 @@ void L1SpillManagementBase<MemoryTracker>::run() {
                    "    BACKEND_ERROR at pos {0} for {1}: {2}. "
                    "Demoting to DRAM.",
                    pos, ttmlir::opToString(op), result.errorMessage);
+      prepareOperandsForDramDemotion(op, pos, data);
       demoteToDram(op);
       ++spillCount;
       continue;
@@ -1705,8 +1705,26 @@ L1SpillManagementBase<MemoryTracker>::computeLastUsePositions(
 }
 
 //===----------------------------------------------------------------------===//
-// demoteToDram
+// demoteToDram / prepareOperandsForDramDemotion / demoteOpToDramChecked
 //===----------------------------------------------------------------------===//
+
+namespace {
+
+/// True when `value` is an L1-sharded tensor. Demoting a consumer to DRAM
+/// Interleaved while leaving such an operand sharded violates ops that
+/// require matching in/out memory layouts (TypecastOp — tt-mlir#9094).
+bool isL1Sharded(Value value) {
+  auto tensorType = mlir::dyn_cast<RankedTensorType>(value.getType());
+  if (!tensorType) {
+    return false;
+  }
+  auto layoutAttr =
+      mlir::dyn_cast_or_null<TTNNLayoutAttr>(tensorType.getEncoding());
+  return layoutAttr && layoutAttr.hasL1BufferType() &&
+         layoutAttr.hasShardedTensorMemoryLayout();
+}
+
+} // namespace
 
 template <typename MemoryTracker>
 void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
@@ -1732,6 +1750,70 @@ void L1SpillManagementBase<MemoryTracker>::demoteToDram(Operation *op) {
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer, "Demoted to DRAM: {0}",
                ttmlir::opToString(op));
+}
+
+template <typename MemoryTracker>
+void L1SpillManagementBase<MemoryTracker>::prepareOperandsForDramDemotion(
+    Operation *op, int64_t pos, ScheduleData &data) {
+  // Only Typecast (and future ops with the same metal constraint) need
+  // matching in/out memory layouts. Other ops accept DRAM-Interleaved
+  // outputs with sharded L1 inputs via inserted reshards on the consumer
+  // side; spilling every operand here would over-spill.
+  if (!isa<TypecastOp>(op)) {
+    return;
+  }
+
+  llvm::SmallVector<Value> liveToEvict;
+  for (OpOperand &use : op->getOpOperands()) {
+    Value operand = use.get();
+    if (!isL1Sharded(operand)) {
+      continue;
+    }
+    if (liveValues.count(operand)) {
+      liveToEvict.push_back(operand);
+      continue;
+    }
+    // Not tracked as live (block arg, already past last-use, etc.) but still
+    // L1-sharded in IR. Insert a DRAM-Interleaved ToMemoryConfig just before
+    // `op` and rewire only this use — spillToDram needs a defining op and
+    // would crash on block arguments.
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    PREPARE_DEMOTE: inserting DRAM-Interleaved spill before "
+                 "typecast operand #{0} (tt-mlir#9094)",
+                 use.getOperandNumber());
+    auto tensorType = mlir::cast<RankedTensorType>(operand.getType());
+    auto layoutAttr = mlir::cast<TTNNLayoutAttr>(tensorType.getEncoding());
+    TTNNLayoutAttr dramLayout =
+        TTNNLayoutAttr::Builder(layoutAttr, tensorType.getShape())
+            .setBufferType(BufferType::DRAM)
+            .setMemoryLayout(TensorMemoryLayout::Interleaved)
+            .build();
+    RankedTensorType dramType =
+        utils::RankedTensorTypeFactory::create(tensorType, dramLayout);
+    OpBuilder builder(op);
+    Location loc = ttmlir::utils::appendLocationSuffix(op->getLoc(), "_spill");
+    Operation *spillOp =
+        builder.create<ToMemoryConfigOp>(loc, dramType, operand);
+    use.set(spillOp->getResult(0));
+  }
+
+  size_t campaignMin = SIZE_MAX;
+  for (Value victim : liveToEvict) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "    PREPARE_DEMOTE: evicting live L1-sharded operand {0} "
+                 "before demoting typecast (tt-mlir#9094)",
+                 ttmlir::opToString(victim.getDefiningOp()));
+    // skipReshardConsumer=op: do not restore this typecast's operand to L1.
+    evictValue(victim, pos, data, campaignMin, /*skipReshardConsumer=*/op);
+  }
+}
+
+template <typename MemoryTracker>
+void AddressSimSpillManagement<MemoryTracker>::demoteOpToDramChecked(
+    Operation *op, int64_t pos, ScheduleData &data) {
+  prepareOperandsForDramDemotion(op, pos, data);
+  demoteToDram(op);
+  evictForDramCBGrowth(op, pos, data);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2212,6 +2294,8 @@ void StatefulL1SpillManagement::recoverFromOOM(
         ttmlir::LogComponent::GreedyOptimizer,
         "    DEMOTE SELF (stateful): {0} unplaceable after draining L1",
         ttmlir::opToString(op));
+    // Prepare Typecast operands before demote (tt-mlir#9094).
+    prepareOperandsForDramDemotion(op, pos, data);
     demoteToDram(op);
     return; // no rewind; sweep advances to pos+1
   }

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -132,38 +132,38 @@ TEST_F(SelfSpillTest, TypecastDemoteSpillsShardedInput) {
   // Stage-3 self-demote: typecast output alone exceeds the budget. The input
   // is a block argument (never in the live set), so prepareOperands must
   // insert a spill before `op` rather than calling spillToDram.
-  auto typecast =
-      builder.create<TypecastOp>(builder.getUnknownLoc(), tt, args[0]);
-  setL1Usage(typecast.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
-  finishFunc({typecast.getResult()});
+  auto typecastOp = builder.create<mlir::tt::ttnn::TypecastOp>(
+      builder.getUnknownLoc(), tt, args[0]);
+  setL1Usage(typecastOp.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
+  finishFunc({typecastOp.getResult()});
 
   auto [obs] = run();
 
   EXPECT_FALSE(pass->hasFailed())
       << "demotion must not leave an illegal Typecast layout pair";
   ASSERT_FALSE(obs->selfSpills.empty());
-  EXPECT_EQ(obs->selfSpills.front().op, typecast.getOperation());
+  EXPECT_EQ(obs->selfSpills.front().op, typecastOp.getOperation());
 
   // Output demoted to DRAM Interleaved.
   auto outRt =
-      mlir::cast<mlir::RankedTensorType>(typecast.getResult().getType());
+      mlir::cast<mlir::RankedTensorType>(typecastOp.getResult().getType());
   auto outLayout =
       mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(outRt.getEncoding());
   EXPECT_FALSE(outLayout.hasL1BufferType());
   EXPECT_EQ(outLayout.getMemLayout().getValue(),
-            TensorMemoryLayout::Interleaved);
+            mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
 
   // Input rewired through a ToMemoryConfig spill to DRAM Interleaved.
-  mlir::Value typecastIn = typecast.getInput();
+  mlir::Value typecastIn = typecastOp.getInput();
   auto *spill = typecastIn.getDefiningOp();
-  ASSERT_TRUE(spill && mlir::isa<ToMemoryConfigOp>(spill))
+  ASSERT_TRUE(spill && mlir::isa<mlir::tt::ttnn::ToMemoryConfigOp>(spill))
       << "expected a ToMemoryConfigOp spill on the typecast input";
   auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
   auto inLayout =
       mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(inRt.getEncoding());
   EXPECT_FALSE(inLayout.hasL1BufferType());
   EXPECT_EQ(inLayout.getMemLayout().getValue(),
-            TensorMemoryLayout::Interleaved);
+            mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
 }
 
 // tt-mlir#9094 (live-operand path): typecast consumes a live L1-sharded
@@ -179,35 +179,35 @@ TEST_F(SelfSpillTest, TypecastDemoteEvictsLiveShardedProducer) {
   auto args = beginFunc({tt});
   // Small producer that stays in the live set until the typecast demotes.
   auto *producer = addUnary(args[0], tt, /*l1UsageBytes=*/100 * kKiB);
-  auto typecast = builder.create<TypecastOp>(builder.getUnknownLoc(), tt,
-                                             producer->getResult(0));
-  setL1Usage(typecast.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
-  finishFunc({typecast.getResult()});
+  auto typecastOp = builder.create<mlir::tt::ttnn::TypecastOp>(
+      builder.getUnknownLoc(), tt, producer->getResult(0));
+  setL1Usage(typecastOp.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
+  finishFunc({typecastOp.getResult()});
 
   auto [obs] = run();
 
   EXPECT_FALSE(pass->hasFailed());
   ASSERT_FALSE(obs->selfSpills.empty());
-  EXPECT_EQ(obs->selfSpills.front().op, typecast.getOperation());
+  EXPECT_EQ(obs->selfSpills.front().op, typecastOp.getOperation());
 
   auto outRt =
-      mlir::cast<mlir::RankedTensorType>(typecast.getResult().getType());
+      mlir::cast<mlir::RankedTensorType>(typecastOp.getResult().getType());
   auto outLayout =
       mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(outRt.getEncoding());
   EXPECT_FALSE(outLayout.hasL1BufferType());
   EXPECT_EQ(outLayout.getMemLayout().getValue(),
-            TensorMemoryLayout::Interleaved);
+            mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
 
   // Live producer was spilled to DRAM Interleaved for the typecast.
   EXPECT_TRUE(wasSpilled(producer->getResult(0)))
       << "live L1-sharded producer must be spilled before typecast demote";
-  mlir::Value typecastIn = typecast.getInput();
+  mlir::Value typecastIn = typecastOp.getInput();
   auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
   auto inLayout =
       mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(inRt.getEncoding());
   EXPECT_FALSE(inLayout.hasL1BufferType());
   EXPECT_EQ(inLayout.getMemLayout().getValue(),
-            TensorMemoryLayout::Interleaved);
+            mlir::tt::ttnn::TensorMemoryLayout::Interleaved);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -117,6 +117,98 @@ TEST_F(SelfSpillTest, OpTooLargeForBudgetDemotes) {
   EXPECT_EQ(obs->selfSpills.front().op, opA);
 }
 
+// tt-mlir#9094: demoting a Typecast whose input is still L1-sharded must
+// insert a DRAM-Interleaved spill on that input first. Otherwise demoteToDram
+// leaves Typecast with HEIGHT/BLOCK_SHARDED in and INTERLEAVED out, which
+// tt-metal rejects (matching memory-layout fatal).
+TEST_F(SelfSpillTest, TypecastDemoteSpillsShardedInput) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 2048, 1024};
+  auto l1Layout = makeL1Sharded(shape);
+  auto tt = tensorType(shape, l1Layout);
+
+  auto args = beginFunc({tt});
+  // Stage-3 self-demote: typecast output alone exceeds the budget. The input
+  // is a block argument (never in the live set), so prepareOperands must
+  // insert a spill before `op` rather than calling spillToDram.
+  auto typecast =
+      builder.create<TypecastOp>(builder.getUnknownLoc(), tt, args[0]);
+  setL1Usage(typecast.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
+  finishFunc({typecast.getResult()});
+
+  auto [obs] = run();
+
+  EXPECT_FALSE(pass->hasFailed())
+      << "demotion must not leave an illegal Typecast layout pair";
+  ASSERT_FALSE(obs->selfSpills.empty());
+  EXPECT_EQ(obs->selfSpills.front().op, typecast.getOperation());
+
+  // Output demoted to DRAM Interleaved.
+  auto outRt =
+      mlir::cast<mlir::RankedTensorType>(typecast.getResult().getType());
+  auto outLayout =
+      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(outRt.getEncoding());
+  EXPECT_FALSE(outLayout.hasL1BufferType());
+  EXPECT_EQ(outLayout.getMemLayout().getValue(),
+            TensorMemoryLayout::Interleaved);
+
+  // Input rewired through a ToMemoryConfig spill to DRAM Interleaved.
+  Value typecastIn = typecast.getInput();
+  auto *spill = typecastIn.getDefiningOp();
+  ASSERT_TRUE(spill && isa<ToMemoryConfigOp>(spill))
+      << "expected a ToMemoryConfigOp spill on the typecast input";
+  auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
+  auto inLayout =
+      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(inRt.getEncoding());
+  EXPECT_FALSE(inLayout.hasL1BufferType());
+  EXPECT_EQ(inLayout.getMemLayout().getValue(),
+            TensorMemoryLayout::Interleaved);
+}
+
+// tt-mlir#9094 (live-operand path): typecast consumes a live L1-sharded
+// producer that itself fits, but the typecast's output forces Stage-3 demote.
+// prepareOperands must evictValue the live producer (skipReshard back to the
+// typecast) so the demoted typecast sees DRAM Interleaved input.
+TEST_F(SelfSpillTest, TypecastDemoteEvictsLiveShardedProducer) {
+  l1BudgetPerCore = 1300 * kKiB;
+  llvm::SmallVector<int64_t> shape = {1, 1, 2048, 1024};
+  auto l1Layout = makeL1Sharded(shape);
+  auto tt = tensorType(shape, l1Layout);
+
+  auto args = beginFunc({tt});
+  // Small producer that stays in the live set until the typecast demotes.
+  auto *producer = addUnary(args[0], tt, /*l1UsageBytes=*/100 * kKiB);
+  auto typecast = builder.create<TypecastOp>(builder.getUnknownLoc(), tt,
+                                             producer->getResult(0));
+  setL1Usage(typecast.getOperation(), /*l1UsageBytes=*/2000 * kKiB);
+  finishFunc({typecast.getResult()});
+
+  auto [obs] = run();
+
+  EXPECT_FALSE(pass->hasFailed());
+  ASSERT_FALSE(obs->selfSpills.empty());
+  EXPECT_EQ(obs->selfSpills.front().op, typecast.getOperation());
+
+  auto outRt =
+      mlir::cast<mlir::RankedTensorType>(typecast.getResult().getType());
+  auto outLayout =
+      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(outRt.getEncoding());
+  EXPECT_FALSE(outLayout.hasL1BufferType());
+  EXPECT_EQ(outLayout.getMemLayout().getValue(),
+            TensorMemoryLayout::Interleaved);
+
+  // Live producer was spilled to DRAM Interleaved for the typecast.
+  EXPECT_TRUE(wasSpilled(producer->getResult(0)))
+      << "live L1-sharded producer must be spilled before typecast demote";
+  Value typecastIn = typecast.getInput();
+  auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
+  auto inLayout =
+      mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(inRt.getEncoding());
+  EXPECT_FALSE(inLayout.hasL1BufferType());
+  EXPECT_EQ(inLayout.getMemLayout().getValue(),
+            TensorMemoryLayout::Interleaved);
+}
+
 //===----------------------------------------------------------------------===//
 // NotImplementedTest
 //===----------------------------------------------------------------------===//

--- a/test/unittests/Optimizer/TestL1SpillManagement.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagement.cpp
@@ -8,6 +8,7 @@
 
 #include "gtest/gtest.h"
 
+using namespace mlir::tt::ttnn;
 using namespace mlir::tt::ttnn::test;
 
 //===----------------------------------------------------------------------===//
@@ -153,9 +154,9 @@ TEST_F(SelfSpillTest, TypecastDemoteSpillsShardedInput) {
             TensorMemoryLayout::Interleaved);
 
   // Input rewired through a ToMemoryConfig spill to DRAM Interleaved.
-  Value typecastIn = typecast.getInput();
+  mlir::Value typecastIn = typecast.getInput();
   auto *spill = typecastIn.getDefiningOp();
-  ASSERT_TRUE(spill && isa<ToMemoryConfigOp>(spill))
+  ASSERT_TRUE(spill && mlir::isa<ToMemoryConfigOp>(spill))
       << "expected a ToMemoryConfigOp spill on the typecast input";
   auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
   auto inLayout =
@@ -200,7 +201,7 @@ TEST_F(SelfSpillTest, TypecastDemoteEvictsLiveShardedProducer) {
   // Live producer was spilled to DRAM Interleaved for the typecast.
   EXPECT_TRUE(wasSpilled(producer->getResult(0)))
       << "live L1-sharded producer must be spilled before typecast demote";
-  Value typecastIn = typecast.getInput();
+  mlir::Value typecastIn = typecast.getInput();
   auto inRt = mlir::cast<mlir::RankedTensorType>(typecastIn.getType());
   auto inLayout =
       mlir::cast<mlir::tt::ttnn::TTNNLayoutAttr>(inRt.getEncoding());


### PR DESCRIPTION
## Summary
- When `demoteToDram` forces a `TypecastOp` output to DRAM Interleaved, L1-sharded inputs were left unchanged, producing illegal `BLOCK_SHARDED` in / `INTERLEAVED` out layouts that tt-metal rejects.
- Spill L1-sharded Typecast operands to DRAM Interleaved before demotion (`prepareOperandsForDramDemotion`), via live `evictValue` or an inserted `ToMemoryConfig` for non-live/block-arg inputs.
- Adds unit tests for both the block-arg spill path and the live-producer eviction path.

Fixes #9094

ci run: https://github.com/tenstorrent/tt-xla/actions/runs/30898733340/job/91962132103

Made with [Cursor](https://cursor.com)