### PR TITLE
[D2M-JIT] Add fabric CCL kernel API

### DIFF
--- a/test/d2m-jit/lit/ccl_all_gather.py
+++ b/test/d2m-jit/lit/ccl_all_gather.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""Compile a minimal 1x2 fabric all-gather through the full backend."""
+
+import torch
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import (
+    _Builder,
+    _emit_returns_and_finalise,
+    _pipeline_passes,
+)
+from ttmlir.passmanager import PassManager
+
+
+@d2m.kernel
+def all_gather(input_, output, start_sem, end_sem):
+    dy = mesh_position(0)
+    dx = mesh_position(1)
+    cy = core_index(0)
+    cx = core_index(1)
+    device_synchronize(
+        start_sem,
+        start_device=[dy, 0],
+        mcast_shape=[1, 2],
+        num_receivers=1,
+        core_indices=[cy, cx],
+    )
+    scratch = empty([2, 2])
+    scratch = remote_load(scratch, input_, [0, 0])
+    remote_store(
+        output,
+        [dx, 0],
+        scratch,
+        start_device=[dy, 0],
+        device_mcast_shape=[1, 2],
+        semaphore=end_sem,
+        semaphore_indices=[cy, cx],
+    )
+    semaphore_wait(end_sem, 2)
+
+
+d2m.mesh((1, 2), topology=("linear", "linear"))
+input_layout = d2m.Layout(
+    shape=(64, 64),
+    dtype=d2m.float32,
+    block_shape=[2, 2],
+    grid_shape=[1, 1],
+)
+output_layout = d2m.Layout(
+    shape=(128, 64),
+    dtype=d2m.float32,
+    block_shape=[2, 2],
+    grid_shape=[2, 1],
+)
+full = torch.randn(64, 128, dtype=torch.float32)
+input_ = d2m.mesh_shard(
+    full,
+    input_layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+output = d2m.empty(output_layout)
+start_sem = d2m.global_semaphore(grid_shape=(8, 8))
+end_sem = d2m.global_semaphore(grid_shape=(8, 8))
+all_gather(
+    input_,
+    output,
+    start_sem,
+    end_sem,
+    grid=(1, 1),
+    fabric=d2m.fabric_config(cluster_axis=1, topology="linear"),
+)
+gathered = d2m.mesh_gather(
+    output,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [gathered])
+pipeline = (
+    "builtin.module("
+    "ttcore-register-device{mock-system-desc-arch=wormhole_b0 "
+    "mesh-shape=1,2 mesh-topology=linear,linear}," + ",".join(_pipeline_passes()) + ")"
+)
+PassManager.parse(pipeline, context=builder.ctx).run(builder.module.operation)
+builder.module.operation.verify()
+lowered = str(builder.module)
+assert "setup_fabric_connections" in lowered
+print("fabric lowering: ok")
+_Builder.reset()
+
+
+# CHECK: fabric lowering: ok

--- a/test/d2m-jit/lit/ccl_ops.py
+++ b/test/d2m-jit/lit/ccl_ops.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""IR coverage for d2m-jit fabric and CCL kernel operations."""
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import _Builder, _emit_returns_and_finalise
+from ttmlir.passmanager import PassManager
+
+
+@d2m.kernel
+def ccl_kernel(input_, output, start_sem, end_sem):
+    dy = mesh_position(0)
+    cy = core_index(0)
+    cx = core_index(1)
+    device_synchronize(
+        start_sem,
+        start_device=[dy, 0],
+        mcast_shape=[1, 2],
+        num_receivers=1,
+        core_indices=[cy, cx],
+    )
+    scratch = empty([1, 1])
+    scratch = remote_load(scratch, input_, [cy, cx])
+    remote_store(
+        output,
+        [cy, cx],
+        scratch,
+        start_device=[dy, 0],
+        device_mcast_shape=[1, 2],
+        semaphore=end_sem,
+        semaphore_indices=[cy, cx],
+    )
+    semaphore_wait(end_sem, 2)
+
+
+d2m.mesh((1, 2), topology=("linear", "ring"))
+layout = d2m.Layout(
+    shape=(32, 32),
+    dtype=d2m.float32,
+    block_shape=[1, 1],
+    grid_shape=[1, 1],
+)
+input_ = d2m.empty(layout)
+output = d2m.empty(layout)
+start_sem = d2m.global_semaphore(grid_shape=(8, 8))
+end_sem = d2m.global_semaphore(grid_shape=(8, 8))
+ccl_kernel(
+    input_,
+    output,
+    start_sem,
+    end_sem,
+    grid=(1, 1),
+    fabric=d2m.fabric_config(cluster_axis=1),
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [output])
+PassManager.parse(
+    "builtin.module(ttcore-register-device{mock-system-desc-arch=wormhole_b0 "
+    "mesh-shape=1,2 mesh-topology=linear,ring})",
+    context=builder.ctx,
+).run(builder.module.operation)
+builder.module.operation.verify()
+print(builder.module)
+_Builder.reset()
+
+
+# CHECK: d2m.generic
+# CHECK-SAME: fabricConnectionConfig = #ttcore.fabric_connection_config<noc_index = noc0, topology = ring, cluster_axis = 1, routing_mode = unidir_ring_torus, num_links = 1>
+# CHECK: %[[DY:.*]] = "d2m.mesh_position"
+# CHECK: d2m.device_synchronize
+# CHECK-SAME: %[[DY]]
+# CHECK: tensor.empty()
+# CHECK: d2m.remote_load
+# CHECK: d2m.remote_store
+# CHECK-SAME: devices startDevice
+# CHECK-SAME: deviceMcastShape
+# CHECK-SAME: semaphore increment
+# CHECK: d2m.semaphore_wait

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -40,6 +40,16 @@ requires_mesh = pytest.mark.skipif(
     reason="requires SYSTEM_DESC_PATH for a system with at least two devices",
 )
 
+requires_fabric_mesh = pytest.mark.skipif(
+    runtime is None
+    or _num_devices() < 2
+    or os.environ.get("D2M_JIT_RUN_FABRIC_TESTS") != "1",
+    reason=(
+        "requires a two-device system and D2M_JIT_RUN_FABRIC_TESTS=1 "
+        "to opt into fabric execution"
+    ),
+)
+
 
 def test_mesh_configuration():
     d2m.mesh((1, 2), topology=("linear", "ring"))
@@ -48,6 +58,21 @@ def test_mesh_configuration():
     assert '#ttcore.meshes<[<"mesh" = 1x2>]>' in str(builder.module.operation)
     assert builder._mesh_shape == [1, 2]
     assert builder._mesh_topology == ["linear", "ring"]
+
+
+def test_fabric_configuration_matches_mesh():
+    d2m.mesh((1, 2), topology=("linear", "ring"))
+    builder = _Builder.get()
+    fabric = d2m.fabric_config(cluster_axis=1)
+
+    builder.enable_fabric(fabric)
+
+    assert fabric.topology == "ring"
+    assert fabric.routing == "unidir_ring_torus"
+    assert builder._fabric_runtime_mode == "FABRIC_1D_RING"
+
+    with pytest.raises(ValueError, match="does not match mesh topology"):
+        builder.enable_fabric(d2m.fabric_config(cluster_axis=1, topology="linear"))
 
 
 def test_mesh_gather_derives_full_shape():
@@ -131,3 +156,76 @@ def test_mesh_compute_round_trip_1x2():
 
     assert result.shape == full.shape
     assert (torch.sigmoid(full) - result).abs().max().item() < 0.05
+
+
+@requires_fabric_mesh
+def test_all_gather_round_trip_1x2():
+    @d2m.kernel
+    def all_gather(input_, output, start_sem, end_sem):
+        dy = mesh_position(0)
+        dx = mesh_position(1)
+        cy = core_index(0)
+        cx = core_index(1)
+        device_synchronize(
+            start_sem,
+            start_device=[dy, 0],
+            mcast_shape=[1, 2],
+            num_receivers=1,
+            core_indices=[cy, cx],
+        )
+        scratch = empty([2, 2])
+        scratch = remote_load(scratch, input_, [0, 0])
+        remote_store(
+            output,
+            [dx, 0],
+            scratch,
+            start_device=[dy, 0],
+            device_mcast_shape=[1, 2],
+            semaphore=end_sem,
+            semaphore_indices=[cy, cx],
+        )
+        semaphore_wait(end_sem, 2)
+
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    input_layout = d2m.Layout(
+        shape=(64, 64),
+        dtype=d2m.float32,
+        block_shape=[2, 2],
+        grid_shape=[1, 1],
+    )
+    output_layout = d2m.Layout(
+        shape=(128, 64),
+        dtype=d2m.float32,
+        block_shape=[2, 2],
+        grid_shape=[2, 1],
+    )
+    full = torch.randn(64, 128, dtype=torch.float32)
+    input_ = d2m.mesh_shard(
+        full,
+        input_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    output = d2m.empty(output_layout)
+    start_sem = d2m.global_semaphore()
+    end_sem = d2m.global_semaphore()
+    all_gather(
+        input_,
+        output,
+        start_sem,
+        end_sem,
+        grid=(1, 1),
+        fabric=d2m.fabric_config(cluster_axis=1, topology="linear"),
+    )
+    result = d2m.mesh_gather(
+        output,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    ).to_host()
+
+    shard0 = full[:, :64]
+    shard1 = full[:, 64:]
+    gathered = torch.cat([shard0, shard1], dim=0)
+    expected = torch.cat([gathered, gathered], dim=1)
+    assert result.shape == expected.shape
+    assert (expected - result).abs().max().item() < 0.05

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -99,6 +99,92 @@ def _to_runtime_data_type(dtype):
     return mapping[dtype]
 
 
+class FabricConfig:
+    """Host-side description of a generic's 1D fabric connection."""
+
+    __slots__ = ("cluster_axis", "topology", "routing", "noc", "num_links")
+
+    _ROUTING_BY_TOPOLOGY = {
+        "linear": "bidir_line_mesh",
+        "ring": "unidir_ring_torus",
+    }
+
+    def __init__(
+        self,
+        cluster_axis,
+        topology="ring",
+        routing=None,
+        noc="noc0",
+        num_links=1,
+    ):
+        if (
+            not isinstance(cluster_axis, int)
+            or isinstance(cluster_axis, bool)
+            or cluster_axis < 0
+        ):
+            raise ValueError(
+                f"fabric cluster_axis must be a non-negative integer, got {cluster_axis!r}"
+            )
+
+        topology = str(topology).lower()
+        if topology not in self._ROUTING_BY_TOPOLOGY:
+            raise ValueError(
+                "fabric topology must be 'linear' or 'ring', " f"got {topology!r}"
+            )
+
+        expected_routing = self._ROUTING_BY_TOPOLOGY[topology]
+        routing = expected_routing if routing is None else str(routing).lower()
+        if routing != expected_routing:
+            raise ValueError(
+                f"fabric topology {topology!r} requires routing "
+                f"{expected_routing!r}, got {routing!r}"
+            )
+
+        noc = str(noc).lower()
+        if noc not in {"noc0", "noc1"}:
+            raise ValueError(f"fabric noc must be 'noc0' or 'noc1', got {noc!r}")
+        if (
+            not isinstance(num_links, int)
+            or isinstance(num_links, bool)
+            or num_links <= 0
+        ):
+            raise ValueError(
+                f"fabric num_links must be a positive integer, got {num_links!r}"
+            )
+
+        self.cluster_axis = cluster_axis
+        self.topology = topology
+        self.routing = routing
+        self.noc = noc
+        self.num_links = num_links
+
+    @property
+    def runtime_mode(self):
+        return "FABRIC_1D_RING" if self.topology == "ring" else "FABRIC_1D"
+
+    def build_attr(self, ctx):
+        return Attribute.parse(
+            "#ttcore.fabric_connection_config<"
+            f"noc_index = {self.noc}, "
+            f"topology = {self.topology}, "
+            f"cluster_axis = {self.cluster_axis}, "
+            f"routing_mode = {self.routing}, "
+            f"num_links = {self.num_links}>",
+            ctx,
+        )
+
+
+def fabric_config(
+    cluster_axis,
+    topology="ring",
+    routing=None,
+    noc="noc0",
+    num_links=1,
+):
+    """Create a validated 1D fabric configuration for a kernel call."""
+    return FabricConfig(cluster_axis, topology, routing, noc, num_links)
+
+
 # --- Builder singleton -------------------------------------------------------
 
 
@@ -269,6 +355,7 @@ class _Builder:
         self._mesh_shape = None
         self._mesh_topology = None
         self._mesh_name = None
+        self._fabric_runtime_mode = None
         # Reset the MLIR-free mesh mirror the simulator reads (a fresh graph
         # declares its own mesh).
         _clear_current_mesh()
@@ -321,6 +408,49 @@ class _Builder:
         self._mesh_topology = requested_topology
         self._mesh_name = "mesh"
         _set_current_mesh(self._mesh_shape, self._mesh_topology, self._mesh_name)
+
+    def enable_fabric(self, fabric):
+        """Validate a kernel fabric config and record its runtime mode."""
+        if not isinstance(fabric, FabricConfig):
+            raise TypeError(
+                "fabric must be created with d2m.fabric_config(), "
+                f"got {type(fabric).__name__}"
+            )
+        if self._mesh_shape is None:
+            raise RuntimeError(
+                "fabric kernels require a device mesh; call d2m.mesh() first"
+            )
+        if fabric.cluster_axis >= len(self._mesh_shape):
+            raise ValueError(
+                f"fabric cluster_axis {fabric.cluster_axis} is out of range for "
+                f"mesh shape {tuple(self._mesh_shape)}"
+            )
+        if self._mesh_shape[fabric.cluster_axis] < 2:
+            raise ValueError(
+                f"fabric cluster_axis {fabric.cluster_axis} has size "
+                f"{self._mesh_shape[fabric.cluster_axis]}; expected at least 2"
+            )
+        if self._mesh_topology is None:
+            raise RuntimeError(
+                "fabric kernels require an explicit mesh topology; pass "
+                "topology= to d2m.mesh()"
+            )
+        mesh_topology = self._mesh_topology[fabric.cluster_axis]
+        if mesh_topology != fabric.topology:
+            raise ValueError(
+                f"fabric topology {fabric.topology!r} does not match mesh "
+                f"topology {mesh_topology!r} on axis {fabric.cluster_axis}"
+            )
+        if (
+            self._fabric_runtime_mode is not None
+            and self._fabric_runtime_mode != fabric.runtime_mode
+        ):
+            raise ValueError(
+                "all fabric kernels in one graph must use the same runtime "
+                f"mode; already using {self._fabric_runtime_mode}, got "
+                f"{fabric.runtime_mode}"
+            )
+        self._fabric_runtime_mode = fabric.runtime_mode
 
     def _refresh_function_type(self, results=None):
         with self.ctx, self.loc:
@@ -1616,15 +1746,30 @@ def _execute(b: _Builder, lts):
             )
         )
 
-    device = runtime.open_mesh_device(device_options)
-    submitted = runtime.submit(device, fbb, program_index, rt_inputs)
-    runtime.wait(submitted)
-    for i, rt_out in enumerate(submitted):
-        host_view = runtime.to_host(rt_out, untilize=True)[0]
-        runtime.memcpy(rt_outputs[i], host_view)
-        runtime.deallocate_tensor(rt_out, force=True)
-    runtime.close_mesh_device(device)
-    return out_torch
+    device = None
+    fabric_enabled = False
+    try:
+        if b._fabric_runtime_mode is not None:
+            runtime.set_fabric_config(
+                getattr(runtime.FabricConfig, b._fabric_runtime_mode)
+            )
+            fabric_enabled = True
+
+        device = runtime.open_mesh_device(device_options)
+        submitted = runtime.submit(device, fbb, program_index, rt_inputs)
+        runtime.wait(submitted)
+        for i, rt_out in enumerate(submitted):
+            host_view = runtime.to_host(rt_out, untilize=True)[0]
+            runtime.memcpy(rt_outputs[i], host_view)
+            runtime.deallocate_tensor(rt_out, force=True)
+        return out_torch
+    finally:
+        try:
+            if device is not None:
+                runtime.close_mesh_device(device)
+        finally:
+            if fabric_enabled:
+                runtime.set_fabric_config(runtime.FabricConfig.DISABLED)
 
 
 def to_host(*lts: LazyTensor):
@@ -1824,6 +1969,7 @@ def _emit_kernel_generic(
     block_factors,
     indexing_maps,
     iterator_types,
+    fabric=None,
     kernel_io_in_dram=None,
     grid_offset=(0, 0),
 ):
@@ -1848,6 +1994,17 @@ def _emit_kernel_generic(
             hint=hint,
             cause=cause,
         )
+
+    fabric_attr = None
+    if fabric is not None:
+        if not isinstance(b, _Builder):
+            raise _call_error(
+                "fabric kernels require the top-level lazy builder and are not "
+                "supported inside a pattern rewrite or d2m.spatial",
+                cause=TypeError(),
+            )
+        b.enable_fabric(fabric)
+        fabric_attr = fabric.build_attr(b.ctx)
 
     # Split args while preserving the GenericOp contract: all tensors precede
     # all additional args (runtime scalars and global semaphores).
@@ -2016,6 +2173,7 @@ def _emit_kernel_generic(
             iter_attr,
             threads,
             1,  # num_regions
+            fabricConnectionConfig=fabric_attr,
         )
 
         region = generic.regions[0]
@@ -2075,6 +2233,7 @@ class CompiledKernel:
         block_factors=None,
         indexing_maps=None,
         iterator_types=None,
+        fabric=None,
         kernel_io_in_dram=None,
     ):
         b = _get_scope()
@@ -2087,9 +2246,14 @@ class CompiledKernel:
                 block_factors=block_factors,
                 indexing_maps=indexing_maps,
                 iterator_types=iterator_types,
+                fabric=fabric,
                 kernel_io_in_dram=kernel_io_in_dram,
             )
         else:
+            if fabric is not None:
+                raise ValueError(
+                    "fabric kernels are not currently supported inside d2m.spatial"
+                )
             b._emit_kernel_for_spatial(
                 self,
                 args,

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -8,7 +8,7 @@ import ast
 import functools
 
 from ttmlir.ir import *
-from ttmlir.dialects import d2m, ttcore, arith, linalg
+from ttmlir.dialects import d2m, ttcore, arith, linalg, tensor
 from ttmlir.dialects._ods_common import get_default_loc_context
 
 from ._src.utils import _asindex
@@ -26,9 +26,11 @@ from ._src.tensor_layout import (
 from ._src import builder as _builder
 from ._src.builder import (
     CompiledKernel,
+    FabricConfig,
     GlobalSemaphore,
     LazyTensor,
     MeshShard,
+    fabric_config,
     reduction_layout,
     arange,
     view_layout,
@@ -204,10 +206,77 @@ def _tile_bcast_type_attr(node):
     return _parse_tile_bcast_type(node.value)
 
 
+def _as_value(value):
+    """Coerce an OpView to its result Value; leave Values untouched."""
+    return value.result if hasattr(value, "result") else value
+
+
+def _idx_list(value):
+    """Normalize an optional index or index sequence to a list of Values."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [_asindex(item) for item in value]
+    return [_asindex(value)]
+
+
+def _i64_attr_from_literal(node):
+    if (
+        not isinstance(node, ast.Constant)
+        or not isinstance(node.value, int)
+        or isinstance(node.value, bool)
+    ):
+        raise D2mJitError("expected an integer literal")
+    return IntegerAttr.get(IntegerType.get_signless(64), node.value)
+
+
+def _static_int_from_ast(node, visitor):
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, int)
+        and not isinstance(node.value, bool)
+    ):
+        return node.value
+    if isinstance(node, ast.Name):
+        value = visitor.captures.get(node.id)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    if isinstance(node, ast.UnaryOp):
+        value = _static_int_from_ast(node.operand, visitor)
+        if isinstance(node.op, ast.UAdd):
+            return value
+        if isinstance(node.op, ast.USub):
+            return -value
+    if isinstance(node, ast.BinOp):
+        lhs = _static_int_from_ast(node.left, visitor)
+        rhs = _static_int_from_ast(node.right, visitor)
+        if isinstance(node.op, ast.Add):
+            return lhs + rhs
+        if isinstance(node.op, ast.Sub):
+            return lhs - rhs
+        if isinstance(node.op, ast.Mult):
+            return lhs * rhs
+        if isinstance(node.op, ast.FloorDiv):
+            return lhs // rhs
+        if isinstance(node.op, ast.Mod):
+            return lhs % rhs
+    raise D2mJitError("expected a compile-time integer expression")
+
+
 @syntax("remote_load")
 def remote_load(
-    src, indices, mcast_start_index=None, mcast_shape=None, mcast_dims=None
+    *args, mcast_start_index=None, mcast_shape=None, mcast_dims=None
 ) -> MemTx:
+    if len(args) == 2:
+        local_buffer, src, indices = None, args[0], args[1]
+    elif len(args) == 3:
+        local_buffer, src, indices = args
+    else:
+        raise D2mJitError(
+            "remote_load expects (src, indices) or (buffer, src, indices); "
+            f"got {len(args)} positional arguments"
+        )
+
     if mcast_dims is not None:
         if isinstance(mcast_dims, tuple):
             mcast_dims = list(mcast_dims)
@@ -215,10 +284,15 @@ def remote_load(
             if isinstance(mcast_dims, int):
                 mcast_dims = arith.constant(IndexType.get(src.context), mcast_dims)
             mcast_dims = [mcast_dims]
-    dst_type = RankedTensorType.get(
-        src.type.shape[len(indices) :], src.type.element_type
-    )
-    dst = d2m.empty(dst_type)
+    if local_buffer is None:
+        dst_type = RankedTensorType.get(
+            src.type.shape[len(indices) :], src.type.element_type
+        )
+        local_buffer = d2m.empty(dst_type)
+    else:
+        local_buffer = _as_value(local_buffer)
+        dst_type = local_buffer.type
+
     return d2m.remote_load(
         dst_type,
         src,
@@ -226,31 +300,77 @@ def remote_load(
         mcast_start_index=mcast_start_index,
         mcast_shape=mcast_shape,
         mcast_dims=mcast_dims,
-        local_buffer=dst,
+        local_buffer=local_buffer,
     )
 
 
 @syntax("remote_store")
-def remote_store(dst, indices, src):
+def remote_store(
+    dst,
+    indices,
+    src,
+    *,
+    start_device=None,
+    device_mcast_shape=None,
+    semaphore=None,
+    semaphore_indices=None,
+):
+    """Store a shard locally or across a mesh-device range."""
     return d2m.remote_store(
         dst.type,
         dst,
         indices,
-        start_device=[],
-        device_mcast_shape=[],
-        semaphore_indices=[],
+        start_device=_idx_list(start_device),
+        device_mcast_shape=_idx_list(device_mcast_shape),
+        semaphore_indices=_idx_list(semaphore_indices),
         local_buffer=src,
+        semaphore=semaphore,
     )
 
 
 @syntax(
     "core_index",
-    args_as_attr=[
-        lambda node: IntegerAttr.get(IntegerType.get_signless(64), node.value)
-    ],
+    args_as_attr=[_i64_attr_from_literal],
 )
 def core_index(index):
     return d2m.core_index(index)
+
+
+@syntax("mesh_position", args_as_attr=[_i64_attr_from_literal])
+def mesh_position(dim):
+    """Return this device's position along a mesh dimension."""
+    return d2m.mesh_position(dim)
+
+
+@syntax("semaphore_wait")
+def semaphore_wait(semaphore, value, reset=None):
+    return d2m.semaphore_wait(semaphore, _asindex(value), reset_value=_asindex(reset))
+
+
+@syntax(
+    "device_synchronize",
+    kwargs_as_attr={
+        "num_receivers": lambda node, visitor: IntegerAttr.get(
+            IntegerType.get_signless(32), _static_int_from_ast(node, visitor)
+        )
+    },
+)
+def device_synchronize(
+    semaphore,
+    *,
+    start_device=None,
+    mcast_shape=None,
+    num_receivers=0,
+    core_indices=None,
+):
+    """Synchronize fabric senders with their receiving mesh devices."""
+    return d2m.device_synchronize(
+        semaphore,
+        _idx_list(start_device),
+        _idx_list(mcast_shape),
+        num_receivers,
+        _idx_list(core_indices),
+    )
 
 
 # --- Block-level elementwise free functions ---------------------------------
@@ -801,7 +921,7 @@ def _shape_literal(node):
     if isinstance(node, (ast.List, ast.Tuple)):
         return [int(_const_value(element)) for element in node.elts]
     raise D2mJitError(
-        "zeros() expects a literal block shape, e.g. zeros([m_tiles, n_tiles]); "
+        "expected a literal block shape, e.g. [m_tiles, n_tiles]; "
         f"got {type(node).__name__}"
     )
 
@@ -813,6 +933,14 @@ def _zeros_op(shape):
     tile_ty = ttcore.ir.TileType.get(ctx, 32, 32, float32)
     block_ty = RankedTensorType.get(list(shape), tile_ty)
     return _zeros_block(block_ty)
+
+
+@syntax("empty", args_as_attr=[_shape_literal])
+def _empty_op(shape):
+    """Kernel-body uninitialized L1 scratch block."""
+    ctx = get_default_loc_context()
+    tile_ty = ttcore.ir.TileType.get(ctx, 32, 32, float32)
+    return tensor.empty(list(shape), tile_ty)
 
 
 def _bool_attr_from_ast(node):


### PR DESCRIPTION
## Summary

- add a validated `d2m.fabric_config()` API and initialize/tear down the matching TT-Metal fabric mode around D2M execution
- expose mesh position, semaphore wait, device synchronization, and fabric-aware remote load/store primitives to D2M kernels
- lower fabric configuration through generic attributes and cover the generated all-gather/CCL programs

## Stack

This draft is stacked on #9156, which is stacked on #9096. The next draft adds router-owned multicore fabric operations.

## Validation

- D2M CCL lit coverage (`ccl_all_gather.py`, `ccl_ops.py`)
- mesh/fabric API unit coverage in `test/d2m-jit/test_mesh.py`
- reconstructed stack passes `pre-commit run --all-files`

Split from #9170 to keep the public kernel API independently reviewable.