### PR TITLE
[Optimizer] Split PermuteRuleBook off ReshapeRuleBook (closes #7988)

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/DataMovementRules.h
@@ -19,6 +19,7 @@ namespace mlir::tt::ttnn {
 //     https://github.com/tenstorrent/tt-metal/issues/39074
 //   ReshapeOp, PermuteOp: reject width-sharded inputs
 //     (round-trip through interleaved internally in tt-metal)
+//     Each has its own rule book; they share only this input restriction.
 //
 // Output hints:
 //   All: non-sharded only
@@ -94,10 +95,22 @@ bool canPermuteBeView(Operation *op);
 /// the op onto its source's L1 slot instead of tracking a fresh allocation.
 bool isAliasingViewOp(Operation *op);
 
-/// ReshapeOp, PermuteOp: reject width-sharded inputs, no reshards.
+/// ReshapeOp: reject width-sharded inputs, no reshards.
 /// View-eligible reshapes use NULL hint only (inherit input memory config).
 /// Non-view reshapes use non-sharded output hints.
 struct ReshapeRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
+/// PermuteOp: reject width-sharded inputs, non-sharded output only, no
+/// reshards. Split off `ReshapeRuleBook` (#7988) so reshape-specific rule
+/// changes cannot leak into permute; the rules here are permute's long-standing
+/// behavior, since `canReshapeBeView` never held for a PermuteOp.
+struct PermuteRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
   bool shouldExploreReshards() const override;
   OutputHints

--- a/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/DataMovementRules.cpp
@@ -214,9 +214,9 @@ SliceRuleBook::getOutputHints(Operation * /*op*/,
 /// Check if a reshape can be optimized to a view (no kernel launch) by
 /// tt-metal. Mirrors the `this_is_view` condition in tt-metal's
 /// reshape.cpp:378-384. Only applies to ReshapeOp — PermuteOp has its own
-/// NOP optimization (is_permute_nop) with different conditions.
-/// TODO(#7988): Split PermuteOp into its own PermuteRuleBook to avoid this
-/// op-kind check.
+/// NOP optimization (`canPermuteBeView`, below) with different conditions.
+/// Like the other view predicates, this self-guards on its op kind so that
+/// `isAliasingViewOp` can dispatch it over any operation.
 bool canReshapeBeView(Operation *op) {
   if (!mlir::isa<ReshapeOp>(op)) {
     return false;
@@ -425,8 +425,8 @@ bool isAliasingViewOp(Operation *op) {
 
 LayoutFilterFn
 ReshapeRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
-  // Reshape/Permute: width-sharded inputs round-trip through interleaved
-  // internally in tt-metal; height/block sharding is handled natively.
+  // Reshape: width-sharded inputs round-trip through interleaved internally in
+  // tt-metal; height/block sharding is handled natively.
   // https://github.com/tenstorrent/tt-mlir/issues/7681
   return layout_filter_utils::rejectWidthSharded;
 }
@@ -445,6 +445,31 @@ OutputHints ReshapeRuleBook::getOutputHints(
     return layout_filter_utils::nullHintOnly();
   }
   // Non-view reshape: sharded output not beneficial, use non-sharded configs.
+  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+}
+
+//===----------------------------------------------------------------------===//
+// PermuteRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+PermuteRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  // Permute: width-sharded inputs round-trip through interleaved internally in
+  // tt-metal; height/block sharding is handled natively.
+  // https://github.com/tenstorrent/tt-mlir/issues/7681
+  return layout_filter_utils::rejectWidthSharded;
+}
+
+bool PermuteRuleBook::shouldExploreReshards() const { return false; }
+
+OutputHints PermuteRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
+  // Sharded output not beneficial for permute: use non-sharded configs.
+  // TODO(rpavlovicTT): `canPermuteBeView` already models tt-metal's
+  // permute-nop, but is only consumed by `isAliasingViewOp` today. A view
+  // branch returning `nullHintOnly()` here (mirroring reshape) would keep the
+  // zero-copy path off the optimizer's DRAM->L1 upgrades; that is a behavior
+  // change and is deliberately left out of the #7988 split.
   return layout_filter_utils::nonShardedOutputHints(legalConfigs);
 }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -61,7 +61,14 @@ bool OpRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
 }
 
 //===----------------------------------------------------------------------===//
-// Registry: maps OperationName -> OpRuleBook
+// Registry: maps op name -> OpRuleBook
+//
+// Keyed by the op's string name, not by `OperationName`: an `OperationName` is
+// only meaningful within the `MLIRContext` it was built in, and this registry
+// is initialized once per process. Keying it by `OperationName` bound every
+// entry to whichever context happened to make the first query, so ops from any
+// later context missed the registry and silently fell back to `defaultRules`.
+// Op names are process-wide constants, so a name-keyed map is context-safe.
 //===----------------------------------------------------------------------===//
 
 const OpRuleBook &getRuleBook(Operation *op) {
@@ -72,6 +79,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static ConcatRuleBook concat;
   static SliceRuleBook slice;
   static ReshapeRuleBook reshape;
+  static PermuteRuleBook permute;
   static PadRuleBook pad;
   static RepeatRuleBook repeat;
   static ConcatenateHeadsRuleBook concatHeads;
@@ -89,12 +97,11 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PagedUpdateCacheRuleBook pagedUpdateCache;
   static ArgMaxRuleBook argMax;
 
-  static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
+  static llvm::DenseMap<StringRef, const OpRuleBook *> registry;
   static std::once_flag initFlag;
   std::call_once(initFlag, [&] {
-    MLIRContext *ctx = op->getContext();
     auto reg = [&](StringRef name, const OpRuleBook *rb) {
-      registry[OperationName(name, ctx)] = rb;
+      registry[name] = rb;
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
@@ -105,10 +112,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(SliceStaticOp::getOperationName(), &slice);
     reg(SliceDynamicOp::getOperationName(), &slice);
     reg(ReshapeOp::getOperationName(), &reshape);
-
-    // TODO(rpavlovicTT): split permute's from reshape's rule book
-    // https://github.com/tenstorrent/tt-mlir/issues/7988
-    reg(PermuteOp::getOperationName(), &reshape);
+    reg(PermuteOp::getOperationName(), &permute);
     reg(PadOp::getOperationName(), &pad);
     reg(RepeatOp::getOperationName(), &repeat);
     reg(ConcatenateHeadsOp::getOperationName(), &concatHeads);
@@ -132,7 +136,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(ArgMaxOp::getOperationName(), &argMax);
   });
-  auto it = registry.find(op->getName());
+  auto it = registry.find(op->getName().getStringRef());
   return it != registry.end() ? *it->second : defaultRules;
 }
 

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 #include "ttmlir/Dialect/TTCore/Transforms/Transforms.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
@@ -127,6 +128,32 @@ public:
     return builder.create<ReshapeOp>(builder.getUnknownLoc(), outputTensorType,
                                      input.getResult(),
                                      builder.getI32ArrayAttr(outputShapeI32));
+  }
+
+  // Create a PermuteOp for testing. The default permutation transposes the
+  // last two (non-unit) dims, so it is not a permute-nop.
+  PermuteOp createMockPermuteOp(
+      const llvm::ArrayRef<int64_t> &inputShape = {1, 1, 32, 64},
+      const llvm::ArrayRef<int64_t> &permutation = {0, 1, 3, 2}) {
+    auto inputLayout = createL1InterleavedLayout(inputShape);
+    auto inputTensorType = mlir::RankedTensorType::get(
+        inputShape, builder.getBF16Type(), inputLayout);
+
+    llvm::SmallVector<int64_t> outputShape;
+    for (int64_t dim : permutation) {
+      outputShape.push_back(inputShape[dim]);
+    }
+    auto outputLayout = createDRAMInterleavedLayout(outputShape);
+    auto outputTensorType = mlir::RankedTensorType::get(
+        outputShape, builder.getBF16Type(), outputLayout);
+
+    auto input = builder.create<OnesOp>(
+        builder.getUnknownLoc(), inputTensorType,
+        /*device=*/nullptr, ShapeAttr::get(&context, inputShape));
+
+    return builder.create<PermuteOp>(
+        builder.getUnknownLoc(), outputTensorType, input.getResult(),
+        builder.getDenseI64ArrayAttr(permutation), /*pad_value=*/nullptr);
   }
 
   // Create a MatmulOp for testing.
@@ -250,6 +277,79 @@ TEST_F(OpModelStrategyTest, ReshapeOpSkipsL1Sharding) {
   }
 }
 
+// PermuteOp has its own rule book (#7988); reshape-specific output-hint
+// changes must not leak into it. Permute output hints are non-sharded only.
+TEST_F(OpModelStrategyTest, PermuteOpSkipsL1Sharding) {
+  auto permuteOp = createMockPermuteOp();
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints hints = getOutputHints(permuteOp, legalConfigs);
+
+  // The sharded config is dropped, and there are no sharded fallbacks.
+  EXPECT_LT(hints.hints.size(), legalConfigs.size());
+  EXPECT_TRUE(hints.fallbackHints.empty());
+
+  for (const auto &hint : hints.hints) {
+    if (hint.outputLayout && hint.outputLayout.getMemLayout()) {
+      EXPECT_FALSE(
+          isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
+    }
+  }
+}
+
+// The split itself: permute must not resolve to reshape's rule book, or a
+// reshape-only rule change silently applies to permute too (#7988).
+TEST_F(OpModelStrategyTest, PermuteAndReshapeHaveDistinctRuleBooks) {
+  auto permuteOp = createMockPermuteOp();
+  auto reshapeOp = createMockReshapeOp();
+
+  const OpRuleBook &permuteRules = getRuleBook(permuteOp);
+  const OpRuleBook &reshapeRules = getRuleBook(reshapeOp);
+
+  // Distinct rule-book instances, and neither is the default rule book (which
+  // explores reshards).
+  EXPECT_NE(&permuteRules, &reshapeRules);
+  EXPECT_FALSE(permuteRules.shouldExploreReshards());
+  EXPECT_FALSE(reshapeRules.shouldExploreReshards());
+}
+
+// A view-eligible reshape uses the NULL-hint-only branch. The equivalent
+// permute-nop does not: PermuteRuleBook has no view branch, so it keeps the
+// same non-sharded hints as any other permute.
+TEST_F(OpModelStrategyTest, ViewReshapeUsesNullHintOnlyButPermuteNopDoesNot) {
+  // Same trailing dims -> canReshapeBeView holds.
+  auto viewReshapeOp = createMockReshapeOp(/*inputShape=*/{1, 1, 32, 32},
+                                           /*outputShape=*/{1, 32, 32});
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints reshapeHints = getOutputHints(viewReshapeOp, legalConfigs);
+  EXPECT_EQ(reshapeHints.hints.size(), 1u);
+  EXPECT_FALSE(reshapeHints.hints[0].outputLayout);
+
+  auto nopPermuteOp = createMockPermuteOp(/*inputShape=*/{1, 1, 32, 32},
+                                          /*permutation=*/{0, 1, 2, 3});
+  OutputHints permuteHints = getOutputHints(nopPermuteOp, legalConfigs);
+  EXPECT_GT(permuteHints.hints.size(), 1u);
+}
+
+// A permute-nop is still not view-eligible for hint purposes: unlike reshape,
+// PermuteRuleBook has no NULL-hint-only branch.
+TEST_F(OpModelStrategyTest, PermuteNopStillSkipsL1Sharding) {
+  auto permuteOp = createMockPermuteOp(/*inputShape=*/{1, 1, 32, 32},
+                                       /*permutation=*/{0, 1, 2, 3});
+  auto legalConfigs = createElementwiseLegalConfigs();
+
+  OutputHints hints = getOutputHints(permuteOp, legalConfigs);
+
+  EXPECT_GT(hints.hints.size(), 1u);
+  for (const auto &hint : hints.hints) {
+    if (hint.outputLayout && hint.outputLayout.getMemLayout()) {
+      EXPECT_FALSE(
+          isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
+    }
+  }
+}
+
 TEST_F(OpModelStrategyTest, UnknownOpUsesDefaultStrategy) {
   // Use AddOp as a stand-in for "default" path testing.
   auto addOp = createMockAddOp();
@@ -273,6 +373,11 @@ TEST_F(OpModelStrategyTest, ShouldExploreReshardsElementwiseTrue) {
 TEST_F(OpModelStrategyTest, ShouldExploreReshardsReshapeFalse) {
   auto reshapeOp = createMockReshapeOp();
   EXPECT_FALSE(shouldExploreReshards(reshapeOp));
+}
+
+TEST_F(OpModelStrategyTest, ShouldExploreReshardsPermuteFalse) {
+  auto permuteOp = createMockPermuteOp();
+  EXPECT_FALSE(shouldExploreReshards(permuteOp));
 }
 
 TEST_F(OpModelStrategyTest, ShouldExploreReshardsMatmulTrue) {


### PR DESCRIPTION
### What

Give `PermuteOp` its own `PermuteRuleBook` instead of sharing `ReshapeRuleBook`. Pure refactor — no behavior change.

Closes #7988.

### Why

`OpRuleBook.cpp` registered `PermuteOp` against the *same* `ReshapeRuleBook` instance as `ReshapeOp`, with a standing `TODO(#7988)`. That coupling is not benign, because `ReshapeRuleBook::getOutputHints` branches on `canReshapeBeView`, whose first statement is:

```cpp
if (!mlir::isa<ReshapeOp>(op)) { return false; }
```

So a `PermuteOp` *always* fell through to the non-view branch. Any edit to that one branch — intended for reshape — silently changed the output hints of every permute in the graph as well.

This is not hypothetical. #9155 (#8020) edits exactly that line, and on segformer it flips sharded `ttnn.permute` outputs from 0/108 to 108/108, which re-solves the whole-graph layout assignment, flips 4 `ttnn.conv2d` ops' `conv2d_config.shard_layout` from `block_sharded` to `height_sharded`, and lands as a PCC failure. Splitting the rule books removes that coupling; #9155 then stacks on top of this and applies to reshape only.

### The split

`PermuteRuleBook` gets the rules permute effectively has today:

| | value | same as today? |
|---|---|---|
| `getInputLayoutFilter` | `rejectWidthSharded` | yes |
| `shouldExploreReshards` | `false` | yes |
| `getOutputHints` | `nonShardedOutputHints` | yes — permute always took the non-view branch |

No other `OpRuleBook` virtual was overridden by `ReshapeRuleBook`, so `PermuteRuleBook` overriding the same three with the same bodies is behavior-identical by construction.

`canReshapeBeView` keeps its `isa<ReshapeOp>` guard — it is not an artifact of the shared rule book. `isAliasingViewOp` dispatches all four view predicates over an arbitrary op, and each one self-guards on its op kind. The stale `TODO(#7988)` comment there is replaced with a note saying so.

`canPermuteBeView` already models tt-metal's permute-nop but is only consumed by `isAliasingViewOp`. Wiring it into a `nullHintOnly()` view branch (mirroring reshape) would be a *behavior* change, so it is deliberately left out and marked with a TODO.

### Also: rule-book registry keying

Found while adding tests. The registry is built once per process under `std::call_once`, but was keyed by `mlir::OperationName` — which is only meaningful inside the `MLIRContext` it was built in. Every entry was therefore bound to whichever context happened to make the *first* query, and ops from any later context missed the registry and silently fell back to `defaultRules`.

It is keyed by the op's string name now (a process-wide constant), which is context-safe. This is a no-op for single-context compiles — every real compile and every lit invocation — but it makes the `OpModelStrategy` unit tests, which build a fresh `MLIRContext` per test, deterministic instead of dependent on whether a fresh context happened to land at the same address as the first one.

That flake was already live on `main`: `OpModelStrategyTest.ShouldExploreReshardsReshapeFalse` passes when run alone and fails when run in the full suite. It passes deterministically now.

### Verification — behavior-preserving

**On a real graph.** Recompiled segformer's CI TTIR (tt-xla run `30831052547`, artifact `8864329221`) at `optimization-level=2` on this branch and on `main`:

```
1f1be82cf7294a2fe10fffcbd68fc872  xla_seg_split.mlir
1f1be82cf7294a2fe10fffcbd68fc872  xla_seg_base.mlir     (main)
```

**Byte-identical TTNN IR** across a 775-op graph — same layouts, same `conv2d_config`s, same reshard placement. The flatbuffers translated from those two IRs are byte-identical too (`93bfe2f4cca56fc48628973d4a94109f`, both translated from the same path since `ttmlir-translate` embeds the input filename).

**Tests.** `check-ttmlir` shows no golden churn against `main`. `OpModelStrategyTests` pass, with new coverage:

- `PermuteAndReshapeHaveDistinctRuleBooks` — the regression guard: permute and reshape must not resolve to the same rule-book instance.
- `PermuteOpSkipsL1Sharding`, `PermuteNopStillSkipsL1Sharding` — permute hints are non-sharded, with no sharded fallbacks.
- `ViewReshapeUsesNullHintOnlyButPermuteNopDoesNot` — reshape keeps its view branch; the equivalent permute-nop does not gain one.
- `ShouldExploreReshardsPermuteFalse`.

### Notes

Built with `-DTTMLIR_ENABLE_OPMODEL=ON`, tt-metal pinned at `5beed318d0f0d1c6212e605947fb0be80c9e0a1d`, n150.
