### PR TITLE
[StableHLO] Fix slice on sharded dim reading wrong offsets

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -571,10 +571,17 @@ def ReplicateNonSplittableValuesPass : Pass<"replicate-non-splittable-values", "
     which fails for non-splat, non-periodic data (and, for iota, would drop
     the per-shard offset so every shard emits 0..local-1).
 
+    It also handles stablehlo.slice that narrows a sharded dimension: start and
+    limit are absolute positions, so dividing them by the shard factor only
+    lines up when the slice spans the whole dimension. Strided slices with
+    start < stride (e.g. [::2], [1::2]) are a valid per-shard interleave and are
+    left alone.
+
     Example values that are non-splittable:
       - dense<[0, 1, 2, ..., 63]> : tensor<64xi64>  (position indices)
       - dense<[[[0.0, 1.0, ..., 63.0]]]> : tensor<1x1x64xf32>  (RoPE freqs)
       - stablehlo.iota dim = 0 : tensor<64xui32>  (sharded along dim 0)
+      - stablehlo.slice [0:2560] of tensor<2x1x30720xbf16> sharded on dim 2
   }];
 
   let dependentDialects = [

--- a/lib/Dialect/StableHLO/Transforms/ReplicateNonSplittableValues.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReplicateNonSplittableValues.cpp
@@ -146,6 +146,59 @@ public:
       shardy_utils::setReplicatedSharding(
           iotaOp, context, globalMeshOp.getSymName(), oldType.getRank());
     });
+
+    rootModule.walk([&](mlir::stablehlo::SliceOp sliceOp) {
+      mlir::sdy::TensorShardingAttr sharding =
+          shardy_utils::getFirstSharding(sliceOp);
+      if (!sharding) {
+        return;
+      }
+
+      if (shardy_utils::isFullyReplicatedTensor(sharding, globalMeshOp)) {
+        return;
+      }
+
+      auto inputType =
+          mlir::cast<mlir::RankedTensorType>(sliceOp.getOperand().getType());
+      llvm::ArrayRef<int64_t> inputShape = inputType.getShape();
+      llvm::ArrayRef<int64_t> startIndices = sliceOp.getStartIndices();
+      llvm::ArrayRef<int64_t> limitIndices = sliceOp.getLimitIndices();
+      llvm::ArrayRef<int64_t> strides = sliceOp.getStrides();
+
+      llvm::ArrayRef<mlir::sdy::DimensionShardingAttr> dimShardings =
+          sharding.getDimShardings();
+
+      for (size_t i = 0; i < dimShardings.size() && i < startIndices.size();
+           ++i) {
+        if (dimShardings[i].getAxes().empty()) {
+          continue;
+        }
+
+        // Contiguous slice covering the whole dimension: the local slice is a
+        // no-op on each shard, so dividing start/limit is trivially correct.
+        if (startIndices[i] == 0 && limitIndices[i] == inputShape[i] &&
+            strides[i] == 1) {
+          continue;
+        }
+
+        // Strided interleave ([::2], [1::2]): shard d's local index k maps to
+        // global d*shardWidth + k, so the extracted phase survives only if the
+        // stride divides the per-shard width, and the shards only tile the
+        // result if the slice runs to the end of the dimension.
+        if (strides[i] > 1 && startIndices[i] < strides[i] &&
+            limitIndices[i] == inputShape[i]) {
+          FailureOr<int64_t> shardWidth = shardy_utils::calculateUpdatedDim(
+              globalMeshOp.getMesh(), dimShardings[i], inputShape[i]);
+          if (succeeded(shardWidth) && *shardWidth % strides[i] == 0) {
+            continue;
+          }
+        }
+
+        shardy_utils::setReplicatedSharding(
+            sliceOp, context, globalMeshOp.getSymName(), inputType.getRank());
+        return;
+      }
+    });
   }
 };
 

--- a/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --replicate-non-splittable-values %s | FileCheck %s
+
+// A slice narrowing a dimension sharded on _axis_0 (4 devices): dividing [0:4]
+// by 4 gives [0:1], so shard 1 reads global 12 where it must hold global 1.
+// Sharding must become replicated so Shardy gathers before the slice.
+module @ShardedSlice attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<2x1x48xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_0"}]>}) -> tensor<2x1x4xf32> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {}]>]>
+    %0 = stablehlo.slice %arg0 [0:2, 0:1, 0:4] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>} : (tensor<2x1x48xf32>) -> tensor<2x1x4xf32>
+    return %0 : tensor<2x1x4xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_offset_unchanged.mlir
+++ b/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_offset_unchanged.mlir
@@ -1,0 +1,14 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --replicate-non-splittable-values %s | FileCheck %s
+
+// A slice narrowing only dim 0 (unsharded) while the sharded dim 2 is taken in
+// full: localizes correctly by shrinking the shape, so sharding is unchanged.
+module @ShardedSliceUnshardedDim attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<4x1x48xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_0"}]>}) -> tensor<2x1x48xf32> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>
+    %0 = stablehlo.slice %arg0 [0:2, 0:1, 0:48] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>} : (tensor<4x1x48xf32>) -> tensor<2x1x48xf32>
+    return %0 : tensor<2x1x48xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_indivisible.mlir
+++ b/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_indivisible.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --replicate-non-splittable-values %s | FileCheck %s
+
+// A strided slice whose stride does not divide the per-shard width (48/4 = 12,
+// stride 8): shard d's first match is at local (start - d*12) mod 8, not start,
+// so keeping start unchanged is invalid and the sharding must become replicated.
+module @ShardedSliceStridedIndivisible attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<2x1x48xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_0"}]>}) -> tensor<2x1x6xf32> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {}]>]>
+    %0 = stablehlo.slice %arg0 [0:2, 0:1, 0:48:8] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>} : (tensor<2x1x48xf32>) -> tensor<2x1x6xf32>
+    return %0 : tensor<2x1x6xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_partial.mlir
+++ b/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_partial.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --replicate-non-splittable-values %s | FileCheck %s
+
+// A strided slice that stops before the end of a sharded dim: the shards no
+// longer tile the result (the slice ends inside shard 0), so dividing the limit
+// is invalid and the sharding must become replicated.
+module @ShardedSliceStridedPartial attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<2x1x48xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_0"}]>}) -> tensor<2x1x12xf32> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {}]>]>
+    %0 = stablehlo.slice %arg0 [0:2, 0:1, 0:24:2] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>} : (tensor<2x1x48xf32>) -> tensor<2x1x12xf32>
+    return %0 : tensor<2x1x12xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_unchanged.mlir
+++ b/test/ttmlir/Dialect/StableHLO/replicate_non_splittable_values/sharded_slice_strided_unchanged.mlir
@@ -1,0 +1,15 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --replicate-non-splittable-values %s | FileCheck %s
+
+// A strided slice [::2] over a sharded dimension: with start < stride every
+// shard extracts the same pattern from its own data, which localizes correctly
+// by adjusting only the limit, so sharding is unchanged.
+module @ShardedSliceStrided attributes {mhlo.cross_program_prefetches = [], mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<2x1x48xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}, {"_axis_0"}]>}) -> tensor<2x1x24xf32> {
+    // CHECK: stablehlo.slice
+    // CHECK-SAME: sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>
+    %0 = stablehlo.slice %arg0 [0:2, 0:1, 0:48:2] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {}, {"_axis_0", ?}]>]>} : (tensor<2x1x48xf32>) -> tensor<2x1x24xf32>
+    return %0 : tensor<2x1x24xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/shardy/op_propagation_registry/slice.mlir
@@ -59,8 +59,12 @@ func.func @partial_arg(%arg0: tensor<4x128x16384xbf16> {sdy.sharding = #sdy.shar
 func.func @multiple_slice_unique_operand(%arg0: tensor<2560x9728xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22batch\22}]>"}, mhlo.sharding = "{devices=[1,2]<=[2]}", ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg1: tensor<19456x2560xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22batch\22}, {}]>"}, mhlo.sharding = "{devices=[2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<2560xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}]>"}, mhlo.sharding = "{replicated}", ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<1x32x2560xbf16> {
   // CHECK-LABEL: func.func @multiple_slice_unique_operand(
   // CHECK: sdy.manual_computation(%arg0, %arg1, %arg2) in_shardings=[<@mesh, [{}, {"batch"}]>, <@mesh, [{"batch"}, {}]>, <@mesh, [{}]>] out_shardings=[<@mesh, [{}, {}, {}]>] manual_axes={"model", "batch"} (%arg3: tensor<2560x4864xbf16>, %arg4: tensor<9728x2560xbf16>, %arg5: tensor<2560xbf16>)
-  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 0:4864] : (tensor<1x32x9728xbf16>) -> tensor<1x32x4864xbf16>
-  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 4864:9728] : (tensor<1x32x9728xbf16>) -> tensor<1x32x4864xbf16>
+  // Both slices narrow the sharded dim, so each result is redistributed across
+  // devices: gather first, then cut at global offsets.
+  // CHECK: stablehlo.all_gather
+  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 0:9728] : (tensor<1x32x19456xbf16>) -> tensor<1x32x9728xbf16>
+  // CHECK: stablehlo.all_gather
+  // CHECK: %{{.*}} = stablehlo.slice %{{.*}} [0:1, 0:32, 9728:19456] : (tensor<1x32x19456xbf16>) -> tensor<1x32x9728xbf16>
   // CHECK: stablehlo.all_reduce
   // CHECK: sdy.return %{{.*}} : tensor<1x32x2560xbf16>
   %0 = stablehlo.reshape %arg2 : (tensor<2560xbf16>) -> tensor<1x1x2560xbf16>


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-xla/issues/5862

### Problem description

`UpdateGlobalToLocalShapes` localizes a `stablehlo.slice` by dividing its `start_indices` and `limit_indices` by the shard factor (`shardy_utils::calculateUpdatedDim`, which only checks that the factor divides the dimension evenly).

That rewrite is valid only when the slice spans the whole dimension. For a dim of size `dim` sharded `N` ways, the emitted code has shard `d` read global `[d*dim/N + start/N, d*dim/N + limit/N)`, while the declared result sharding requires it to hold `[start + d*(limit-start)/N, start + (d+1)*(limit-start)/N)`. Those agree for every `d` only when `start == 0` and `limit == dim`.

So any slice that narrows a sharded dimension reads the wrong elements on every shard but the first — silently, because the per-shard shapes still add up to the expected size.

Hit in HiDream-I1: `adaLN_modulation` is `Linear(2560, 12*2560)` sharded column-parallel, so each of 4 devices holds a contiguous 7680-wide slab of the 30720 outputs, and `chunk(12, dim=-1)` cuts every 2560. Global `[0:2560]` was localized to `[0:640]`, so 3 of 4 devices returned data belonging to other chunks. 

For the model-side analysis, see https://github.com/tenstorrent/tt-xla/issues/5862#issuecomment-5190257863

### What's changed

Added a `stablehlo::SliceOp` walk to `ReplicateNonSplittableValues`: when a sharded dimension is narrowed, the slice's sharding is set to fully replicated. `InsertExplicitReshards` then inserts the reshards on both sides, which `ReshardToCollectives` lowers to an `all_gather` before the slice and an `all_slice` after. This is the same mechanism the existing `stablehlo.constant` and `stablehlo.iota` cases in that pass already rely on, so no new pass or pipeline change is needed.

Three guards keep it off the paths that localize correctly today:
- dimension is not sharded
- strided interleaves (`[::2]`, `[1::2]`) that run to the end of the dimension and whose stride divides the per-shard width — a genuine per-shard pattern handled by the existing strided branch
- slice covers the whole dimension

`op_propagation_registry/slice.mlir` is updated because `multiple_slice_unique_operand` encoded the miscompile: for `slice [0:9728]` of a 2-way-sharded `1x32x19456`, device 1 must hold global `[4864:9728]`, but the old expectation gave it local `[0:4864]` = global `[9728:14592]` — the second slice's data. It now expects `all_gather` + global-offset slices, matching the sibling case above it in the same file.

Impact: HiDream double-stream block 0 goes from PCC `0.4016 / 0.1226 / 0.0714` to `1.0 / 1.0 / 1.0`

### Checklist

- [x] Verify the changes on sanity and sliced model in QB2
- [x] New/Existing tests provide coverage for changes —  5 lit tests in replicate_non_splittable_values

### Logs

- [sanity_before_fix.zip](https://github.com/user-attachments/files/30739620/s1.zip)
- [sliced_model_before_fix.zip](https://github.com/user-attachments/files/30739617/d12.zip)
- [sliced_model_after_fix.log](https://github.com/user-attachments/files/30831427/aug7_hidream_transformer_exp12_after_fix_f2.log)
- [sanity_after_fix.log](https://github.com/user-attachments/files/30831433/aug7_sanity_after_fix_f2.log)




