### PR TITLE
[Do not merge] Capture ttnn graph reports from the ttnn runtime

### DIFF
--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -124,14 +124,22 @@
 #include "operations/transformer/scaled_dot_product_attention_decode.h"
 #include "operations/transformer/split_query_key_value_and_split_heads.h"
 #include "tt/runtime/debug.h"
+#include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/types/types.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "tt/runtime/perf.h"
 #include "tt/runtime/utils.h"
 
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_serialization.hpp"
+
 #include "tracy/Tracy.hpp"
 
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <unistd.h>
 
 namespace tt::runtime::ttnn {
 
@@ -213,11 +221,187 @@ void ProgramExecutor::runProgramCallback(
   }
 }
 
+namespace {
+
+uint64_t graphCaptureEnvUInt(const char *name, uint64_t fallback) {
+  const char *value = std::getenv(name);
+  return value ? std::strtoull(value, nullptr, 10) : fallback;
+}
+
+// Writes one ttnn graph report per top-level program execution; const-eval
+// subprograms execute nested and land in their parent's report. State is
+// thread_local because GraphTracker's processors are.
+class GraphCaptureWindow {
+public:
+  explicit GraphCaptureWindow(const char *programName)
+      : topLevel(state().depth++ == 0) {
+    if (topLevel) {
+      open(programName);
+    }
+  }
+
+  ~GraphCaptureWindow() {
+    --state().depth;
+    if (!topLevel || !state().capture) {
+      return;
+    }
+    state().capture.reset();
+    ::ttnn::graph::GraphProcessor::disable_detailed_buffer_tracing();
+    writeOperationRecords();
+  }
+
+  GraphCaptureWindow(const GraphCaptureWindow &) = delete;
+  GraphCaptureWindow &operator=(const GraphCaptureWindow &) = delete;
+
+  static bool isRecording() { return state().capture.has_value(); }
+
+  static void recordOperation(nlohmann::json &&record) {
+    state().operationRecords.push_back(std::move(record));
+  }
+
+private:
+  struct State {
+    std::optional<::ttnn::graph::ScopedGraphCapture> capture;
+    std::filesystem::path reportPath;
+    nlohmann::json operationRecords = nlohmann::json::array();
+    uint64_t executions = 0;
+    uint64_t reports = 0;
+    uint64_t depth = 0;
+  };
+
+  static State &state() {
+    static thread_local State state;
+    return state;
+  }
+
+  static void open(const char *programName) {
+    static const char *captureDir =
+        std::getenv("TT_RUNTIME_GRAPH_CAPTURE_DIR");
+    if (!captureDir) {
+      return;
+    }
+    static const uint64_t first =
+        graphCaptureEnvUInt("TT_RUNTIME_GRAPH_CAPTURE_FIRST", 0);
+    // Zero reports means every execution from `first` onwards.
+    static const uint64_t reportLimit =
+        graphCaptureEnvUInt("TT_RUNTIME_GRAPH_CAPTURE_REPORTS", 1);
+
+    uint64_t index = state().executions++;
+    if (index < first ||
+        (reportLimit != 0 && state().reports >= reportLimit)) {
+      return;
+    }
+    ++state().reports;
+
+    state().reportPath =
+        std::filesystem::path(captureDir) /
+        (std::string(programName) + "_pid" + std::to_string(::getpid()) +
+         "_tid" + std::to_string(::gettid()) + "_exec" + std::to_string(index) +
+         ".json");
+    state().operationRecords = nlohmann::json::array();
+    ::ttnn::graph::GraphProcessor::enable_detailed_buffer_tracing();
+    state().capture.emplace(::tt::tt_metal::IGraphProcessor::RunMode::NORMAL,
+                            state().reportPath);
+  }
+
+  // Sidecar name and record shape are the contract ttnn's graph_report importer
+  // reads as `python_io`.
+  static void writeOperationRecords() {
+    std::filesystem::path sidecarPath = state().reportPath;
+    sidecarPath.replace_extension(".python_io.json");
+    std::ofstream sidecar(sidecarPath);
+    sidecar << state().operationRecords;
+    state().operationRecords = nlohmann::json::array();
+  }
+
+  const bool topLevel;
+};
+
+// Opens a tracked scope named after the program op so the report has one
+// operation per op, with the ttnn calls it dispatches nested inside it.
+class TrackedOperation {
+public:
+  TrackedOperation(const ::tt::target::ttnn::Operation *op,
+                   ProgramContext *programContext)
+      : op(GraphCaptureWindow::isRecording() ? op : nullptr),
+        programContext(programContext) {
+    if (!this->op) {
+      return;
+    }
+    name = ::tt::target::ttnn::EnumNameOpType(this->op->type_type());
+    std::string locInfo = getOpLocInfo(context());
+    std::vector<::ttnn::Tensor> inputs = poolTensors(getOpInputRefs(context()));
+    record["name"] = name;
+    record["arguments"] = {{"loc", locInfo},
+                           {"mlir", getOpDebugString(context())}};
+    record["python_stack_trace"] = nlohmann::json::array({locInfo});
+    record["input_tensor_ids"] = tensorIds(inputs);
+    ::tt::tt_metal::GraphTracker::instance().track_function_start(name, inputs);
+  }
+
+  ~TrackedOperation() {
+    if (!op) {
+      return;
+    }
+    std::vector<::ttnn::Tensor> outputs;
+    try {
+      outputs = poolTensors(getOpOutputRefs(context()));
+      record["output_tensor_ids"] = tensorIds(outputs);
+      GraphCaptureWindow::recordOperation(std::move(record));
+    } catch (...) {
+    }
+    ::tt::tt_metal::GraphTracker::instance().track_function_end(outputs);
+  }
+
+  TrackedOperation(const TrackedOperation &) = delete;
+  TrackedOperation &operator=(const TrackedOperation &) = delete;
+
+private:
+  OpContext context() const {
+    return OpContext(::tt::runtime::utils::unsafeBorrowShared(
+                         const_cast<::tt::target::ttnn::Operation *>(op)),
+                     DeviceRuntime::TTNN);
+  }
+
+  std::vector<::ttnn::Tensor>
+  poolTensors(std::vector<::tt::runtime::TensorRef> refs) const {
+    const ProgramTensorPool &pool = programContext->getTensorPool();
+    std::vector<::ttnn::Tensor> tensors;
+    for (::tt::runtime::TensorRef &ref : refs) {
+      const auto *tensorRef =
+          &ref.as<::tt::target::ttnn::TensorRef>(DeviceRuntime::TTNN);
+      if (tensorRef != nullptr && pool.contains(tensorRef)) {
+        tensors.push_back(pool.getTTNNTensorAndValidate(tensorRef));
+      }
+    }
+    return tensors;
+  }
+
+  static std::vector<uint64_t>
+  tensorIds(const std::vector<::ttnn::Tensor> &tensors) {
+    std::vector<uint64_t> ids;
+    for (const ::ttnn::Tensor &tensor : tensors) {
+      if (tensor.tensor_id != ::ttnn::Tensor::INVALID_TENSOR_ID) {
+        ids.push_back(tensor.tensor_id);
+      }
+    }
+    return ids;
+  }
+
+  const ::tt::target::ttnn::Operation *op;
+  ProgramContext *programContext;
+  std::string name;
+  nlohmann::json record;
+};
+
+} // namespace
+
 void ProgramExecutor::execute() {
   ZoneScopedN("program_execute");
   ZoneText(program->name()->c_str(), std::strlen(program->name()->c_str()));
   LOG_DEBUG(LogType::LogRuntimeTTNN,
             "Starting execution of program: ", program->name()->c_str());
+  GraphCaptureWindow graphCapture(program->name()->c_str());
   runProgramCallback(debug::Hooks::get().getpreProgramCallback(),
                      executableHandle, context.get());
   for (const ::tt::target::ttnn::Operation *op : *program->operations()) {
@@ -231,7 +415,10 @@ void ProgramExecutor::execute() {
         perf::Env::get().tracyProgramMetadata);
     runOpCallback(debug::Hooks::get().getPreOperatorCallback(),
                   executableHandle, op, context.get());
-    runOperation(op);
+    {
+      TrackedOperation trackedOperation(op, context.get());
+      runOperation(op);
+    }
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
     syncAfterOpIfNeeded();
 #endif


### PR DESCRIPTION
### Ticket

tenstorrent/tt-xla#5816 — validate the ttnn-visualizer workflow against models running through tt-xla. The consumer of this change is tenstorrent/tt-xla#5894, which adds the capture and import scripts plus a walkthrough per framework.

### Problem description

ttnn-visualizer reads a memory report written by ttnn's graph tracker: the operations that ran, the buffers they allocated, per-core pages and the cluster topology. The documented way to produce one is to open a capture from Python around the model call, which works for code that issues ttnn ops directly and does not work for anything running through this runtime.

Two reasons. `GraphTracker` keeps its processors in `thread_local` storage, and torch_xla dispatches execution to a worker thread, so a capture opened around a `torch.compile` call records what the calling thread did rather than what ran — measured at 2 nodes, against 1706 for the same run captured from inside the runtime. Under JAX the same Python capture does work, because `Execute` stays on the caller's thread, which makes the failure mode look like a JAX-versus-torch difference rather than a threading one. And even where the window lands correctly, a capture opened from C++ writes no [`python_io`](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md) records — the sidecar data ttnn's Python decorators produce — so the importer has no operation names, no arguments, no stack traces and no dataflow to draw the Graph tab from. It falls back to scanning the graph tracker's serialized arguments, which matches only plain `Tensor`-shaped types and folds plumbing ops away, rejecting inputs whose producer went with them.

The capture therefore has to be opened by the runtime, and it has to write the `python_io` records itself.

### What's changed

C++ only, all of it in `runtime/lib/ttnn/program_executor.cpp` — 188 added lines in one file. No Python changes, no flatbuffer or schema change, no new build option, and nothing for a framework integration to call. Capture stays off unless `TT_RUNTIME_GRAPH_CAPTURE_DIR` is set, so a build carrying this behaves as it does today until asked for a report.

**A capture window around each program execution.** `ProgramExecutor::execute()` opens a `ttnn::graph::ScopedGraphCapture` with detailed buffer tracing on and closes it when the program finishes, writing one report named `<program>_pid<pid>_tid<tid>_exec<index>.json`. The window's state is `thread_local`, matching `GraphTracker`'s own processor stack. Only top-level executions are counted and reported: a const-eval subprogram executes nested inside the program that needs its result and lands in that program's report, so a file carries a complete program tree rather than a slice of one. Three variables govern it — `TT_RUNTIME_GRAPH_CAPTURE_DIR` enables capture, `_FIRST` picks the first execution to record (default 0) and `_REPORTS` caps how many to write (default 1, zero meaning every execution).

**A tracked scope around each program op.** Each flatbuffer op is wrapped in `GraphTracker::track_function_start`/`track_function_end` named after its `OpType`, so the ttnn device operations it dispatches nest inside it as its captured sub-graph — the same shape ttnn's Python decorators produce. Each op also appends a record to a `<report>.python_io.json` sidecar carrying its MLIR location, its full op text and the tensor ids it read and wrote. Inputs and outputs come from the program tensor pool through the existing `getOpInputRefs`/`getOpOutputRefs` mapping, so nothing here needs its own op-type switch to maintain. Because consecutive ops name the same pool tensors, their ids match and the importer can draw the edges.

The result, measured on an n300 (wh-17) across the four captures in the tt-xla PR: operations are named `Conv2dOp`, `LinearOp`, `Pool2dOp` and carry the HLO instruction they were lowered from as `loc("convolution.49")`, and the Graph tab connects — mnist 71 operations in 11 components with a largest of 61, the ConvNet 93 in 25 with a largest of 69, JAX 23 in 9 with a largest of 7, one TinyLlama serving program 38 in 5 with a largest of 34. What stays isolated is what has no edge to draw: the deallocation of a program input, and `GetDeviceOp`. A mnist forward is a 12.15 MB report with a 53 KB sidecar; one TinyLlama serving program is 2.99 MB with a 17 KB sidecar, with the server ready in 4m51s and answering normally.

Two limits are worth naming, neither of them new code paths in this change.

`buffer_chunks`, the per-page detail behind the Buffers tab, comes out empty — 0 rows for the mnist capture, against 1327 before the per-op scope existed and 10463 for the same network captured natively through ttnn. The importer attaches pages to an operation by address, and [`graph_processor.cpp`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/core/graph/graph_processor.cpp) snapshots live buffers only at graph stacking level 1, which the per-op scope now occupies; at a program-op boundary the live buffers are program tensors allocated before the window opened, so no page snapshot exists for them, while the intermediates that were snapshotted are freed by then. Fixing it means snapshotting at every stacking level, or capturing pages lazily for a live buffer with no page timeline — both on the tt-metal side.

`_REPORTS=0` against a serving model dies in the allocator during weight load: the per-op buffer snapshot walks every buffer and asks for its bank count, and `AllocatorImpl::get_num_banks` throws `Unsupported buffer type!` on the host-side `SYSTEM_MEMORY` buffers that weight loading allocates. That is upstream in tt-metal too, and a bounded window avoids it — those buffers are transient, so a window opened after weight loading is unaffected.

### Performance

With capture off — the default, and the only path a normal run takes — each program execution costs one `thread_local` state access, a depth increment, and a `getenv` that is a function-local static, so evaluated once per process. Each flatbuffer op costs a `TrackedOperation` whose constructor reads `isRecording()` (a `thread_local` access and an `optional` check), stores `nullptr` and returns; its `std::string` and `nlohmann::json` members default-construct without allocating, because the name and the record are only filled while recording.

Measured on an n300 (wh-17), three runs each of tt-xla's `examples/jax/simple_regression.py` (~500 program executions) and `examples/pytorch/mnist.py` (one execution, 71 ops), in ms:

| Build | jax | mnist |
| --- | --- | --- |
| base, no hook | 4634 / 4656 / 4642 | 6479 / 6402 / 6368 |
| hook, capture off, round A | 4637 / 4639 / 4667 | 6288 / 6176 / 6189 |
| hook, capture off, round B | 4696 / 4747 / 4752 | 6870 / 6772 / 6754 |

Rounds A and B are the same library measured either side of a rebuild cycle, and they differ by ~580 ms on mnist — more than the gap to the no-hook build, and in the opposite direction depending on which round you pick. End-to-end sample timing therefore does not resolve the cost of the disabled path: it sits under a noise floor of roughly ±100 ms within a round and ±600 ms across rounds on a 6.2–6.8 s run. The tightest data point is the JAX sample at 4634 ms without the hook against 4637 ms with it, in the nearest-in-time pair, across ~500 executions and ~4000 op scopes. The intermediate revision carrying the capture window but no per-op scope measured a 6218 ms mnist mean against the full hook's 6218 ms in the same session, so the per-op wrapper specifically costs nothing measurable. Both library states were confirmed loaded rather than stale: with the base runtime installed, setting `TT_RUNTIME_GRAPH_CAPTURE_DIR` produced zero files, and with the hook installed it produced two files and one sidecar.

With capture on, one mnist report cost 6218 → 6424 ms in the tightest paired round, about 200 ms on that sample, and writes 12.15 MB; in the noisier round the difference was not separable from run-to-run variation. On the JAX sample at `_REPORTS=1` the cost is invisible, since 1 execution in ~500 is recorded — the mode that matters for anything long-running. Detailed buffer tracing and report serialization dominate, not the tracking. The window leaves `enable_fast_runtime_mode` alone, unlike ttnn's Python `full_graph_capture`, so it avoids that path's slow-dispatch cost. Moving per-op buffer snapshots from each device op to each program op was cost-neutral on report size, 12.19 MB to 12.15 MB.

### Checklist

- [ ] New/Existing tests provide coverage for changes

Not covered by tests here. The behaviour needs a device, a capture directory and an offline Python importer to assert anything about, and the assertions worth making live in ttnn's own graph-report tests. Verified by hand on an n300 (wh-17) end to end for a torch_xla sample, a JAX sample, a synthetic ConvNet and a vLLM TinyLlama-1.1B-Chat-v1.0 server, each captured, imported and opened in ttnn-visualizer; the tt-xla PR records the measurements per walkthrough. Suggestions on what a runnable test should assert are welcome.

### References

- [Graph tracing in ttnn](https://github.com/tenstorrent/tt-metal/blob/main/tech_reports/ttnn/graph-tracing.md) — the mechanism this hooks into: what the graph tracker records, what `python_io` adds, and how tensor ids link operations.
- [`ttnn/ttnn/graph_report.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph_report.py) — the offline importer, and the authority on which report keys fill which database table.
- [`ttnn/ttnn/graph.py`](https://github.com/tenstorrent/tt-metal/blob/main/ttnn/ttnn/graph.py) — the Python capture entry points this mirrors from C++.
- [ttnn-visualizer](https://github.com/tenstorrent/ttnn-visualizer) — the viewer the reports are for.
- [tenstorrent/tt-xla#5894](https://github.com/tenstorrent/tt-xla/pull/5894) — the capture and import scripts, the per-framework walkthroughs, and a tab-by-tab account of what a tt-xla capture contains.

