### PR TITLE
[D2M/TTMetal] Scope fabric config to kernels via shared table index

### DIFF
--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -697,6 +697,10 @@ def TTCore_FabricConnectionConfigAttr: TTCore_Attr<"FabricConnectionConfig", "fa
   let assemblyFormat = "`<` `noc_index` `=` $noc_index `,` `topology` `=` $topology `,` `cluster_axis` `=` $cluster_axis `,` `routing_mode` `=` $routing_mode `,` `num_links` `=` $num_links `>`";
 }
 
+def TTCore_FabricConnectionConfigArrayAttr
+    : TypedArrayAttrBase<TTCore_FabricConnectionConfigAttr,
+                         "FabricConnectionConfig array attribute">;
+
 //===----------------------------------------------------------------------===//
 // TT type definitions
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
+++ b/include/ttmlir/Dialect/TTKernel/IR/TTKernelOps.td
@@ -4298,10 +4298,10 @@ def TTKernel_SetupFabricConnectionsOp : TTKernel_Op<"experimental.setup_fabric_c
   let summary = "SetupFabricConnections";
   let description = [{
     Setup fabric connections for inter-device communication. The connection scheme
-    is derived from the attribute `TTMetal_FabricConnectionConfigAttr` in the
-    `EnqueueProgramOp`.
+    is selected by the owning kernel's `fabric_config_index`, which indexes into
+    `EnqueueProgramOp`'s `fabricConnectionConfigs` table.
 
-   `TTMetal_FabricConnectionConfigAttr` specifies:
+    `FabricConnectionConfig` specifies:
       - `noc_index`: Which NOC the fabric uses (must match kernel's NocConfig)
       - `topology`: The routing scheme to use for the mesh device (e.g. Line, Ring)
       - `cluster_axis`: The axis along which the to route for 1D topologies

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOps.td
@@ -31,7 +31,7 @@ def TTMetal_EnqueueProgramOp : TTMetal_Op<"enqueue_program", [MemoryEffects<[Mem
                          Variadic<AnyNon0RankedMemRef>:$cbs,
                          DenseI64ArrayAttr:$cb_ports,
                          TTMetal_KernelConfigArrayAttr:$kernelConfigs,
-                         OptionalAttr<TTCore_FabricConnectionConfigAttr>:$fabricConnectionConfig);
+                         OptionalAttr<TTCore_FabricConnectionConfigArrayAttr>:$fabricConnectionConfigs);
     let hasVerifier = 1;
 }
 

--- a/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
+++ b/include/ttmlir/Dialect/TTMetal/IR/TTMetalOpsAttrs.td
@@ -113,13 +113,17 @@ def TTMetal_NocConfigAttr: TTMetal_Attr<"NocConfig", "noc_config", [TTMetal_Kern
     The dm_core_index selects the DM core this kernel launches on; noc_index
     selects the NoC it drives. See ttcore::getDmCoreDefaultNoc for the default
     DM core -> NoC convention.
+
+    Optional fabric_config_index indexes into EnqueueProgramOp's
+    fabricConnectionConfigs.
   }];
   let parameters = (ins "SymbolRefAttr":$kernel_symbol,
                         "CoreRangeAttr":$core_range,
                         "KernelArgsAttr":$kernel_args,
                         "int32_t":$dm_core_index,
-                        "mlir::tt::ttcore::NocIndex":$noc_index);
-  let assemblyFormat = "`<` $kernel_symbol `,` qualified($core_range) `,` qualified($kernel_args) `,` `dm_core` `=` $dm_core_index `,` $noc_index `>`";
+                        "mlir::tt::ttcore::NocIndex":$noc_index,
+                        OptionalParameter<"std::optional<uint32_t>">:$fabric_config_index);
+  let assemblyFormat = "`<` $kernel_symbol `,` qualified($core_range) `,` qualified($kernel_args) `,` `dm_core` `=` $dm_core_index `,` $noc_index (`,` `fabric_config_index` `=` $fabric_config_index^)? `>`";
   let extraClassDeclaration = [{
     mlir::tt::ttkernel::ThreadType getThreadType() const { return mlir::tt::ttkernel::ThreadType::Noc; }
   }];

--- a/include/ttmlir/Target/TTMetal/command.fbs
+++ b/include/ttmlir/Target/TTMetal/command.fbs
@@ -17,7 +17,7 @@ table EnqueueProgramCommand {
   arg_refs: [ArgRef];
   cbs: [CBRef];
   program: ProgramDesc;
-  fabric_connection_config: tt.target.FabricConnectionConfig;
+  fabric_connection_configs: [tt.target.FabricConnectionConfig];
 }
 
 table CreateGlobalSemaphoreCommand {

--- a/include/ttmlir/Target/TTMetal/program.fbs
+++ b/include/ttmlir/Target/TTMetal/program.fbs
@@ -11,6 +11,7 @@ enum EthType : ushort {
 table NocConfig {
   processor: DataMovementProcessor;
   noc_index: NocIndex;
+  fabric_config_index: uint32 = null;
 }
 
 table ComputeConfig {

--- a/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
+++ b/lib/Conversion/D2MToTTMetal/D2MToTTMetal.cpp
@@ -123,7 +123,8 @@ public:
       Builder &builder, mlir::ValueRange inputOutputOperands, ArrayAttr threads,
       CoreRangeAttr coreRange, ttmetal::MathFidelity mathFidelity,
       const DenseMap<size_t, size_t> &cbOperandIndexToPort,
-      const DenseMap<uint32_t, uint32_t> &argMapping) const {
+      const DenseMap<uint32_t, uint32_t> &argMapping,
+      bool hasFabricConnectionConfig) const {
     SmallVector<Attribute> kernelConfigs;
 
     for (Attribute threadAttr : threads) {
@@ -161,9 +162,16 @@ public:
         const int32_t dmCoreIndex = thread.getDmCoreIndex();
         TT_assert(dmCoreIndex >= 0);
         const auto nocIdx = ttcore::getDmCoreDefaultNoc(arch_, dmCoreIndex);
+        std::optional<uint32_t> fabricConfigIndex = std::nullopt;
+        if (hasFabricConnectionConfig &&
+            kernelContainsOp<ttkernel::SetupFabricConnectionsOp>(
+                *symbolTable_, thread.getKernelSymbol())) {
+          // Single fabric config on this enqueue is at index 0.
+          fabricConfigIndex = 0u;
+        }
         kernelConfig = builder.getAttr<ttmetal::NocConfigAttr>(
             thread.getKernelSymbol(), coreRange, kernelArgs, dmCoreIndex,
-            nocIdx);
+            nocIdx, fabricConfigIndex);
         break;
       }
       case d2m::ThreadType::Unified: {
@@ -257,12 +265,17 @@ public:
 
     ArrayAttr threads = op.getThreads();
     CoreRangeAttr coreRange = coreRangeAttrFromOp(rewriter, op);
+    auto fabricConfig = op.getFabricConnectionConfigAttr();
     auto kernelConfigs = convertThreadsToKernelConfigs(
         rewriter, op.getInputsAndOutputs(), threads, coreRange, mathFidelity_,
-        cbOperandIndexToPort, argMapping);
+        cbOperandIndexToPort, argMapping, /*hasFabricConnectionConfig=*/
+        static_cast<bool>(fabricConfig));
+    ArrayAttr fabricConnectionConfigs = nullptr;
+    if (fabricConfig) {
+      fabricConnectionConfigs = rewriter.getArrayAttr({fabricConfig});
+    }
     rewriter.replaceOpWithNewOp<ttmetal::EnqueueProgramOp>(
-        op, args, cbs, cbPorts, kernelConfigs,
-        op.getFabricConnectionConfigAttr());
+        op, args, cbs, cbPorts, kernelConfigs, fabricConnectionConfigs);
     return success();
   };
 
@@ -637,7 +650,7 @@ public:
     SmallVector<Value> mergedCbs;
     SmallVector<int64_t> mergedCbPorts;
     SmallVector<Attribute> mergedKernelConfigs;
-    ttcore::FabricConnectionConfigAttr mergedFabricConfig = nullptr;
+    SmallVector<Attribute> mergedFabricConfigs;
     SmallVector<Operation *> preEnqueueOps;
     SmallVector<Operation *> postEnqueueOps;
 
@@ -664,19 +677,16 @@ public:
           mergedCbPorts,
           llvm::seq<int64_t>(
               portBase, portBase + static_cast<int64_t>(regionCbPortCount)));
-      for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
-        mergedKernelConfigs.push_back(remapKernelConfig(
-            kernelConfig, enqueueProgram, remapTable, mergedCbSlotBase));
-      }
 
-      auto enqueueFabricConfig = enqueueProgram.getFabricConnectionConfigAttr();
-      if (hasConflictingFabricConfig(mergedFabricConfig, enqueueFabricConfig)) {
-        return rewriter.notifyMatchFailure(
-            op, "failed to merge region enqueue_program ops due to fabric "
-                "config conflict");
+      const size_t fabricConfigBase = mergedFabricConfigs.size();
+      if (ArrayAttr regionFabricConfigs =
+              enqueueProgram.getFabricConnectionConfigsAttr()) {
+        llvm::append_range(mergedFabricConfigs, regionFabricConfigs);
       }
-      if (enqueueFabricConfig) {
-        mergedFabricConfig = enqueueFabricConfig;
+      for (Attribute kernelConfig : enqueueProgram.getKernelConfigs()) {
+        mergedKernelConfigs.push_back(
+            remapKernelConfig(kernelConfig, enqueueProgram, remapTable,
+                              mergedCbSlotBase, fabricConfigBase));
       }
     }
 
@@ -689,9 +699,13 @@ public:
       rewriter.moveOpBefore(operation, op);
     }
 
+    ArrayAttr fabricConnectionConfigs =
+        mergedFabricConfigs.empty()
+            ? nullptr
+            : rewriter.getArrayAttr(mergedFabricConfigs);
     rewriter.create<ttmetal::EnqueueProgramOp>(
         op.getLoc(), remapTable.getUnifiedArgs(), mergedCbs, mergedCbPorts,
-        rewriter.getArrayAttr(mergedKernelConfigs), mergedFabricConfig);
+        rewriter.getArrayAttr(mergedKernelConfigs), fabricConnectionConfigs);
 
     for (Operation *operation : postEnqueueOps) {
       rewriter.moveOpBefore(operation, op);
@@ -838,7 +852,8 @@ private:
   static Attribute remapKernelConfig(Attribute kernelConfig,
                                      ttmetal::EnqueueProgramOp enqueueProgram,
                                      const SpatialRemapTable &remapTable,
-                                     size_t mergedCbSlotBase) {
+                                     size_t mergedCbSlotBase,
+                                     size_t fabricConfigBase) {
     Builder builder(kernelConfig.getContext());
     return TypeSwitch<Attribute, Attribute>(kernelConfig)
         .Case<ComputeConfigAttr>([&](ComputeConfigAttr computeConfig) {
@@ -853,12 +868,19 @@ private:
               computeConfig.getUnpackToDestMode());
         })
         .Case<NocConfigAttr>([&](NocConfigAttr nocConfig) {
+          std::optional<uint32_t> fabricConfigIndex = std::nullopt;
+          if (std::optional<uint32_t> localIndex =
+                  nocConfig.getFabricConfigIndex()) {
+            fabricConfigIndex =
+                static_cast<uint32_t>(*localIndex + fabricConfigBase);
+          }
           return NocConfigAttr::get(
               nocConfig.getContext(), nocConfig.getKernelSymbol(),
               nocConfig.getCoreRange(),
               remapKernelArgs(builder, nocConfig.getKernelArgs(),
                               enqueueProgram, remapTable, mergedCbSlotBase),
-              nocConfig.getDmCoreIndex(), nocConfig.getNocIndex());
+              nocConfig.getDmCoreIndex(), nocConfig.getNocIndex(),
+              fabricConfigIndex);
         })
         .Case<EthernetConfigAttr>([&](EthernetConfigAttr ethernetConfig) {
           return EthernetConfigAttr::get(
@@ -872,13 +894,6 @@ private:
           llvm_unreachable(
               "unexpected kernel config attribute kind in spatial merge");
         });
-  }
-
-  static bool hasConflictingFabricConfig(
-      ttcore::FabricConnectionConfigAttr mergedFabricConfig,
-      ttcore::FabricConnectionConfigAttr enqueueFabricConfig) {
-    return mergedFabricConfig && enqueueFabricConfig &&
-           mergedFabricConfig != enqueueFabricConfig;
   }
 
   static FailureOr<ttmetal::EnqueueProgramOp>

--- a/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
+++ b/lib/Dialect/TTMetal/IR/TTMetalOps.cpp
@@ -52,6 +52,34 @@ namespace mlir::tt::ttmetal {
       continue;
     }
   }
+
+  ArrayAttr fabricConfigs = getFabricConnectionConfigsAttr();
+  const size_t numFabricConfigs =
+      fabricConfigs ? fabricConfigs.size() : static_cast<size_t>(0);
+  for (Attribute kernelConfigAttr : getKernelConfigs()) {
+    auto nocConfig = mlir::dyn_cast<NocConfigAttr>(kernelConfigAttr);
+    if (!nocConfig) {
+      continue;
+    }
+    std::optional<uint32_t> fabricConfigIndex =
+        nocConfig.getFabricConfigIndex();
+    if (!fabricConfigIndex) {
+      continue;
+    }
+    if (*fabricConfigIndex >= numFabricConfigs) {
+      return emitOpError("fabric_config_index ")
+             << *fabricConfigIndex
+             << " is out of range for fabricConnectionConfigs of size "
+             << numFabricConfigs;
+    }
+    auto fabricConfig = mlir::cast<ttcore::FabricConnectionConfigAttr>(
+        fabricConfigs[*fabricConfigIndex]);
+    if (fabricConfig.getNocIndex() != nocConfig.getNocIndex()) {
+      return emitOpError("fabric_config_index ")
+             << *fabricConfigIndex
+             << " noc_index does not match NocConfig noc_index";
+    }
+  }
   return success();
 }
 

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -1268,6 +1268,8 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
 
         std::vector<flatbuffers::Offset<target::FabricConnectionConfig>>
             fabricConnectionConfigs;
+        const std::vector<flatbuffers::Offset<target::FabricConnectionConfig>>
+            *fabricConnectionConfigsPtr = nullptr;
         if (ArrayAttr fabricConfigsAttr =
                 enqueueProgramOp.getFabricConnectionConfigsAttr()) {
           fabricConnectionConfigs.reserve(fabricConfigsAttr.size());
@@ -1277,13 +1279,14 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
                     cache, mlir::cast<ttcore::FabricConnectionConfigAttr>(
                                fabricConfigAttr)));
           }
+          fabricConnectionConfigsPtr = &fabricConnectionConfigs;
         }
 
         cqBuilder.appendCommand(
             target::metal::CreateEnqueueProgramCommandDirect(
                 fbb, &argTypes, &args, &cbs,
                 target::metal::CreateProgramDescDirect(fbb, &kernelConfigs),
-                &fabricConnectionConfigs),
+                fabricConnectionConfigsPtr),
             op);
       } else if (auto createBufferOp =
                      dyn_cast_if_present<tt::ttmetal::CreateBufferOp>(op);

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -957,10 +957,14 @@ kernelArgsToFlatbuffer(FlatbufferObjectCache &cache,
 static flatbuffers::Offset<target::metal::NocConfig>
 nocConfigToFlatbuffer(FlatbufferObjectCache &cache,
                       NocConfigAttr nocConfigAttr) {
+  ::flatbuffers::Optional<uint32_t> fabricConfigIndex = ::flatbuffers::nullopt;
+  if (std::optional<uint32_t> index = nocConfigAttr.getFabricConfigIndex()) {
+    fabricConfigIndex = *index;
+  }
   return target::metal::CreateNocConfig(
       *cache.fbb,
       toFlatbufferDataMovementProcessor(nocConfigAttr.getDmCoreIndex()),
-      toFlatbuffer(cache, nocConfigAttr.getNocIndex()));
+      toFlatbuffer(cache, nocConfigAttr.getNocIndex()), fabricConfigIndex);
 }
 
 static flatbuffers::Offset<target::metal::ComputeConfig>
@@ -1262,18 +1266,24 @@ std::shared_ptr<void> translateTTMetalToFlatbuffer(
               symbolTable));
         }
 
-        flatbuffers::Offset<target::FabricConnectionConfig>
-            fabricConnectionConfig;
-        if (enqueueProgramOp.getFabricConnectionConfigAttr()) {
-          fabricConnectionConfig = fabricConnectionConfigToFlatbuffer(
-              cache, enqueueProgramOp.getFabricConnectionConfigAttr());
+        std::vector<flatbuffers::Offset<target::FabricConnectionConfig>>
+            fabricConnectionConfigs;
+        if (ArrayAttr fabricConfigsAttr =
+                enqueueProgramOp.getFabricConnectionConfigsAttr()) {
+          fabricConnectionConfigs.reserve(fabricConfigsAttr.size());
+          for (Attribute fabricConfigAttr : fabricConfigsAttr) {
+            fabricConnectionConfigs.push_back(
+                fabricConnectionConfigToFlatbuffer(
+                    cache, mlir::cast<ttcore::FabricConnectionConfigAttr>(
+                               fabricConfigAttr)));
+          }
         }
 
         cqBuilder.appendCommand(
             target::metal::CreateEnqueueProgramCommandDirect(
                 fbb, &argTypes, &args, &cbs,
                 target::metal::CreateProgramDescDirect(fbb, &kernelConfigs),
-                fabricConnectionConfig),
+                &fabricConnectionConfigs),
             op);
       } else if (auto createBufferOp =
                      dyn_cast_if_present<tt::ttmetal::CreateBufferOp>(op);

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -404,14 +404,30 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
           local_semaphore_initializer, command->cbs(), deviceAddressValidator,
           createSemaphore, hostBuffers);
 
-      if (command->fabric_connection_config() &&
-          kernelConfig->type_type() ==
+      const target::FabricConnectionConfig *fabricConnectionConfig = nullptr;
+      if (kernelConfig->type_type() ==
               target::metal::KernelConfigType::NocConfig &&
-          command->fabric_connection_config()->noc_index() ==
-              kernelConfig->type_as_NocConfig()->noc_index()) {
+          command->fabric_connection_configs() &&
+          kernelConfig->type_as_NocConfig()->fabric_config_index()) {
+        const uint32_t fabricConfigIndex =
+            *kernelConfig->type_as_NocConfig()->fabric_config_index();
+        LOG_ASSERT(fabricConfigIndex <
+                       command->fabric_connection_configs()->size(),
+                   "fabric_config_index ", fabricConfigIndex,
+                   " out of range for fabric_connection_configs of size ",
+                   command->fabric_connection_configs()->size());
+        fabricConnectionConfig =
+            command->fabric_connection_configs()->Get(fabricConfigIndex);
+        LOG_ASSERT(fabricConnectionConfig->noc_index() ==
+                       kernelConfig->type_as_NocConfig()->noc_index(),
+                   "fabric_connection_configs[", fabricConfigIndex,
+                   "] noc_index does not match NocConfig noc_index");
+      }
+
+      if (fabricConnectionConfig) {
         auto fabricConfigArgs = common::appendFabricConfigArgs(
-            command->fabric_connection_config(), kernelConfig, program, handle,
-            deviceCoord, meshDevice, rtArgsVec, coreRangeSet);
+            fabricConnectionConfig, kernelConfig, program, handle, deviceCoord,
+            meshDevice, rtArgsVec, coreRangeSet);
 
         for (auto core : tt::tt_metal::corerange_to_cores(coreRangeSet)) {
           tt_metal::SetRuntimeArgs(program, handle, core,
@@ -448,7 +464,8 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
 
     // fabric connected cores all have separate runtime args so we add a
     // separate program for each device
-    if (command->fabric_connection_config()) {
+    if (command->fabric_connection_configs() &&
+        command->fabric_connection_configs()->size() > 0) {
       meshWorkload.add_program(distributed::MeshCoordinateRange(deviceCoord),
                                std::move(program));
     } else {

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -366,6 +366,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
   auto deviceRange = distributed::MeshCoordinateRange(meshDevice->shape());
   for (auto deviceCoord : deviceRange) {
     tt_metal::Program program = tt_metal::CreateProgram();
+    bool hasFabricConfiguredKernel = false;
     for (const target::metal::KernelConfig *kernelConfig :
          *command->program()->kernels()) {
       const target::metal::KernelSource *kernelSource =
@@ -425,6 +426,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       }
 
       if (fabricConnectionConfig) {
+        hasFabricConfiguredKernel = true;
         auto fabricConfigArgs = common::appendFabricConfigArgs(
             fabricConnectionConfig, kernelConfig, program, handle, deviceCoord,
             meshDevice, rtArgsVec, coreRangeSet);
@@ -462,10 +464,9 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
     }
 
-    // fabric connected cores all have separate runtime args so we add a
-    // separate program for each device
-    if (command->fabric_connection_configs() &&
-        command->fabric_connection_configs()->size() > 0) {
+    // Fabric-configured kernels have device-specific runtime args, so emit a
+    // separate program per device.
+    if (hasFabricConfiguredKernel) {
       meshWorkload.add_program(distributed::MeshCoordinateRange(deviceCoord),
                                std::move(program));
     } else {

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -409,17 +409,17 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
               target::metal::KernelConfigType::NocConfig &&
           command->fabric_connection_configs() &&
           kernelConfig->type_as_NocConfig()->fabric_config_index()) {
-        const uint32_t fabricConfigIndex =
-            *kernelConfig->type_as_NocConfig()->fabric_config_index();
-        LOG_ASSERT(fabricConfigIndex <
-                       command->fabric_connection_configs()->size(),
+        const auto *nocConfig = kernelConfig->type_as_NocConfig();
+        const auto *fabricConfigs = command->fabric_connection_configs();
+        const uint32_t fabricConfigIndex = *nocConfig->fabric_config_index();
+
+        LOG_ASSERT(fabricConfigIndex < fabricConfigs->size(),
                    "fabric_config_index ", fabricConfigIndex,
                    " out of range for fabric_connection_configs of size ",
-                   command->fabric_connection_configs()->size());
-        fabricConnectionConfig =
-            command->fabric_connection_configs()->Get(fabricConfigIndex);
+                   fabricConfigs->size());
+        fabricConnectionConfig = fabricConfigs->Get(fabricConfigIndex);
         LOG_ASSERT(fabricConnectionConfig->noc_index() ==
-                       kernelConfig->type_as_NocConfig()->noc_index(),
+                       nocConfig->noc_index(),
                    "fabric_connection_configs[", fabricConfigIndex,
                    "] noc_index does not match NocConfig noc_index");
       }

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_mcast.mlir
@@ -8,7 +8,7 @@ module attributes {} {
     %0 = "ttmetal.mesh_shard"(%arg0) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: insert_mesh_shape_0, insert_mesh_shape_1>, shard_type = #ttcore.shard_type<devices>}> : (!full_tensor_layout) -> !mesh_shard_layout
     %1 = "ttmetal.create_buffer"() <{address = 104128 : i64}> : () -> !l1_shard_layout
     "ttmetal.enqueue_write_buffer"(%0, %1) : (!mesh_shard_layout, !l1_shard_layout) -> ()
-    "ttmetal.enqueue_program"(%1, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>]>, dm_core = 1, noc0>], operandSegmentSizes = array<i32: 1, 1>, fabricConnectionConfig = #ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>}> : (!l1_shard_layout, !l1_shard_layout) -> ()
+    "ttmetal.enqueue_program"(%1, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>]>, dm_core = 1, noc0, fabric_config_index = 0>], operandSegmentSizes = array<i32: 1, 1>, fabricConnectionConfigs = [#ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>]}> : (!l1_shard_layout, !l1_shard_layout) -> ()
     %alloc_1 = memref.alloc() : !mesh_shard_layout
     "ttmetal.enqueue_read_buffer"(%1, %alloc_1) : (!l1_shard_layout, !mesh_shard_layout) -> ()
     "ttmetal.finish"() : () -> ()

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_sem_inc.mlir
@@ -10,7 +10,7 @@ module attributes {} {
     "ttmetal.enqueue_write_buffer"(%0, %1) : (!mesh_shard_layout, !l1_shard_layout) -> ()
     %semaphore = "ttmetal.create_global_semaphore"() <{address = 300736 : i64, initial_value = 10 : ui32, core_range = #ttmetal.core_range<0x0, 8x8>}> : () -> !ttmetal.global_semaphore
     "ttmetal.reset_global_semaphore"(%semaphore) <{value = 0 : ui32}> : (!ttmetal.global_semaphore) -> ()
-    "ttmetal.enqueue_program"(%1, %semaphore, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <global_semaphore[1]>]>, dm_core = 1, noc0>], operandSegmentSizes = array<i32: 2, 1>, fabricConnectionConfig = #ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>}> : (!l1_shard_layout, !ttmetal.global_semaphore, !l1_shard_layout) -> ()
+    "ttmetal.enqueue_program"(%1, %semaphore, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>, <global_semaphore[1]>]>, dm_core = 1, noc0, fabric_config_index = 0>], operandSegmentSizes = array<i32: 2, 1>, fabricConnectionConfigs = [#ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>]}> : (!l1_shard_layout, !ttmetal.global_semaphore, !l1_shard_layout) -> ()
     %alloc_1 = memref.alloc() : !mesh_shard_layout
     "ttmetal.enqueue_read_buffer"(%1, %alloc_1) : (!l1_shard_layout, !mesh_shard_layout) -> ()
     "ttmetal.finish"() : () -> ()

--- a/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
+++ b/test/python/golden/d2m/fabric_api_snippets/test_fabric_unicast.mlir
@@ -8,7 +8,7 @@ module attributes {} {
     %0 = "ttmetal.mesh_shard"(%arg0) <{shard_dims = array<i64: 0, 1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: insert_mesh_shape_0, insert_mesh_shape_1>, shard_type = #ttcore.shard_type<devices>}> : (!full_tensor_layout) -> !mesh_shard_layout
     %1 = "ttmetal.create_buffer"() <{address = 104128 : i64}> : () -> !l1_shard_layout
     "ttmetal.enqueue_write_buffer"(%0, %1) : (!mesh_shard_layout, !l1_shard_layout) -> ()
-    "ttmetal.enqueue_program"(%1, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>]>, dm_core = 1, noc0>], operandSegmentSizes = array<i32: 1, 1>, fabricConnectionConfig = #ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>}> : (!l1_shard_layout, !l1_shard_layout) -> ()
+    "ttmetal.enqueue_program"(%1, %1) <{cb_ports = array<i64: 0>, kernelConfigs = [#ttmetal.noc_config<@datamovement_kernel0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< ct_args = [<cb_port[0]>]>, dm_core = 1, noc0, fabric_config_index = 0>], operandSegmentSizes = array<i32: 1, 1>, fabricConnectionConfigs = [#ttcore.fabric_connection_config<noc_index = noc0, topology = insert_topology, cluster_axis = insert_cluster_axis, routing_mode = insert_routing_mode, num_links = 1>]}> : (!l1_shard_layout, !l1_shard_layout) -> ()
     %alloc_1 = memref.alloc() : !mesh_shard_layout
     "ttmetal.enqueue_read_buffer"(%1, %alloc_1) : (!l1_shard_layout, !mesh_shard_layout) -> ()
     "ttmetal.finish"() : () -> ()

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_fabric_config_scope.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_fabric_config_scope.mlir
@@ -1,0 +1,52 @@
+// RUN: ttmlir-opt --split-input-file --ttcore-register-device --convert-d2m-to-ttkernel --convert-d2m-to-ttmetal -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// After spatial merge, only kernels with setup_fabric_connections get
+// fabric_config_index.
+#l1 = #ttcore.memory_space<l1>
+#fabric = #ttcore.fabric_connection_config<noc_index = noc0, topology = ring, cluster_axis = 1, routing_mode = unidir_ring_torus, num_links = 1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_fabric_scoped_to_setup_kernel
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK-DAG: fabricConnectionConfigs = [#ttcore.fabric_connection_config<noc_index = noc0, topology = ring, cluster_axis = 1, routing_mode = unidir_ring_torus, num_links = 1>]
+  // CHECK-DAG: #ttmetal.noc_config<@dm_fabric, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, dm_core = 1, noc0, fabric_config_index = 0
+  // CHECK-DAG: #ttmetal.noc_config<@dm_local, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< >, dm_core = 1, noc0>
+  // CHECK-NOT: #ttmetal.noc_config<@dm_local{{.*}}fabric_config_index
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_fabric_scoped_to_setup_kernel(
+      %arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>,
+      %arg1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      -> (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>,
+          memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2000, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_fabric, dm_core = 1>], fabricConnectionConfig = #fabric}
+            ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_local, dm_core = 1>]}
+            ins(%arg1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      }
+    return %out0, %out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  }
+
+  func.func private @dm_fabric() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
+    %fcm = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    return
+  }
+  func.func private @dm_local() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
+    return
+  }
+}

--- a/test/ttmlir/Conversion/D2MToTTMetal/spatial_fabric_config_scope.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/spatial_fabric_config_scope.mlir
@@ -50,3 +50,57 @@ module {
     return
   }
 }
+
+// -----
+
+// Spatial merge concatenates per-region fabric tables and remaps indices.
+#l1 = #ttcore.memory_space<l1>
+#fabric0 = #ttcore.fabric_connection_config<noc_index = noc0, topology = ring, cluster_axis = 1, routing_mode = unidir_ring_torus, num_links = 1>
+#fabric1 = #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 0, routing_mode = bidir_line_mesh, num_links = 1>
+#vgm_11_inv = affine_map<(d0, d1) -> (0, d0 - 1, d1 - 1)>
+#vgm_11_fwd = affine_map<(d0, d1, d2, d3) -> (d0 + 1, d1 + 1, d2, d3)>
+module {
+  ttcore.device @default_device = <workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1, s2, s3, s4, s5, s6] -> (0, 0, (((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) mod 12, ((((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) floordiv s4) floordiv 12) * s4 + ((d0 * s1) * (s2 * (s3 * s6)) + d1 * (s2 * (s3 * s6)) + d2) mod s4 + s5), meshShape = , chipIds = [0]>
+  // CHECK-LABEL: func.func @spatial_fabric_multi_config_index_remap
+  // CHECK-COUNT-1: "ttmetal.enqueue_program"
+  // CHECK-DAG: fabricConnectionConfigs = [#ttcore.fabric_connection_config<noc_index = noc0, topology = ring, cluster_axis = 1, routing_mode = unidir_ring_torus, num_links = 1>, #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 0, routing_mode = bidir_line_mesh, num_links = 1>]
+  // CHECK-DAG: #ttmetal.noc_config<@dm_fabric0, #ttmetal.core_range<0x0, 1x1>, #ttmetal.kernel_args< >, dm_core = 1, noc0, fabric_config_index = 0
+  // CHECK-DAG: #ttmetal.noc_config<@dm_fabric1, #ttmetal.core_range<1x1, 1x1>, #ttmetal.kernel_args< >, dm_core = 1, noc0, fabric_config_index = 1
+  // CHECK-NOT: d2m.spatial
+  func.func @spatial_fabric_multi_config_index_remap(
+      %arg0: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>,
+      %arg1: memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      -> (memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>,
+          memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+    %out0 = memref.alloc() {alignment = 64 : i64, address = 0x1000} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+    %out1 = memref.alloc() {alignment = 64 : i64, address = 0x2000, d2m.virtualGridInverseMapping = #vgm_11_inv, d2m.virtualGridForwardMapping = #vgm_11_fwd} : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+
+    d2m.spatial {grid_ranges = [#ttcore.core_range<(0, 0), (0, 0)>, #ttcore.core_range<(1, 1), (1, 1)>]}
+        ins(%arg0, %arg1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+        outs(%out0, %out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>) {
+      ^region_0:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_fabric0, dm_core = 1>], fabricConnectionConfig = #fabric0}
+            ins(%arg0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+            outs(%out0 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      }, {
+      ^region_1:
+        d2m.generic {block_factors = [], grid = #ttcore.grid<1x1, virt_to_physical_map = (d0, d1) -> (0, d0 + 1, d1 + 1), physical_to_virt_map = (d0, d1) -> (0, d0 - 1, d1 - 1)>, indexing_maps = [], iterator_types = [], threads = [#d2m.thread<datamovement, @dm_fabric1, dm_core = 1>], fabricConnectionConfig = #fabric1}
+            ins(%arg1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+            outs(%out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>)
+      }
+    return %out0, %out1 : memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>, memref<1x1x1x1x!ttcore.tile<32x32, f32>, #ttcore.shard<4096x4096, 1>, #l1>
+  }
+
+  func.func private @dm_fabric0() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
+    %fcm = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    return
+  }
+  func.func private @dm_fabric1() attributes {tt.function_type = "kernel", ttkernel.arg_spec = #ttkernel.arg_spec< >, ttkernel.thread = #ttkernel.thread<noc>} {
+    %fcm = "ttkernel.experimental.create_fabric_connection_manager"() : () -> !ttkernel.fabric_connection_manager
+    "ttkernel.experimental.setup_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    "ttkernel.experimental.close_fabric_connections"(%fcm) : (!ttkernel.fabric_connection_manager) -> ()
+    return
+  }
+}


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/8520

### Problem description
`EnqueueProgramOp` carried a single `FabricConnectionConfig`, and runtime applied it to every matching `NocConfig` kernel in that enqueue (by `noc_index`).

After spatial fusion, a fabric-using region and a local-only region can share one enqueue and the same `noc_index`. The local kernels then incorrectly receive fabric setup, which can fail routing-plane capacity checks.

### What's changed
- Keep fabric configs as an enqueue-level table (`fabricConnectionConfigs`).
- Let each `NocConfig` optionally reference an entry via `fabric_config_index`.
- Lowering sets the index only for kernels that contain `setup_fabric_connections`.
- Spatial merge concatenates fabric tables and remaps indices.
- Runtime applies fabric rt args only when `fabric_config_index` is set.

### Checklist
- [x] New/Existing tests provide coverage for changes
