### PR TITLE
[StableHLOToTTIR] Generalize the single-dimensional scatter lowering

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7050,23 +7050,61 @@ public:
   }
 
 private:
-  // How a StableHLO update tensor lines up with the operand's dimensions.
-  struct OperandAlignedLayout {
-    // The update shape rewritten to the operand's rank: every window dimension
-    // sits at the operand dimension it writes to, the scatter-batch dimension
-    // (if any) sits at the scattered dimension, and the rest are 1.
-    llvm::SmallVector<int64_t> updateShape;
-    // The index tensor's shape rewritten to the operand's rank, each of its
-    // batch dimensions sitting at the operand dimension it varies.
-    llvm::SmallVector<int64_t> indexShape;
+  // Where each operand dimension draws its extent and its written position
+  // from: how a StableHLO scatter lines up with the operand's dimensions.
+  struct OperandDimSources {
+    static constexpr int64_t kNone = -1;
+
+    struct Source {
+      // Update dimension whose extent lands at this operand dimension, or kNone
+      // when the operand dimension gets extent 1.
+      int64_t updateDim = kNone;
+      // Index tensor dimension that varies the position written along this
+      // operand dimension, or kNone when that position does not vary.
+      int64_t indexDim = kNone;
+      // Window dimension a scatter-batch dimension took this slot from, or
+      // kNone. Only legal where that window is a single element wide.
+      int64_t displacedWindowDim = kNone;
+    };
+
+    // One entry per operand dimension.
+    llvm::SmallVector<Source> byOperandDim;
     // The operand dimension the indices address - the ttir.scatter `dim`.
     int64_t scatterDim = 0;
-    // Whether the update window runs along the scattered dimension, so that an
-    // index fixes only where the window starts.
-    bool scatterDimSpansWindow = false;
     // Whether the scatter indexes the operand at all.
     bool hasIndexValue = false;
+    // Update dimensions with nowhere to go: ttir.scatter tracks one scattered
+    // dimension, so at most one non-batching scatter-batch dimension fits.
+    llvm::SmallVector<int64_t> unplacedUpdateDims;
   };
+
+  // The update shape rewritten to the operand's rank: every mapped dimension's
+  // extent at the operand dimension it lands on, 1 everywhere else.
+  static llvm::SmallVector<int64_t>
+  alignUpdateShape(const OperandDimSources &sources,
+                   ArrayRef<int64_t> updateShape) {
+    return llvm::map_to_vector(
+        sources.byOperandDim,
+        [&](const OperandDimSources::Source &source) -> int64_t {
+          return source.updateDim == OperandDimSources::kNone
+                     ? 1
+                     : updateShape[source.updateDim];
+        });
+  }
+
+  // The index shape rewritten to the operand's rank: each of its batch
+  // dimensions at the operand dimension whose position it varies, 1 elsewhere.
+  static llvm::SmallVector<int64_t>
+  alignIndexShape(const OperandDimSources &sources,
+                  ArrayRef<int64_t> indexShape) {
+    return llvm::map_to_vector(
+        sources.byOperandDim,
+        [&](const OperandDimSources::Source &source) -> int64_t {
+          return source.indexDim == OperandDimSources::kNone
+                     ? 1
+                     : indexShape[source.indexDim];
+        });
+  }
 
   // Lowers a scatter that addresses at most one operand dimension onto
   // ttir.scatter, which is a torch-style scatter: for every coordinate `c` of
@@ -7076,7 +7114,6 @@ private:
   //
   // so the scattered dimension takes its position from `index` while every
   // other dimension is addressed positionally, by the source's own coordinate.
-  // OperandAlignedLayout works out how a StableHLO scatter lines up with that.
   LogicalResult
   convertToSingleDimScatter(mlir::stablehlo::ScatterOp srcOp,
                             mlir::stablehlo::ScatterOp::Adaptor adaptor,
@@ -7089,35 +7126,36 @@ private:
       return success();
     }
 
-    FailureOr<OperandAlignedLayout> layout =
-        computeOperandAlignedLayout(srcOp, rewriter);
-    if (failed(layout)) {
+    OperandDimSources sources = computeOperandDimSources(srcOp);
+    if (failed(checkAlignedScatterLegality(srcOp, sources, rewriter))) {
       return failure();
     }
 
     Value updates = srcOp.getUpdates()[0];
-    if (mlir::cast<RankedTensorType>(updates.getType()).getShape() !=
-        ArrayRef<int64_t>(layout->updateShape)) {
+    auto updateType = mlir::cast<RankedTensorType>(updates.getType());
+    llvm::SmallVector<int64_t> alignedUpdateShape =
+        alignUpdateShape(sources, updateType.getShape());
+    if (updateType.getShape() != ArrayRef<int64_t>(alignedUpdateShape)) {
       updates = ttir::utils::createReshapeOp(
           rewriter,
           ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_update_align"),
-          updates, layout->updateShape);
+          updates, alignedUpdateShape);
     }
 
-    Value indices = buildOperandAlignedIndices(srcOp, *layout, rewriter);
+    Value indices =
+        buildAlignedIndices(srcOp, sources, alignedUpdateShape, rewriter);
 
     rewriter.replaceOpWithNewOp<ttir::ScatterOp>(
         srcOp, outputType, srcOp.getInputs()[0], indices, updates,
-        rewriter.getI32IntegerAttr(layout->scatterDim),
+        rewriter.getI32IntegerAttr(sources.scatterDim),
         ttcore::ReduceTypeAttr::get(rewriter.getContext(), reduceType));
     return success();
   }
 
-  // Works out where each update dimension lands among the operand's
-  // dimensions, or reports why the scatter cannot be expressed that way.
-  FailureOr<OperandAlignedLayout>
-  computeOperandAlignedLayout(mlir::stablehlo::ScatterOp srcOp,
-                              ConversionPatternRewriter &rewriter) const {
+  // Fills in the table. What TTIR cannot express is recorded there rather than
+  // rejected here; checkAlignedScatterLegality reports it.
+  OperandDimSources
+  computeOperandDimSources(mlir::stablehlo::ScatterOp srcOp) const {
     auto dimensionNumbers = srcOp.getScatterDimensionNumbers();
     ArrayRef<int64_t> updateWindowDims = dimensionNumbers.getUpdateWindowDims();
     ArrayRef<int64_t> inputBatchingDims =
@@ -7128,13 +7166,14 @@ private:
         dimensionNumbers.getScatterDimsToOperandDims();
     int64_t indexVectorDim = dimensionNumbers.getIndexVectorDim();
 
-    ArrayRef<int64_t> updateShape =
-        mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType())
-            .getShape();
-    ArrayRef<int64_t> indexShape =
-        srcOp.getScatterIndices().getType().getShape();
     int64_t rank =
         mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType()).getRank();
+    int64_t updateRank =
+        mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType()).getRank();
+    int64_t indexRank = srcOp.getScatterIndices().getType().getRank();
+
+    OperandDimSources sources;
+    sources.byOperandDim.assign(rank, {});
 
     // The window spans every operand dimension that is not collapsed away.
     // Batching dimensions are collapsed too: like inserted ones they get no
@@ -7147,169 +7186,194 @@ private:
         llvm::filter_to_vector(llvm::seq<int64_t>(rank), [&](int64_t dim) {
           return !llvm::is_contained(collapsedDims, dim);
         });
-    if (windowOperandDims.size() != updateWindowDims.size()) {
-      return rewriter.notifyMatchFailure(
-          srcOp, "update_window_dims does not cover every operand dimension "
-                 "left by inserted_window_dims and input_batching_dims");
-    }
-
-    OperandAlignedLayout layout;
-    layout.updateShape.assign(rank, 1);
-    layout.indexShape.assign(rank, 1);
-
-    // Remember where each update dimension goes, to tell a reshape apart from a
-    // transpose further down.
-    llvm::SmallVector<int64_t> updateDimToOperandDim(updateShape.size(), -1);
+    TT_assertv(windowOperandDims.size() == updateWindowDims.size(),
+               "update_window_dims must cover every operand dimension left by "
+               "inserted_window_dims and input_batching_dims (guaranteed by "
+               "StableHLO scatter_c2)");
     for (auto [windowIndex, operandDim] : llvm::enumerate(windowOperandDims)) {
-      int64_t updateDim = updateWindowDims[windowIndex];
-      layout.updateShape[operandDim] = updateShape[updateDim];
-      updateDimToOperandDim[updateDim] = operandDim;
+      sources.byOperandDim[operandDim].updateDim =
+          updateWindowDims[windowIndex];
     }
 
-    // Whatever update dimensions are left are its scatter dimensions, matching
-    // one for one - and in order - the index tensor's dimensions other than
-    // index_vector_dim.
+    // With no scatter_dims_to_operand_dims no position is read from the index,
+    // so any dimension can carry the scatter; 0 will do.
+    sources.hasIndexValue = !scatterDimsToOperandDims.empty();
+    if (sources.hasIndexValue) {
+      sources.scatterDim = scatterDimsToOperandDims[0];
+    }
+
+    // Whatever update dimensions are not window dimensions are its scatter
+    // dimensions, matching one for one - and in order - the index tensor's
+    // dimensions other than index_vector_dim.
     llvm::SmallVector<int64_t> updateScatterDims = llvm::filter_to_vector(
-        llvm::seq<int64_t>(updateShape.size()), [&](int64_t dim) {
+        llvm::seq<int64_t>(updateRank), [&](int64_t dim) {
           return !llvm::is_contained(updateWindowDims, dim);
         });
-    llvm::SmallVector<int64_t> indexBatchDims = llvm::filter_to_vector(
-        llvm::seq<int64_t>(indexShape.size()),
-        [&](int64_t dim) { return dim != indexVectorDim; });
-    if (updateScatterDims.size() != indexBatchDims.size()) {
-      return rewriter.notifyMatchFailure(
-          srcOp, "the update's scatter dimensions do not match the index "
-                 "tensor's batch dimensions one for one");
-    }
-
-    // StableHLO ties the index vector's length to the number of scattered
-    // operand dimensions, so with at most one of those the vector holds a
-    // single component and index_vector_dim may sit anywhere.
-    if (indexVectorDim < static_cast<int64_t>(indexShape.size()) &&
-        indexShape[indexVectorDim] !=
-            static_cast<int64_t>(scatterDimsToOperandDims.size())) {
-      return rewriter.notifyMatchFailure(
-          srcOp, "the index vector's length does not match the number of "
-                 "scattered operand dimensions");
-    }
-
-    // With no scatter_dims_to_operand_dims nothing indexes the operand: there
-    // is no position to read and every window starts at the operand's origin.
-    // Any dimension can carry those constant positions, so 0 will do.
-    layout.hasIndexValue = !scatterDimsToOperandDims.empty();
-    if (layout.hasIndexValue) {
-      layout.scatterDim = scatterDimsToOperandDims[0];
-    }
+    llvm::SmallVector<int64_t> indexBatchDims =
+        llvm::filter_to_vector(llvm::seq<int64_t>(indexRank), [&](int64_t dim) {
+          return dim != indexVectorDim;
+        });
+    TT_assertv(updateScatterDims.size() == indexBatchDims.size(),
+               "the update's scatter dimensions must match the index tensor's "
+               "batch dimensions one for one (guaranteed by StableHLO "
+               "scatter_c4)");
 
     // Place each scatter dimension of the update at the operand dimension whose
     // position it varies. A batching dimension varies its own operand batching
     // dimension; anything else varies the scattered one, of which ttir.scatter
     // can only track one.
-    bool scatterDimCarriesBatch = false;
-    for (auto [scatterIndex, indexDim] : llvm::enumerate(indexBatchDims)) {
+    bool scatterDimTaken = false;
+    for (auto [updateDim, indexDim] :
+         llvm::zip_equal(updateScatterDims, indexBatchDims)) {
       int64_t operandDim;
       const auto *batching = llvm::find(scatterIndicesBatchingDims, indexDim);
       if (batching != scatterIndicesBatchingDims.end()) {
         operandDim =
             inputBatchingDims[batching - scatterIndicesBatchingDims.begin()];
-      } else if (layout.hasIndexValue && !scatterDimCarriesBatch) {
-        operandDim = layout.scatterDim;
-        scatterDimCarriesBatch = true;
+      } else if (sources.hasIndexValue && !scatterDimTaken) {
+        operandDim = sources.scatterDim;
+        scatterDimTaken = true;
       } else {
-        return rewriter.notifyMatchFailure(
-            srcOp, "TTIR scatter supports at most one non-batching "
-                   "scatter-batch dimension");
+        sources.unplacedUpdateDims.push_back(updateDim);
+        continue;
       }
 
-      if (layout.updateShape[operandDim] != 1) {
+      // The slot may already hold a window dimension: the scattered dimension
+      // can be spanned by the window and carry the batch of window starts at
+      // once. The batch takes the slot; the window it displaces then
+      // contributes no extent of its own.
+      OperandDimSources::Source &source = sources.byOperandDim[operandDim];
+      source.displacedWindowDim = source.updateDim;
+      source.updateDim = updateDim;
+      source.indexDim = indexDim;
+    }
+
+    return sources;
+  }
+
+  // Reports the scatters whose operand-aligned mapping TTIR cannot express.
+  LogicalResult
+  checkAlignedScatterLegality(mlir::stablehlo::ScatterOp srcOp,
+                              const OperandDimSources &sources,
+                              ConversionPatternRewriter &rewriter) const {
+    if (!sources.unplacedUpdateDims.empty()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "TTIR scatter supports at most one non-batching "
+                 "scatter-batch dimension");
+    }
+
+    ArrayRef<int64_t> updateShape =
+        mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType())
+            .getShape();
+    for (const OperandDimSources::Source &source : sources.byOperandDim) {
+      if (source.displacedWindowDim != OperandDimSources::kNone &&
+          updateShape[source.displacedWindowDim] != 1) {
         return rewriter.notifyMatchFailure(
             srcOp, "an operand dimension carries both a scatter-batch "
                    "dimension and a window wider than one element");
       }
-      int64_t updateDim = updateScatterDims[scatterIndex];
-      layout.updateShape[operandDim] = updateShape[updateDim];
-      layout.indexShape[operandDim] = indexShape[indexDim];
-      updateDimToOperandDim[updateDim] = operandDim;
     }
 
-    // The scattered dimension can be spanned by the window and carry the batch
-    // of window starts at once, but only if the window extent there is 1 - the
-    // check above rejects any wider overlap. There is then no offset within the
-    // window to account for, so it counts as not spanned.
-    layout.scatterDimSpansWindow =
-        !llvm::is_contained(collapsedDims, layout.scatterDim) &&
-        !scatterDimCarriesBatch;
-
-    // Only a reshape is emitted from this layout, which reproduces it just when
-    // the update's dimensions are in operand order already; anything else would
-    // need a transpose. Window and scatter dimensions together cover the
-    // update, so every entry has been mapped by now.
-    if (!llvm::is_sorted(updateDimToOperandDim)) {
+    // Only a reshape is emitted from this mapping, so the update's dimensions
+    // have to be in operand order already; anything else would need a
+    // transpose. Displaced window dimensions are left out: a reshape can move a
+    // single-element dimension anywhere without disturbing the element order.
+    llvm::SmallVector<int64_t> updateDimsInOperandOrder;
+    for (const OperandDimSources::Source &source : sources.byOperandDim) {
+      if (source.updateDim != OperandDimSources::kNone) {
+        updateDimsInOperandOrder.push_back(source.updateDim);
+      }
+    }
+    if (!llvm::is_sorted(updateDimsInOperandOrder)) {
       return rewriter.notifyMatchFailure(
           srcOp, "the update tensor's dimensions are not in operand order, "
                  "which would need a transpose");
     }
 
-    return layout;
+    // StableHLO ties the index vector's length to the number of scattered
+    // operand dimensions (scatter_c19), so with at most one of those the vector
+    // holds a single component and index_vector_dim may sit anywhere. Only a
+    // dynamic bound there can disagree, and the reshapes cannot honour one.
+    auto dimensionNumbers = srcOp.getScatterDimensionNumbers();
+    ArrayRef<int64_t> indexShape =
+        srcOp.getScatterIndices().getType().getShape();
+    int64_t indexVectorDim = dimensionNumbers.getIndexVectorDim();
+    if (indexVectorDim < static_cast<int64_t>(indexShape.size()) &&
+        indexShape[indexVectorDim] !=
+            static_cast<int64_t>(
+                dimensionNumbers.getScatterDimsToOperandDims().size())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "the index vector's length does not match the number of "
+                 "scattered operand dimensions");
+    }
+
+    return success();
   }
 
   // Builds the ttir.scatter index tensor: operand-aligned, shaped like the
   // rewritten update tensor, holding for each element the position it is
   // written to along the scattered dimension.
-  Value buildOperandAlignedIndices(mlir::stablehlo::ScatterOp srcOp,
-                                   const OperandAlignedLayout &layout,
-                                   ConversionPatternRewriter &rewriter) const {
+  Value buildAlignedIndices(mlir::stablehlo::ScatterOp srcOp,
+                            const OperandDimSources &sources,
+                            ArrayRef<int64_t> alignedUpdateShape,
+                            ConversionPatternRewriter &rewriter) const {
     TypedValue<RankedTensorType> indices = srcOp.getScatterIndices();
     RankedTensorType indicesType = indices.getType();
     RankedTensorType targetType =
-        RankedTensorType::get(layout.updateShape, indicesType.getElementType(),
+        RankedTensorType::get(alignedUpdateShape, indicesType.getElementType(),
                               indicesType.getEncoding());
+
+    // Each element's own coordinate along the scattered dimension. Degenerates
+    // to a constant 0 where that dimension has extent 1.
+    auto buildCoordinateIota = [&] {
+      return rewriter.create<ttir::ArangeOp>(
+          srcOp.getLoc(), targetType, /*start=*/0,
+          /*end=*/alignedUpdateShape[sources.scatterDim],
+          /*step=*/1, /*arange_dimension=*/sources.scatterDim);
+    };
+
+    // Without an index value every position is the element's own coordinate:
+    // the window's origin, or the batch's coordinate where the scattered
+    // dimension turns out to be a batching one.
+    if (!sources.hasIndexValue) {
+      return buildCoordinateIota();
+    }
 
     // Where each window starts along the scattered dimension. There is one
     // index value per window, so it only varies along the dimensions carrying
     // the scatter batch and has to be stretched over the window - every element
     // of a window is written relative to the position its index picked out.
-    Value windowStart;
-    if (layout.hasIndexValue) {
-      windowStart = indices;
-      if (indicesType.getShape() != ArrayRef<int64_t>(layout.indexShape)) {
-        windowStart = ttir::utils::createReshapeOp(
-            rewriter,
-            ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_index_align"),
-            indices, layout.indexShape);
+    llvm::SmallVector<int64_t> startShape =
+        alignIndexShape(sources, indicesType.getShape());
+    Value windowStart = indices;
+    if (indicesType.getShape() != ArrayRef<int64_t>(startShape)) {
+      windowStart = ttir::utils::createReshapeOp(
+          rewriter,
+          ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_index_align"),
+          indices, startShape);
+    }
+    if (ArrayRef<int64_t>(startShape) != alignedUpdateShape) {
+      llvm::SmallVector<int64_t> repeatDims;
+      for (auto [startSize, windowSize] :
+           llvm::zip_equal(startShape, alignedUpdateShape)) {
+        repeatDims.push_back(startSize == windowSize ? 1 : windowSize);
       }
-      if (layout.indexShape != layout.updateShape) {
-        llvm::SmallVector<int64_t> repeatDims;
-        for (auto [startSize, windowSize] :
-             llvm::zip_equal(layout.indexShape, layout.updateShape)) {
-          repeatDims.push_back(startSize == windowSize ? 1 : windowSize);
-        }
-        windowStart = rewriter.create<ttir::RepeatOp>(
-            srcOp.getLoc(), targetType, windowStart,
-            rewriter.getDenseI64ArrayAttr(repeatDims));
-      }
-
-      if (!layout.scatterDimSpansWindow) {
-        return windowStart;
-      }
+      windowStart = rewriter.create<ttir::RepeatOp>(
+          srcOp.getLoc(), targetType, windowStart,
+          rewriter.getDenseI64ArrayAttr(repeatDims));
     }
 
-    // An index only says where a window starts. When the window spans the
-    // scattered dimension, each of its elements lands at its own offset from
-    // that start, so the within-window position has to be added on.
-    //
-    // With no index at all the start is the origin, and this iota is the whole
-    // answer - degenerating to a constant 0 when the scattered dimension has
-    // extent 1.
-    Value withinWindow = rewriter.create<ttir::ArangeOp>(
-        srcOp.getLoc(), targetType, /*start=*/0,
-        /*end=*/layout.updateShape[layout.scatterDim],
-        /*step=*/1, /*arange_dimension=*/layout.scatterDim);
-    if (!windowStart) {
-      return withinWindow;
+    // An index only fixes where a window starts, so a within-window offset is
+    // needed exactly when the update dimension sitting at the scattered
+    // dimension is a window dimension - where the scatter batch took that slot,
+    // or nothing did, the window contributes no offset of its own.
+    if (!llvm::is_contained(
+            srcOp.getScatterDimensionNumbers().getUpdateWindowDims(),
+            sources.byOperandDim[sources.scatterDim].updateDim)) {
+      return windowStart;
     }
     return rewriter.create<ttir::AddOp>(srcOp.getLoc(), targetType, windowStart,
-                                        withinWindow);
+                                        buildCoordinateIota());
   }
 
   // Folds away a scatter that overwrites the operand in its entirety, which
@@ -7317,9 +7381,8 @@ private:
   // emits this for an update whose index array turned out to be statically
   // empty (the index operand is then a `tensor<0x...>`).
   //
-  // This is an optimization, not a legality check: anything it does not
-  // recognize is left to the general lowering, so it reports plain failure
-  // without a diagnostic and without touching the IR.
+  // An optimization, not a legality check: what it does not recognize is left
+  // to the general lowering, so it fails plainly, without a diagnostic.
   LogicalResult foldFullOverwrite(mlir::stablehlo::ScatterOp srcOp,
                                   mlir::stablehlo::ScatterOp::Adaptor adaptor,
                                   ttcore::ReduceType reduceType,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -7003,61 +7003,50 @@ public:
                  "arguments nor returns the update value");
     }
 
-    Value inputTensor = srcOp.getInputs()[0];
-    Value updateTensor = srcOp.getUpdates()[0];
-    auto scatterDimsToOperandDims =
-        adaptor.getScatterDimensionNumbers().getScatterDimsToOperandDims();
-    RankedTensorType inputType =
-        mlir::cast<RankedTensorType>(inputTensor.getType());
-    ArrayRef<int64_t> inputShape = inputType.getShape();
     RankedTensorType outputType = mlir::cast<RankedTensorType>(
         this->getTypeConverter()->convertType(srcOp.getResults()[0].getType()));
-    RankedTensorType updateType =
-        mlir::cast<RankedTensorType>(updateTensor.getType());
-    ArrayRef<int64_t> updateShape = updateType.getShape();
 
     // A scatter that writes along at most one operand dimension is exactly what
     // ttir.scatter expresses, including the degenerate case of writing along
     // none of them.
+    ArrayRef<int64_t> scatterDimsToOperandDims =
+        adaptor.getScatterDimensionNumbers().getScatterDimsToOperandDims();
     if (scatterDimsToOperandDims.size() <= 1) {
       return convertToSingleDimScatter(srcOp, adaptor, *scatterReduceType,
                                        outputType, rewriter);
     }
 
-    // Multi-dimensional scatter.
-    if (scatterDimsToOperandDims.size() > 1) {
-      // Always scatter along dimension 0 for flattened tensors.
-      constexpr int32_t SCATTER_DIMENSION = 0;
+    // Multi-dimensional scatter: flatten everything to 1D and scatter scalars
+    // along dimension 0.
+    constexpr int32_t SCATTER_DIMENSION = 0;
+    Value inputTensor = srcOp.getInputs()[0];
+    Value updateTensor = srcOp.getUpdates()[0];
+    ArrayRef<int64_t> inputShape =
+        mlir::cast<RankedTensorType>(inputTensor.getType()).getShape();
+    ArrayRef<int64_t> updateShape =
+        mlir::cast<RankedTensorType>(updateTensor.getType()).getShape();
 
-      // Scatter indices, input, and update tensors flattened to 1D.
-      Value flattenedIndices = flattenMultiDimScatterIndices(
-          srcOp, inputShape, updateShape, rewriter);
-      Value flattenedInput = ttir::utils::flattenTensor(
-          rewriter, srcOp.getLoc(), inputTensor, "_input_flatten");
-      Value flattenedUpdate = ttir::utils::flattenTensor(
-          rewriter, srcOp.getLoc(), updateTensor, "_update_flatten");
+    Value flattenedIndices =
+        flattenMultiDimScatterIndices(srcOp, inputShape, updateShape, rewriter);
+    Value flattenedInput = ttir::utils::flattenTensor(
+        rewriter, srcOp.getLoc(), inputTensor, "_input_flatten");
+    Value flattenedUpdate = ttir::utils::flattenTensor(
+        rewriter, srcOp.getLoc(), updateTensor, "_update_flatten");
 
-      // Scatter scalars on flattened tensors.
-      Value scatterResult = rewriter.create<ttir::ScatterOp>(
-          srcOp.getLoc(),
-          mlir::cast<RankedTensorType>(flattenedInput.getType()),
-          flattenedInput, flattenedIndices, flattenedUpdate,
-          rewriter.getI32IntegerAttr(SCATTER_DIMENSION),
-          ttcore::ReduceTypeAttr::get(rewriter.getContext(),
-                                      *scatterReduceType));
+    Value scatterResult = rewriter.create<ttir::ScatterOp>(
+        srcOp.getLoc(), mlir::cast<RankedTensorType>(flattenedInput.getType()),
+        flattenedInput, flattenedIndices, flattenedUpdate,
+        rewriter.getI32IntegerAttr(SCATTER_DIMENSION),
+        ttcore::ReduceTypeAttr::get(rewriter.getContext(), *scatterReduceType));
 
-      // Reshape result back to original input shape.
-      Value reshapedResult =
-          ttir::utils::createReshapeOp(rewriter,
-                                       ttmlir::utils::appendLocationSuffix(
-                                           srcOp.getLoc(), "_result_reshape"),
-                                       scatterResult, inputShape);
+    // Reshape result back to original input shape.
+    Value reshapedResult = ttir::utils::createReshapeOp(
+        rewriter,
+        ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_result_reshape"),
+        scatterResult, inputShape);
 
-      rewriter.replaceOp(srcOp, reshapedResult);
-      return success();
-    }
-
-    return failure();
+    rewriter.replaceOp(srcOp, reshapedResult);
+    return success();
   }
 
 private:
@@ -7067,22 +7056,16 @@ private:
     // sits at the operand dimension it writes to, the scatter-batch dimension
     // (if any) sits at the scattered dimension, and the rest are 1.
     llvm::SmallVector<int64_t> updateShape;
-    // The operand dimension the indices address - the ttir.scatter `dim`.
-    int64_t scatterDim = 0;
-    // Whether the scattered dimension is spanned by the update window. If it
-    // is, an index only fixes where the window starts and the position of each
-    // element within the window still has to be added on.
-    bool scatterDimIsWindow = false;
-    // Whether the scattered dimension carries the scatter-batch dimension, i.e.
-    // whether there is more than one window to write.
-    bool scatterDimCarriesBatch = false;
-    // Whether the scatter indexes the operand at all. With no
-    // scatter_dims_to_operand_dims there is nothing to read a position from and
-    // every window starts at the operand's origin.
-    bool hasIndexValue = false;
     // The index tensor's shape rewritten to the operand's rank, each of its
     // batch dimensions sitting at the operand dimension it varies.
     llvm::SmallVector<int64_t> indexShape;
+    // The operand dimension the indices address - the ttir.scatter `dim`.
+    int64_t scatterDim = 0;
+    // Whether the update window runs along the scattered dimension, so that an
+    // index fixes only where the window starts.
+    bool scatterDimSpansWindow = false;
+    // Whether the scatter indexes the operand at all.
+    bool hasIndexValue = false;
   };
 
   // Lowers a scatter that addresses at most one operand dimension onto
@@ -7093,9 +7076,7 @@ private:
   //
   // so the scattered dimension takes its position from `index` while every
   // other dimension is addressed positionally, by the source's own coordinate.
-  // Lining StableHLO up with that means giving the update and index tensors the
-  // operand's rank, with each update window dimension placed at the operand
-  // dimension it writes to.
+  // OperandAlignedLayout works out how a StableHLO scatter lines up with that.
   LogicalResult
   convertToSingleDimScatter(mlir::stablehlo::ScatterOp srcOp,
                             mlir::stablehlo::ScatterOp::Adaptor adaptor,
@@ -7103,23 +7084,20 @@ private:
                             RankedTensorType outputType,
                             ConversionPatternRewriter &rewriter) const {
     // An overwrite of the entire operand needs no scatter at all.
-    if (adaptor.getScatterDimensionNumbers()
-            .getScatterDimsToOperandDims()
-            .empty() &&
-        succeeded(foldFullOverwrite(srcOp, adaptor, reduceType, outputType,
+    if (succeeded(foldFullOverwrite(srcOp, adaptor, reduceType, outputType,
                                     rewriter))) {
       return success();
     }
 
     FailureOr<OperandAlignedLayout> layout =
-        computeOperandAlignedLayout(srcOp, adaptor, rewriter);
+        computeOperandAlignedLayout(srcOp, rewriter);
     if (failed(layout)) {
       return failure();
     }
 
     Value updates = srcOp.getUpdates()[0];
-    auto updateType = mlir::cast<RankedTensorType>(updates.getType());
-    if (updateType.getShape() != ArrayRef<int64_t>(layout->updateShape)) {
+    if (mlir::cast<RankedTensorType>(updates.getType()).getShape() !=
+        ArrayRef<int64_t>(layout->updateShape)) {
       updates = ttir::utils::createReshapeOp(
           rewriter,
           ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_update_align"),
@@ -7139,12 +7117,9 @@ private:
   // dimensions, or reports why the scatter cannot be expressed that way.
   FailureOr<OperandAlignedLayout>
   computeOperandAlignedLayout(mlir::stablehlo::ScatterOp srcOp,
-                              mlir::stablehlo::ScatterOp::Adaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
-    auto dimensionNumbers = adaptor.getScatterDimensionNumbers();
+    auto dimensionNumbers = srcOp.getScatterDimensionNumbers();
     ArrayRef<int64_t> updateWindowDims = dimensionNumbers.getUpdateWindowDims();
-    ArrayRef<int64_t> insertedWindowDims =
-        dimensionNumbers.getInsertedWindowDims();
     ArrayRef<int64_t> inputBatchingDims =
         dimensionNumbers.getInputBatchingDims();
     ArrayRef<int64_t> scatterIndicesBatchingDims =
@@ -7153,36 +7128,34 @@ private:
         dimensionNumbers.getScatterDimsToOperandDims();
     int64_t indexVectorDim = dimensionNumbers.getIndexVectorDim();
 
-    auto inputType =
-        mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType());
     ArrayRef<int64_t> updateShape =
         mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType())
             .getShape();
     ArrayRef<int64_t> indexShape =
         srcOp.getScatterIndices().getType().getShape();
-    int64_t rank = inputType.getRank();
-
-    OperandAlignedLayout layout;
-    layout.updateShape.assign(rank, 1);
+    int64_t rank =
+        mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType()).getRank();
 
     // The window spans every operand dimension that is not collapsed away.
     // Batching dimensions are collapsed too: like inserted ones they get no
     // window extent, and the position along them is implied by the batch rather
     // than read out of the index vector.
-    llvm::DenseSet<int64_t> collapsedDims(insertedWindowDims.begin(),
-                                          insertedWindowDims.end());
-    collapsedDims.insert(inputBatchingDims.begin(), inputBatchingDims.end());
-    llvm::SmallVector<int64_t> windowOperandDims;
-    for (int64_t dim = 0; dim < rank; ++dim) {
-      if (!collapsedDims.contains(dim)) {
-        windowOperandDims.push_back(dim);
-      }
-    }
+    llvm::SmallVector<int64_t> collapsedDims(
+        dimensionNumbers.getInsertedWindowDims());
+    llvm::append_range(collapsedDims, inputBatchingDims);
+    llvm::SmallVector<int64_t> windowOperandDims =
+        llvm::filter_to_vector(llvm::seq<int64_t>(rank), [&](int64_t dim) {
+          return !llvm::is_contained(collapsedDims, dim);
+        });
     if (windowOperandDims.size() != updateWindowDims.size()) {
       return rewriter.notifyMatchFailure(
           srcOp, "update_window_dims does not cover every operand dimension "
                  "left by inserted_window_dims and input_batching_dims");
     }
+
+    OperandAlignedLayout layout;
+    layout.updateShape.assign(rank, 1);
+    layout.indexShape.assign(rank, 1);
 
     // Remember where each update dimension goes, to tell a reshape apart from a
     // transpose further down.
@@ -7196,24 +7169,13 @@ private:
     // Whatever update dimensions are left are its scatter dimensions, matching
     // one for one - and in order - the index tensor's dimensions other than
     // index_vector_dim.
-    llvm::DenseSet<int64_t> windowUpdateDims(updateWindowDims.begin(),
-                                             updateWindowDims.end());
-    llvm::SmallVector<int64_t> updateScatterDims;
-    for (int64_t dim = 0; dim < static_cast<int64_t>(updateShape.size());
-         ++dim) {
-      if (!windowUpdateDims.contains(dim)) {
-        updateScatterDims.push_back(dim);
-      }
-    }
-
-    // The index tensor's dimensions other than index_vector_dim, in order.
-    llvm::SmallVector<int64_t> indexBatchDims;
-    for (int64_t dim = 0; dim < static_cast<int64_t>(indexShape.size());
-         ++dim) {
-      if (dim != indexVectorDim) {
-        indexBatchDims.push_back(dim);
-      }
-    }
+    llvm::SmallVector<int64_t> updateScatterDims = llvm::filter_to_vector(
+        llvm::seq<int64_t>(updateShape.size()), [&](int64_t dim) {
+          return !llvm::is_contained(updateWindowDims, dim);
+        });
+    llvm::SmallVector<int64_t> indexBatchDims = llvm::filter_to_vector(
+        llvm::seq<int64_t>(indexShape.size()),
+        [&](int64_t dim) { return dim != indexVectorDim; });
     if (updateScatterDims.size() != indexBatchDims.size()) {
       return rewriter.notifyMatchFailure(
           srcOp, "the update's scatter dimensions do not match the index "
@@ -7224,36 +7186,35 @@ private:
     // operand dimensions, so with at most one of those the vector holds a
     // single component and index_vector_dim may sit anywhere.
     if (indexVectorDim < static_cast<int64_t>(indexShape.size()) &&
-        indexShape[indexVectorDim] != static_cast<int64_t>(
-                                          scatterDimsToOperandDims.size())) {
+        indexShape[indexVectorDim] !=
+            static_cast<int64_t>(scatterDimsToOperandDims.size())) {
       return rewriter.notifyMatchFailure(
           srcOp, "the index vector's length does not match the number of "
                  "scattered operand dimensions");
     }
 
-    if (!scatterDimsToOperandDims.empty()) {
-      layout.hasIndexValue = true;
+    // With no scatter_dims_to_operand_dims nothing indexes the operand: there
+    // is no position to read and every window starts at the operand's origin.
+    // Any dimension can carry those constant positions, so 0 will do.
+    layout.hasIndexValue = !scatterDimsToOperandDims.empty();
+    if (layout.hasIndexValue) {
       layout.scatterDim = scatterDimsToOperandDims[0];
-    } else {
-      // Nothing indexes the operand, so every window starts at its origin. Any
-      // dimension can carry those constant positions; dimension 0 will do.
-      layout.scatterDim = 0;
     }
 
     // Place each scatter dimension of the update at the operand dimension whose
     // position it varies. A batching dimension varies its own operand batching
     // dimension; anything else varies the scattered one, of which ttir.scatter
     // can only track one.
-    layout.indexShape.assign(rank, 1);
+    bool scatterDimCarriesBatch = false;
     for (auto [scatterIndex, indexDim] : llvm::enumerate(indexBatchDims)) {
       int64_t operandDim;
-      auto *batching = llvm::find(scatterIndicesBatchingDims, indexDim);
+      const auto *batching = llvm::find(scatterIndicesBatchingDims, indexDim);
       if (batching != scatterIndicesBatchingDims.end()) {
         operandDim =
             inputBatchingDims[batching - scatterIndicesBatchingDims.begin()];
-      } else if (layout.hasIndexValue && !layout.scatterDimCarriesBatch) {
+      } else if (layout.hasIndexValue && !scatterDimCarriesBatch) {
         operandDim = layout.scatterDim;
-        layout.scatterDimCarriesBatch = true;
+        scatterDimCarriesBatch = true;
       } else {
         return rewriter.notifyMatchFailure(
             srcOp, "TTIR scatter supports at most one non-batching "
@@ -7262,8 +7223,8 @@ private:
 
       if (layout.updateShape[operandDim] != 1) {
         return rewriter.notifyMatchFailure(
-            srcOp, "an operand dimension carries both a window and a "
-                   "scatter-batch dimension");
+            srcOp, "an operand dimension carries both a scatter-batch "
+                   "dimension and a window wider than one element");
       }
       int64_t updateDim = updateScatterDims[scatterIndex];
       layout.updateShape[operandDim] = updateShape[updateDim];
@@ -7271,21 +7232,22 @@ private:
       updateDimToOperandDim[updateDim] = operandDim;
     }
 
-    layout.scatterDimIsWindow = !collapsedDims.contains(layout.scatterDim);
+    // The scattered dimension can be spanned by the window and carry the batch
+    // of window starts at once, but only if the window extent there is 1 - the
+    // check above rejects any wider overlap. There is then no offset within the
+    // window to account for, so it counts as not spanned.
+    layout.scatterDimSpansWindow =
+        !llvm::is_contained(collapsedDims, layout.scatterDim) &&
+        !scatterDimCarriesBatch;
 
-    // Only a reshape is emitted below, which reproduces the operand-aligned
-    // layout only when the update's dimensions are already in operand order.
-    int64_t previousOperandDim = -1;
-    for (int64_t operandDim : updateDimToOperandDim) {
-      if (operandDim < 0) {
-        continue;
-      }
-      if (operandDim < previousOperandDim) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "the update tensor's dimensions are not in operand order, "
-                   "which would need a transpose");
-      }
-      previousOperandDim = operandDim;
+    // Only a reshape is emitted from this layout, which reproduces it just when
+    // the update's dimensions are in operand order already; anything else would
+    // need a transpose. Window and scatter dimensions together cover the
+    // update, so every entry has been mapped by now.
+    if (!llvm::is_sorted(updateDimToOperandDim)) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "the update tensor's dimensions are not in operand order, "
+                 "which would need a transpose");
     }
 
     return layout;
@@ -7299,39 +7261,36 @@ private:
                                    ConversionPatternRewriter &rewriter) const {
     TypedValue<RankedTensorType> indices = srcOp.getScatterIndices();
     RankedTensorType indicesType = indices.getType();
-    RankedTensorType targetType = RankedTensorType::get(
-        layout.updateShape, indicesType.getElementType(),
-        indicesType.getEncoding());
+    RankedTensorType targetType =
+        RankedTensorType::get(layout.updateShape, indicesType.getElementType(),
+                              indicesType.getEncoding());
 
-    // Where each window starts along the scattered dimension.
+    // Where each window starts along the scattered dimension. There is one
+    // index value per window, so it only varies along the dimensions carrying
+    // the scatter batch and has to be stretched over the window - every element
+    // of a window is written relative to the position its index picked out.
     Value windowStart;
     if (layout.hasIndexValue) {
-      // One index value per window, so the index only varies along the
-      // dimensions carrying the scatter batch.
-      ArrayRef<int64_t> alignedShape = layout.indexShape;
-
       windowStart = indices;
-      if (indicesType.getShape() != alignedShape) {
+      if (indicesType.getShape() != ArrayRef<int64_t>(layout.indexShape)) {
         windowStart = ttir::utils::createReshapeOp(
             rewriter,
             ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_index_align"),
-            indices, alignedShape);
+            indices, layout.indexShape);
       }
-
-      // Stretch it over the window, so every element of a window is written
-      // relative to the position that window's index picked out.
-      llvm::SmallVector<int64_t> repeatDims(layout.updateShape.size(), 1);
-      bool needsRepeat = false;
-      for (auto [dim, size] : llvm::enumerate(layout.updateShape)) {
-        if (alignedShape[dim] != size) {
-          repeatDims[dim] = size;
-          needsRepeat = true;
+      if (layout.indexShape != layout.updateShape) {
+        llvm::SmallVector<int64_t> repeatDims;
+        for (auto [startSize, windowSize] :
+             llvm::zip_equal(layout.indexShape, layout.updateShape)) {
+          repeatDims.push_back(startSize == windowSize ? 1 : windowSize);
         }
-      }
-      if (needsRepeat) {
         windowStart = rewriter.create<ttir::RepeatOp>(
             srcOp.getLoc(), targetType, windowStart,
             rewriter.getDenseI64ArrayAttr(repeatDims));
+      }
+
+      if (!layout.scatterDimSpansWindow) {
+        return windowStart;
       }
     }
 
@@ -7342,10 +7301,6 @@ private:
     // With no index at all the start is the origin, and this iota is the whole
     // answer - degenerating to a constant 0 when the scattered dimension has
     // extent 1.
-    if (!layout.scatterDimIsWindow && windowStart) {
-      return windowStart;
-    }
-
     Value withinWindow = rewriter.create<ttir::ArangeOp>(
         srcOp.getLoc(), targetType, /*start=*/0,
         /*end=*/layout.updateShape[layout.scatterDim],
@@ -7358,13 +7313,9 @@ private:
   }
 
   // Folds away a scatter that overwrites the operand in its entirety, which
-  // needs no scatter op at all - the result is just the update tensor.
-  //
-  // Only reachable when `scatter_dims_to_operand_dims` is empty, so every
-  // window starts at the operand's origin; it then covers the whole operand
-  // exactly when the shapes match. JAX emits this for an update whose index
-  // array turned out to be statically empty (the index operand is then a
-  // `tensor<0x...>`).
+  // needs no scatter op at all - the result is just the update tensor. JAX
+  // emits this for an update whose index array turned out to be statically
+  // empty (the index operand is then a `tensor<0x...>`).
   //
   // This is an optimization, not a legality check: anything it does not
   // recognize is left to the general lowering, so it reports plain failure
@@ -7374,39 +7325,25 @@ private:
                                   ttcore::ReduceType reduceType,
                                   RankedTensorType outputType,
                                   ConversionPatternRewriter &rewriter) const {
-    if (srcOp.getInputs().size() != 1 || srcOp.getUpdates().size() != 1) {
-      return failure();
-    }
-
     auto dimensionNumbers = adaptor.getScatterDimensionNumbers();
-    if (!dimensionNumbers.getInsertedWindowDims().empty() ||
-        !dimensionNumbers.getInputBatchingDims().empty()) {
-      return failure();
-    }
-
-    auto inputType =
-        mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType());
     auto updateType =
         mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType());
 
-    // Every update dimension must be a window dimension mapped onto the operand
-    // dimensions in order; a leftover one would be a scatter-batch dimension,
-    // i.e. more than one window to write.
-    ArrayRef<int64_t> updateWindowDims = dimensionNumbers.getUpdateWindowDims();
-    bool isSingleIdentityWindow =
-        updateWindowDims.size() == static_cast<size_t>(updateType.getRank());
-    for (auto [index, dim] : llvm::enumerate(updateWindowDims)) {
-      isSingleIdentityWindow &= dim == static_cast<int64_t>(index);
-    }
-    if (!isSingleIdentityWindow ||
-        updateType.getShape() != inputType.getShape()) {
-      return failure();
-    }
-
-    // Anything that combines the operand with the update has to keep the
-    // operand around, so it cannot fold away. matchAndRewrite has already
-    // established that ReduceType::Invalid here means an overwrite.
-    if (reduceType != ttcore::ReduceType::Invalid) {
+    // With no scatter_dims_to_operand_dims the single window starts at the
+    // operand's origin, and it then covers the whole operand exactly when every
+    // update dimension is a window dimension mapped onto an operand dimension
+    // of the same size, in order. A combining update computation would have to
+    // keep the operand around, so it cannot fold either - matchAndRewrite has
+    // established that ReduceType::Invalid here means a plain overwrite.
+    if (!dimensionNumbers.getScatterDimsToOperandDims().empty() ||
+        !dimensionNumbers.getInsertedWindowDims().empty() ||
+        !dimensionNumbers.getInputBatchingDims().empty() ||
+        !llvm::equal(dimensionNumbers.getUpdateWindowDims(),
+                     llvm::seq<int64_t>(updateType.getRank())) ||
+        updateType.getShape() !=
+            mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType())
+                .getShape() ||
+        reduceType != ttcore::ReduceType::Invalid) {
       return failure();
     }
 
@@ -7437,43 +7374,40 @@ private:
   LogicalResult checkBasicLegality(mlir::stablehlo::ScatterOp &op,
                                    mlir::stablehlo::ScatterOp::Adaptor adaptor,
                                    ConversionPatternRewriter &rewriter) const {
-    ArrayRef<int64_t> insertedWindowDims =
-        adaptor.getScatterDimensionNumbers().getInsertedWindowDims();
+    // Both lowerings read the first input and update and produce one result.
+    if (op.getInputs().size() != 1 || op.getUpdates().size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "TTIR scatter does not support scattering several tensors at "
+              "once");
+    }
 
-    // Get index tensor shape.
-    RankedTensorType indexType = op.getScatterIndices().getType();
-    ArrayRef<int64_t> indexShape = indexType.getShape();
-
-    // Check that scatter_dims_to_operand_dims is in order.
+    auto dimensionNumbers = adaptor.getScatterDimensionNumbers();
     ArrayRef<int64_t> scatterDimsToOperandDims =
-        adaptor.getScatterDimensionNumbers().getScatterDimsToOperandDims();
+        dimensionNumbers.getScatterDimsToOperandDims();
     if (!llvm::is_sorted(scatterDimsToOperandDims)) {
       return rewriter.notifyMatchFailure(
           op,
           "scatter_dims_to_operand_dims must be in strictly increasing order.");
     }
 
-    bool multiDimensionalScatter = scatterDimsToOperandDims.size() > 1;
-    uint32_t indexVectorDim =
-        adaptor.getScatterDimensionNumbers().getIndexVectorDim();
+    // Scatters along at most one operand dimension are checked by
+    // computeOperandAlignedLayout instead, which has to work the mapping out in
+    // full anyway. Everything below is specific to the multi-dimensional path.
+    if (scatterDimsToOperandDims.size() <= 1) {
+      return success();
+    }
 
-    // Checks that apply to multi dimensional scatter.
-
-    // Batching dimensions are handled by computeOperandAlignedLayout, which
-    // only covers scatters along at most one dimension; the flattening the
-    // multi-dimensional path does takes no account of them.
-    if (multiDimensionalScatter &&
-        (!adaptor.getScatterDimensionNumbers().getInputBatchingDims().empty() ||
-         !adaptor.getScatterDimensionNumbers()
-              .getScatterIndicesBatchingDims()
-              .empty())) {
+    // That path flattens the operand, which takes no account of batching
+    // dimensions.
+    if (!dimensionNumbers.getInputBatchingDims().empty() ||
+        !dimensionNumbers.getScatterIndicesBatchingDims().empty()) {
       return rewriter.notifyMatchFailure(
           op, "TTIR multi-dimensional scatter does not support batching "
               "dimensions");
     }
 
-    if (multiDimensionalScatter &&
-        indexVectorDim != static_cast<uint32_t>(indexShape.size() - 1)) {
+    int64_t indexRank = op.getScatterIndices().getType().getRank();
+    if (dimensionNumbers.getIndexVectorDim() != indexRank - 1) {
       return rewriter.notifyMatchFailure(
           op, "TTIR multi-dimensional scatter currently only supports "
               "index_vector_dim being the last dimension");
@@ -7481,24 +7415,14 @@ private:
 
     // Check that scatter_dims_to_operand_dims is a superset of
     // inserted_window_dims.
-    if (multiDimensionalScatter) {
-      llvm::DenseSet<int64_t> scatterDimsSet(scatterDimsToOperandDims.begin(),
-                                             scatterDimsToOperandDims.end());
-      for (int64_t dim : insertedWindowDims) {
-        if (!scatterDimsSet.contains(dim)) {
-          return rewriter.notifyMatchFailure(
-              op, "TTIR multi-dimensional scatter requires every "
-                  "inserted_window_dim to also be in "
-                  "scatter_dims_to_operand_dims");
-        }
+    for (int64_t dim : dimensionNumbers.getInsertedWindowDims()) {
+      if (!llvm::is_contained(scatterDimsToOperandDims, dim)) {
+        return rewriter.notifyMatchFailure(
+            op, "TTIR multi-dimensional scatter requires every "
+                "inserted_window_dim to also be in "
+                "scatter_dims_to_operand_dims");
       }
     }
-
-    // Scatters along at most one operand dimension are checked by
-    // computeOperandAlignedLayout instead, which has to work the mapping out in
-    // full anyway. It places no constraint on index_vector_dim: with a single
-    // scattered dimension the index vector holds one component, so the
-    // dimension it lives in may sit anywhere in the index tensor.
 
     return success();
   }

--- a/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOToTTIRPatterns.cpp
@@ -6991,6 +6991,18 @@ public:
           srcOp, "ScatterOp cannot specify reduce type.");
     }
 
+    // ReduceType::Invalid only records that the update computation does no
+    // arithmetic - it does not say which of the two arguments comes back out.
+    // `(operand, update) -> update` overwrites, which is what every lowering
+    // below assumes, but `(operand, update) -> operand` keeps the original
+    // value and would be silently turned into an overwrite.
+    if (*scatterReduceType == ttcore::ReduceType::Invalid &&
+        !returnsUpdateValue(srcOp.getUpdateComputation())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "the scatter's update computation neither combines its "
+                 "arguments nor returns the update value");
+    }
+
     Value inputTensor = srcOp.getInputs()[0];
     Value updateTensor = srcOp.getUpdates()[0];
     auto scatterDimsToOperandDims =
@@ -7004,20 +7016,12 @@ public:
         mlir::cast<RankedTensorType>(updateTensor.getType());
     ArrayRef<int64_t> updateShape = updateType.getShape();
 
-    // Single-dimensional scatter.
-    if (scatterDimsToOperandDims.size() == 1) {
-      // Process indices to match update tensor shape.
-      int32_t dim = scatterDimsToOperandDims[0];
-      Value finalIndexTensor =
-          extractElementWiseScatterIndices(srcOp, rewriter);
-
-      // Create ScatterOp.
-      rewriter.replaceOpWithNewOp<ttir::ScatterOp>(
-          srcOp, outputType, inputTensor, finalIndexTensor, updateTensor,
-          rewriter.getI32IntegerAttr(dim),
-          ttcore::ReduceTypeAttr::get(rewriter.getContext(),
-                                      *scatterReduceType));
-      return success();
+    // A scatter that writes along at most one operand dimension is exactly what
+    // ttir.scatter expresses, including the degenerate case of writing along
+    // none of them.
+    if (scatterDimsToOperandDims.size() <= 1) {
+      return convertToSingleDimScatter(srcOp, adaptor, *scatterReduceType,
+                                       outputType, rewriter);
     }
 
     // Multi-dimensional scatter.
@@ -7057,24 +7061,384 @@ public:
   }
 
 private:
+  // How a StableHLO update tensor lines up with the operand's dimensions.
+  struct OperandAlignedLayout {
+    // The update shape rewritten to the operand's rank: every window dimension
+    // sits at the operand dimension it writes to, the scatter-batch dimension
+    // (if any) sits at the scattered dimension, and the rest are 1.
+    llvm::SmallVector<int64_t> updateShape;
+    // The operand dimension the indices address - the ttir.scatter `dim`.
+    int64_t scatterDim = 0;
+    // Whether the scattered dimension is spanned by the update window. If it
+    // is, an index only fixes where the window starts and the position of each
+    // element within the window still has to be added on.
+    bool scatterDimIsWindow = false;
+    // Whether the scattered dimension carries the scatter-batch dimension, i.e.
+    // whether there is more than one window to write.
+    bool scatterDimCarriesBatch = false;
+    // Whether the scatter indexes the operand at all. With no
+    // scatter_dims_to_operand_dims there is nothing to read a position from and
+    // every window starts at the operand's origin.
+    bool hasIndexValue = false;
+    // The index tensor's shape rewritten to the operand's rank, each of its
+    // batch dimensions sitting at the operand dimension it varies.
+    llvm::SmallVector<int64_t> indexShape;
+  };
+
+  // Lowers a scatter that addresses at most one operand dimension onto
+  // ttir.scatter, which is a torch-style scatter: for every coordinate `c` of
+  // the source tensor it writes
+  //
+  //   input[c_0, ..., index[c], ..., c_{R-1}] = source[c]
+  //
+  // so the scattered dimension takes its position from `index` while every
+  // other dimension is addressed positionally, by the source's own coordinate.
+  // Lining StableHLO up with that means giving the update and index tensors the
+  // operand's rank, with each update window dimension placed at the operand
+  // dimension it writes to.
+  LogicalResult
+  convertToSingleDimScatter(mlir::stablehlo::ScatterOp srcOp,
+                            mlir::stablehlo::ScatterOp::Adaptor adaptor,
+                            ttcore::ReduceType reduceType,
+                            RankedTensorType outputType,
+                            ConversionPatternRewriter &rewriter) const {
+    // An overwrite of the entire operand needs no scatter at all.
+    if (adaptor.getScatterDimensionNumbers()
+            .getScatterDimsToOperandDims()
+            .empty() &&
+        succeeded(foldFullOverwrite(srcOp, adaptor, reduceType, outputType,
+                                    rewriter))) {
+      return success();
+    }
+
+    FailureOr<OperandAlignedLayout> layout =
+        computeOperandAlignedLayout(srcOp, adaptor, rewriter);
+    if (failed(layout)) {
+      return failure();
+    }
+
+    Value updates = srcOp.getUpdates()[0];
+    auto updateType = mlir::cast<RankedTensorType>(updates.getType());
+    if (updateType.getShape() != ArrayRef<int64_t>(layout->updateShape)) {
+      updates = ttir::utils::createReshapeOp(
+          rewriter,
+          ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_update_align"),
+          updates, layout->updateShape);
+    }
+
+    Value indices = buildOperandAlignedIndices(srcOp, *layout, rewriter);
+
+    rewriter.replaceOpWithNewOp<ttir::ScatterOp>(
+        srcOp, outputType, srcOp.getInputs()[0], indices, updates,
+        rewriter.getI32IntegerAttr(layout->scatterDim),
+        ttcore::ReduceTypeAttr::get(rewriter.getContext(), reduceType));
+    return success();
+  }
+
+  // Works out where each update dimension lands among the operand's
+  // dimensions, or reports why the scatter cannot be expressed that way.
+  FailureOr<OperandAlignedLayout>
+  computeOperandAlignedLayout(mlir::stablehlo::ScatterOp srcOp,
+                              mlir::stablehlo::ScatterOp::Adaptor adaptor,
+                              ConversionPatternRewriter &rewriter) const {
+    auto dimensionNumbers = adaptor.getScatterDimensionNumbers();
+    ArrayRef<int64_t> updateWindowDims = dimensionNumbers.getUpdateWindowDims();
+    ArrayRef<int64_t> insertedWindowDims =
+        dimensionNumbers.getInsertedWindowDims();
+    ArrayRef<int64_t> inputBatchingDims =
+        dimensionNumbers.getInputBatchingDims();
+    ArrayRef<int64_t> scatterIndicesBatchingDims =
+        dimensionNumbers.getScatterIndicesBatchingDims();
+    ArrayRef<int64_t> scatterDimsToOperandDims =
+        dimensionNumbers.getScatterDimsToOperandDims();
+    int64_t indexVectorDim = dimensionNumbers.getIndexVectorDim();
+
+    auto inputType =
+        mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType());
+    ArrayRef<int64_t> updateShape =
+        mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType())
+            .getShape();
+    ArrayRef<int64_t> indexShape =
+        srcOp.getScatterIndices().getType().getShape();
+    int64_t rank = inputType.getRank();
+
+    OperandAlignedLayout layout;
+    layout.updateShape.assign(rank, 1);
+
+    // The window spans every operand dimension that is not collapsed away.
+    // Batching dimensions are collapsed too: like inserted ones they get no
+    // window extent, and the position along them is implied by the batch rather
+    // than read out of the index vector.
+    llvm::DenseSet<int64_t> collapsedDims(insertedWindowDims.begin(),
+                                          insertedWindowDims.end());
+    collapsedDims.insert(inputBatchingDims.begin(), inputBatchingDims.end());
+    llvm::SmallVector<int64_t> windowOperandDims;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+      if (!collapsedDims.contains(dim)) {
+        windowOperandDims.push_back(dim);
+      }
+    }
+    if (windowOperandDims.size() != updateWindowDims.size()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "update_window_dims does not cover every operand dimension "
+                 "left by inserted_window_dims and input_batching_dims");
+    }
+
+    // Remember where each update dimension goes, to tell a reshape apart from a
+    // transpose further down.
+    llvm::SmallVector<int64_t> updateDimToOperandDim(updateShape.size(), -1);
+    for (auto [windowIndex, operandDim] : llvm::enumerate(windowOperandDims)) {
+      int64_t updateDim = updateWindowDims[windowIndex];
+      layout.updateShape[operandDim] = updateShape[updateDim];
+      updateDimToOperandDim[updateDim] = operandDim;
+    }
+
+    // Whatever update dimensions are left are its scatter dimensions, matching
+    // one for one - and in order - the index tensor's dimensions other than
+    // index_vector_dim.
+    llvm::DenseSet<int64_t> windowUpdateDims(updateWindowDims.begin(),
+                                             updateWindowDims.end());
+    llvm::SmallVector<int64_t> updateScatterDims;
+    for (int64_t dim = 0; dim < static_cast<int64_t>(updateShape.size());
+         ++dim) {
+      if (!windowUpdateDims.contains(dim)) {
+        updateScatterDims.push_back(dim);
+      }
+    }
+
+    // The index tensor's dimensions other than index_vector_dim, in order.
+    llvm::SmallVector<int64_t> indexBatchDims;
+    for (int64_t dim = 0; dim < static_cast<int64_t>(indexShape.size());
+         ++dim) {
+      if (dim != indexVectorDim) {
+        indexBatchDims.push_back(dim);
+      }
+    }
+    if (updateScatterDims.size() != indexBatchDims.size()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "the update's scatter dimensions do not match the index "
+                 "tensor's batch dimensions one for one");
+    }
+
+    // StableHLO ties the index vector's length to the number of scattered
+    // operand dimensions, so with at most one of those the vector holds a
+    // single component and index_vector_dim may sit anywhere.
+    if (indexVectorDim < static_cast<int64_t>(indexShape.size()) &&
+        indexShape[indexVectorDim] != static_cast<int64_t>(
+                                          scatterDimsToOperandDims.size())) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "the index vector's length does not match the number of "
+                 "scattered operand dimensions");
+    }
+
+    if (!scatterDimsToOperandDims.empty()) {
+      layout.hasIndexValue = true;
+      layout.scatterDim = scatterDimsToOperandDims[0];
+    } else {
+      // Nothing indexes the operand, so every window starts at its origin. Any
+      // dimension can carry those constant positions; dimension 0 will do.
+      layout.scatterDim = 0;
+    }
+
+    // Place each scatter dimension of the update at the operand dimension whose
+    // position it varies. A batching dimension varies its own operand batching
+    // dimension; anything else varies the scattered one, of which ttir.scatter
+    // can only track one.
+    layout.indexShape.assign(rank, 1);
+    for (auto [scatterIndex, indexDim] : llvm::enumerate(indexBatchDims)) {
+      int64_t operandDim;
+      auto *batching = llvm::find(scatterIndicesBatchingDims, indexDim);
+      if (batching != scatterIndicesBatchingDims.end()) {
+        operandDim =
+            inputBatchingDims[batching - scatterIndicesBatchingDims.begin()];
+      } else if (layout.hasIndexValue && !layout.scatterDimCarriesBatch) {
+        operandDim = layout.scatterDim;
+        layout.scatterDimCarriesBatch = true;
+      } else {
+        return rewriter.notifyMatchFailure(
+            srcOp, "TTIR scatter supports at most one non-batching "
+                   "scatter-batch dimension");
+      }
+
+      if (layout.updateShape[operandDim] != 1) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "an operand dimension carries both a window and a "
+                   "scatter-batch dimension");
+      }
+      int64_t updateDim = updateScatterDims[scatterIndex];
+      layout.updateShape[operandDim] = updateShape[updateDim];
+      layout.indexShape[operandDim] = indexShape[indexDim];
+      updateDimToOperandDim[updateDim] = operandDim;
+    }
+
+    layout.scatterDimIsWindow = !collapsedDims.contains(layout.scatterDim);
+
+    // Only a reshape is emitted below, which reproduces the operand-aligned
+    // layout only when the update's dimensions are already in operand order.
+    int64_t previousOperandDim = -1;
+    for (int64_t operandDim : updateDimToOperandDim) {
+      if (operandDim < 0) {
+        continue;
+      }
+      if (operandDim < previousOperandDim) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "the update tensor's dimensions are not in operand order, "
+                   "which would need a transpose");
+      }
+      previousOperandDim = operandDim;
+    }
+
+    return layout;
+  }
+
+  // Builds the ttir.scatter index tensor: operand-aligned, shaped like the
+  // rewritten update tensor, holding for each element the position it is
+  // written to along the scattered dimension.
+  Value buildOperandAlignedIndices(mlir::stablehlo::ScatterOp srcOp,
+                                   const OperandAlignedLayout &layout,
+                                   ConversionPatternRewriter &rewriter) const {
+    TypedValue<RankedTensorType> indices = srcOp.getScatterIndices();
+    RankedTensorType indicesType = indices.getType();
+    RankedTensorType targetType = RankedTensorType::get(
+        layout.updateShape, indicesType.getElementType(),
+        indicesType.getEncoding());
+
+    // Where each window starts along the scattered dimension.
+    Value windowStart;
+    if (layout.hasIndexValue) {
+      // One index value per window, so the index only varies along the
+      // dimensions carrying the scatter batch.
+      ArrayRef<int64_t> alignedShape = layout.indexShape;
+
+      windowStart = indices;
+      if (indicesType.getShape() != alignedShape) {
+        windowStart = ttir::utils::createReshapeOp(
+            rewriter,
+            ttmlir::utils::appendLocationSuffix(srcOp.getLoc(), "_index_align"),
+            indices, alignedShape);
+      }
+
+      // Stretch it over the window, so every element of a window is written
+      // relative to the position that window's index picked out.
+      llvm::SmallVector<int64_t> repeatDims(layout.updateShape.size(), 1);
+      bool needsRepeat = false;
+      for (auto [dim, size] : llvm::enumerate(layout.updateShape)) {
+        if (alignedShape[dim] != size) {
+          repeatDims[dim] = size;
+          needsRepeat = true;
+        }
+      }
+      if (needsRepeat) {
+        windowStart = rewriter.create<ttir::RepeatOp>(
+            srcOp.getLoc(), targetType, windowStart,
+            rewriter.getDenseI64ArrayAttr(repeatDims));
+      }
+    }
+
+    // An index only says where a window starts. When the window spans the
+    // scattered dimension, each of its elements lands at its own offset from
+    // that start, so the within-window position has to be added on.
+    //
+    // With no index at all the start is the origin, and this iota is the whole
+    // answer - degenerating to a constant 0 when the scattered dimension has
+    // extent 1.
+    if (!layout.scatterDimIsWindow && windowStart) {
+      return windowStart;
+    }
+
+    Value withinWindow = rewriter.create<ttir::ArangeOp>(
+        srcOp.getLoc(), targetType, /*start=*/0,
+        /*end=*/layout.updateShape[layout.scatterDim],
+        /*step=*/1, /*arange_dimension=*/layout.scatterDim);
+    if (!windowStart) {
+      return withinWindow;
+    }
+    return rewriter.create<ttir::AddOp>(srcOp.getLoc(), targetType, windowStart,
+                                        withinWindow);
+  }
+
+  // Folds away a scatter that overwrites the operand in its entirety, which
+  // needs no scatter op at all - the result is just the update tensor.
+  //
+  // Only reachable when `scatter_dims_to_operand_dims` is empty, so every
+  // window starts at the operand's origin; it then covers the whole operand
+  // exactly when the shapes match. JAX emits this for an update whose index
+  // array turned out to be statically empty (the index operand is then a
+  // `tensor<0x...>`).
+  //
+  // This is an optimization, not a legality check: anything it does not
+  // recognize is left to the general lowering, so it reports plain failure
+  // without a diagnostic and without touching the IR.
+  LogicalResult foldFullOverwrite(mlir::stablehlo::ScatterOp srcOp,
+                                  mlir::stablehlo::ScatterOp::Adaptor adaptor,
+                                  ttcore::ReduceType reduceType,
+                                  RankedTensorType outputType,
+                                  ConversionPatternRewriter &rewriter) const {
+    if (srcOp.getInputs().size() != 1 || srcOp.getUpdates().size() != 1) {
+      return failure();
+    }
+
+    auto dimensionNumbers = adaptor.getScatterDimensionNumbers();
+    if (!dimensionNumbers.getInsertedWindowDims().empty() ||
+        !dimensionNumbers.getInputBatchingDims().empty()) {
+      return failure();
+    }
+
+    auto inputType =
+        mlir::cast<RankedTensorType>(srcOp.getInputs()[0].getType());
+    auto updateType =
+        mlir::cast<RankedTensorType>(srcOp.getUpdates()[0].getType());
+
+    // Every update dimension must be a window dimension mapped onto the operand
+    // dimensions in order; a leftover one would be a scatter-batch dimension,
+    // i.e. more than one window to write.
+    ArrayRef<int64_t> updateWindowDims = dimensionNumbers.getUpdateWindowDims();
+    bool isSingleIdentityWindow =
+        updateWindowDims.size() == static_cast<size_t>(updateType.getRank());
+    for (auto [index, dim] : llvm::enumerate(updateWindowDims)) {
+      isSingleIdentityWindow &= dim == static_cast<int64_t>(index);
+    }
+    if (!isSingleIdentityWindow ||
+        updateType.getShape() != inputType.getShape()) {
+      return failure();
+    }
+
+    // Anything that combines the operand with the update has to keep the
+    // operand around, so it cannot fold away. matchAndRewrite has already
+    // established that ReduceType::Invalid here means an overwrite.
+    if (reduceType != ttcore::ReduceType::Invalid) {
+      return failure();
+    }
+
+    Value update = adaptor.getUpdates()[0];
+    if (update.getType() != outputType) {
+      return failure();
+    }
+
+    rewriter.replaceOp(srcOp, update);
+    return success();
+  }
+
+  // True when the update computation is `(operand, update) -> update`.
+  static bool returnsUpdateValue(Region &updateComputation) {
+    if (!updateComputation.hasOneBlock()) {
+      return false;
+    }
+    Block &block = updateComputation.front();
+    auto returnOp =
+        mlir::dyn_cast<mlir::stablehlo::ReturnOp>(block.getTerminator());
+    if (!returnOp || block.getNumArguments() != 2 ||
+        returnOp.getNumOperands() != 1) {
+      return false;
+    }
+    return returnOp.getOperand(0) == block.getArgument(1);
+  }
+
   LogicalResult checkBasicLegality(mlir::stablehlo::ScatterOp &op,
                                    mlir::stablehlo::ScatterOp::Adaptor adaptor,
                                    ConversionPatternRewriter &rewriter) const {
-    auto inputBatchingDims =
-        adaptor.getScatterDimensionNumbers().getInputBatchingDims();
-    auto scatterIndicesBatchingDims =
-        adaptor.getScatterDimensionNumbers().getScatterIndicesBatchingDims();
-    if (!inputBatchingDims.empty() || !scatterIndicesBatchingDims.empty()) {
-      return rewriter.notifyMatchFailure(
-          op, "Scatter doesn't currently support scatter with batching "
-              "dimensions");
-    }
-
     ArrayRef<int64_t> insertedWindowDims =
         adaptor.getScatterDimensionNumbers().getInsertedWindowDims();
-    RankedTensorType updateType =
-        mlir::cast<RankedTensorType>(op.getUpdates()[0].getType());
-    ArrayRef<int64_t> updateShape = updateType.getShape();
 
     // Get index tensor shape.
     RankedTensorType indexType = op.getScatterIndices().getType();
@@ -7094,6 +7458,19 @@ private:
         adaptor.getScatterDimensionNumbers().getIndexVectorDim();
 
     // Checks that apply to multi dimensional scatter.
+
+    // Batching dimensions are handled by computeOperandAlignedLayout, which
+    // only covers scatters along at most one dimension; the flattening the
+    // multi-dimensional path does takes no account of them.
+    if (multiDimensionalScatter &&
+        (!adaptor.getScatterDimensionNumbers().getInputBatchingDims().empty() ||
+         !adaptor.getScatterDimensionNumbers()
+              .getScatterIndicesBatchingDims()
+              .empty())) {
+      return rewriter.notifyMatchFailure(
+          op, "TTIR multi-dimensional scatter does not support batching "
+              "dimensions");
+    }
 
     if (multiDimensionalScatter &&
         indexVectorDim != static_cast<uint32_t>(indexShape.size() - 1)) {
@@ -7117,19 +7494,11 @@ private:
       }
     }
 
-    // Checks that apply to single dimensional scatter.
-
-    if (!multiDimensionalScatter && indexShape.size() > updateShape.size()) {
-      return rewriter.notifyMatchFailure(
-          op, "TTIR scatter requires indices.rank <= updates.rank. Please add "
-              "support for rank promotion if needed.");
-    }
-
-    if (!multiDimensionalScatter && indexVectorDim != 1u) {
-      return rewriter.notifyMatchFailure(
-          op,
-          "TTIR single dimensional scatter requires index_vector_dim to be 1");
-    }
+    // Scatters along at most one operand dimension are checked by
+    // computeOperandAlignedLayout instead, which has to work the mapping out in
+    // full anyway. It places no constraint on index_vector_dim: with a single
+    // scattered dimension the index vector holds one component, so the
+    // dimension it lives in may sit anywhere in the index tensor.
 
     return success();
   }
@@ -7426,81 +7795,6 @@ private:
     // Flatten the computed indices to 1D.
     return ttir::utils::flattenTensor(rewriter, loc, flatIndices,
                                       "_flatten_expanded_indices");
-  }
-
-  Value extractElementWiseScatterIndices(mlir::stablehlo::ScatterOp op,
-                                         PatternRewriter &rewriter) const {
-    // Build an index tensor shape-aligned with the update tensor: size-1 at
-    // each update_window_dim, and the index batch dims (all dims except
-    // index_vector_dim) at the remaining positions. Window axes are then
-    // expanded via repeat.
-    TypedValue<RankedTensorType> indexTensor = op.getScatterIndices();
-    RankedTensorType updateType =
-        mlir::cast<RankedTensorType>(op.getUpdates()[0].getType());
-    RankedTensorType indexType = indexTensor.getType();
-    ArrayRef<int64_t> origIndexShape = indexType.getShape();
-    ArrayRef<int64_t> updateShape = updateType.getShape();
-
-    int64_t indexVectorDim =
-        op.getScatterDimensionNumbers().getIndexVectorDim();
-    ArrayRef<int64_t> updateWindowDims =
-        op.getScatterDimensionNumbers().getUpdateWindowDims();
-
-    // Collect the scatter-batch dims of the original index tensor (all dims
-    // except index_vector_dim). For implicit index_vector_dim (== rank), no
-    // dim is excluded.
-    llvm::SmallVector<int64_t> indexBatchShape;
-    indexBatchShape.reserve(origIndexShape.size());
-    for (int64_t i = 0; i < static_cast<int64_t>(origIndexShape.size()); ++i) {
-      if (i != indexVectorDim) {
-        indexBatchShape.push_back(origIndexShape[i]);
-      }
-    }
-
-    // Compose the reshape target: size-1 at each update_window_dim, and the
-    // index batch dims at the remaining positions.
-    llvm::DenseSet<int64_t> windowDimSet(updateWindowDims.begin(),
-                                         updateWindowDims.end());
-    llvm::SmallVector<int64_t> reshapedIndexShape(updateShape.size(), 1);
-    size_t batchIdx = 0;
-    for (size_t i = 0; i < updateShape.size(); ++i) {
-      if (windowDimSet.contains(static_cast<int64_t>(i))) {
-        continue;
-      }
-      if (batchIdx < indexBatchShape.size()) {
-        reshapedIndexShape[i] = indexBatchShape[batchIdx++];
-      }
-    }
-
-    if (origIndexShape != ArrayRef<int64_t>(reshapedIndexShape)) {
-      indexTensor = ttir::utils::createReshapeOp(
-          rewriter, op.getLoc(), indexTensor, reshapedIndexShape);
-      indexType = mlir::cast<RankedTensorType>(indexTensor.getType());
-    }
-
-    // Repeat each update_window_dim from 1 up to updateShape[dim].
-    llvm::SmallVector<int64_t> repeatDims(updateShape.size(), 1);
-    bool needsRepeat = false;
-    for (int64_t dim : updateWindowDims) {
-      if (reshapedIndexShape[dim] != updateShape[dim]) {
-        repeatDims[dim] = updateShape[dim];
-        needsRepeat = true;
-      }
-    }
-
-    if (needsRepeat) {
-      llvm::SmallVector<int64_t> targetIndexShape(updateShape.begin(),
-                                                  updateShape.end());
-      RankedTensorType targetIndexType =
-          RankedTensorType::get(targetIndexShape, indexType.getElementType(),
-                                indexType.getEncoding());
-      auto repeatDimsAttr = rewriter.getDenseI64ArrayAttr(repeatDims);
-
-      indexTensor = rewriter.create<ttir::RepeatOp>(
-          op.getLoc(), targetIndexType, indexTensor, repeatDimsAttr);
-    }
-
-    return indexTensor;
   }
 };
 } // namespace

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_batching_dims.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_batching_dims.mlir
@@ -7,13 +7,9 @@
 
 // Scatters with batching dimensions, which StableHLO uses for the vmap of a
 // scatter: operand dimension 0 is batched against index dimension 0, so batch
-// element i only ever writes into operand[i].
-//
-// ttir.scatter addresses every dimension other than the scattered one
-// positionally, by the source's own coordinate, which is exactly what a
-// batching dimension wants. So they need no index arithmetic at all - the
-// batching dimension just has to be laid out at the operand dimension it
-// batches over. Shapes are from the ORB model.
+// element i only ever writes into operand[i]. A batching dimension needs no
+// index arithmetic - it only has to be laid out at the operand dimension it
+// batches over.
 
 module @scatter_batching_dims {
   // operand[i, idx[i, j]] = updates[i, j]
@@ -38,5 +34,24 @@ module @scatter_batching_dims {
       "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
     }) : (tensor<2x3x3xf64>, tensor<2x2x1xi32>, tensor<2x2x3xf64>) -> tensor<2x3x3xf64>
     return %0 : tensor<2x3x3xf64>
+  }
+
+  // operand[i, 0] = updates[i]
+  //
+  // Batching dimensions with an empty `scatter_dims_to_operand_dims`: nothing is
+  // read out of the index vector, which is why it has extent 0. The scattered
+  // dimension then defaults to 0 - here the batching dimension - and the iota
+  // supplies the batch coordinate it needs.
+  // CHECK-LABEL: func.func @batched_origin
+  // CHECK: %[[IOTA:.*]] = "ttir.arange"()
+  // CHECK-SAME: arange_dimension = 0
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 0
+  func.func @batched_origin(%operand: tensor<2x3xi32>, %indices: tensor<2x0xi32>, %updates: tensor<2xi32>) -> tensor<2x3xi32> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [1], input_batching_dims = [0], scatter_indices_batching_dims = [0], index_vector_dim = 1>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      "stablehlo.return"(%arg1) : (tensor<i32>) -> ()
+    }) : (tensor<2x3xi32>, tensor<2x0xi32>, tensor<2xi32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
   }
 }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_batching_dims.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_batching_dims.mlir
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
+
+// Scatters with batching dimensions, which StableHLO uses for the vmap of a
+// scatter: operand dimension 0 is batched against index dimension 0, so batch
+// element i only ever writes into operand[i].
+//
+// ttir.scatter addresses every dimension other than the scattered one
+// positionally, by the source's own coordinate, which is exactly what a
+// batching dimension wants. So they need no index arithmetic at all - the
+// batching dimension just has to be laid out at the operand dimension it
+// batches over. Shapes are from the ORB model.
+
+module @scatter_batching_dims {
+  // operand[i, idx[i, j]] = updates[i, j]
+  // CHECK-LABEL: func.func @batched_2d
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @batched_2d(%operand: tensor<2x3xi32>, %indices: tensor<2x2x1xi32>, %updates: tensor<2x2xi32>) -> tensor<2x3xi32> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [1], input_batching_dims = [0], scatter_indices_batching_dims = [0], scatter_dims_to_operand_dims = [1], index_vector_dim = 2>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      "stablehlo.return"(%arg1) : (tensor<i32>) -> ()
+    }) : (tensor<2x3xi32>, tensor<2x2x1xi32>, tensor<2x2xi32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+
+  // operand[i, idx[i, j], k] = updates[i, j, k]
+  // CHECK-LABEL: func.func @batched_3d
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @batched_3d(%operand: tensor<2x3x3xf64>, %indices: tensor<2x2x1xi32>, %updates: tensor<2x2x3xf64>) -> tensor<2x3x3xf64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [2], inserted_window_dims = [1], input_batching_dims = [0], scatter_indices_batching_dims = [0], scatter_dims_to_operand_dims = [1], index_vector_dim = 2>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
+    }) : (tensor<2x3x3xf64>, tensor<2x2x1xi32>, tensor<2x2x3xf64>) -> tensor<2x3x3xf64>
+    return %0 : tensor<2x3x3xf64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_index_vector_dim_zero.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_index_vector_dim_zero.mlir
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
+
+// Single-dimensional scatters whose index tensor has no batch dimensions, so
+// index_vector_dim is 0 rather than 1 and there is exactly one window to write.
+// Because inserted_window_dims collapses a dimension, the update tensor also
+// has a lower rank than the operand and has to be reshaped up to it before
+// ttir.scatter - which requires input, index and source to share a rank - will
+// take it. All three shapes are taken from the ORB model.
+
+module @scatter_index_vector_dim_zero {
+  // operand[:, idx] = updates
+  // CHECK-LABEL: func.func @column_2d
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @column_2d(%operand: tensor<2x3xi32>, %indices: tensor<1xi32>, %updates: tensor<2xi32>) -> tensor<2x3xi32> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0], inserted_window_dims = [1], scatter_dims_to_operand_dims = [1]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      "stablehlo.return"(%arg1) : (tensor<i32>) -> ()
+    }) : (tensor<2x3xi32>, tensor<1xi32>, tensor<2xi32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+
+  // operand[:, :, idx] = updates
+  // CHECK-LABEL: func.func @plane_3d
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 2
+  func.func @plane_3d(%operand: tensor<2x3x3xf64>, %indices: tensor<1xi32>, %updates: tensor<2x3xf64>) -> tensor<2x3x3xf64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 1], inserted_window_dims = [2], scatter_dims_to_operand_dims = [2]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
+    }) : (tensor<2x3x3xf64>, tensor<1xi32>, tensor<2x3xf64>) -> tensor<2x3x3xf64>
+    return %0 : tensor<2x3x3xf64>
+  }
+
+  // operand[idx] = scalar update
+  // CHECK-LABEL: func.func @scalar_1d
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 0
+  func.func @scalar_1d(%operand: tensor<2xi64>, %indices: tensor<1xi64>, %updates: tensor<i64>) -> tensor<2xi64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<inserted_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      "stablehlo.return"(%arg1) : (tensor<i64>) -> ()
+    }) : (tensor<2xi64>, tensor<1xi64>, tensor<i64>) -> tensor<2xi64>
+    return %0 : tensor<2xi64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_index_vector_dim_zero.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_index_vector_dim_zero.mlir
@@ -7,10 +7,8 @@
 
 // Single-dimensional scatters whose index tensor has no batch dimensions, so
 // index_vector_dim is 0 rather than 1 and there is exactly one window to write.
-// Because inserted_window_dims collapses a dimension, the update tensor also
-// has a lower rank than the operand and has to be reshaped up to it before
-// ttir.scatter - which requires input, index and source to share a rank - will
-// take it. All three shapes are taken from the ORB model.
+// inserted_window_dims also leaves the update tensor a rank short of the
+// operand, so it has to be reshaped up to the operand's rank.
 
 module @scatter_index_vector_dim_zero {
   // operand[:, idx] = updates

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_keeps_operand_negative.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_keeps_operand_negative.mlir
@@ -6,13 +6,9 @@
 // RUN: not ttmlir-opt --convert-stablehlo-to-ttir %s 2>&1 | FileCheck %s
 
 // An update computation that returns its *first* argument, the operand, rather
-// than the update. The scatter therefore leaves the operand untouched.
-//
-// getReduceTypeFromRegion reports ReduceType::Invalid for this, exactly as it
-// does for a real overwrite - it only looks for an arithmetic op in the region
-// and finds none either way. Lowering on the reduce type alone would turn this
-// into an overwrite and silently produce the wrong values, so the returned
-// value has to be checked as well.
+// than the update, so the scatter leaves the operand untouched. Its reduce type
+// is ReduceType::Invalid, exactly as a real overwrite's is, so lowering on the
+// reduce type alone would silently turn this into an overwrite.
 
 // CHECK: failed to legalize operation 'stablehlo.scatter'
 module @scatter_keeps_operand {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_keeps_operand_negative.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_keeps_operand_negative.mlir
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: not ttmlir-opt --convert-stablehlo-to-ttir %s 2>&1 | FileCheck %s
+
+// An update computation that returns its *first* argument, the operand, rather
+// than the update. The scatter therefore leaves the operand untouched.
+//
+// getReduceTypeFromRegion reports ReduceType::Invalid for this, exactly as it
+// does for a real overwrite - it only looks for an arithmetic op in the region
+// and finds none either way. Lowering on the reduce type alone would turn this
+// into an overwrite and silently produce the wrong values, so the returned
+// value has to be checked as well.
+
+// CHECK: failed to legalize operation 'stablehlo.scatter'
+module @scatter_keeps_operand {
+  func.func @main(%operand: tensor<2x3xi32>, %indices: tensor<1xi32>, %updates: tensor<2xi32>) -> tensor<2x3xi32> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0], inserted_window_dims = [1], scatter_dims_to_operand_dims = [1]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      "stablehlo.return"(%arg0) : (tensor<i32>) -> ()
+    }) : (tensor<2x3xi32>, tensor<1xi32>, tensor<2xi32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -165,10 +165,8 @@ module @jit_scatter attributes {} {
         return %0 : tensor<3x394xi64>
     }
 
-    // Single-dimensional scatter-add where the indices carry an explicit
-    // size-1 index_vector_dim, making indices.rank (2) exceed updates.rank (1).
-    // The degenerate index_vector_dim must be squeezed and the op must still
-    // lower to a scatter-add along dim 0.
+    // Single-dimensional scatter-add whose indices carry an explicit size-1
+    // index_vector_dim, so indices.rank (2) exceeds updates.rank (1).
     func.func public @test_scatter_index_vector_dim_rank_promotion(%operand: tensor<2xi64>, %indices: tensor<256x1xi64>, %updates: tensor<256xi64>) -> tensor<2xi64> {
         // CHECK-LABEL: func.func public @test_scatter_index_vector_dim_rank_promotion
         // CHECK: [[RS:%[0-9]+]] = "ttir.reshape"(%arg1)

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_op.mlir
@@ -165,6 +165,30 @@ module @jit_scatter attributes {} {
         return %0 : tensor<3x394xi64>
     }
 
+    // Single-dimensional scatter-add where the indices carry an explicit
+    // size-1 index_vector_dim, making indices.rank (2) exceed updates.rank (1).
+    // The degenerate index_vector_dim must be squeezed and the op must still
+    // lower to a scatter-add along dim 0.
+    func.func public @test_scatter_index_vector_dim_rank_promotion(%operand: tensor<2xi64>, %indices: tensor<256x1xi64>, %updates: tensor<256xi64>) -> tensor<2xi64> {
+        // CHECK-LABEL: func.func public @test_scatter_index_vector_dim_rank_promotion
+        // CHECK: [[RS:%[0-9]+]] = "ttir.reshape"(%arg1)
+        // CHECK-SAME: (tensor<256x1xi64>) -> tensor<256xi64>
+        // CHECK: "ttir.scatter"(%arg0, [[RS]], %arg2)
+        // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>
+        // CHECK-SAME: (tensor<2xi64>, tensor<256xi64>, tensor<256xi64>) -> tensor<2xi64>
+        %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{
+          scatter_dimension_numbers = #stablehlo.scatter<
+            inserted_window_dims = [0],
+            scatter_dims_to_operand_dims = [0],
+            index_vector_dim = 1>
+        }> ({
+        ^bb0(%a: tensor<i64>, %b: tensor<i64>):
+          %r = stablehlo.add %a, %b : tensor<i64>
+          stablehlo.return %r : tensor<i64>
+        }) : (tensor<2xi64>, tensor<256x1xi64>, tensor<256xi64>) -> tensor<2xi64>
+        return %0 : tensor<2xi64>
+    }
+
     func.func @test_multidim_scatter_with_window_extracted_from_model(%arg186: tensor<1x2xbf16>, %arg187: tensor<1xi64>, %arg188: tensor<1xi64>) -> (tensor<1x7x2xbf16>) {
         // CHECK: "ttir.scatter"
         // CHECK-SAME: <{dim = 0 : i32, scatter_reduce_type = #ttcore.reduce_type<sum>}>

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_op.mlir
@@ -5,11 +5,10 @@
 // REQUIRES: stablehlo
 // RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
 
-// Scatters with an empty `scatter_dims_to_operand_dims`. Every start index is
-// then 0, so the single update window is written at the operand's origin; when
-// it also covers the whole operand the op is a plain overwrite and folds away
-// to the update tensor. JAX emits this for an update whose index array turned
-// out to be statically empty, hence the `tensor<0x...>` index operands.
+// Scatters with an empty `scatter_dims_to_operand_dims` - hence the zero-extent
+// index operands. Every start index is then 0, so the single update window is
+// written at the operand's origin; when it also covers the whole operand the op
+// is a plain overwrite and folds away to the update tensor.
 
 module @scatter_origin {
   // CHECK-LABEL: func.func @overwrite_1d

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_op.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_op.mlir
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
+
+// Scatters with an empty `scatter_dims_to_operand_dims`. Every start index is
+// then 0, so the single update window is written at the operand's origin; when
+// it also covers the whole operand the op is a plain overwrite and folds away
+// to the update tensor. JAX emits this for an update whose index array turned
+// out to be statically empty, hence the `tensor<0x...>` index operands.
+
+module @scatter_origin {
+  // CHECK-LABEL: func.func @overwrite_1d
+  // CHECK-NOT: ttir.scatter
+  // CHECK: return %arg2
+  func.func @overwrite_1d(%operand: tensor<256xi64>, %indices: tensor<0xi64>, %updates: tensor<256xi64>) -> tensor<256xi64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      "stablehlo.return"(%arg1) : (tensor<i64>) -> ()
+    }) : (tensor<256xi64>, tensor<0xi64>, tensor<256xi64>) -> tensor<256xi64>
+    return %0 : tensor<256xi64>
+  }
+
+  // CHECK-LABEL: func.func @overwrite_3d
+  // CHECK-NOT: ttir.scatter
+  // CHECK: return %arg2
+  func.func @overwrite_3d(%operand: tensor<2x3x3xf64>, %indices: tensor<0xi32>, %updates: tensor<2x3x3xf64>) -> tensor<2x3x3xf64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 1, 2]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
+    }) : (tensor<2x3x3xf64>, tensor<0xi32>, tensor<2x3x3xf64>) -> tensor<2x3x3xf64>
+    return %0 : tensor<2x3x3xf64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_partial_window.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_partial_window.mlir
@@ -7,15 +7,11 @@
 
 // An origin scatter (empty scatter_dims_to_operand_dims) whose window covers
 // only part of the operand. Elements 4..255 keep their original values, so this
-// is not an overwrite and must not fold to the update tensor.
-//
-// It still lowers: the window starts at the origin, so the position of each
-// element along the scattered dimension is just its own offset within the
-// window, which an iota supplies. Every other dimension is already addressed
-// positionally by ttir.scatter.
+// is not an overwrite and must not fold to the update tensor. It still lowers:
+// with the window at the origin, each element's position along the scattered
+// dimension is just its own offset within the window, which an iota supplies.
 
 // CHECK-LABEL: func.func @main
-// The update tensor must not simply be returned.
 // CHECK-NOT: return %arg2
 // CHECK: ttir.arange
 // CHECK: ttir.scatter

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_partial_window.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_origin_partial_window.mlir
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
+
+// An origin scatter (empty scatter_dims_to_operand_dims) whose window covers
+// only part of the operand. Elements 4..255 keep their original values, so this
+// is not an overwrite and must not fold to the update tensor.
+//
+// It still lowers: the window starts at the origin, so the position of each
+// element along the scattered dimension is just its own offset within the
+// window, which an iota supplies. Every other dimension is already addressed
+// positionally by ttir.scatter.
+
+// CHECK-LABEL: func.func @main
+// The update tensor must not simply be returned.
+// CHECK-NOT: return %arg2
+// CHECK: ttir.arange
+// CHECK: ttir.scatter
+// CHECK-SAME: dim = 0
+module @scatter_origin_partial_window {
+  func.func @main(%operand: tensor<256xi64>, %indices: tensor<0xi64>, %updates: tensor<4xi64>) -> tensor<256xi64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<i64>, %arg1: tensor<i64>):
+      "stablehlo.return"(%arg1) : (tensor<i64>) -> ()
+    }) : (tensor<256xi64>, tensor<0xi64>, tensor<4xi64>) -> tensor<256xi64>
+    return %0 : tensor<256xi64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
@@ -31,6 +31,23 @@ module @scatter_window_dim {
     return %0 : tensor<6400x16xf64>
   }
 
+  // The scattered dimension can be a window dimension and carry the batch of
+  // window starts at the same time, but only when the window is a single
+  // element wide - here operand[0, idx[j]] = updates[j, 0] for each of the four
+  // indices. The window then contributes no offset of its own, so there must be
+  // no iota: adding one would write to idx[j] + j.
+  // CHECK-LABEL: func.func @window_carries_batch
+  // CHECK-NOT: ttir.arange
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @window_carries_batch(%operand: tensor<2x3xi32>, %indices: tensor<4x1xi32>, %updates: tensor<4x1xi32>) -> tensor<2x3xi32> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = false, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [1], index_vector_dim = 1>, unique_indices = false}> ({
+    ^bb0(%arg0: tensor<i32>, %arg1: tensor<i32>):
+      "stablehlo.return"(%arg1) : (tensor<i32>) -> ()
+    }) : (tensor<2x3xi32>, tensor<4x1xi32>, tensor<4x1xi32>) -> tensor<2x3xi32>
+    return %0 : tensor<2x3xi32>
+  }
+
   // A single-column window is the same shape of lowering, just with a
   // degenerate iota.
   // CHECK-LABEL: func.func @single_column

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --convert-stablehlo-to-ttir %s | FileCheck %s
+
+// A scatter whose update window spans the very dimension being scattered
+// along: nothing is collapsed, so the index says where the window starts along
+// dimension 1 and the window then runs on from there.
+//
+//   operand[i, idx + j] = updates[i, j]
+//
+// ttir.scatter needs an absolute position per element, so the index tensor is
+// the broadcast start plus an iota of the within-window offsets. Shapes are
+// from the ORB model, where the Pade approximant writes a run of columns into
+// a wider buffer.
+
+module @scatter_window_dim {
+  // CHECK-LABEL: func.func @column_run
+  // CHECK: %[[IOTA:.*]] = "ttir.arange"()
+  // CHECK-SAME: arange_dimension = 1
+  // CHECK: ttir.add
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @column_run(%operand: tensor<6400x16xf64>, %indices: tensor<1xi64>, %updates: tensor<6400x3xf64>) -> tensor<6400x16xf64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 1], scatter_dims_to_operand_dims = [1]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
+    }) : (tensor<6400x16xf64>, tensor<1xi64>, tensor<6400x3xf64>) -> tensor<6400x16xf64>
+    return %0 : tensor<6400x16xf64>
+  }
+
+  // A single-column window is the same shape of lowering, just with a
+  // degenerate iota.
+  // CHECK-LABEL: func.func @single_column
+  // CHECK: ttir.scatter
+  // CHECK-SAME: dim = 1
+  func.func @single_column(%operand: tensor<6400x16xf64>, %indices: tensor<1xi64>, %updates: tensor<6400x1xf64>) -> tensor<6400x16xf64> {
+    %0 = "stablehlo.scatter"(%operand, %indices, %updates) <{indices_are_sorted = true, scatter_dimension_numbers = #stablehlo.scatter<update_window_dims = [0, 1], scatter_dims_to_operand_dims = [1]>, unique_indices = true}> ({
+    ^bb0(%arg0: tensor<f64>, %arg1: tensor<f64>):
+      "stablehlo.return"(%arg1) : (tensor<f64>) -> ()
+    }) : (tensor<6400x16xf64>, tensor<1xi64>, tensor<6400x1xf64>) -> tensor<6400x16xf64>
+    return %0 : tensor<6400x16xf64>
+  }
+}

--- a/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/scatter_window_dim.mlir
@@ -11,10 +11,8 @@
 //
 //   operand[i, idx + j] = updates[i, j]
 //
-// ttir.scatter needs an absolute position per element, so the index tensor is
-// the broadcast start plus an iota of the within-window offsets. Shapes are
-// from the ORB model, where the Pade approximant writes a run of columns into
-// a wider buffer.
+// The index tensor is therefore the broadcast start plus an iota of the
+// within-window offsets.
 
 module @scatter_window_dim {
   // CHECK-LABEL: func.func @column_run
@@ -31,11 +29,12 @@ module @scatter_window_dim {
     return %0 : tensor<6400x16xf64>
   }
 
-  // The scattered dimension can be a window dimension and carry the batch of
-  // window starts at the same time, but only when the window is a single
-  // element wide - here operand[0, idx[j]] = updates[j, 0] for each of the four
-  // indices. The window then contributes no offset of its own, so there must be
-  // no iota: adding one would write to idx[j] + j.
+  // operand[0, idx[j]] = updates[j, 0]
+  //
+  // The scattered dimension is a window dimension and carries the batch of
+  // window starts at the same time, which is legal because the window is a
+  // single element wide. It contributes no offset of its own, so there must be
+  // no iota here - adding one would write to idx[j] + j.
   // CHECK-LABEL: func.func @window_carries_batch
   // CHECK-NOT: ttir.arange
   // CHECK: ttir.scatter


### PR DESCRIPTION
### Ticket
No issue, but there is an external request that depends on this

### Problem description
While running an external model, I ran into multiple cases of unsupported scatters. Alongside that while working on those I encountered at least 2 possible correctness bugs.

### What's changed
Rebuild the "at most one scattered dimension" path around what ttir.scatter actually does. It is a torch-style scatter:

  input[c_0, ..., index[c], ..., c_R-1] = source[c]

so the scattered dimension takes its position from the index tensor while every other dimension is addressed positionally, by the source's own coordinate. Lining StableHLO up with that means giving the update and index tensors the operand's rank, each window dimension sitting at the operand dimension it writes to.
Four shapes of scatter lower that did not before.

### Checklist
- [X] New/Existing tests provide coverage for changes

Vibed, thanks Claude