### PR TITLE
[op-by-op] Record real compile diagnostics and per-op timestamps

### DIFF
--- a/test/python/op_by_op/test_mlir_module_executor.py
+++ b/test/python/op_by_op/test_mlir_module_executor.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import time
+
 from op_by_op_infra.mlir_module_executor import (
     ExecutionPhase,
     ExecutionResult,
@@ -11,6 +13,21 @@ from op_by_op_infra.utils import ModuleWrapper
 from ttmlir.compile_and_run_utils import ModuleDialect
 
 from .fixtures import *
+
+
+def test_execution_result_timestamps_are_per_instance():
+    """Each ExecutionResult must timestamp itself, not share an import-time value.
+
+    Regression test: these fields used to default to a bare ``datetime.now()``,
+    which a dataclass evaluates once at class creation. Every instance then
+    reported the same start time, making per-op durations meaningless.
+    """
+    first = ExecutionResult(ExecutionPhase.GENERATED_STABLE_HLO, None)
+    time.sleep(0.01)
+    second = ExecutionResult(ExecutionPhase.GENERATED_STABLE_HLO, None)
+
+    assert first.execution_started != second.execution_started
+    assert second.execution_started > first.execution_started
 
 
 def test_shlo_compile(shlo_module_str: str):

--- a/test/python/op_by_op/test_mlir_module_executor.py
+++ b/test/python/op_by_op/test_mlir_module_executor.py
@@ -2,7 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import time
+import dataclasses
+from datetime import datetime
 
 from op_by_op_infra.mlir_module_executor import (
     ExecutionPhase,
@@ -21,13 +22,28 @@ def test_execution_result_timestamps_are_per_instance():
     Regression test: these fields used to default to a bare ``datetime.now()``,
     which a dataclass evaluates once at class creation. Every instance then
     reported the same start time, making per-op durations meaningless.
-    """
-    first = ExecutionResult(ExecutionPhase.GENERATED_STABLE_HLO, None)
-    time.sleep(0.01)
-    second = ExecutionResult(ExecutionPhase.GENERATED_STABLE_HLO, None)
 
-    assert first.execution_started != second.execution_started
-    assert second.execution_started > first.execution_started
+    Asserted on the field definitions rather than by sleeping and comparing
+    wall-clock values: `default_factory` *is* the fix, and checking it directly
+    keeps the test independent of clock resolution and of the clock moving
+    backwards.
+    """
+    fields = {f.name: f for f in dataclasses.fields(ExecutionResult)}
+
+    for name in ("execution_started", "last_update"):
+        field = fields[name]
+        assert field.default is dataclasses.MISSING, (
+            f"{name} must not carry a fixed default -- a bare datetime.now() is "
+            f"evaluated once at class creation and shared by every instance"
+        )
+        # `==`, not `is`: `datetime.now` is a builtin method, and every attribute
+        # access returns a fresh bound object, so identity never holds.
+        assert field.default_factory == datetime.now
+
+    # The factory therefore runs per instance rather than once at import.
+    result = ExecutionResult(ExecutionPhase.GENERATED_STABLE_HLO, None)
+    assert isinstance(result.execution_started, datetime)
+    assert isinstance(result.last_update, datetime)
 
 
 def test_shlo_compile(shlo_module_str: str):

--- a/tools/op-by-op-infra/op_by_op_infra/execution_result.py
+++ b/tools/op-by-op-infra/op_by_op_infra/execution_result.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Optional
@@ -46,9 +46,13 @@ class ExecutionResult:
     error_message: Optional[str] = None
 
     # Timestamp taken when execution was started.
-    execution_started: datetime = datetime.now()
+    # `default_factory`, not `datetime.now()`: a bare call is evaluated once when
+    # the class is created, so every instance would share the import-time value
+    # and each op's reported start time -- and therefore its duration -- would be
+    # wrong.
+    execution_started: datetime = field(default_factory=datetime.now)
     # Timestamp which updated with each successful execution step.
-    last_update: datetime = datetime.now()
+    last_update: datetime = field(default_factory=datetime.now)
 
     @property
     def execution_ended(self) -> datetime:

--- a/tools/op-by-op-infra/op_by_op_infra/mlir_module_executor.py
+++ b/tools/op-by-op-infra/op_by_op_infra/mlir_module_executor.py
@@ -126,6 +126,21 @@ class MLIRModuleExecutor:
 
         self._execution_result.last_update = datetime.now()
 
+    def _record_error(self, error: Exception) -> None:
+        """
+        Stores the diagnostic from a failed execution step.
+
+        Each step swallows its exception by design: execution stops where it
+        failed and the result reports how far it got (see `_execute`). Without
+        recording the message here, `convert_to_pydantic_model` has nothing to
+        put in `OpTest.error_message` and falls back to a placeholder
+        ("Last step successfully finished: <phase>."), which tells you *where* an
+        op died but never *why*. Only the first error is kept -- it is the cause;
+        anything after it is a consequence.
+        """
+        if self._execution_result.error_message is None:
+            self._execution_result.error_message = str(error)
+
     def _compile(self) -> ModuleWrapper:
         """
         Attempts compiling stored module down to TTNN.
@@ -183,8 +198,10 @@ class MLIRModuleExecutor:
                 ),
             )
             self._debug_print_module(ttnn)
-        finally:
-            return self._execution_result.last_generated_module
+        except Exception as e:  # noqa: BLE001 - record and continue, see _execute
+            self._record_error(e)
+
+        return self._execution_result.last_generated_module
 
     def _compile_ttir_to_ttnn(self) -> ModuleWrapper:
         """
@@ -209,8 +226,10 @@ class MLIRModuleExecutor:
                 ),
             )
             self._debug_print_module(ttnn)
-        finally:
-            return self._execution_result.last_generated_module
+        except Exception as e:  # noqa: BLE001 - record and continue, see _execute
+            self._record_error(e)
+
+        return self._execution_result.last_generated_module
 
     def _generate_flatbuffer(
         self, flatbuffer_name: str = "ttnn_fb.ttnn"
@@ -230,8 +249,10 @@ class MLIRModuleExecutor:
                 ExecutionPhase.GENERATED_FLATBUFFER,
                 generated_flatbuffer_path=flatbuffer_path,
             )
-        finally:
-            return self._execution_result.flatbuffer_path
+        except Exception as e:  # noqa: BLE001 - record and continue, see _execute
+            self._record_error(e)
+
+        return self._execution_result.flatbuffer_path
 
     def _run(self) -> bool:
         """


### PR DESCRIPTION
### Problem description

Two defects in `op_by_op_infra` that make the data landing in the ops-status database wrong. Found while auditing the op-by-op pipeline end to end (tt-xla side: tenstorrent/tt-xla#5867). Both are verified with standalone reproductions rather than inferred from reading.

**1. Every compile-phase error message is silently discarded.**

`_compile_shlo_to_ttnn`, `_compile_ttir_to_ttnn` and `_generate_flatbuffer` each ended with:

```python
try:
    ...
finally:
    return self._execution_result.last_generated_module
```

A `return` inside `finally` swallows the in-flight exception. Reproduction:

```
returned='SHLO'  exception_propagated=False  error_message=None
```

So `error_message` stays `None`, and `convert_to_pydantic_model` (`execution_result.py:121`) substitutes a placeholder:

```
"Last step successfully finished: GENERATED_TTIR."
```

**Every compile failure in the database carries that synthetic string instead of the actual MLIR diagnostic.** You can see *where* an op died but never *why* — which is the purpose of op-by-op triage. Only device-run failures get real text, because `_run` catches `RuntimeError` explicitly.

**2. Per-op timestamps are all identical.**

```python
execution_started: datetime = datetime.now()   # evaluated ONCE at class creation
last_update: datetime = datetime.now()
```

A dataclass evaluates a bare default once, and `_reset` never passes either field. Reproduction — two instances created 1.2s apart:

```
a.started == b.started -> True   (both = import time)
```

So `test_start_ts` is the process import time for every op, and duration is `end - import_time`, growing monotonically across the job. **All per-op timing in the database is meaningless** — which also means there is currently no data from which to calibrate job sizing.

### What's changed

- **Diagnostics preserved.** Each `finally: return` becomes an explicit `except` that records the message through a new `_record_error` helper, then returns normally. Swallowing the exception is still deliberate — execution stops where it failed and the result reports how far it got via `ExecutionPhase` — but the diagnostic is no longer thrown away. Only the **first** error is stored: it is the cause, anything after it is a consequence.
- **Timestamps per instance.** Both fields switch to `field(default_factory=datetime.now)`.
- **Regression test** for the timestamp bug, hermetic and needing no device.

Behaviour on the success path is unchanged: the same value is returned, just from outside the `finally` instead of inside it.

### Verification

| Check | Result |
|---|---|
| `finally:` blocks remaining in the executor | **0** (was 3) |
| `_record_error` call sites | 3 |
| Only first error kept | yes |
| Timestamps distinct per instance | yes, and monotonic |
| Existing op-by-op tests | success paths untouched |
| `py_compile`, `black` | clean on all three changed files |

The one file `black` still wants to reformat is `mlir_module_splitter.py`, which this PR does not touch (pre-existing, different black version).

### Impact

After this lands, compile failures in ops-status carry the real MLIR error, and per-op durations become usable — which unblocks calibrating job sizing in the tt-xla pipeline (tenstorrent/tt-xla#5868) and the failure-clustering work that a placeholder message makes impossible.

Two further issues found in the same audit are **not** in this PR, since they are a different file and a different failure mode (concurrency/robustness rather than data fidelity), and I would rather they be reviewed separately:

- `ProcessManager.run()` does not drain `result_queue` on timeout, so a result arriving just after the deadline can be attributed to the **next** op.
- `ProcessManager.stop()` calls `process.join()` with no timeout, so a wedged worker blocks forever; with the report written only at the end of a job, that loses every result in it.

Happy to send those next if this approach looks right.
