### PR TITLE
[D2M] Add block overlap and fabric saturation reports

### DIFF
--- a/test/d2m-jit/fabric_saturation_benchmark.py
+++ b/test/d2m-jit/fabric_saturation_benchmark.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Measure sustained bidirectional D2M DRAM-to-DRAM fabric bandwidth."""
+
+import argparse
+import collections
+import csv
+import os
+import pathlib
+import re
+import shutil
+import time
+
+import torch
+
+import d2m_jit as d2m
+
+
+@d2m.kernel
+def exchange_payload(source, destination, start, done, packet_count):
+    dy = mesh_position(0)
+    dx = mesh_position(1)
+    cy = core_index(0)
+    cx = core_index(1)
+    device_synchronize(
+        start,
+        start_device=[dy, 0],
+        mcast_shape=[1, 2],
+        num_receivers=1,
+        core_indices=[cy, cx],
+    )
+    profile_event("d2m.fabric.saturation.begin", "datamovement")
+    for _ in range(packet_count):
+        payload = remote_load(source, [0, 0])
+        remote_store(
+            destination,
+            [0, 0],
+            payload,
+            start_device=[dy, 1 - dx],
+            device_mcast_shape=[1, 1],
+            semaphore=done,
+            semaphore_indices=[cy, cx],
+        )
+    semaphore_wait(done, packet_count)
+    profile_event("d2m.fabric.saturation.end", "datamovement")
+
+
+def _payload_geometry(payload_kib):
+    payload_bytes = payload_kib * 1024
+    tile_bytes = 32 * 32 * 2
+    if payload_bytes % tile_bytes:
+        raise ValueError("payload size must contain a whole number of BF16 tiles")
+    tile_count = payload_bytes // tile_bytes
+    tiles_x = min(tile_count, 32)
+    if tile_count % tiles_x:
+        raise ValueError("payload tile count must factor into at most 32 columns")
+    return tile_count // tiles_x, tiles_x
+
+
+def _build(payload_kib, packet_count, seed):
+    tiles_y, tiles_x = _payload_geometry(payload_kib)
+    shape = (tiles_y * 32, tiles_x * 32)
+    layout = d2m.Layout(
+        shape=shape,
+        dtype=d2m.bfloat16,
+        block_shape=[tiles_y, tiles_x],
+        grid_shape=[1, 1],
+        mem_space="dram",
+    )
+    generator = torch.Generator()
+    generator.manual_seed(seed)
+    source_host = torch.randn(shape, dtype=torch.bfloat16, generator=generator)
+
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    source = d2m.mesh_shard(
+        source_host,
+        layout,
+        shard_dims=[-1, -1],
+        shard_shape=[1, 1],
+    )
+    destination = d2m.empty(layout)
+    exchange_payload(
+        source,
+        destination,
+        d2m.global_semaphore(),
+        d2m.global_semaphore(init=0),
+        packet_count,
+        grid=(1, 1),
+        fabric=d2m.fabric_config(
+            cluster_axis=1,
+            topology="linear",
+            num_links=1,
+            router_cores=[(0, 0)],
+        ),
+        kernel_io_in_dram=True,
+    )
+    replicated = d2m.mesh_gather(
+        destination,
+        shard_dims=[-1, -1],
+        shard_shape=[1, 1],
+    )
+    return d2m.prepare(replicated), source_host
+
+
+def _device_durations_ns(profile_csv, warmup, iterations):
+    events = collections.defaultdict(list)
+    with profile_csv.open(encoding="utf-8", newline="") as input_file:
+        header = input_file.readline()
+        match = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", header)
+        if match is None:
+            raise ValueError(f"chip frequency is missing from {profile_csv}")
+        frequency_mhz = float(match.group(1))
+        for raw_row in csv.DictReader(input_file):
+            row = {key.strip().lower(): value.strip() for key, value in raw_row.items()}
+            label = row["zone name"]
+            if label not in (
+                "d2m.fabric.saturation.begin",
+                "d2m.fabric.saturation.end",
+            ):
+                continue
+            device = row.get("device id") or row.get("pcie slot") or "unknown"
+            stream = (
+                device,
+                row["core_x"],
+                row["core_y"],
+                row["risc processor type"],
+            )
+            events[stream].append(
+                (
+                    int(row["time[cycles since reset]"]),
+                    label.rpartition(".")[2],
+                )
+            )
+
+    captured_runs = warmup + iterations
+    durations = collections.defaultdict(list)
+    for stream, stream_events in events.items():
+        stream_events.sort()
+        intervals = []
+        start = None
+        for cycle, boundary in stream_events:
+            if boundary == "begin":
+                if start is not None:
+                    raise ValueError(f"nested profiler events on stream {stream}")
+                start = cycle
+            else:
+                if start is None:
+                    raise ValueError(f"unmatched profiler end event on stream {stream}")
+                intervals.append((cycle - start) * 1000 / frequency_mhz)
+                start = None
+        if start is not None or len(intervals) != captured_runs:
+            raise ValueError(
+                f"expected {captured_runs} intervals on stream {stream}, "
+                f"found {len(intervals)}"
+            )
+        durations[stream[0]].extend(intervals[warmup:])
+    if not durations:
+        raise ValueError("fabric saturation events are missing from the device profile")
+    return durations
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--payload-kib", type=int, default=128)
+    parser.add_argument("--packet-count", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--profile-dir",
+        type=pathlib.Path,
+        default=pathlib.Path("/tmp/d2m-fabric-saturation"),
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    if args.payload_kib <= 0 or args.packet_count <= 0:
+        raise ValueError("payload size and packet count must be positive")
+    if args.warmup < 0 or args.iterations <= 0:
+        raise ValueError("warmup must be non-negative and iterations must be positive")
+
+    args.profile_dir.mkdir(parents=True, exist_ok=True)
+    shutil.rmtree(args.profile_dir / ".logs", ignore_errors=True)
+    os.environ["TT_METAL_PROFILER_DIR"] = str(args.profile_dir)
+    os.environ["TT_METAL_CACHE"] = str(args.profile_dir / "kernel-cache")
+    os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
+    os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+
+    from d2m_jit._src.builder import _Builder
+    from d2m_jit._src.config import config as d2m_config
+
+    d2m_config.enable_perf_trace = True
+    _Builder.reset()
+    executable, expected = _build(args.payload_kib, args.packet_count, args.seed)
+    result = None
+    host_samples_ms = []
+    try:
+        for _ in range(args.warmup):
+            result = executable.run()[0]
+        for _ in range(args.iterations):
+            begin = time.perf_counter_ns()
+            result = executable.run()[0]
+            host_samples_ms.append((time.perf_counter_ns() - begin) / 1_000_000)
+    finally:
+        executable.close()
+        _Builder.reset()
+
+    if result is None or not torch.equal(result, expected):
+        max_diff = None if result is None else (result - expected).abs().max().item()
+        raise ValueError(f"fabric exchange failed correctness, max_diff={max_diff}")
+
+    profile_csv = args.profile_dir / ".logs" / "profile_log_device.csv"
+    durations = _device_durations_ns(profile_csv, args.warmup, args.iterations)
+    bytes_per_direction = args.payload_kib * 1024 * args.packet_count
+    all_samples_ns = [sample for samples in durations.values() for sample in samples]
+    mean_ns = sum(all_samples_ns) / len(all_samples_ns)
+    per_direction_gbps = bytes_per_direction / mean_ns
+    print(
+        f"payload_kib={args.payload_kib} packets={args.packet_count} "
+        f"bytes_per_direction={bytes_per_direction}"
+    )
+    for device, samples in sorted(durations.items()):
+        bandwidth = [bytes_per_direction / sample for sample in samples]
+        print(
+            f"device={device} duration_us={[round(sample / 1000, 3) for sample in samples]} "
+            f"directional_GBps={[round(sample, 3) for sample in bandwidth]}"
+        )
+    print(
+        f"mean_directional_GBps={per_direction_gbps:.3f} "
+        f"mean_full_duplex_GBps={2 * per_direction_gbps:.3f} "
+        f"host_ms={[round(sample, 3) for sample in host_samples_ms]} "
+        f"profile={profile_csv}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/d2m-jit/fabric_saturation_benchmark.py
+++ b/test/d2m-jit/fabric_saturation_benchmark.py
@@ -33,10 +33,10 @@ def exchange_payload(source, destination, start, done, packet_count):
     )
     profile_event("d2m.fabric.saturation.begin", "datamovement")
     for _ in range(packet_count):
-        payload = remote_load(source, [0, 0])
+        payload = remote_load(source, [0, cx])
         remote_store(
             destination,
-            [0, 0],
+            [0, cx],
             payload,
             start_device=[dy, 1 - dx],
             device_mcast_shape=[1, 1],
@@ -59,14 +59,14 @@ def _payload_geometry(payload_kib):
     return tile_count // tiles_x, tiles_x
 
 
-def _build(payload_kib, packet_count, seed):
+def _build(payload_kib, packet_count, num_links, num_senders, seed):
     tiles_y, tiles_x = _payload_geometry(payload_kib)
-    shape = (tiles_y * 32, tiles_x * 32)
+    shape = (tiles_y * 32, num_senders * tiles_x * 32)
     layout = d2m.Layout(
         shape=shape,
         dtype=d2m.bfloat16,
         block_shape=[tiles_y, tiles_x],
-        grid_shape=[1, 1],
+        grid_shape=[1, num_senders],
         mem_space="dram",
     )
     generator = torch.Generator()
@@ -84,15 +84,15 @@ def _build(payload_kib, packet_count, seed):
     exchange_payload(
         source,
         destination,
-        d2m.global_semaphore(),
-        d2m.global_semaphore(init=0),
+        d2m.global_semaphore(grid_shape=(8, 8)),
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
         packet_count,
-        grid=(1, 1),
+        grid=(1, num_senders),
         fabric=d2m.fabric_config(
             cluster_axis=1,
             topology="linear",
-            num_links=1,
-            router_cores=[(0, 0)],
+            num_links=num_links,
+            router_cores=[(0, x) for x in range(num_senders)],
         ),
         kernel_io_in_dram=True,
     )
@@ -155,7 +155,7 @@ def _device_durations_ns(profile_csv, warmup, iterations):
                 f"expected {captured_runs} intervals on stream {stream}, "
                 f"found {len(intervals)}"
             )
-        durations[stream[0]].extend(intervals[warmup:])
+        durations[stream] = intervals[warmup:]
     if not durations:
         raise ValueError("fabric saturation events are missing from the device profile")
     return durations
@@ -165,6 +165,8 @@ def _parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--payload-kib", type=int, default=128)
     parser.add_argument("--packet-count", type=int, default=512)
+    parser.add_argument("--num-links", type=int, choices=(1, 2), default=1)
+    parser.add_argument("--num-senders", type=int, choices=(1, 2), default=1)
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--iterations", type=int, default=3)
     parser.add_argument("--seed", type=int, default=0)
@@ -182,6 +184,9 @@ def main():
         raise ValueError("payload size and packet count must be positive")
     if args.warmup < 0 or args.iterations <= 0:
         raise ValueError("warmup must be non-negative and iterations must be positive")
+    num_senders = args.num_senders
+    if num_senders > args.num_links:
+        raise ValueError("number of senders cannot exceed number of links")
 
     args.profile_dir.mkdir(parents=True, exist_ok=True)
     shutil.rmtree(args.profile_dir / ".logs", ignore_errors=True)
@@ -195,7 +200,13 @@ def main():
 
     d2m_config.enable_perf_trace = True
     _Builder.reset()
-    executable, expected = _build(args.payload_kib, args.packet_count, args.seed)
+    executable, expected = _build(
+        args.payload_kib,
+        args.packet_count,
+        args.num_links,
+        num_senders,
+        args.seed,
+    )
     result = None
     host_samples_ms = []
     try:
@@ -214,13 +225,30 @@ def main():
         raise ValueError(f"fabric exchange failed correctness, max_diff={max_diff}")
 
     profile_csv = args.profile_dir / ".logs" / "profile_log_device.csv"
-    durations = _device_durations_ns(profile_csv, args.warmup, args.iterations)
-    bytes_per_direction = args.payload_kib * 1024 * args.packet_count
+    stream_durations = _device_durations_ns(profile_csv, args.warmup, args.iterations)
+    streams_by_device = collections.defaultdict(list)
+    for stream, samples in stream_durations.items():
+        streams_by_device[stream[0]].append(samples)
+    for device, streams in streams_by_device.items():
+        if len(streams) != num_senders:
+            raise ValueError(
+                f"expected {num_senders} profiler streams on device {device}, "
+                f"found {len(streams)}"
+            )
+    durations = {
+        device: [
+            max(stream[iteration] for stream in streams)
+            for iteration in range(args.iterations)
+        ]
+        for device, streams in streams_by_device.items()
+    }
+    bytes_per_direction = args.payload_kib * 1024 * args.packet_count * num_senders
     all_samples_ns = [sample for samples in durations.values() for sample in samples]
     mean_ns = sum(all_samples_ns) / len(all_samples_ns)
     per_direction_gbps = bytes_per_direction / mean_ns
     print(
         f"payload_kib={args.payload_kib} packets={args.packet_count} "
+        f"num_links={args.num_links} num_senders={num_senders} "
         f"bytes_per_direction={bytes_per_direction}"
     )
     for device, samples in sorted(durations.items()):
@@ -231,6 +259,7 @@ def main():
         )
     print(
         f"mean_directional_GBps={per_direction_gbps:.3f} "
+        f"mean_per_sender_GBps={per_direction_gbps / num_senders:.3f} "
         f"mean_full_duplex_GBps={2 * per_direction_gbps:.3f} "
         f"host_ms={[round(sample, 3) for sample in host_samples_ms]} "
         f"profile={profile_csv}"

--- a/test/d2m-jit/llama_down_projection_workload.py
+++ b/test/d2m-jit/llama_down_projection_workload.py
@@ -207,17 +207,23 @@ def serialized_two_chip_down_projection(
         n_slot = item % n_blocks_per_core
         m_block = cy * m_blocks_per_core + m_slot
         n_block = cx * n_blocks_per_core + n_slot
+        profile_event("d2m.block.compute.begin", "compute")
         acc = zeros([1, 4], dtype="bf16")
         for k_block in range(k_blocks):
             lhs = remote_load(activations, [m_block, k_block])
             rhs = remote_load(weight, [k_block, n_block])
             acc += lhs @ rhs
+        profile_event("d2m.block.compute.end", "compute")
         semaphore_inc(ready, 1, core=[0, 0], compute=True)
 
         if is_router_core():
             dy = mesh_position(0)
+            profile_event("d2m.router.ready_wait.begin", "datamovement")
             semaphore_wait(ready, (item + 1) * worker_count)
+            profile_event("d2m.router.ready_wait.end", "datamovement")
             dx = mesh_position(1)
+            # Per-worker timestamp pairs overflow the profiler's per-RISC buffer.
+            profile_event("d2m.router.transfer.begin", "datamovement")
             for ty in range(grid_y):
                 target_m = ty * m_blocks_per_core + m_slot
                 for tx in range(grid_x):
@@ -234,7 +240,10 @@ def serialized_two_chip_down_projection(
                         semaphore=fabric_done,
                         semaphore_indices=[cy, cx],
                     )
+            profile_event("d2m.router.transfer.end", "datamovement")
+            profile_event("d2m.router.fabric_wait.begin", "datamovement")
             semaphore_wait(fabric_done, (item + 1) * 2 * worker_count)
+            profile_event("d2m.router.fabric_wait.end", "datamovement")
             for ty in range(grid_y):
                 for tx in range(grid_x):
                     semaphore_inc(transfer_done, 1, core=[ty, tx])
@@ -276,17 +285,23 @@ def overlapped_two_chip_down_projection(
         n_slot = item % n_blocks_per_core
         m_block = cy * m_blocks_per_core + m_slot
         n_block = cx * n_blocks_per_core + n_slot
+        profile_event("d2m.block.compute.begin", "compute")
         acc = zeros([1, 4], dtype="bf16")
         for k_block in range(k_blocks):
             lhs = remote_load(activations, [m_block, k_block])
             rhs = remote_load(weight, [k_block, n_block])
             acc += lhs @ rhs
+        profile_event("d2m.block.compute.end", "compute")
         semaphore_inc(ready, 1, core=[0, 0], compute=True)
 
         if is_router_core():
             dy = mesh_position(0)
+            profile_event("d2m.router.ready_wait.begin", "datamovement")
             semaphore_wait(ready, (item + 1) * worker_count)
+            profile_event("d2m.router.ready_wait.end", "datamovement")
             dx = mesh_position(1)
+            # Per-worker timestamp pairs overflow the profiler's per-RISC buffer.
+            profile_event("d2m.router.transfer.begin", "datamovement")
             for ty in range(grid_y):
                 target_m = ty * m_blocks_per_core + m_slot
                 for tx in range(grid_x):
@@ -303,7 +318,10 @@ def overlapped_two_chip_down_projection(
                         semaphore=fabric_done,
                         semaphore_indices=[cy, cx],
                     )
+            profile_event("d2m.router.transfer.end", "datamovement")
+            profile_event("d2m.router.fabric_wait.begin", "datamovement")
             semaphore_wait(fabric_done, (item + 1) * 2 * worker_count)
+            profile_event("d2m.router.fabric_wait.end", "datamovement")
         semaphore_wait(consumed, item + 1, compute=True)
 
 
@@ -321,9 +339,11 @@ def reduce_two_chip_partials(
         m_block = cy * m_blocks_per_core + m_slot
         for n_slot in range(n_blocks_per_core):
             n_block = cx * n_blocks_per_core + n_slot
+            profile_event("d2m.block.reduction.begin", "compute")
             first = remote_load(partials, [m_block, n_block])
             second = remote_load(partials, [m_blocks + m_block, n_block])
             remote_store(output, [m_block, n_block], first + second)
+            profile_event("d2m.block.reduction.end", "compute")
 
 
 def _stage_k_segments(config, activation_sources, weight_sources, k_elements):

--- a/test/d2m-jit/multichip_overlap_benchmark.py
+++ b/test/d2m-jit/multichip_overlap_benchmark.py
@@ -268,6 +268,376 @@ def _device_critical_path_ns(profile_csv, warmup, iterations):
     return _device_timing_samples(profile_csv, warmup, iterations)["critical_path_ns"]
 
 
+def _device_profile_event_intervals(profile_csv, warmup, iterations):
+    events_by_stream = collections.defaultdict(list)
+    with profile_csv.open(encoding="utf-8", newline="") as input_file:
+        header = input_file.readline()
+        match = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", header)
+        if match is None:
+            raise ValueError(f"chip frequency is missing from {profile_csv}")
+        frequency_mhz = float(match.group(1))
+        for raw_row in csv.DictReader(input_file):
+            row = {key.strip().lower(): value.strip() for key, value in raw_row.items()}
+            label = row["zone name"]
+            if not label.startswith("d2m."):
+                continue
+            phase, separator, boundary = label.rpartition(".")
+            if not separator or boundary not in ("begin", "end"):
+                raise ValueError(
+                    f"device profile event {label!r} is not an interval boundary"
+                )
+            device = row.get("device id") or row.get("pcie slot") or "unknown"
+            stream = (
+                device,
+                row["run host id"],
+                row["core_x"],
+                row["core_y"],
+                row["risc processor type"],
+                phase,
+            )
+            events_by_stream[stream].append(
+                (int(row["time[cycles since reset]"]), boundary)
+            )
+
+    captured_runs = warmup + iterations
+    intervals_by_phase = collections.defaultdict(lambda: collections.defaultdict(list))
+    for stream, events in events_by_stream.items():
+        events.sort()
+        intervals = []
+        start = None
+        for cycle, boundary in events:
+            if boundary == "begin":
+                if start is not None:
+                    raise ValueError(f"nested begin events in profiler stream {stream}")
+                start = cycle
+            else:
+                if start is None:
+                    raise ValueError(f"unmatched end event in profiler stream {stream}")
+                if cycle < start:
+                    raise ValueError(f"negative interval in profiler stream {stream}")
+                intervals.append((start, cycle))
+                start = None
+        if start is not None:
+            raise ValueError(f"unmatched begin event in profiler stream {stream}")
+        if len(intervals) % captured_runs:
+            raise ValueError(
+                f"profiler stream {stream} does not divide into captured runs"
+            )
+
+        intervals_per_run = len(intervals) // captured_runs
+        device, program, core_x, core_y, risc, phase = stream
+        stream_id = (program, core_x, core_y, risc)
+        for run_index in range(warmup, captured_runs):
+            begin = run_index * intervals_per_run
+            end = begin + intervals_per_run
+            intervals_by_phase[(device, run_index, phase)][stream_id].extend(
+                intervals[begin:end]
+            )
+
+    return frequency_mhz, intervals_by_phase
+
+
+def _block_envelopes(intervals_by_stream, blocks_per_core, phase):
+    if not intervals_by_stream:
+        raise ValueError(f"device profile is missing {phase} events")
+    envelopes = []
+    for stream, intervals in intervals_by_stream.items():
+        if len(intervals) != blocks_per_core:
+            raise ValueError(
+                f"{phase} stream {stream} has {len(intervals)} intervals; "
+                f"expected {blocks_per_core}"
+            )
+    for block in range(blocks_per_core):
+        intervals = [
+            stream_intervals[block] for stream_intervals in intervals_by_stream.values()
+        ]
+        envelopes.append(
+            {
+                "start": min(start for start, _ in intervals),
+                "end": max(end for _, end in intervals),
+                "active": sum(end - start for start, end in intervals),
+                "streams": len(intervals),
+            }
+        )
+    return envelopes
+
+
+def _mean(values):
+    values = [value for value in values if value is not None]
+    return sum(values) / len(values) if values else None
+
+
+def _device_block_timeline(
+    profile_csv, warmup, iterations, blocks_per_core, timeline_csv=None
+):
+    frequency_mhz, intervals_by_phase = _device_profile_event_intervals(
+        profile_csv, warmup, iterations
+    )
+    device_runs = sorted(
+        {
+            (device, run_index)
+            for device, run_index, phase in intervals_by_phase
+            if phase == "d2m.block.compute"
+        }
+    )
+    rows = []
+    for device, run_index in device_runs:
+        phases = {
+            phase: intervals_by_phase.get((device, run_index, phase), {})
+            for phase in (
+                "d2m.block.compute",
+                "d2m.router.ready_wait",
+                "d2m.router.transfer",
+                "d2m.router.fabric_wait",
+                "d2m.block.reduction",
+            )
+        }
+        # Compute events run on all three TRISCs, so their envelope represents
+        # the complete unpack, math, and pack wave across the worker grid.
+        compute = _block_envelopes(
+            phases["d2m.block.compute"], blocks_per_core, "d2m.block.compute"
+        )
+        ready_wait = _block_envelopes(
+            phases["d2m.router.ready_wait"],
+            blocks_per_core,
+            "d2m.router.ready_wait",
+        )
+        transfer = _block_envelopes(
+            phases["d2m.router.transfer"], blocks_per_core, "d2m.router.transfer"
+        )
+        fabric_wait = _block_envelopes(
+            phases["d2m.router.fabric_wait"],
+            blocks_per_core,
+            "d2m.router.fabric_wait",
+        )
+        reduction = (
+            _block_envelopes(
+                phases["d2m.block.reduction"],
+                blocks_per_core,
+                "d2m.block.reduction",
+            )
+            if phases["d2m.block.reduction"]
+            else [None] * blocks_per_core
+        )
+        origin = compute[0]["start"]
+        for block in range(blocks_per_core):
+            ccl_start = transfer[block]["start"]
+            ccl_end = fabric_wait[block]["end"]
+            next_compute = compute[block + 1] if block + 1 < blocks_per_core else None
+            overlap = None
+            compute_gap = None
+            if next_compute is not None:
+                overlap = max(
+                    0,
+                    min(ccl_end, next_compute["end"])
+                    - max(ccl_start, next_compute["start"]),
+                )
+                compute_gap = next_compute["start"] - compute[block]["end"]
+            rows.append(
+                {
+                    "device": device,
+                    "iteration": run_index - warmup + 1,
+                    "block": block,
+                    "origin_cycles": origin,
+                    "compute_start_cycles": compute[block]["start"],
+                    "compute_end_cycles": compute[block]["end"],
+                    "compute_stream_active_cycles": compute[block]["active"],
+                    "compute_streams": compute[block]["streams"],
+                    "ready_wait_start_cycles": ready_wait[block]["start"],
+                    "ready_wait_end_cycles": ready_wait[block]["end"],
+                    "transfer_start_cycles": transfer[block]["start"],
+                    "transfer_end_cycles": transfer[block]["end"],
+                    "fabric_wait_start_cycles": fabric_wait[block]["start"],
+                    "fabric_wait_end_cycles": fabric_wait[block]["end"],
+                    "ccl_start_cycles": ccl_start,
+                    "ccl_end_cycles": ccl_end,
+                    "next_compute_overlap_cycles": overlap,
+                    "next_compute_gap_cycles": compute_gap,
+                    "reduction_start_cycles": (
+                        reduction[block]["start"] if reduction[block] else None
+                    ),
+                    "reduction_end_cycles": (
+                        reduction[block]["end"] if reduction[block] else None
+                    ),
+                }
+            )
+
+    scale_ns = 1_000 / frequency_mhz
+    summaries = {}
+    for device in sorted({row["device"] for row in rows}):
+        device_rows = [row for row in rows if row["device"] == device]
+        iteration_rows = collections.defaultdict(list)
+        for row in device_rows:
+            iteration_rows[row["iteration"]].append(row)
+        block_periods = []
+        down_stages = []
+        down_to_reduction_gaps = []
+        reduction_stages = []
+        for run_rows in iteration_rows.values():
+            run_rows.sort(key=lambda row: row["block"])
+            block_periods.extend(
+                second["compute_start_cycles"] - first["compute_start_cycles"]
+                for first, second in zip(run_rows, run_rows[1:])
+            )
+            down_end = max(
+                max(row["compute_end_cycles"], row["ccl_end_cycles"])
+                for row in run_rows
+            )
+            down_stages.append(down_end - run_rows[0]["compute_start_cycles"])
+            reduction_rows = [
+                row for row in run_rows if row["reduction_start_cycles"] is not None
+            ]
+            if reduction_rows:
+                reduction_start = min(
+                    row["reduction_start_cycles"] for row in reduction_rows
+                )
+                reduction_end = max(
+                    row["reduction_end_cycles"] for row in reduction_rows
+                )
+                down_to_reduction_gaps.append(reduction_start - down_end)
+                reduction_stages.append(reduction_end - reduction_start)
+        eligible_rows = [
+            row for row in device_rows if row["next_compute_overlap_cycles"] is not None
+        ]
+        eligible_ccl = sum(
+            row["ccl_end_cycles"] - row["ccl_start_cycles"] for row in eligible_rows
+        )
+        all_ccl = sum(
+            row["ccl_end_cycles"] - row["ccl_start_cycles"] for row in device_rows
+        )
+        overlap = sum(row["next_compute_overlap_cycles"] for row in eligible_rows)
+        summaries[device] = {
+            "compute_wave_mean_ns": _mean(
+                [
+                    (row["compute_end_cycles"] - row["compute_start_cycles"]) * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "compute_stream_mean_ns": _mean(
+                [
+                    row["compute_stream_active_cycles"]
+                    / row["compute_streams"]
+                    * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "block_period_mean_ns": _mean(
+                [period * scale_ns for period in block_periods]
+            ),
+            "ready_wait_mean_ns": _mean(
+                [
+                    (row["ready_wait_end_cycles"] - row["ready_wait_start_cycles"])
+                    * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "transfer_mean_ns": _mean(
+                [
+                    (row["transfer_end_cycles"] - row["transfer_start_cycles"])
+                    * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "fabric_wait_mean_ns": _mean(
+                [
+                    (row["fabric_wait_end_cycles"] - row["fabric_wait_start_cycles"])
+                    * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "ccl_mean_ns": _mean(
+                [
+                    (row["ccl_end_cycles"] - row["ccl_start_cycles"]) * scale_ns
+                    for row in device_rows
+                ]
+            ),
+            "next_compute_overlap_mean_ns": _mean(
+                [row["next_compute_overlap_cycles"] * scale_ns for row in eligible_rows]
+            ),
+            "next_compute_gap_mean_ns": _mean(
+                [row["next_compute_gap_cycles"] * scale_ns for row in eligible_rows]
+            ),
+            "steady_state_ccl_compute_overlap_pct": (
+                100 * overlap / eligible_ccl if eligible_ccl else None
+            ),
+            "end_to_end_ccl_compute_overlap_pct": (
+                100 * overlap / all_ccl if all_ccl else None
+            ),
+            "down_stage_mean_ns": _mean(
+                [duration * scale_ns for duration in down_stages]
+            ),
+            "down_to_reduction_gap_mean_ns": _mean(
+                [duration * scale_ns for duration in down_to_reduction_gaps]
+            ),
+            "reduction_stage_mean_ns": _mean(
+                [duration * scale_ns for duration in reduction_stages]
+            ),
+            "reduction_wave_mean_ns": _mean(
+                [
+                    (row["reduction_end_cycles"] - row["reduction_start_cycles"])
+                    * scale_ns
+                    for row in device_rows
+                    if row["reduction_start_cycles"] is not None
+                ]
+            ),
+        }
+
+    if timeline_csv:
+        timeline_csv.parent.mkdir(parents=True, exist_ok=True)
+        time_fields = [
+            "compute_start",
+            "compute_end",
+            "ready_wait_start",
+            "ready_wait_end",
+            "transfer_start",
+            "transfer_end",
+            "fabric_wait_start",
+            "fabric_wait_end",
+            "ccl_start",
+            "ccl_end",
+            "reduction_start",
+            "reduction_end",
+        ]
+        fieldnames = (
+            ["device", "iteration", "block"]
+            + [f"{field}_us" for field in time_fields]
+            + [
+                "compute_stream_mean_us",
+                "next_compute_overlap_us",
+                "next_compute_gap_us",
+            ]
+        )
+        with timeline_csv.open("w", encoding="utf-8", newline="") as output:
+            writer = csv.DictWriter(output, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                output_row = {
+                    "device": row["device"],
+                    "iteration": row["iteration"],
+                    "block": row["block"],
+                }
+                for field in time_fields:
+                    cycles = row[f"{field}_cycles"]
+                    output_row[f"{field}_us"] = (
+                        ""
+                        if cycles is None
+                        else f"{(cycles - row['origin_cycles']) / frequency_mhz:.3f}"
+                    )
+                output_row["compute_stream_mean_us"] = (
+                    row["compute_stream_active_cycles"]
+                    / row["compute_streams"]
+                    / frequency_mhz
+                )
+                for field in ("next_compute_overlap", "next_compute_gap"):
+                    cycles = row[f"{field}_cycles"]
+                    output_row[f"{field}_us"] = (
+                        "" if cycles is None else f"{cycles / frequency_mhz:.3f}"
+                    )
+                writer.writerow(output_row)
+
+    return {"rows": rows, "summaries": summaries}
+
+
 def _pcc(actual, expected):
     import torch
 
@@ -301,6 +671,7 @@ def _parse_args():
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--tracy-file", type=pathlib.Path)
     parser.add_argument("--device-profile-dir", type=pathlib.Path)
+    parser.add_argument("--block-timeline-file", type=pathlib.Path)
     return parser.parse_args()
 
 
@@ -308,6 +679,10 @@ def main():
     args = _parse_args()
     if args.iterations < 1 or args.warmup < 0:
         raise ValueError("iterations must be positive and warmup must be non-negative")
+    if args.block_timeline_file and not args.device_profile_dir:
+        raise ValueError("--block-timeline-file requires --device-profile-dir")
+    if args.block_timeline_file and args.mode == "single":
+        raise ValueError("block overlap timelines require a two-chip mode")
 
     trace_context = contextlib.nullcontext()
     if args.tracy_file:
@@ -479,6 +854,42 @@ def main():
                 "device active_program_ns="
                 f"{active_samples} mean_ns={sum(active_samples) / len(active_samples)}"
             )
+        if args.mode != "single":
+            timeline_csv = args.block_timeline_file or (
+                args.device_profile_dir / ".logs" / "d2m_block_timeline.csv"
+            )
+            timeline = _device_block_timeline(
+                profile_csv,
+                args.warmup,
+                args.iterations,
+                config.output_blocks_per_core,
+                timeline_csv,
+            )
+            for device, summary in timeline["summaries"].items():
+                print(
+                    f"device={device} block_timeline "
+                    f"compute_wave_mean_ns={summary['compute_wave_mean_ns']:.1f} "
+                    f"compute_stream_mean_ns={summary['compute_stream_mean_ns']:.1f} "
+                    f"block_period_mean_ns={summary['block_period_mean_ns']:.1f} "
+                    f"ready_wait_mean_ns={summary['ready_wait_mean_ns']:.1f} "
+                    f"transfer_mean_ns={summary['transfer_mean_ns']:.1f} "
+                    f"fabric_wait_mean_ns={summary['fabric_wait_mean_ns']:.1f} "
+                    f"ccl_mean_ns={summary['ccl_mean_ns']:.1f} "
+                    "next_compute_overlap_mean_ns="
+                    f"{summary['next_compute_overlap_mean_ns']:.1f} "
+                    f"next_compute_gap_mean_ns={summary['next_compute_gap_mean_ns']:.1f} "
+                    "steady_state_ccl_compute_overlap_pct="
+                    f"{summary['steady_state_ccl_compute_overlap_pct']:.1f} "
+                    "end_to_end_ccl_compute_overlap_pct="
+                    f"{summary['end_to_end_ccl_compute_overlap_pct']:.1f} "
+                    f"down_stage_mean_ns={summary['down_stage_mean_ns']:.1f} "
+                    "down_to_reduction_gap_mean_ns="
+                    f"{summary['down_to_reduction_gap_mean_ns']:.1f} "
+                    "reduction_stage_mean_ns="
+                    f"{summary['reduction_stage_mean_ns']:.1f} "
+                    f"reduction_wave_mean_ns={summary['reduction_wave_mean_ns']:.1f}"
+                )
+            print(f"device block timeline: {timeline_csv}")
         print(f"device profile: {profile_csv}")
 
 

--- a/test/d2m-jit/test_multichip_overlap_benchmark.py
+++ b/test/d2m-jit/test_multichip_overlap_benchmark.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import csv
+
 import torch
 
 from multichip_overlap_benchmark import (
+    _device_block_timeline,
     _device_critical_path_ns,
     _device_kernel_ns,
     _device_timing_samples,
@@ -127,6 +130,77 @@ def test_device_critical_path_compares_per_device_spans(tmp_path):
     )
 
     assert _device_critical_path_ns(profile_csv, warmup=0, iterations=1) == [300]
+
+
+def test_device_block_timeline_reconstructs_compute_ccl_overlap(tmp_path):
+    profile_csv = tmp_path / "profile_log_device.csv"
+    rows = []
+
+    def add_interval(core_x, core_y, risc, program, label, start, end):
+        for boundary, cycle in (("begin", start), ("end", end)):
+            rows.append(
+                f"0,{core_x},{core_y},{risc},1,{cycle},0,{program},,,"
+                f"{label}.{boundary},TS_DATA,0,,\n"
+            )
+
+    for core_x, first, second in (
+        (1, (100, 200), (250, 350)),
+        (2, (110, 210), (260, 360)),
+    ):
+        add_interval(core_x, 1, "TRISC", 7, "d2m.block.compute", *first)
+        add_interval(core_x, 1, "TRISC", 7, "d2m.block.compute", *second)
+    for label, intervals in (
+        ("d2m.router.ready_wait", ((105, 215), (300, 365))),
+        ("d2m.router.transfer", ((215, 240), (365, 390))),
+        ("d2m.router.fabric_wait", ((240, 300), (390, 430))),
+    ):
+        for interval in intervals:
+            add_interval(1, 1, "BRISC", 7, label, *interval)
+    for core_x, first, second in (
+        (1, (500, 520), (530, 550)),
+        (2, (505, 525), (535, 555)),
+    ):
+        add_interval(core_x, 1, "TRISC", 8, "d2m.block.reduction", *first)
+        add_interval(core_x, 1, "TRISC", 8, "d2m.block.reduction", *second)
+
+    profile_csv.write_text(
+        "ARCH: wormhole_b0, CHIP_FREQ[MHz]: 1000, Max Compute Cores: 64\n"
+        "device id,core_x,core_y,RISC processor type,timer_id,"
+        "time[cycles since reset],data,run host ID,trace id,trace id counter,"
+        "zone name,type,source line,source file,meta data\n" + "".join(rows)
+    )
+    timeline_csv = tmp_path / "timeline.csv"
+
+    timeline = _device_block_timeline(
+        profile_csv,
+        warmup=0,
+        iterations=1,
+        blocks_per_core=2,
+        timeline_csv=timeline_csv,
+    )
+
+    summary = timeline["summaries"]["0"]
+    assert summary["compute_wave_mean_ns"] == 110
+    assert summary["compute_stream_mean_ns"] == 100
+    assert summary["block_period_mean_ns"] == 150
+    assert summary["ready_wait_mean_ns"] == 87.5
+    assert summary["transfer_mean_ns"] == 25
+    assert summary["fabric_wait_mean_ns"] == 50
+    assert summary["ccl_mean_ns"] == 75
+    assert summary["next_compute_overlap_mean_ns"] == 50
+    assert summary["next_compute_gap_mean_ns"] == 40
+    assert summary["steady_state_ccl_compute_overlap_pct"] == 100 * 50 / 85
+    assert summary["end_to_end_ccl_compute_overlap_pct"] == 100 * 50 / 150
+    assert summary["down_stage_mean_ns"] == 330
+    assert summary["down_to_reduction_gap_mean_ns"] == 70
+    assert summary["reduction_stage_mean_ns"] == 55
+    assert summary["reduction_wave_mean_ns"] == 25
+    with timeline_csv.open(encoding="utf-8", newline="") as input_file:
+        timeline_rows = list(csv.DictReader(input_file))
+    assert timeline_rows[0]["compute_start_us"] == "0.000"
+    assert timeline_rows[0]["compute_end_us"] == "0.110"
+    assert timeline_rows[0]["next_compute_overlap_us"] == "0.050"
+    assert timeline_rows[1]["next_compute_overlap_us"] == ""
 
 
 def test_tracy_summary_aggregates_zones_per_submit(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- add block-level device-profiler reporting for down-projection compute, router readiness, gather/fabric issue, fabric completion, and reduction
- pair timestamp events by device, core, RISC, program, run, and occurrence, then emit a reviewable `d2m_block_timeline.csv`
- add a completion-timed two-chip BF16 DRAM-to-DRAM saturation benchmark with independent initialized-link and active-sender controls
- document the measured overlap/contention behavior and the N300 dispatch-plane limitation discovered by the two-link experiment

## Block-level result

Three measured N300 iterations after one warmup produced these means across both chips:

| Device metric | Serialized | Overlapped | Change |
| --- | ---: | ---: | ---: |
| Compute-stream interval | 0.593 ms | 0.880 ms | +48.4% |
| Block start period | 0.942 ms | 0.845 ms | -10.3% |
| Router transfer | 0.112 ms | 0.620 ms | +455.0% |
| Down-projection stage | 11.309 ms | 10.949 ms | -3.2% |
| Steady-state CCL/next-compute intersection | 0% | 100% | +100 pp |
| Full-MLP device critical path | 69.445 ms | 69.593 ms | +0.2% |

The intended overlap is real, but concurrent compute substantially slows the router gather/transfer path; the complete device critical path is therefore effectively flat.

## Fabric result

At 320 KiB x 205 packets, one workload link sustains about 7.20 GB/s per direction and 14.4 GB/s aggregate full duplex with exact BF16 equality. Initializing both N300 links while using one sender produces the same throughput.

Live UMD discovery confirms two bidirectional physical links. TT-Metal currently reserves the last routing plane for the remote-chip dispatch tunnel, leaving one worker-usable plane. A two-sender attempt maps the second D2M router core to that dispatch plane and stalls during connection startup; the detailed reproduction and source diagnosis are retained in the PR discussion.

## Stack

Depends on #9185. This is now the final experiments/results PR in the review stack; the original #9170 discussion has been preserved.

## Validation

- `pytest -q test/d2m-jit/test_multichip_overlap_benchmark.py` (7 passed on the reconstructed stack)
- one-link and safe two-link-control N300 saturation runs with exact BF16 equality
- block-level serialized/overlapped N300 captures
- `pre-commit run --all-files` on the reconstructed stack

This remains a draft.