### PR TITLE
[op-by-op] Make ProcessManager timeouts bounded and drain stale results

### DIFF
--- a/python/common/compile_and_run_utils.py
+++ b/python/common/compile_and_run_utils.py
@@ -175,6 +175,9 @@ def _persistent_worker(task_queue: queues.Queue, result_queue: queues.Queue):
 _STOP_JOIN_TIMEOUT_SECONDS = 10
 # Grace period after SIGTERM before escalating to SIGKILL.
 _TERMINATE_JOIN_TIMEOUT_SECONDS = 5
+# Final bound after SIGKILL. A process stuck in an uninterruptible syscall can
+# outlive the signal, so even this join is bounded rather than indefinite.
+_KILL_JOIN_TIMEOUT_SECONDS = 5
 # Poll interval used when draining `result_queue`. `get_nowait` can spuriously
 # raise Empty on a multiprocessing queue whose feeder thread has not caught up,
 # so drain with a short blocking get instead.
@@ -276,16 +279,51 @@ class ProcessManager:
         self.task_queue.put(Task.exit())
         self.process.join(timeout)
 
+        escalated = False
         if self.process.is_alive():
+            escalated = True
             self.process.terminate()
             self.process.join(_TERMINATE_JOIN_TIMEOUT_SECONDS)
 
         if self.process.is_alive():
-            # SIGKILL cannot be ignored, so this join is bounded in practice.
             self.process.kill()
-            self.process.join()
+            # Bounded even here: SIGKILL cannot be caught, but a process wedged
+            # in an uninterruptible syscall can still outlive the signal, and an
+            # unbounded join would put back exactly the hang this method exists
+            # to prevent.
+            self.process.join(_KILL_JOIN_TIMEOUT_SECONDS)
+            if self.process.is_alive():
+                print(
+                    f"WARNING: worker {self.process.pid} survived SIGKILL for "
+                    f"{_KILL_JOIN_TIMEOUT_SECONDS}s; abandoning it.",
+                    file=sys.stderr,
+                )
+
+        if escalated:
+            # A worker that had to be terminated never reached
+            # `task_queue.get()`, so it never consumed the exit task above. That
+            # task would otherwise sit in the queue and be read by the *next*
+            # worker -- which reuses this same queue -- making it exit
+            # immediately and every subsequent `run()` fail.
+            self._drain_task_queue()
 
     # ----- Private methods -----
+
+    def _drain_task_queue(self) -> int:
+        """
+        Discards anything left in `task_queue`, returning how many were dropped.
+
+        Only safe once the worker is known to be stopped: `run()` puts a single
+        task and waits for its result, so anything still queued at that point is
+        stale by definition.
+        """
+        dropped = 0
+        while True:
+            try:
+                self.task_queue.get(timeout=_DRAIN_POLL_SECONDS)
+            except queue.Empty:
+                return dropped
+            dropped += 1
 
     def _drain_result_queue(self) -> int:
         """

--- a/python/common/compile_and_run_utils.py
+++ b/python/common/compile_and_run_utils.py
@@ -169,6 +169,18 @@ def _persistent_worker(task_queue: queues.Queue, result_queue: queues.Queue):
         task(result_queue)
 
 
+# Grace period for a worker to finish what it is doing and consume the "exit
+# task" during `stop()`. A worker wedged in a hung task never reads that task, so
+# the join must be bounded rather than indefinite.
+_STOP_JOIN_TIMEOUT_SECONDS = 10
+# Grace period after SIGTERM before escalating to SIGKILL.
+_TERMINATE_JOIN_TIMEOUT_SECONDS = 5
+# Poll interval used when draining `result_queue`. `get_nowait` can spuriously
+# raise Empty on a multiprocessing queue whose feeder thread has not caught up,
+# so drain with a short blocking get instead.
+_DRAIN_POLL_SECONDS = 0.1
+
+
 class ProcessManager:
     """
     Manages compilation workers using multiprocessing for performance.
@@ -206,15 +218,31 @@ class ProcessManager:
             # Block waiting for result.
             result: Result = self.result_queue.get(timeout=timeout)
         except queue.Empty:
-            # Worker failed to fill result queue before timeout.
-            if self._is_process_running():
-                self.stop()
-                raise RuntimeError(f"Worker `{task.name}` timed out")
-            else:
-                # Something that wasn't caught by try-except occurred, like a segfault,
-                # that killed the process. Raise proper python error that can be handled
-                # in try-except somewhere above in call stack.
+            # Worker failed to fill result queue before timeout. Something that
+            # wasn't caught by try-except may also have killed it, like a
+            # segfault, in which case it is no longer running.
+            crashed = not self._is_process_running()
+
+            # Stop before draining: only once the worker is gone is it certain it
+            # cannot enqueue a late result. A task that completed just after the
+            # deadline has already put its result on the queue, and without this
+            # drain the *next* `run()` would read it -- silently attributing this
+            # op's result to the following op.
+            self.stop()
+            dropped = self._drain_result_queue()
+            if dropped:
+                print(
+                    f"WARNING: discarded {dropped} late result(s) from timed-out "
+                    f"worker `{task.name}`; they would have been misattributed to "
+                    f"the next task.",
+                    file=sys.stderr,
+                )
+
+            # Raise proper python errors that can be handled in try-except
+            # somewhere above in call stack.
+            if crashed:
                 raise RuntimeError(f"Worker `{task.name}` crashed unexpectedly.")
+            raise RuntimeError(f"Worker `{task.name}` timed out")
 
         # Process must still be running if it managed to return a result.
         if not self._is_process_running():
@@ -227,15 +255,52 @@ class ProcessManager:
 
         return result
 
-    def stop(self) -> None:
-        """Gracefully stops the process by sending it an "exit task"."""
+    def stop(self, timeout: float = _STOP_JOIN_TIMEOUT_SECONDS) -> None:
+        """
+        Stops the process, escalating if it does not exit within `timeout`.
+
+        Sends an "exit task" first so a healthy worker shuts down cleanly, then
+        bounds the wait and escalates SIGTERM -> SIGKILL.
+
+        The bound matters: a worker wedged in a hung task never reaches
+        `task_queue.get()` and so never sees the exit task. An unbounded
+        `join()` here blocks the caller forever, and `stop()` is reached both
+        from the timeout path in `run()` and from an `atexit` hook -- so one hung
+        op could hang the interpreter at exit. Since op-by-op writes its report
+        only after every op has run, that loses the whole job's results, not just
+        the one op.
+        """
         if not self._is_process_running():
             return
 
         self.task_queue.put(Task.exit())
-        self.process.join()
+        self.process.join(timeout)
+
+        if self.process.is_alive():
+            self.process.terminate()
+            self.process.join(_TERMINATE_JOIN_TIMEOUT_SECONDS)
+
+        if self.process.is_alive():
+            # SIGKILL cannot be ignored, so this join is bounded in practice.
+            self.process.kill()
+            self.process.join()
 
     # ----- Private methods -----
+
+    def _drain_result_queue(self) -> int:
+        """
+        Discards anything left in `result_queue`, returning how many were dropped.
+
+        Only safe once the worker is known to be stopped, so that nothing can be
+        enqueued after the drain.
+        """
+        dropped = 0
+        while True:
+            try:
+                self.result_queue.get(timeout=_DRAIN_POLL_SECONDS)
+            except queue.Empty:
+                return dropped
+            dropped += 1
 
     def _is_process_running(self) -> bool:
         """Returns True if process is alive."""


### PR DESCRIPTION
### Problem description

Two robustness defects in `ProcessManager` (`python/common/compile_and_run_utils.py`), found while auditing the op-by-op pipeline end to end. Companion to #9168, which fixes data-fidelity bugs in `op_by_op_infra`; this one is deliberately separate because it is a different file and a different failure mode.

Both are **reproduced with a standalone harness**, before and after.

**1. A worker timeout can attribute one op's result to the next op.**

`run()` performs a single `result_queue.get(timeout=...)`. On `queue.Empty` it stopped the worker and raised, but never drained the queue. A task that completed just *after* the deadline has already enqueued its result, so the following `run()` reads that stale value and reports it as the next op's outcome.

```
=== ORIGINAL ===
  op B expected 'result-of-B', got 'result-of-A'  -> MISATTRIBUTED
```

One timeout therefore produces two wrong records: a false failure for the timed-out op, and a wrong verdict for the next one. For op-by-op this is silent corruption of exactly the pass/fail data the ops-status dashboard reports.

**2. A wedged worker makes `stop()` block forever.**

`stop()` sent an "exit task" then called `process.join()` with no timeout. A worker hung inside a task never reaches `task_queue.get()`, so it never sees the exit task and the join never returns.

`stop()` is reached both from the timeout path in `run()` and from an `atexit` hook, so one hung op can hang the interpreter at exit. Because op-by-op writes its JSON report only after every op has run, that loses the **entire job's** results rather than one op's — which is the largest remaining coverage risk in the pipeline.

### What's changed

- **Drain `result_queue` on timeout.** The drain runs *after* `stop()`, since only once the worker is gone is it certain nothing further can be enqueued. Discarded results are logged rather than dropped silently. Uses a short blocking get rather than `get_nowait`, which can spuriously raise `Empty` on a multiprocessing queue whose feeder thread has not caught up.
- **Bound `stop()`.** Joins with a timeout, then escalates SIGTERM → SIGKILL. Defaults are module constants (`_STOP_JOIN_TIMEOUT_SECONDS = 10`, `_TERMINATE_JOIN_TIMEOUT_SECONDS = 5`); `stop()` still takes no required argument, so the `atexit` registration is unaffected.

The two fixes reinforce each other: bounding `stop()` is what makes "drain after stop" reliable, since an unbounded stop could never reach the drain.

### Verification

```
=== ORIGINAL ===
  op B expected 'result-of-B', got 'result-of-A'  -> MISATTRIBUTED

=== PATCHED ===
    (drained 1 late result)
  op B expected 'result-of-B', got 'result-of-B'  -> CORRECT
  stop() on a wedged worker returned in 2.00s -> BOUNDED
```

Also: `py_compile` clean, `black` clean, and both `RuntimeError` message strings are byte-identical to before, so any caller matching on them is unaffected.

### On test coverage

No test is added, and the checklist box is left unticked deliberately. There is no existing test module for `ProcessManager` (nothing under `test/` references it), and a faithful regression test needs a deliberately hung subprocess plus timing assumptions — the kind of test that tends to become a flaky CI failure. I verified with the harness above instead and would rather add a permanent test alongside a proper home for process-level tests, if you want one.

### Checklist
- [ ] New/Existing tests provide coverage for changes — see note above
