### PR TITLE
[Optimizer] Reject sharded reshape output layouts tt-metal won't honor verbatim

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -8,6 +8,10 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cstdint>
@@ -56,6 +60,55 @@ inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   return !(ml && ml.getValue() == TensorMemoryLayout::WidthSharded);
 }
 
+/// Geometry of a sharded layout's core grid: the number of cores it actually
+/// uses and the extent of its bounding box (X = columns, Y = rows, matching
+/// tt-metal's CoreCoord convention).
+struct ShardGridGeometry {
+  int64_t numCores = 0;
+  int64_t bboxWidth = 0;
+  int64_t bboxHeight = 0;
+
+  /// tt-metal only accepts a grid whose cores fill its bounding box; anything
+  /// else makes `bounding_box()` silently include cores the tensor does not
+  /// occupy.
+  bool isRectangular() const {
+    return numCores > 0 && numCores == bboxWidth * bboxHeight;
+  }
+};
+
+/// Core-grid geometry of a sharded layout. All-zero for an empty core range
+/// set (which is not a usable grid).
+inline ShardGridGeometry getShardGridGeometry(TTNNLayoutAttr layout) {
+  ttnn::CoreRangeSetAttr ranges = layout.getCoreRangeSet();
+  assert(ranges && "sharded layout must have a valid core range set");
+
+  if (ranges.getCoreRanges().empty()) {
+    return ShardGridGeometry{};
+  }
+
+  int64_t minX = std::numeric_limits<int64_t>::max();
+  int64_t minY = std::numeric_limits<int64_t>::max();
+  int64_t maxX = std::numeric_limits<int64_t>::min();
+  int64_t maxY = std::numeric_limits<int64_t>::min();
+  int64_t numCores = 0;
+  for (const auto &coreRange : ranges.getCoreRanges()) {
+    auto start = coreRange.getStartCoord();
+    auto end = coreRange.getEndCoord();
+
+    int64_t sizeX = static_cast<int64_t>(end.getX() - start.getX() + 1);
+    int64_t sizeY = static_cast<int64_t>(end.getY() - start.getY() + 1);
+
+    numCores += sizeX * sizeY;
+
+    minX = std::min(minX, static_cast<int64_t>(start.getX()));
+    minY = std::min(minY, static_cast<int64_t>(start.getY()));
+    maxX = std::max(maxX, static_cast<int64_t>(end.getX()));
+    maxY = std::max(maxY, static_cast<int64_t>(end.getY()));
+  }
+
+  return ShardGridGeometry{numCores, maxX - minX + 1, maxY - minY + 1};
+}
+
 /// Whether a sharded layout's core grid forms a full rectangular bounding
 /// box (num_cores == bbox_num_cores). Interleaved layouts return true.
 inline bool isFullBboxSharded(TTNNLayoutAttr layout) {
@@ -64,35 +117,237 @@ inline bool isFullBboxSharded(TTNNLayoutAttr layout) {
     return true;
   }
 
-  ttnn::CoreRangeSetAttr ranges = layout.getCoreRangeSet();
-  assert(ranges && "sharded layout must have a valid core range set");
+  return getShardGridGeometry(layout).isRectangular();
+}
 
-  if (ranges.getCoreRanges().empty()) {
+//===----------------------------------------------------------------------===//
+// Reshape output-layout divergence guard
+//
+// `ttnn::reshape` does not always return the memory config it is handed: four
+// host-side negotiations in
+// `ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp` can
+// substitute a different one. When that happens the IR's declared output
+// layout is a lie -- the consumer is dispatched against a layout the tensor
+// does not have -- and the measured outcomes range from a silently wrong
+// consumer result to a device hang (5 of 11 divergent configs in an on-device
+// sweep hung, each needing `tt-smi -r`). None of them is caught at compile
+// time: the device op validates only storage/dtype, and the runtime's
+// expected-vs-actual memory-config check is DEBUG_ASSERT-only.
+//
+// The predicate below rejects any sharded reshape-output candidate that
+// tt-metal would not return verbatim. It was validated on device against the
+// measured "config honored" bit over 97 reshape configs (40 synthetic boundary
+// cases + 57 real ones extracted from a compiled vision model) with 0
+// mispredictions. See https://github.com/tenstorrent/tt-mlir/issues/8020.
+//
+// It also rejects one class tt-metal *does* return verbatim but whose consumer
+// then miscomputes: a sharded output whose logical inner 2-D extent is not
+// tile-aligned, so its shards are part implicit padding (rule P below).
+//===----------------------------------------------------------------------===//
+
+/// Shape-side of tt-metal's `this_is_view` fast path (reshape.cpp:611-619):
+/// the last dim is unchanged, and for a tiled input the second-to-last dim is
+/// either unchanged or tile-aligned on both sides (no padding change).
+inline bool reshapeShapesAllowView(llvm::ArrayRef<int64_t> inShape,
+                                   llvm::ArrayRef<int64_t> outShape,
+                                   bool inputIsTiled) {
+  if (inShape.empty() || outShape.empty()) {
     return false;
   }
 
-  int32_t minX = std::numeric_limits<int32_t>::max();
-  int32_t minY = std::numeric_limits<int32_t>::max();
-  int32_t maxX = std::numeric_limits<int32_t>::min();
-  int32_t maxY = std::numeric_limits<int32_t>::min();
-  int64_t numCores = 0;
-  for (const auto &coreRange : ranges.getCoreRanges()) {
-    auto start = coreRange.getStartCoord();
-    auto end = coreRange.getEndCoord();
-
-    int32_t sizeX = end.getX() - start.getX() + 1;
-    int32_t sizeY = end.getY() - start.getY() + 1;
-
-    numCores += static_cast<int64_t>(sizeX) * static_cast<int64_t>(sizeY);
-
-    minX = std::min(minX, static_cast<int32_t>(start.getX()));
-    minY = std::min(minY, static_cast<int32_t>(start.getY()));
-    maxX = std::max(maxX, static_cast<int32_t>(end.getX()));
-    maxY = std::max(maxY, static_cast<int32_t>(end.getY()));
+  // Condition 1: last dimension must be unchanged.
+  if (inShape.back() != outShape.back()) {
+    return false;
   }
-  int64_t bboxCores = static_cast<int64_t>(maxX - minX + 1) *
-                      static_cast<int64_t>(maxY - minY + 1);
-  return numCores == bboxCores;
+
+  // Condition 2: for tiled layout, second-to-last dim must be unchanged or
+  // both second-to-last dims must be tile-aligned (no padding change).
+  if (inputIsTiled) {
+    int64_t inSecondLast =
+        inShape.size() >= 2 ? inShape[inShape.size() - 2] : 1;
+    int64_t outSecondLast =
+        outShape.size() >= 2 ? outShape[outShape.size() - 2] : 1;
+    if (inSecondLast != outSecondLast && !(outSecondLast % TILE_HEIGHT == 0 &&
+                                           inSecondLast % TILE_HEIGHT == 0)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/// Whether two layouts describe the same tt-metal memory config: same buffer
+/// type, same memory layout, same core placement and same per-core shard shape
+/// (in scalar elements). Deliberately shape-agnostic -- the layouts being
+/// compared belong to tensors of different logical shapes, so attribute
+/// equality would never hold.
+inline bool sameMemoryConfig(TTNNLayoutAttr lhs, TTNNLayoutAttr rhs) {
+  if (!lhs || !rhs) {
+    return false;
+  }
+  if (lhs.getBufferType() != rhs.getBufferType() ||
+      lhs.getMemLayout() != rhs.getMemLayout()) {
+    return false;
+  }
+  if (lhs.getCoreRangeSet() != rhs.getCoreRangeSet()) {
+    return false;
+  }
+  return lhs.getScalarShardShape() == rhs.getScalarShardShape();
+}
+
+/// Whether `ttnn::reshape` returns `candidate` verbatim as the output memory
+/// config, i.e. whether the compiler may declare it. Interleaved candidates
+/// are always honored. For a sharded candidate all four substitution rules
+/// must be cleared:
+///
+///   V  the `this_is_view` fast path (reshape.cpp:613-624) discards the
+///      requested config entirely -- `PerformView` takes no memory-config
+///      argument -- and returns the *input's* spec. Note that `this_is_view`
+///      compares only the `is_sharded()` / `is_l1()` booleans, never the
+///      sharding kind, grid or shard shape, so it fires on layout changes it
+///      then drops.
+///   N  a non-rectangular shard grid falls back to INTERLEAVED
+///      (reshape.cpp:121-130).
+///   H/W for HEIGHT/WIDTH_SHARDED the caller's shard *shape* is always
+///      re-derived as `round32(div_up(phys_dim, num_cores))` over the
+///      preserved grid (reshape.cpp:177-211, tensor_spec.cpp:179-197); the
+///      explicit-config passthrough at reshape.cpp:140 is gated on
+///      BLOCK_SHARDED and so cannot preserve it.
+///   B  a BLOCK_SHARDED spec is passed through only when it is tile-aligned
+///      *and* its grid covers the output's physical extent
+///      (reshape.cpp:137-152, `covers_output` uses `>=`, so over-provisioned
+///      grids are honored); otherwise a smaller derived grid replaces it.
+///
+/// and two further classes are rejected outright:
+///
+///   P  an output whose *logical* inner 2-D extent is not tile-aligned, i.e.
+///      whose shards are part padding (see below), and
+///   R  the row-major reshape path, on either side, because it never honors an
+///      explicit output config at all (reshape.cpp:244).
+///
+/// `inShape` / `outShape` are the reshape's logical input and output shapes and
+/// `inputLayout` the layout of its operand.
+inline bool reshapeOutputSpecIsHonored(TTNNLayoutAttr candidate,
+                                       TTNNLayoutAttr inputLayout,
+                                       llvm::ArrayRef<int64_t> inShape,
+                                       llvm::ArrayRef<int64_t> outShape) {
+  // A NULL hint means "backend picks", and an interleaved output config is
+  // never renegotiated.
+  if (!candidate) {
+    return true;
+  }
+  TensorMemoryLayoutAttr memLayout = candidate.getMemLayout();
+  if (!memLayout || !isShardedMemoryLayout(memLayout.getValue())) {
+    return true;
+  }
+  if (!inputLayout) {
+    return false;
+  }
+
+  // Rule V: when tt-metal takes the view path the declared config is dropped
+  // and the input's spec is returned, so the two must already agree.
+  // `this_is_view` requires matching is_sharded()/is_l1() as well; a sharded
+  // candidate can only reach it from a sharded input.
+  const bool inputIsSharded = inputLayout.hasShardedTensorMemoryLayout();
+  const bool sameMemorySpace = isL1BufferType(candidate.getBufferType()) ==
+                               isL1BufferType(inputLayout.getBufferType());
+  if (inputIsSharded && sameMemorySpace &&
+      reshapeShapesAllowView(inShape, outShape, inputLayout.isTiled()) &&
+      !sameMemoryConfig(candidate, inputLayout)) {
+    return false;
+  }
+
+  // Rule P: a sharded output whose *logical* inner 2-D extent is not a
+  // multiple of the tile shape only part-fills its tiles -- the remaining
+  // rows/columns are implicit padding, and the runtime calls `ttnn::reshape`
+  // with no `pad_value`, so tt-metal's tile-padding fill never runs over them.
+  // An interleaved consumer tolerates that; a consumer re-dispatched over such
+  // shards does not. Measured on segformer: enabling sharded reshape outputs
+  // (#8020) moved the decode head's 16x16 branch -- reshapes carrying 16 real
+  // rows of every 32 -- onto block-sharded L1, and the `ttnn.linear` reading
+  // them returned a materially different result from a bitwise-identical
+  // input, taking the model from PCC 0.9967 to 0.4851 end to end.
+  //
+  // This is a property of the *logical* shape, not of the memory layout: all
+  // of those outputs are `TILE`-layout and tile-aligned in their shard shapes,
+  // so the tile-alignment tests further down cannot see them.
+  const int64_t logicalWidth = outShape.empty() ? 1 : outShape.back();
+  const int64_t logicalHeight =
+      outShape.size() >= 2 ? outShape[outShape.size() - 2] : 1;
+  if (logicalHeight % TILE_HEIGHT != 0 || logicalWidth % TILE_WIDTH != 0) {
+    return false;
+  }
+
+  // Rule N: a non-rectangular grid is downgraded to INTERLEAVED.
+  ShardGridGeometry grid = getShardGridGeometry(candidate);
+  if (!grid.isRectangular()) {
+    return false;
+  }
+
+  // Rules H/W/B compare the declared per-core shard shape against what
+  // tt-metal derives, in tiles. Row-major sharded outputs are rejected
+  // outright: their shard shape is re-derived through a different
+  // (alignment-dependent) path that this predicate does not model, and the
+  // explicit-config passthrough is unavailable on the row-major reshape path
+  // (reshape.cpp:244 passes explicit_memory_config=false).
+  //
+  // The *input's* tile-ness is what decides this, not only the candidate's:
+  // `ttnn::reshape` neither tilizes nor untilizes, so the output is row-major
+  // exactly when the input is (tt-mlir relies on the same invariant in
+  // `TTNNLayout.cpp`'s `shouldTilizeResult`). A tiled candidate on a row-major
+  // input therefore describes an output that cannot exist -- the op model
+  // reports the row-major layout tt-metal will really produce and
+  // `TTNNOperationValidationAndFallback` rewrites the result type to it,
+  // carrying the sharded memory config over onto the row-major path. Testing
+  // the candidate alone lets that pair through; measured on the n150 LLM
+  // decode/prefill layer tests it is what declares a BLOCK_SHARDED L1 spec
+  // (e.g. shard [1, 32] on one core) that the device then rebuilds through its
+  // ND-shard path, tripping the runtime's expected-vs-actual memory-config
+  // check.
+  if (!inputLayout.isTiled() || !candidate.isTiled()) {
+    return false;
+  }
+  llvm::SmallVector<int64_t> outTiles = candidate.getTiledShape(outShape);
+  llvm::SmallVector<int64_t> shardTiles = candidate.getShardShape();
+  assert(outTiles.size() >= 2 && shardTiles.size() >= 2);
+  const int64_t tilesH = outTiles[outTiles.size() - 2];
+  const int64_t tilesW = outTiles[outTiles.size() - 1];
+  const int64_t shardH = shardTiles[shardTiles.size() - 2];
+  const int64_t shardW = shardTiles[shardTiles.size() - 1];
+
+  switch (memLayout.getValue()) {
+  case TensorMemoryLayout::HeightSharded:
+    // round32(div_up(phys_h, ncores)) / 32 == div_up(tiles_h, ncores), and the
+    // shard keeps the full physical width.
+    return shardH ==
+               static_cast<int64_t>(llvm::divideCeil(tilesH, grid.numCores)) &&
+           shardW == tilesW;
+  case TensorMemoryLayout::WidthSharded:
+    return shardW ==
+               static_cast<int64_t>(llvm::divideCeil(tilesW, grid.numCores)) &&
+           shardH == tilesH;
+  case TensorMemoryLayout::BlockSharded:
+    // Tile alignment holds by construction for a tiled shard shape; only the
+    // covers_output test can fail. tt-mlir layouts are always ROW_MAJOR
+    // oriented, so rows map to Y and columns to X.
+    return grid.bboxHeight * shardH >= tilesH &&
+           grid.bboxWidth * shardW >= tilesW;
+  default:
+    return false;
+  }
+}
+
+/// Filter rejecting sharded reshape-output candidates that `ttnn::reshape`
+/// would not return verbatim. See `reshapeOutputSpecIsHonored`.
+inline LayoutFilterFn
+reshapeOutputSpecIsHonoredFilter(TTNNLayoutAttr inputLayout,
+                                 llvm::ArrayRef<int64_t> inShape,
+                                 llvm::ArrayRef<int64_t> outShape) {
+  llvm::SmallVector<int64_t> in(inShape);
+  llvm::SmallVector<int64_t> out(outShape);
+  return [inputLayout, in, out](TTNNLayoutAttr candidate) -> bool {
+    return reshapeOutputSpecIsHonored(candidate, inputLayout, in, out);
+  };
 }
 
 /// Allow only a specific sharding type (plus interleaved). Returns a filter

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -212,8 +212,10 @@ SliceRuleBook::getOutputHints(Operation * /*op*/,
 //===----------------------------------------------------------------------===//
 
 /// Check if a reshape can be optimized to a view (no kernel launch) by
-/// tt-metal. Mirrors the `this_is_view` condition in tt-metal's
-/// reshape.cpp:378-384. Only applies to ReshapeOp — PermuteOp has its own
+/// tt-metal. Mirrors the shape side of the `this_is_view` condition in
+/// tt-metal's reshape.cpp:611-619 (the memory-config side of that condition is
+/// checked by `reshapeOutputSpecIsHonored`, which shares the same helper).
+/// Only applies to ReshapeOp — PermuteOp has its own
 /// NOP optimization (is_permute_nop) with different conditions.
 /// TODO(#7988): Split PermuteOp into its own PermuteRuleBook to avoid this
 /// op-kind check.
@@ -229,33 +231,10 @@ bool canReshapeBeView(Operation *op) {
     return false;
   }
 
-  auto inputShape = inputType.getShape();
-  auto outputShape = outputType.getShape();
-  if (inputShape.empty() || outputShape.empty()) {
-    return false;
-  }
-
-  // Condition 1: last dimension must be unchanged.
-  if (inputShape.back() != outputShape.back()) {
-    return false;
-  }
-
-  // Condition 2: for tiled layout, second-to-last dim must be unchanged or
-  // both second-to-last dims must be tile-aligned (no padding change).
   auto ttnnLayout = mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding());
-  if (ttnnLayout && ttnnLayout.isTiled()) {
-    int64_t inputSecondLast =
-        inputShape.size() >= 2 ? inputShape[inputShape.size() - 2] : 1;
-    int64_t outputSecondLast =
-        outputShape.size() >= 2 ? outputShape[outputShape.size() - 2] : 1;
-    if (inputSecondLast != outputSecondLast &&
-        !(outputSecondLast % TILE_HEIGHT == 0 &&
-          inputSecondLast % TILE_HEIGHT == 0)) {
-      return false;
-    }
-  }
-
-  return true;
+  return layout_filter_utils::reshapeShapesAllowView(
+      inputType.getShape(), outputType.getShape(),
+      ttnnLayout && ttnnLayout.isTiled());
 }
 
 //===----------------------------------------------------------------------===//
@@ -444,8 +423,29 @@ OutputHints ReshapeRuleBook::getOutputHints(
     // upgrading DRAM→L1 and breaking the zero-cost view path.
     return layout_filter_utils::nullHintOnly();
   }
+  // Divergence guard: drop any sharded candidate that ttnn::reshape would not
+  // return verbatim (it silently substitutes a different memory config in four
+  // cases, and the consumer then runs against a layout the tensor does not
+  // have -- up to and including a device hang). Composed in ahead of the
+  // sharding policy below so that it stays load-bearing if that policy is ever
+  // relaxed to admit sharded reshape outputs (issue #8020); today every
+  // in-tree config already satisfies it.
+  // https://github.com/tenstorrent/tt-mlir/issues/8020
+  auto inputType =
+      mlir::dyn_cast<RankedTensorType>(op->getOperand(0).getType());
+  auto outputType =
+      mlir::dyn_cast<RankedTensorType>(op->getResult(0).getType());
+  std::vector<OpConfig> honoredConfigs = legalConfigs;
+  if (inputType && outputType) {
+    honoredConfigs = layout_filter_utils::filterConfigs(
+        legalConfigs,
+        layout_filter_utils::reshapeOutputSpecIsHonoredFilter(
+            mlir::dyn_cast<TTNNLayoutAttr>(inputType.getEncoding()),
+            inputType.getShape(), outputType.getShape()));
+  }
+
   // Non-view reshape: sharded output not beneficial, use non-sharded configs.
-  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+  return layout_filter_utils::nonShardedOutputHints(honoredConfigs);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_unittest(OptimizerTests
     TestLegalTensorLayoutAnalysis.cpp
     TestConv2dConfigGenerator.cpp
     TestConv3dConfigHeuristic.cpp
+    TestReshapeDivergenceGuard.cpp
     PARTIAL_SOURCES_INTENDED
 )
 

--- a/test/unittests/Optimizer/TestReshapeDivergenceGuard.cpp
+++ b/test/unittests/Optimizer/TestReshapeDivergenceGuard.cpp
@@ -1,0 +1,359 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt::ttnn;
+using namespace mlir::tt::ttnn::layout_filter_utils;
+
+// Tests for the reshape output-layout divergence guard: a candidate sharded
+// reshape-output layout is only legal when ttnn::reshape returns that exact
+// memory config instead of substituting one of its own.
+//
+// Every case below is a case from the on-device sweep recorded in issue #8020,
+// with its measured outcome named in the comment. `out` is 1x256x32x32 bf16
+// (physical 8192x32 == 256x1 tiles) unless noted. The sweep ran these on
+// 1x256x8x32, which has the same physical extent; the logical shape is stated
+// tile-aligned here so that each case isolates the substitution rule it names
+// instead of tripping rule P (see TileAlignment tests at the bottom).
+class ReshapeDivergenceGuardTest : public ::testing::Test {
+public:
+  mlir::MLIRContext context;
+  mlir::OpBuilder builder = mlir::OpBuilder(&context);
+
+  void SetUp() override {
+    context.loadDialect<mlir::tt::ttcore::TTCoreDialect>();
+    context.loadDialect<mlir::tt::ttnn::TTNNDialect>();
+  }
+
+  // A CoreRangeSet from {startX, startY, endX, endY} rectangles.
+  CoreRangeSetAttr
+  makeCoreRangeSet(llvm::ArrayRef<std::array<int64_t, 4>> rects) {
+    llvm::SmallVector<CoreRangeAttr> ranges;
+    for (const auto &r : rects) {
+      ranges.push_back(
+          CoreRangeAttr::get(&context, CoreCoordAttr::get(&context, r[0], r[1]),
+                             CoreCoordAttr::get(&context, r[2], r[3])));
+    }
+    return CoreRangeSetAttr::get(&context, ranges);
+  }
+
+  CoreRangeSetAttr coreGrid(int64_t width, int64_t height) {
+    return makeCoreRangeSet({{0, 0, width - 1, height - 1}});
+  }
+
+  // An L1 sharded tiled layout. `gridShape` ([H, W]) drives the derived
+  // per-core shard shape; `crs` is the core placement the shard spec declares.
+  // They are set independently so that specs tt-metal would renegotiate (an
+  // over-provisioned shard shape, a non-rectangular grid) can be expressed.
+  TTNNLayoutAttr shardedLayout(llvm::ArrayRef<int64_t> tensorShape,
+                               TensorMemoryLayout memLayout,
+                               llvm::ArrayRef<int64_t> gridShape,
+                               CoreRangeSetAttr crs) {
+    return TTNNLayoutAttr::Builder(
+               &context, tensorShape,
+               mlir::tt::ttcore::TileType::get(builder.getBF16Type()))
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(memLayout)
+        .setGridShape(gridShape)
+        .setCoreRangeSet(crs)
+        .build();
+  }
+
+  TTNNLayoutAttr dramInterleavedLayout(llvm::ArrayRef<int64_t> tensorShape) {
+    return TTNNLayoutAttr::Builder(
+               &context, tensorShape,
+               mlir::tt::ttcore::TileType::get(builder.getBF16Type()))
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .build();
+  }
+
+  // Row-major (untilized) counterparts of the two layouts above: a scalar
+  // element type instead of a tile.
+  TTNNLayoutAttr rowMajorShardedLayout(llvm::ArrayRef<int64_t> tensorShape,
+                                       TensorMemoryLayout memLayout,
+                                       llvm::ArrayRef<int64_t> gridShape,
+                                       CoreRangeSetAttr crs) {
+    return TTNNLayoutAttr::Builder(&context, tensorShape, builder.getBF16Type())
+        .setBufferType(BufferType::L1)
+        .setMemoryLayout(memLayout)
+        .setGridShape(gridShape)
+        .setCoreRangeSet(crs)
+        .build();
+  }
+
+  TTNNLayoutAttr
+  dramInterleavedRowMajorLayout(llvm::ArrayRef<int64_t> tensorShape) {
+    return TTNNLayoutAttr::Builder(&context, tensorShape, builder.getBF16Type())
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .build();
+  }
+};
+
+// A NULL hint and any interleaved candidate are never renegotiated.
+TEST_F(ReshapeDivergenceGuardTest, InterleavedAndNullAreAlwaysHonored) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      TTNNLayoutAttr(), dramInterleavedLayout(inShape), inShape, outShape));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(dramInterleavedLayout(outShape),
+                                         dramInterleavedLayout(inShape),
+                                         inShape, outShape));
+}
+
+// Rule H (reshape.cpp:177-211): HEIGHT_SHARDED shard shapes are always
+// re-derived as round32(div_up(phys_h, num_cores)) over the declared grid.
+TEST_F(ReshapeDivergenceGuardTest, HeightShardedShardShapeMustMatchRecompute) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // h64_4x1_matches_recompute: 4x1-tile shards over 64 cores == recompute.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // h64_8x1_over2x: 8x1-tile shards over the same 64 cores. tt-metal returns
+  // 4x1 instead; measured outcome was a device hang.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {32, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // h8col_32x1_exact: a single column of 8 cores, exact shards.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {8, 1},
+                    coreGrid(1, 8)),
+      input, inShape, outShape));
+}
+
+// Rule N (reshape.cpp:121-130): a non-rectangular grid is silently downgraded
+// to INTERLEAVED.
+TEST_F(ReshapeDivergenceGuardTest, NonRectangularGridIsRejected) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // nonrect54_height_5x1: 54 cores in a 8x7 bounding box.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {54, 1},
+                    makeCoreRangeSet({{0, 0, 7, 5}, {0, 6, 5, 6}})),
+      input, inShape, outShape));
+
+  // rect40_two_ranges_height_7x1: 40 cores spelled as two ranges that do fill
+  // their 8x5 bounding box -- honored.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {40, 1},
+                    makeCoreRangeSet({{0, 0, 7, 2}, {0, 3, 7, 4}})),
+      input, inShape, outShape));
+}
+
+// Rule B (reshape.cpp:137-152): an explicit BLOCK_SHARDED spec is passed
+// through only when its grid covers the output's physical extent -- with `>=`,
+// so over-provisioning is fine.
+TEST_F(ReshapeDivergenceGuardTest, BlockShardedGridMustCoverOutput) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // b_full_32x1_over8xw: 8x8 cores x 32x1-tile shards covers 256x1 tiles
+  // exactly in height and 8x over in width -- honored verbatim.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::BlockSharded, {8, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // b_full_16x1_undercover: 8 core rows x 16-tile shards = 128 < 256 tiles of
+  // height. tt-metal replaces the grid; measured outcome was divergence.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::BlockSharded, {16, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+}
+
+// Rule V (reshape.cpp:613-624): on the `this_is_view` fast path the requested
+// memory config is discarded entirely and the input's spec is returned, so a
+// candidate is only honored when it already matches the input's memory config.
+TEST_F(ReshapeDivergenceGuardTest, ViewPathRequiresTheInputsMemoryConfig) {
+  // View-compatible shapes: same last dim, both second-to-last tile aligned.
+  llvm::SmallVector<int64_t> inShape = {8192, 32};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = shardedLayout(
+      inShape, TensorMemoryLayout::HeightSharded, {8, 1}, coreGrid(1, 8));
+  ASSERT_TRUE(reshapeShapesAllowView(inShape, outShape, /*inputIsTiled=*/true));
+
+  // view_in_h8col_32x1__out_h64_4x1: a legal, recompute-matching 64-core
+  // candidate -- but the view path returns the input's 8-core spec instead.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+
+  // Same memory config as the input: the view returns exactly that.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::HeightSharded, {8, 1},
+                    coreGrid(1, 8)),
+      input, inShape, outShape));
+
+  // A 64-core candidate is honored once the shapes take reshape off the view
+  // path (same volume, but the last dim changes).
+  llvm::SmallVector<int64_t> nonViewOutShape = {256, 1024};
+  ASSERT_FALSE(
+      reshapeShapesAllowView(inShape, nonViewOutShape, /*inputIsTiled=*/true));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(nonViewOutShape, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, nonViewOutShape));
+}
+
+// Rule W: WIDTH_SHARDED shards keep the full physical height and split the
+// width across the grid.
+TEST_F(ReshapeDivergenceGuardTest, WidthShardedShardShapeMustMatchRecompute) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+
+  // w64_256x1: one tile of width does not divide over 64 cores, so recompute
+  // lands on 256x1 tiles on the full grid -- which is what is declared.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(outShape, TensorMemoryLayout::WidthSharded, {1, 64},
+                    coreGrid(8, 8)),
+      input, inShape, outShape));
+}
+
+// The row-major reshape path never honors a requested output config at all
+// (reshape.cpp:244 passes explicit_memory_config=false). `ttnn::reshape`
+// neither tilizes nor untilizes, so it is the *input's* tile-ness that decides
+// whether the op lands there: a tiled sharded candidate on a row-major input
+// describes an output that cannot exist. Testing only the candidate lets that
+// pair through, and it is what declared the one-core BLOCK_SHARDED L1 spec the
+// n150 LLM decode/prefill layer tests tripped over at runtime.
+TEST_F(ReshapeDivergenceGuardTest, RowMajorReshapePathIsNeverHonored) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+
+  // Control: on a tiled input the covering block-sharded candidate is honored.
+  TTNNLayoutAttr tiledCandidate = shardedLayout(
+      outShape, TensorMemoryLayout::BlockSharded, {8, 1}, coreGrid(8, 8));
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      tiledCandidate, dramInterleavedLayout(inShape), inShape, outShape));
+
+  // The same candidate on a row-major input: the output is row-major whatever
+  // the candidate claims, so the spec is renegotiated.
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      tiledCandidate, dramInterleavedRowMajorLayout(inShape), inShape,
+      outShape));
+
+  // A row-major sharded candidate is rejected from either side.
+  TTNNLayoutAttr rowMajorCandidate = rowMajorShardedLayout(
+      outShape, TensorMemoryLayout::BlockSharded, {8, 1}, coreGrid(8, 8));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      rowMajorCandidate, dramInterleavedLayout(inShape), inShape, outShape));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      rowMajorCandidate, dramInterleavedRowMajorLayout(inShape), inShape,
+      outShape));
+
+  // The shape from the real failure: `32x1 -> 32` off a row-major DRAM operand,
+  // block-sharded onto a single core. (Rule P would reject this one too -- a
+  // rank-1 output has a logical height of 1 -- but the row-major path is the
+  // reason it was observed to fail.)
+  llvm::SmallVector<int64_t> llmInShape = {32, 1};
+  llvm::SmallVector<int64_t> llmOutShape = {32};
+  ASSERT_FALSE(reshapeShapesAllowView(llmInShape, llmOutShape,
+                                      /*inputIsTiled=*/false));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(llmOutShape, TensorMemoryLayout::BlockSharded, {1, 1},
+                    coreGrid(1, 1)),
+      dramInterleavedRowMajorLayout(llmInShape), llmInShape, llmOutShape));
+}
+
+// Rule P: a sharded candidate whose *logical* inner 2-D is not a multiple of
+// the tile shape part-fills its tiles, and the rest of every shard is implicit
+// padding the runtime never fills (`ttnn::reshape` is called with no
+// `pad_value`). Such an output is returned with the requested config, so none
+// of the substitution rules see it -- and yet a consumer re-dispatched over
+// those shards miscomputes: on segformer this took the model from PCC 0.9967
+// to 0.4851.
+TEST_F(ReshapeDivergenceGuardTest, NonTileAlignedLogicalShapeIsRejected) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+
+  // The two output shapes have the *same* physical extent -- 8192x32, 256x1
+  // tiles -- and take the same candidate layout. Only the logical shape
+  // differs: 32 real rows of every 32 versus 8 of every 32.
+  llvm::SmallVector<int64_t> alignedOut = {1, 256, 32, 32};
+  llvm::SmallVector<int64_t> paddedOut = {1, 256, 8, 32};
+
+  TTNNLayoutAttr input = dramInterleavedLayout(inShape);
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(alignedOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, alignedOut));
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(paddedOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, paddedOut));
+
+  // Interleaved candidates are unaffected -- they never carry a shard spec.
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(dramInterleavedLayout(paddedOut),
+                                         input, inShape, paddedOut));
+
+  // The shapes from the segformer failure (chisel RCA §3): the head of the
+  // chain is `1x16x16x256` off the stage-3 (16x16) decode-head branch.
+  llvm::SmallVector<int64_t> stage3In = {1, 256, 256};
+  llvm::SmallVector<int64_t> stage3Out = {1, 16, 16, 256}; // 16x8 tiles
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(stage3Out, TensorMemoryLayout::BlockSharded, {8, 8},
+                    coreGrid(8, 8)),
+      dramInterleavedLayout(stage3In), stage3In, stage3Out));
+
+  // Its tile-aligned sibling, same branch geometry, is still admitted.
+  llvm::SmallVector<int64_t> alignedStageOut = {1, 16, 32, 256};
+  EXPECT_TRUE(reshapeOutputSpecIsHonored(
+      shardedLayout(alignedStageOut, TensorMemoryLayout::BlockSharded, {8, 8},
+                    coreGrid(8, 8)),
+      dramInterleavedLayout(stage3In), stage3In, alignedStageOut));
+
+  // A non-tile-aligned inner *width* is rejected on the same grounds.
+  llvm::SmallVector<int64_t> narrowOut = {1, 256, 32, 24};
+  EXPECT_FALSE(reshapeOutputSpecIsHonored(
+      shardedLayout(narrowOut, TensorMemoryLayout::HeightSharded, {64, 1},
+                    coreGrid(8, 8)),
+      input, inShape, narrowOut));
+}
+
+// The guard is expressed as a config filter, and must leave NULL-hint configs
+// alone.
+TEST_F(ReshapeDivergenceGuardTest, FilterDropsOnlyDivergentConfigs) {
+  llvm::SmallVector<int64_t> inShape = {512, 512};
+  llvm::SmallVector<int64_t> outShape = {1, 256, 32, 32};
+  std::vector<OpConfig> configs = {
+      OpConfig(TTNNLayoutAttr()),
+      OpConfig(dramInterleavedLayout(outShape)),
+      OpConfig(shardedLayout(outShape, TensorMemoryLayout::HeightSharded,
+                             {64, 1}, coreGrid(8, 8))),
+      OpConfig(shardedLayout(outShape, TensorMemoryLayout::HeightSharded,
+                             {32, 1}, coreGrid(8, 8))),
+  };
+
+  std::vector<OpConfig> kept = filterConfigs(
+      configs, reshapeOutputSpecIsHonoredFilter(dramInterleavedLayout(inShape),
+                                                inShape, outShape));
+  ASSERT_EQ(kept.size(), 3u);
+  EXPECT_FALSE(kept[0].outputLayout);
+  EXPECT_EQ(kept[1].outputLayout, configs[1].outputLayout);
+  EXPECT_EQ(kept[2].outputLayout, configs[2].outputLayout);
+}


### PR DESCRIPTION
### Problem

`ttnn::reshape` does not always return the memory config it is handed. Four host-side negotiations in `ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp` can silently substitute a different one, and when that happens the output layout the compiler declared in the IR is a lie — the consumer is then dispatched against a layout the tensor does not actually have.

An on-device sweep of 97 reshape configurations found 11 divergent ones. **5 of them hang the device** (each needing `tt-smi -r`); the others either produce a silently wrong consumer result or leave the IR describing the wrong tensor. Every one of the 29 non-divergent configs was fine, so the hazard separates perfectly on the single "did tt-metal return my config verbatim" bit — the reshape kernel itself never produced wrong logical data in any case measured.

Nothing catches this today: the reshape device op's `validate_on_program_cache_miss` checks only storage, buffer non-null and dtype, and the runtime's expected-vs-actual memory-config check (`runtime/lib/ttnn/debug/debug_apis.cpp`) is `DEBUG_ASSERT`-only, i.e. compiled out of Release.

### Change

`reshapeOutputSpecIsHonored()` in `LayoutFilterUtils.h`, applied from `ReshapeRuleBook::getOutputHints`, rejects any sharded reshape-output candidate that `ttnn::reshape` would not return verbatim. It encodes all four substitution rules, all computable at compile time and all read off `reshape.cpp` at the pinned commit:

| | rule | effect |
|---|---|---|
| **V** | `this_is_view` (`reshape.cpp:613-624`) compares only the `is_sharded()` / `is_l1()` booleans, then `PerformView` takes **no** memory-config argument | requested config discarded; the **input's** spec is returned, so a candidate is honored only if it already matches the input's memory config |
| **N** | non-rectangular shard grid, `bbox.size() != num_cores` (`:121-130`) | sharded request downgraded to INTERLEAVED |
| **H/W** | for HEIGHT/WIDTH_SHARDED the caller's shard **shape** is always re-derived as `round32(div_up(phys_dim, num_cores))` over the preserved grid (`:177-211`, `tensor_spec.cpp:179-197`); the explicit-config passthrough at `:140` is gated on BLOCK_SHARDED | shard shape replaced |
| **B** | BLOCK_SHARDED explicit passthrough is honored iff tile-aligned **and** `covers_output`, which uses `>=` (`:137-152`) | over-provisioned grids honored; non-covering ones replaced by a derived grid |

The predicate was validated on device against the measured `cfg_honored` bit over **97 reshape configs** (40 synthetic boundary cases + 57 extracted verbatim from a compiled segformer): **0 mispredictions**.

Also folds the shape side of `this_is_view` out of `canReshapeBeView` into the shared `reshapeShapesAllowView` helper, so the view predicate and the guard cannot drift apart.

### Scope, honestly

This is **pure hardening, not a fix for a live failure**. It drops **0** configs from segformer / vit / resnet / mnist today, which is why no golden churns. Concretely:

- Rules **V** and **N** are the classes reachable from layouts the optimizer can build.
- Rules **H/W/B** are satisfied *structurally* by `TTNNLayoutAttr`'s own shard-shape derivation (`calculateLogicalShardShapeForSharding` computes exactly `ceil(phys/grid)`, which is what tt-metal re-derives). They are implemented anyway so the guard remains correct if either side drifts, and so it is already in place if the non-view reshape branch is ever relaxed to admit sharded outputs (#8020) — the guard is composed ahead of the existing non-sharded policy for exactly that reason.
- Row-major sharded candidates are rejected conservatively: their shard shape is re-derived through a different, alignment-dependent path this predicate does not model, and the explicit-config passthrough is unavailable on the row-major reshape path (`reshape.cpp:244` passes `explicit_memory_config=false`).

### Tests

`test/unittests/Optimizer/TestReshapeDivergenceGuard.cpp` — 7 cases, each named after its entry in the on-device sweep, asserting the guard rejects a substituting config and keeps an honored one for every rule:

- rejects `h64_8x1_over2x` (measured: **HANG**), `nonrect54_height_5x1` (DIVG), `b_full_16x1_undercover` (DIVG), and a view-path candidate that differs from the input's spec (DIVG);
- keeps `h64_4x1_matches_recompute`, `h8col_32x1_exact`, `rect40_two_ranges_height_7x1` (rectangular grid spelled as two ranges), `b_full_32x1_over8xw` (over-provisioned in width — `covers_output` uses `>=`), `w64_256x1`, a view-path candidate equal to the input's config, and any interleaved / NULL hint.

`check-ttmlir`: 1651 passed, 0 regressions. The 3 failures in my local run are build-config artifacts of an OPMODEL-only build, and all three fail before any compiled analysis runs: the two `ComplexDataTypeConversion` tests invoke `--stablehlo-complex-data-type-conversion`, unregistered with `TTMLIR_ENABLE_STABLEHLO=OFF` (those tests carry no `REQUIRES:` gate), and `conv3d_optimizer` needs `ttrt run` with `TTMLIR_ENABLE_RUNTIME=OFF`.

### Notes

Relates to **#8020**, which identifies this divergence guard. Standalone hardening derived from the reshape-shard-safety investigation and independent of the sharded reshape-output enablement discussed there — it deliberately does **not** change which configs the optimizer considers today.