### PR TITLE
[d2m] Split threads through `scf.if`/`scf.while`

### DIFF
--- a/lib/Dialect/D2M/Transforms/SplitThreads.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitThreads.cpp
@@ -234,8 +234,15 @@ static void collectComputeOpsToErase(Block *block,
     if (op.hasTrait<OpTrait::IsTerminator>()) {
       continue;
     }
-    if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
-      collectComputeOpsToErase(forOp.getBody(), eraseSet);
+    // Descend into structured control flow rather than erasing the whole op:
+    // its regions may host DMA ops that must stay on the datamovement thread
+    // alongside compute ops that must go.
+    if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(&op)) {
+      for (Region &region : op.getRegions()) {
+        for (Block &nested : region) {
+          collectComputeOpsToErase(&nested, eraseSet);
+        }
+      }
       continue;
     }
     bool isDMAOp = isa<ShardDMAOpInterface, DeviceSynchronizeOp>(&op);


### PR DESCRIPTION
`D2MSplitThreads` removed compute ops from the datamovement thread by recursing only into `scf.for`. I see kernels with operations inside `scf.if` and `scf.while`; those operations did not get cleaned up. This change recurses into `scf.if` and `scf.while` regions as well, so nested compute ops are stripped from the datamovement thread.

Assisted-by: opencode/claude-opus-4-8