### PR TITLE
[Optimizer] Never give reductions a sharded output

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ReductionRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/ReductionRules.h
@@ -18,6 +18,23 @@ struct ArgMaxRuleBook : OpRuleBook {
   bool generatesRowMajorInputSiblings(unsigned operandIdx) const override;
 };
 
+/// Reductions must not take a sharded output. Given one they return
+/// reinterpreted memory rather than the reduction: a `ttnn.sum` reducing
+/// 1x1023x128256 -> 1x1023x1 that the optimizer gave a height-sharded L1 result
+/// (32x1 grid over an irregular core set) produced values up to +-5.8e13 plus
+/// infs, where the identical op with a DRAM-interleaved result is correct. The
+/// default rule book offers sharded output fallbacks, so without this the
+/// analysis picks one whenever L1 pressure makes it look profitable.
+///
+/// Demonstrated on SumOp; applied to the reduction family, which shares the
+/// same kernel path. Conservative: it gives up a sharded-output option that is
+/// not known to work for any reduction.
+struct ReductionRuleBook : OpRuleBook {
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_REDUCTIONRULES_H

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -14,7 +14,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
 
 #include <mutex>
 
@@ -61,7 +61,7 @@ bool OpRuleBook::preferCandidate(Operation * /*op*/, const BeamCandidate &a,
 }
 
 //===----------------------------------------------------------------------===//
-// Registry: maps OperationName -> OpRuleBook
+// Registry: maps op mnemonic -> OpRuleBook
 //===----------------------------------------------------------------------===//
 
 const OpRuleBook &getRuleBook(Operation *op) {
@@ -88,13 +88,16 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PagedFillCacheRuleBook pagedFillCache;
   static PagedUpdateCacheRuleBook pagedUpdateCache;
   static ArgMaxRuleBook argMax;
+  static ReductionRuleBook reduction;
 
-  static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
+  // Keyed by the op's mnemonic, not OperationName: an OperationName is owned by
+  // its MLIRContext, so a registry built once per process from context A misses
+  // every op of context B and silently falls back to defaultRules.
+  static llvm::StringMap<const OpRuleBook *> registry;
   static std::once_flag initFlag;
   std::call_once(initFlag, [&] {
-    MLIRContext *ctx = op->getContext();
     auto reg = [&](StringRef name, const OpRuleBook *rb) {
-      registry[OperationName(name, ctx)] = rb;
+      registry[name] = rb;
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
@@ -131,8 +134,13 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PagedFillCacheOp::getOperationName(), &pagedFillCache);
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(ArgMaxOp::getOperationName(), &argMax);
+    reg(SumOp::getOperationName(), &reduction);
+    reg(MeanOp::getOperationName(), &reduction);
+    reg(MaxOp::getOperationName(), &reduction);
+    reg(MinOp::getOperationName(), &reduction);
+    reg(ProdOp::getOperationName(), &reduction);
   });
-  auto it = registry.find(op->getName());
+  auto it = registry.find(op->getName().getStringRef());
   return it != registry.end() ? *it->second : defaultRules;
 }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/ReductionRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/ReductionRules.cpp
@@ -20,4 +20,14 @@ bool ArgMaxRuleBook::generatesRowMajorInputSiblings(unsigned operandIdx) const {
   return operandIdx == 0;
 }
 
+//===----------------------------------------------------------------------===//
+// ReductionRuleBook
+//===----------------------------------------------------------------------===//
+
+OutputHints ReductionRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
+  // Sharded results come back as reinterpreted memory; see the header.
+  return layout_filter_utils::nonShardedOutputHints(legalConfigs);
+}
+
 } // namespace mlir::tt::ttnn

--- a/test/unittests/Optimizer/TestOpModelStrategy.cpp
+++ b/test/unittests/Optimizer/TestOpModelStrategy.cpp
@@ -163,6 +163,42 @@ public:
                                     /*activation=*/nullptr);
   }
 
+  // Create the 1x1x32x64 -> 1x1x32x1 operands shared by the reduction mocks.
+  std::pair<mlir::Value, mlir::Type> createReductionOperands() {
+    const llvm::SmallVector<int64_t> inputShape = {1, 1, 32, 64};
+    const llvm::SmallVector<int64_t> outputShape = {1, 1, 32, 1};
+
+    auto inputTensorType =
+        mlir::RankedTensorType::get(inputShape, builder.getBF16Type(),
+                                    createL1InterleavedLayout(inputShape));
+    auto input = builder.create<OnesOp>(
+        builder.getUnknownLoc(), inputTensorType,
+        /*device=*/nullptr, ShapeAttr::get(&context, inputShape));
+
+    return {input.getResult(), mlir::RankedTensorType::get(
+                                   outputShape, builder.getBF16Type(),
+                                   createDRAMInterleavedLayout(outputShape))};
+  }
+
+  // Create a SumOp/MeanOp/MaxOp/MinOp for testing.
+  template <typename ReductionOpTy>
+  ReductionOpTy createMockReductionOp() {
+    auto [input, outputTensorType] = createReductionOperands();
+    return builder.create<ReductionOpTy>(
+        builder.getUnknownLoc(), outputTensorType, input,
+        /*keep_dim=*/true, builder.getI32ArrayAttr({3}));
+  }
+
+  // ProdOp is a separate op class with a scalar dim_arg.
+  ProdOp createMockProdOp() {
+    auto [input, outputTensorType] = createReductionOperands();
+    return builder.create<ProdOp>(
+        builder.getUnknownLoc(), outputTensorType, input,
+        mlir::IntegerAttr::get(builder.getIntegerType(64, /*isSigned=*/true),
+                               3),
+        builder.getBoolAttr(true));
+  }
+
   // Create legal configs for an elementwise op (DRAM + L1-interleaved).
   std::vector<OpConfig> createElementwiseLegalConfigs(
       const llvm::ArrayRef<int64_t> &shape = {1, 1, 32, 32}) {
@@ -248,6 +284,47 @@ TEST_F(OpModelStrategyTest, ReshapeOpSkipsL1Sharding) {
           isShardedMemoryLayout(hint.outputLayout.getMemLayout().getValue()));
     }
   }
+}
+
+// Reductions return reinterpreted memory instead of the reduction when given a
+// sharded output, so neither the primary nor the fallback hints may offer one.
+static void expectNoShardedOutputHints(llvm::StringRef opName,
+                                       const OutputHints &hints) {
+  SCOPED_TRACE(opName.str());
+  EXPECT_FALSE(hints.hints.empty());
+  for (const auto &hint : hints.hints) {
+    ASSERT_TRUE(hint.outputLayout);
+    auto memLayout = hint.outputLayout.getMemLayout();
+    if (memLayout) {
+      EXPECT_FALSE(isShardedMemoryLayout(memLayout.getValue()));
+    }
+  }
+  EXPECT_TRUE(hints.fallbackHints.empty());
+}
+
+TEST_F(OpModelStrategyTest, ReductionOpsRejectShardedOutput) {
+  auto legalConfigs = createElementwiseLegalConfigs({1, 1, 32, 1});
+
+  expectNoShardedOutputHints(
+      "sum", getOutputHints(createMockReductionOp<SumOp>(), legalConfigs));
+  expectNoShardedOutputHints(
+      "mean", getOutputHints(createMockReductionOp<MeanOp>(), legalConfigs));
+  expectNoShardedOutputHints(
+      "max", getOutputHints(createMockReductionOp<MaxOp>(), legalConfigs));
+  expectNoShardedOutputHints(
+      "min", getOutputHints(createMockReductionOp<MinOp>(), legalConfigs));
+  expectNoShardedOutputHints("prod",
+                             getOutputHints(createMockProdOp(), legalConfigs));
+}
+
+TEST_F(OpModelStrategyTest, ReductionOpsKeepNonShardedOutput) {
+  auto legalConfigs = createElementwiseLegalConfigs({1, 1, 32, 1});
+
+  OutputHints hints =
+      getOutputHints(createMockReductionOp<SumOp>(), legalConfigs);
+
+  // The two non-sharded configs survive: DRAM- and L1-interleaved.
+  EXPECT_EQ(hints.hints.size(), 2u);
 }
 
 TEST_F(OpModelStrategyTest, UnknownOpUsesDefaultStrategy) {


### PR DESCRIPTION
### Ticket
N/A

### Problem description
A reduction with a sharded output returns reinterpreted memory, not the reduction.

A `ttnn.sum` reducing `1x1023x128256 -> 1x1023x1` with a height-sharded L1 result gives values up to `±5.8e13` plus `inf`s; the same op with `#dram, <interleaved>` is correct.

`OpRuleBook::getOutputHints` offers sharded fallbacks, so `optimization-level=2` picks one under L1 pressure.

Blocks opt-level 2 in kurbla.

Second bug, found while writing the tests - `getRuleBook`:

```cpp
static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
std::call_once(initFlag, [&] { registry[OperationName(name, ctx)] = rb; });
```

An `OperationName` is owned by its `MLIRContext`, but `registry` is a process-wide static built once. Ops of any other context miss `registry.find(op->getName())` and get `defaultRules`, making every per-op rule inert. `ShouldExploreReshardsReshapeFalse` fails on `main` for this reason.

### What's changed
- `ReductionRuleBook::getOutputHints` -> `nonShardedOutputHints`, registered for
  `SumOp`, `MeanOp`, `MaxOp`, `MinOp`, `ProdOp`.
- Registry re-keyed to `llvm::StringMap` on `op->getName().getStringRef()`.
- Tests: `ReductionOpsRejectShardedOutput` (no sharded hint *or* fallback, all 5
  ops), `ReductionOpsKeepNonShardedOutput`.

### Checklist
- [x] New/Existing tests provide coverage for changes

