### PR TITLE
[TTNN] Type embedding_bw's result as the 4D gradient tt-metal returns

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -1152,6 +1152,10 @@ def TTNN_EmbeddingBackwardOp : TTNN_Op<"embedding_bw"> {
     let summary = "Embedding backward op.";
     let description = [{
       Embedding backward operation. Generates the gradient of the embedding operation with respect to the input.
+
+      The gradient is returned as a 4D tensor of shape (1, 1, dictionary_size, embedding_size), matching
+      what tt-metal produces; the two leading unit dimensions have to be reshaped away by the producer of
+      this op if the consumer expects the 2D weight shape.
     }];
 
     let arguments = (ins AnyRankedTensor:$input,

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -443,9 +443,25 @@ public:
           rewriter, ttmlir::utils::appendLocationSuffix(loc, "_4d_indices"));
     }
 
-    rewriter.replaceOpWithNewOp<ttnn::EmbeddingBackwardOp>(
-        op, this->getTypeConverter()->convertType(op.getType()), inputIndices,
-        adaptor.getWeight(), reshapedGrad);
+    // tt-metal always returns the weight gradient as a 4D tensor of shape
+    // [1, 1, dictionary_size, embedding_size], so the ttnn op is typed that way
+    // and reshaped back to the 2D weight shape the ttir op declares.
+    auto outputType = mlir::cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
+    llvm::SmallVector<int64_t, 4> gradient4DShape{
+        1, 1, outputType.getDimSize(0), outputType.getDimSize(1)};
+    auto gradient4DType = ttnn::utils::RankedTensorTypeFactory::create(
+        outputType, gradient4DShape);
+
+    auto embeddingBackwardOp = rewriter.create<ttnn::EmbeddingBackwardOp>(
+        ttmlir::utils::appendLocationSuffix(loc, "_embedding_bw"),
+        gradient4DType, inputIndices, adaptor.getWeight(), reshapedGrad);
+
+    llvm::SmallVector<int32_t, 2> outputShapeI32(outputType.getShape().begin(),
+                                                 outputType.getShape().end());
+    rewriter.replaceOpWithNewOp<ttnn::ReshapeOp>(
+        op, outputType, embeddingBackwardOp.getResult(),
+        rewriter.getI32ArrayAttr(outputShapeI32));
     return success();
   }
 };

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -2093,9 +2093,14 @@ mlir::OpFoldResult mlir::tt::ttnn::SliceStaticOp::fold(FoldAdaptor adaptor) {
     return emitOpError("Input gradient and output must have the same dtype");
   }
 
-  // outputType should have the same shape as weightType.
-  if (outputType.getShape() != weightType.getShape()) {
-    return emitOpError("Output must have the same shape as weight");
+  // tt-metal always returns the weight gradient as a 4D tensor of shape
+  // (1, 1, dictionary_size, embedding_size), i.e. the weight shape prefixed
+  // with two unit dimensions.
+  llvm::SmallVector<int64_t, 4> expectedOutputShape{
+      1, 1, weightType.getDimSize(0), weightType.getDimSize(1)};
+  if (!llvm::equal(expectedOutputShape, outputType.getShape())) {
+    return emitOpError() << "expected output shape of (" << expectedOutputShape
+                         << ") but got (" << outputType.getShape() << ")";
   }
 
   return success();

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/embedding_backward_workaround.mlir
@@ -8,6 +8,7 @@
 #ttnn_layout3 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 32 + d1 * 32 + d2, d3), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #ttnn_layout4 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<16x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #ttnn_layout5 = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 32 + d1, d2), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#ttnn_layout6 = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 512 + d1 * 512 + d2, d3), <1x1>, memref<16x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 module attributes {} {
   func.func @backward(%arg0: tensor<1x1x1x32xf32, #ttnn_layout>, %arg1: tensor<512x128xf32, #ttnn_layout1>, %arg2: tensor<1x32x128xf32, #ttnn_layout2>) -> tensor<512x128xf32, #ttnn_layout1> {
     %0 = "ttnn.to_tensor_spec"(%arg0)  : (tensor<1x1x1x32xf32, #ttnn_layout>) -> tensor<1x1x1x32xf32, #ttnn_layout3>
@@ -29,13 +30,17 @@ module attributes {} {
     // CHECK-SAME: -> tensor<1x1x32x128xbf16
     // CHECK-SAME: !ttcore.tile<32x32,
     // Check that the data type of the output operand is transformed in bf16.
-    %4 = "ttnn.embedding_bw"(%0, %1, %3) : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<512x128xf32, #ttnn_layout4>
+    %4 = "ttnn.embedding_bw"(%0, %1, %3) : (tensor<1x1x1x32xf32, #ttnn_layout3>, tensor<512x128xf32, #ttnn_layout4>, tensor<1x1x32x128xf32, #ttnn_layout5>) -> tensor<1x1x512x128xf32, #ttnn_layout6>
     // CHECK: %[[EMBEDDING_BW_OP:.*]] = "ttnn.embedding_bw"(%[[TO_LAYOUT_INPUT]], %[[TO_LAYOUT_WEIGHTS]], %[[TO_LAYOUT_IN_GRADIENT]])
     // Check that the output operand is transformed back into the f32 data type.
-    // CHECK: "ttnn.to_tensor_spec"(%[[EMBEDDING_BW_OP]])
+    // CHECK: %[[TO_LAYOUT_OUTPUT:.*]] = "ttnn.to_tensor_spec"(%[[EMBEDDING_BW_OP]])
+    // CHECK-SAME: -> tensor<1x1x512x128xf32
+    %5 = "ttnn.reshape"(%4) <{shape = [512 : i32, 128 : i32]}> : (tensor<1x1x512x128xf32, #ttnn_layout6>) -> tensor<512x128xf32, #ttnn_layout4>
+    // CHECK: "ttnn.reshape"(%[[TO_LAYOUT_OUTPUT]])
     // CHECK-SAME: -> tensor<512x128xf32
+    %6 = "ttnn.to_tensor_spec"(%5)  : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
+    // CHECK: "ttnn.to_tensor_spec"
     // CHECK-SAME: memref<512x128xf32, #ttnn.buffer_type
-    %5 = "ttnn.to_tensor_spec"(%4)  : (tensor<512x128xf32, #ttnn_layout4>) -> tensor<512x128xf32, #ttnn_layout1>
-    return %5 : tensor<512x128xf32, #ttnn_layout1>
+    return %6 : tensor<512x128xf32, #ttnn_layout1>
   }
 }

--- a/test/ttmlir/Dialect/TTNN/embedding/embedding_backward_1d_indices.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/embedding_backward_1d_indices.mlir
@@ -13,6 +13,10 @@ module attributes {} {
     // CHECK: "ttnn.typecast"
     // CHECK-SAME: -> tensor<1x1x1x32xui32
     // CHECK: "ttnn.embedding_bw"
+    // CHECK-SAME: -> tensor<1x1x512x128xbf16
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [512 : i32, 128 : i32]}>
+    // CHECK-SAME: -> tensor<512x128xbf16
     %1 = "ttir.embedding_backward"(%arg0, %arg1, %arg2) : (tensor<32xsi32>, tensor<512x128xbf16>, tensor<32x128xbf16>) -> tensor<512x128xbf16>
     return %1 : tensor<512x128xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/embedding/simple_embedding_backward.mlir
+++ b/test/ttmlir/Dialect/TTNN/embedding/simple_embedding_backward.mlir
@@ -9,7 +9,13 @@ module attributes {} {
     // CHECK-SAME: <{shape = [1 : i32, 1 : i32, 32 : i32, 128 : i32]}>
     // CHECK-SAME: -> tensor<1x1x32x128xbf16, [[RESHAPE_OUTPUT_LAYOUT]]>
     %1 = "ttir.embedding_backward"(%arg0, %arg1, %arg2) : (tensor<1x32xbf16>, tensor<512x128xbf16>, tensor<1x32x128xbf16>) -> tensor<512x128xbf16>
+    // tt-metal returns the weight gradient as (1, 1, dictionary_size, embedding_size),
+    // which is reshaped back to the 2D weight shape.
     // CHECK: "ttnn.embedding_bw"
+    // CHECK-SAME: -> tensor<1x1x512x128xbf16
+    // CHECK: "ttnn.reshape"
+    // CHECK-SAME: <{shape = [512 : i32, 128 : i32]}>
+    // CHECK-SAME: -> tensor<512x128xbf16
     return %1 : tensor<512x128xbf16>
   }
 }

--- a/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_backward.mlir
+++ b/test/ttmlir/Silicon/TTNN/n150/embedding/embedding_backward.mlir
@@ -4,6 +4,7 @@
 module attributes {} {
   func.func @backward(%arg0: tensor<1x32xf32>, %arg1: tensor<512x128xf32>, %arg2: tensor<1x32x128xf32>) -> tensor<512x128xf32> {
     // CHECK: %{{[0-9]+}} = "ttnn.embedding_bw"
+    // CHECK-SAME: -> tensor<1x1x512x128xbf16
     %1 = "ttir.embedding_backward"(%arg0, %arg1, %arg2) : (tensor<1x32xf32>, tensor<512x128xf32>, tensor<1x32x128xf32>) -> tensor<512x128xf32>
     return %1 : tensor<512x128xf32>
   }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4380,9 +4380,13 @@ TEST_F(OpModelBase, EmbeddingBackwardOp) {
                         CreateRowMajorLayout(weightShape, BufferType::DRAM,
                                              TensorMemoryLayout::Interleaved));
   auto inGradient = createEmptyTensor(inGradientShape);
+  // tt-metal returns the weight gradient as (1, 1, dictionary_size,
+  // embedding_size).
+  llvm::SmallVector<int64_t> outputShape = {1, 1, weightShape[0],
+                                            weightShape[1]};
   auto outputType = createRankedTensorType(
-      inGradientShape, builder.getBF16Type(),
-      CreateTiledLayout(inGradientShape, BufferType::L1,
+      outputShape, builder.getBF16Type(),
+      CreateTiledLayout(outputShape, BufferType::L1,
                         TensorMemoryLayout::Interleaved));
 
   auto embeddingBackward = builder.create<EmbeddingBackwardOp>(


### PR DESCRIPTION
### Ticket
No issue, discovered during work on an external request.

### Problem description
embedding_bw always hands back the weight gradient as a 4D tensor, but ttnn.embedding_bw was typed with a 2D weight shape. This leads to an IR-reality mismatch which can then result in a hard fault in other operations. Notably I ran into a slice that complained about the rank mismatch between the tensor and begins attribute.

### What's changed
Correctly model the 4D output on the TTNN level, insert reshapes in the TTIR to TTNN conversions to bridge the different ranks.

### Checklist
- [X] New/Existing tests provide coverage for changes
