### PR TITLE
[StableHLO] Rescale group_norm num_groups across the flatten/reoutline round-trip

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -24,6 +24,13 @@ inline constexpr llvm::StringLiteral
 inline constexpr llvm::StringLiteral
     kReoutlineResultPosAttr("reoutline.result_pos");
 
+// Global (pre-sharding) channel dim size of a flattened tenstorrent.group_norm,
+// stashed on the seed op alongside kReoutlineCompAttrsAttr. Needed to rescale
+// the stashed (global) `num_groups` when the composite is rebuilt, since by
+// then the shapes have been localized and the global channel count is gone.
+inline constexpr llvm::StringLiteral
+    kReoutlineGroupNormChannelsAttr("reoutline.group_norm_global_channels");
+
 // Composite op related string definitions.
 inline constexpr llvm::StringLiteral kCompDecompositionKey("decomposition");
 inline constexpr llvm::StringLiteral kCompAttrsKey("composite_attributes");
@@ -66,6 +73,11 @@ inline constexpr llvm::StringLiteral
 // Composite name emitted by the frontend for scaled_dot_product_attention.
 inline constexpr llvm::StringLiteral
     kTTSDPACompositeName("tenstorrent.scaled_dot_product_attention");
+
+// Composite name emitted by the frontend for group_norm. Its `num_groups` is a
+// static attribute, so any pass that localizes the channel dim must rescale it.
+inline constexpr llvm::StringLiteral
+    kTTGroupNormCompositeName("tenstorrent.group_norm");
 
 // Composite names that have custom sharding rules. These composites are
 // converted to stablehlo.custom_call ops so that Shardy can propagate shardings

--- a/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
@@ -14,6 +14,37 @@ namespace mlir::tt::stablehlo {
 #define GEN_PASS_DEF_FLATTENORCONVERTCOMPOSITESPASS
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
 
+// Record the global channel dim size of a tenstorrent.group_norm on the seed op
+// of its flattened body, so ReoutlineCompositePass can rescale `num_groups`
+// after the shapes have been localized. Best effort: with nothing stashed,
+// reoutlining leaves `num_groups` alone, which is correct for an unsharded
+// channel dim.
+static void stashGroupNormGlobalChannels(mlir::stablehlo::CompositeOp comp,
+                                         mlir::DictionaryAttr origCompAttrs,
+                                         mlir::Operation *seedOp,
+                                         mlir::OpBuilder &builder) {
+  if (comp.getNumResults() < 1) {
+    return;
+  }
+  auto resultType =
+      llvm::dyn_cast<mlir::RankedTensorType>(comp.getResult(0).getType());
+  if (!resultType) {
+    return;
+  }
+
+  int64_t channelDim = 1;
+  if (auto channelDimAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+          origCompAttrs.get("channel_dim"))) {
+    channelDim = channelDimAttr.getInt();
+  }
+  if (channelDim < 0 || channelDim >= resultType.getRank()) {
+    return;
+  }
+
+  seedOp->setAttr(utils::kReoutlineGroupNormChannelsAttr,
+                  builder.getI64IntegerAttr(resultType.getDimSize(channelDim)));
+}
+
 // Inline a single stablehlo.composite op. Returns success if it was flattened.
 static mlir::LogicalResult
 flattenOneComposite(mlir::stablehlo::CompositeOp comp,
@@ -111,6 +142,11 @@ flattenOneComposite(mlir::stablehlo::CompositeOp comp,
       cloned->setAttr(utils::kReoutlineOrigNameAttr, origName);
       // { approximate = "tanh" }
       cloned->setAttr(utils::kReoutlineCompAttrsAttr, origCompAttrs);
+      // group_norm's stashed `num_groups` counts along the channel dim, so it
+      // goes stale once shapes are localized.
+      if (origName.getValue() == utils::kTTGroupNormCompositeName) {
+        stashGroupNormGlobalChannels(comp, origCompAttrs, cloned, builder);
+      }
       seeded = true;
     }
     clonedOps.push_back(cloned);

--- a/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
@@ -213,16 +213,103 @@ computeSafeInsertAfter(llvm::ArrayRef<mlir::Value> captures,
   return latestDef;
 }
 
+// Rescale a flattened tenstorrent.group_norm's `num_groups` from the global
+// value stashed at flatten time to the one matching the localized channel dim.
+// A stale count is a silent accuracy loss: the ttir.group_norm verifier only
+// checks `channels % num_groups == 0`, which it typically still satisfies.
+//
+// group_size is invariant under sharding, since Shardy shards a dim into
+// contiguous blocks and groups are contiguous channel ranges, so every device
+// holds a whole number of whole groups:
+//   group_size     = global_channels / num_groups
+//   new_num_groups = local_channels  / group_size
+static mlir::LogicalResult
+rescaleGroupNormNumGroups(mlir::Operation *seedOp, mlir::Type localResultType,
+                          mlir::DictionaryAttr &compAttrs) {
+  auto globalChannelsAttr = seedOp->getAttrOfType<mlir::IntegerAttr>(
+      utils::kReoutlineGroupNormChannelsAttr);
+  if (!globalChannelsAttr) {
+    return mlir::success();
+  }
+
+  auto resultType = llvm::dyn_cast<mlir::RankedTensorType>(localResultType);
+  if (!resultType) {
+    return mlir::success();
+  }
+
+  int64_t channelDim = 1;
+  if (auto channelDimAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+          compAttrs.get("channel_dim"))) {
+    channelDim = channelDimAttr.getInt();
+  }
+  if (channelDim < 0 || channelDim >= resultType.getRank()) {
+    return mlir::success();
+  }
+
+  int64_t globalChannels = globalChannelsAttr.getInt();
+  int64_t localChannels = resultType.getDimSize(channelDim);
+
+  // Channel dim was not sharded, so the global group count still applies.
+  if (globalChannels == localChannels) {
+    return mlir::success();
+  }
+
+  // Either a scalar integer or a single-element dense tensor, mirroring
+  // TenstorrentGroupNormConversionPattern.
+  mlir::Attribute numGroupsAttr = compAttrs.get("num_groups");
+  int64_t numGroups = 0;
+  if (auto intAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(numGroupsAttr)) {
+    numGroups = intAttr.getInt();
+  } else if (auto denseAttr =
+                 llvm::dyn_cast_or_null<mlir::DenseIntElementsAttr>(
+                     numGroupsAttr)) {
+    if (denseAttr.getNumElements() != 1) {
+      seedOp->emitError() << "tenstorrent.group_norm num_groups must be a "
+                             "single-element dense tensor";
+      return mlir::failure();
+    }
+    numGroups = *denseAttr.getValues<int64_t>().begin();
+  } else {
+    seedOp->emitError() << "tenstorrent.group_norm is missing an integer "
+                           "num_groups attribute";
+    return mlir::failure();
+  }
+
+  if (numGroups <= 0 || globalChannels % numGroups != 0) {
+    seedOp->emitError() << "cannot rescale num_groups: global channel dim ("
+                        << globalChannels << ") not divisible by num_groups ("
+                        << numGroups << ")";
+    return mlir::failure();
+  }
+
+  int64_t groupSize = globalChannels / numGroups;
+  if (localChannels % groupSize != 0) {
+    seedOp->emitError()
+        << "cannot rescale num_groups: local channel dim (" << localChannels
+        << ") does not hold a whole number of groups of size " << groupSize
+        << ". The channel dim must not be sharded finer than num_groups ("
+        << numGroups << ")";
+    return mlir::failure();
+  }
+
+  mlir::NamedAttrList updated(compAttrs);
+  mlir::MLIRContext *ctx = seedOp->getContext();
+  updated.set("num_groups",
+              mlir::IntegerAttr::get(mlir::IntegerType::get(ctx, 64),
+                                     localChannels / groupSize));
+  compAttrs = updated.getDictionary(ctx);
+
+  return mlir::success();
+}
+
 // Replace the original ops range with a stablehlo.composite, wiring
 // captures/results. Erase the old ops.
-void replaceWithComposite(mlir::func::FuncOp parentFunc,
-                          mlir::Operation *insertBefore,
-                          mlir::Operation *firstOp, mlir::Operation *lastOp,
-                          mlir::func::FuncOp callee,
-                          mlir::ArrayRef<mlir::Value> captures,
-                          mlir::ArrayRef<mlir::Value> escapes,
-                          llvm::ArrayRef<mlir::Operation *> opsToErase,
-                          mlir::StringAttr groupKey) {
+mlir::LogicalResult replaceWithComposite(
+    mlir::func::FuncOp parentFunc, mlir::Operation *insertBefore,
+    mlir::Operation *firstOp, mlir::Operation *lastOp,
+    mlir::func::FuncOp callee, mlir::ArrayRef<mlir::Value> captures,
+    mlir::ArrayRef<mlir::Value> escapes,
+    llvm::ArrayRef<mlir::Operation *> opsToErase, mlir::StringAttr groupKey) {
   mlir::Operation *after = computeSafeInsertAfter(captures, firstOp);
   mlir::OpBuilder builder(after);
   if (after == firstOp) {
@@ -254,8 +341,10 @@ void replaceWithComposite(mlir::func::FuncOp parentFunc,
       mlir::SymbolRefAttr::get(ctx, callee.getSymName());
   mlir::DictionaryAttr compAttrs = mlir::DictionaryAttr::get(ctx);
   mlir::StringAttr targetName = builder.getStringAttr(callee.getSymName());
+  mlir::Operation *seedOp = nullptr;
   for (mlir::Operation *op : opsToErase) {
     if (op->hasAttr(utils::kReoutlineSeedAttr)) {
+      seedOp = op;
       if (auto origName = op->getAttrOfType<mlir::StringAttr>(
               utils::kReoutlineOrigNameAttr)) {
         targetName = origName;
@@ -264,6 +353,16 @@ void replaceWithComposite(mlir::func::FuncOp parentFunc,
               utils::kReoutlineCompAttrsAttr)) {
         compAttrs = compAttr;
       }
+    }
+  }
+
+  // The stashed composite attributes are the pre-sharding ones, so any that
+  // count along a sharded dim need rescaling before being baked back in.
+  if (seedOp && targetName.getValue() == utils::kTTGroupNormCompositeName &&
+      !resultTypes.empty()) {
+    if (mlir::failed(
+            rescaleGroupNormNumGroups(seedOp, resultTypes[0], compAttrs))) {
+      return mlir::failure();
     }
   }
 
@@ -304,6 +403,8 @@ void replaceWithComposite(mlir::func::FuncOp parentFunc,
     }
     op->erase();
   }
+
+  return mlir::success();
 }
 
 // ReoutlineCompositePass: Rebuilds stablehlo.composite from grouped ops after
@@ -354,8 +455,12 @@ public:
             module, "outlined_", base.getValue(), captures, escapes, ops);
 
         // Replace range with a call and erase the grouped ops.
-        replaceWithComposite(func, firstOp, firstOp, lastOp, callee, captures,
-                             escapes, ops, group);
+        if (mlir::failed(replaceWithComposite(func, firstOp, firstOp, lastOp,
+                                              callee, captures, escapes, ops,
+                                              group))) {
+          signalPassFailure();
+          return;
+        }
       }
     }
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups.mlir
@@ -1,0 +1,45 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --split-input-file --reoutline-composite -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// The flattened body is already localized (channel dim 512 -> 128 on a 4-way
+// shard), but the stashed composite attributes still hold the global
+// num_groups=32. Re-outlining must rescale it to 8 to preserve the group size
+// (512/32 = 16) on the local 128-channel shard. Nothing downstream would flag a
+// missed rescale, since 128 % 32 == 0 satisfies the ttir.group_norm verifier.
+module @jit_reoutline_group_norm_sharded attributes {mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<1x512x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x512x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {"_axis_0"}, {}, {}, {}]>] out_shardings=[<@mesh, [{?}, {"_axis_0", ?}, {?}, {?}, {?}]>] manual_axes={"_axis_0"} (%arg1: tensor<1x128x1x60x90xbf16>) {
+      // CHECK: stablehlo.composite "tenstorrent.group_norm"
+      // CHECK-SAME: num_groups = 8 : i64
+      // CHECK-SAME: (tensor<1x128x1x60x90xbf16>) -> tensor<1x128x1x60x90xbf16>
+      %cst = stablehlo.constant {reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}, reoutline.group = "composite_tenstorrent.group_norm.impl", reoutline.group_norm_global_channels = 512 : i64, reoutline.orig_name = "tenstorrent.group_norm", reoutline.seed} dense<1.000000e+00> : tensor<bf16>
+      %1 = stablehlo.broadcast_in_dim %cst, dims = [] {reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<bf16>) -> tensor<1x128x1x60x90xbf16>
+      %2 = stablehlo.multiply %arg1, %1 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x128x1x60x90xbf16>
+      sdy.return %2 : tensor<1x128x1x60x90xbf16>
+    } : (tensor<1x512x1x60x90xbf16>) -> tensor<1x512x1x60x90xbf16>
+    return %0 : tensor<1x512x1x60x90xbf16>
+  }
+}
+
+// -----
+
+// Channel dim left replicated (only the batch dim is sharded), so the stashed
+// global channel count matches the local one and num_groups is left alone.
+module @jit_reoutline_group_norm_replicated attributes {mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<4x512x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<4x512x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{"_axis_0"}, {}, {}, {}, {}]>] out_shardings=[<@mesh, [{"_axis_0", ?}, {?}, {?}, {?}, {?}]>] manual_axes={"_axis_0"} (%arg1: tensor<1x512x1x60x90xbf16>) {
+      // CHECK: stablehlo.composite "tenstorrent.group_norm"
+      // CHECK-SAME: num_groups = 32 : i64
+      // CHECK-SAME: (tensor<1x512x1x60x90xbf16>) -> tensor<1x512x1x60x90xbf16>
+      %cst = stablehlo.constant {reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}, reoutline.group = "composite_tenstorrent.group_norm.impl", reoutline.group_norm_global_channels = 512 : i64, reoutline.orig_name = "tenstorrent.group_norm", reoutline.seed} dense<1.000000e+00> : tensor<bf16>
+      %1 = stablehlo.broadcast_in_dim %cst, dims = [] {reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<bf16>) -> tensor<1x512x1x60x90xbf16>
+      %2 = stablehlo.multiply %arg1, %1 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x512x1x60x90xbf16>
+      sdy.return %2 : tensor<1x512x1x60x90xbf16>
+    } : (tensor<4x512x1x60x90xbf16>) -> tensor<4x512x1x60x90xbf16>
+    return %0 : tensor<4x512x1x60x90xbf16>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups_invalid.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups_invalid.mlir
@@ -1,0 +1,21 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --verify-diagnostics --reoutline-composite %s
+
+// num_groups=2 over 32 global channels is a group size of 16, but a 4-way shard
+// of the channel dim leaves only 8 local channels -- half a group. There is no
+// valid local group count, so re-outlining must fail loudly. The ttir.group_norm
+// verifier would not catch this either: 8 % 2 == 0.
+module @jit_reoutline_group_norm_too_fine attributes {mhlo.use_auto_spmd_partitioning = false} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<1x32x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x32x1x60x90xbf16> {ttcore.shard_status = #ttcore.shard_status<unsharded>}) {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {"_axis_0"}, {}, {}, {}]>] out_shardings=[<@mesh, [{?}, {"_axis_0", ?}, {?}, {?}, {?}]>] manual_axes={"_axis_0"} (%arg1: tensor<1x8x1x60x90xbf16>) {
+      // The diagnostic is reported on the seed op that carries the stashed attrs.
+      // expected-error @+1 {{cannot rescale num_groups: local channel dim (8) does not hold a whole number of groups of size 16}}
+      %cst = stablehlo.constant {reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 2 : i64}, reoutline.group = "composite_tenstorrent.group_norm.impl", reoutline.group_norm_global_channels = 32 : i64, reoutline.orig_name = "tenstorrent.group_norm", reoutline.seed} dense<1.000000e+00> : tensor<bf16>
+      %1 = stablehlo.broadcast_in_dim %cst, dims = [] {reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<bf16>) -> tensor<1x8x1x60x90xbf16>
+      %2 = stablehlo.multiply %arg1, %1 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x8x1x60x90xbf16>
+      sdy.return %2 : tensor<1x8x1x60x90xbf16>
+    } : (tensor<1x32x1x60x90xbf16>) -> tensor<1x32x1x60x90xbf16>
+    return %0 : tensor<1x32x1x60x90xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_group_norm_stash_channels.mlir
+++ b/test/ttmlir/Dialect/StableHLO/flatten_or_convert_composite/flatten_group_norm_stash_channels.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --flatten-or-convert-composites -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// tenstorrent.group_norm has no custom sharding rule, so it is flattened and its
+// composite attributes are stashed on the seed op for later re-outlining. Those
+// attributes hold the *global* num_groups, so the global channel count is stashed
+// alongside them: it is how ReoutlineCompositePass recovers the group size once
+// shapes have been localized.
+module @jit_flatten_group_norm attributes {mhlo.num_partitions = 4 : i32, mhlo.num_replicas = 1 : i32} {
+  sdy.mesh @mesh = <["_axis_0"=4]>
+  func.func @main(%arg0: tensor<1x512x1x60x90xbf16> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"_axis_0"}, {}, {}, {}]>, ttcore.shard_status = #ttcore.shard_status<presharded>}) -> tensor<1x512x1x60x90xbf16> {
+    // CHECK-NOT: stablehlo.composite
+    // CHECK: stablehlo.multiply
+    // CHECK-SAME: reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}
+    // CHECK-SAME: reoutline.group_norm_global_channels = 512 : i64
+    // CHECK-SAME: reoutline.orig_name = "tenstorrent.group_norm"
+    %0 = stablehlo.composite "tenstorrent.group_norm" %arg0 {composite_attributes = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}, decomposition = @tenstorrent.group_norm.impl} : (tensor<1x512x1x60x90xbf16>) -> tensor<1x512x1x60x90xbf16>
+    return %0 : tensor<1x512x1x60x90xbf16>
+  }
+  func.func private @tenstorrent.group_norm.impl(%arg0: tensor<1x512x1x60x90xbf16>) -> tensor<1x512x1x60x90xbf16> {
+    %0 = stablehlo.multiply %arg0, %arg0 : tensor<1x512x1x60x90xbf16>
+    return %0 : tensor<1x512x1x60x90xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
Fixes [#5479](https://github.com/tenstorrent/tt-xla/issues/5479)

### Problem description
CogVideoX VAE decoder test fails with

```
AssertionError: Evaluation result 0 failed: PCC comparison failed.
Calculated: pcc=0.8352076483242976. Required: pcc=0.99.
```

tenstorrent.group_norm is not in kCompositesWithCustomSharding, which is the KEEP list (composites converted to custom_call so a Shardy sharding rule can apply). Everything off that list is flattened by FlattenOrConvertCompositesPass into its constituent stablehlo ops, sharded, localized, then rebuilt by ReoutlineCompositePass from attributes stashed verbatim on the seed op in reoutline.comp_attrs. 

### What's changed

- In FlattenOrConvertComposites.cpp, the global channel count of a tenstorrent.group_norm is now stashed on the seed op alongside reoutline.comp_attrs via a new stashGroupNormGlobalChannels and constant kReoutlineGroupNormChannelsAttr. This is required because by reoutline time only local shapes remain, so the shard factor is otherwise unrecoverable.

- In ReoutlineComposite.cpp, replaceWithComposite now rescales num_groups through rescaleGroupNormNumGroups before baking the stashed attributes back into the composite, using the shard-invariant group size:

- This holds because Shardy shards a dim into contiguous blocks and GroupNorm's groups are contiguous channel ranges, so every device holds a whole number of whole groups. When the channel dim is left replicated the global and local counts match and num_groups is untouched. When a group does not divide evenly into the local shard the pass now fails loudly rather than emitting silently wrong output — replaceWithComposite was changed from void to LogicalResult to carry that failure to signalPassFailure. The grouping, outlining, capture/escape wiring, and attribute restoration are otherwise unchanged.

- The rescale gates only tenstorrent.group_norm reconstruction; all other composites restore their attributes exactly as before. Post this fix, the sharded decoder emits groups=8 on the 34 sharded norms and leaves the 3 replicated 1x256x1x120x180 norms at groups=32, and test_vae_decoder_sharded passes in 93.24s.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[cogvideox_vae_decoder_before_fix_aug6.log](https://github.com/user-attachments/files/30773573/cogvideox_vae_decoder_before_fix_aug6.log)
[cogvideox_vae_decoder_after_fix_aug6.log](https://github.com/user-attachments/files/30773570/cogvideox_vae_decoder_after_fix_aug6.log)


