### PR TITLE
[D2M] Support router-owned multicore fabric operations

### DIFF
--- a/docs/design/d2m-split-unified-thread-redesign.md
+++ b/docs/design/d2m-split-unified-thread-redesign.md
@@ -100,9 +100,10 @@ flow must keep all of them.
    waits on the CB it actually reads.
 10. **Scratch buffers** (`d2m.scratch_buffer`) and **reduction scaler buffers**
     are not treated as synchronized CBs.
-11. **`semaphore_wait` (no reset) is replicated into both threads**, preserving
-    relative order. `semaphore_wait` *with* reset in a unified region is an
-    error (`checkForIllegalSemaphoreOps`).
+11. **Non-mutating `semaphore_wait` is replicated into both threads**, preserving
+    relative order. Semaphore mutations (`semaphore_inc`, `semaphore_set`, and
+    waits with reset), router-only waits, and producer-release waits run only on
+    data movement so they cannot execute twice.
 12. Multicast parameters on `remote_load` and `preallocated_semaphores` /
     semaphore operands on `remote_store` are preserved through the explicit-CB
     conversion.
@@ -166,6 +167,7 @@ compute (see below); Pass 3 consumes and erases them.
 | aliased `remote_load` / `remote_store` | `compute` |
 | ops with `D2MGenericRegionComputeOpTrait` and their enclosing `linalg.generic` | `compute` |
 | `semaphore_wait` (no reset) | replicated → tag `both` |
+| `semaphore_inc` / `semaphore_set` / `semaphore_wait` with reset | `datamovement` |
 
 Structural / pure ops (`arith.constant`, `scf.for`, `d2m.core_index`,
 `view_layout`, `memref.alloc`, `get_cb`, index arithmetic) are **left
@@ -173,9 +175,9 @@ untagged**; Pass 2 replicates them to both threads and lets DCE drop the unused
 copies. This matches the current "clone all to both, then prune" behaviour but
 makes the decision explicit and one-time.
 
-Pass 1 also runs `checkForIllegalSemaphoreOps` (invariant 11) and the scratch /
-reduction-scaler exclusions (invariant 10) when classifying compute CB usage —
-though note these only matter to Pass 3; see §6.
+Pass 1 also applies the scratch / reduction-scaler exclusions (invariant 10)
+when classifying compute CB usage — though note these only matter to Pass 3;
+see §6.
 
 Output: still one unified region, semantically unchanged, now annotated and in
 explicit-CB form for data movement.
@@ -302,7 +304,7 @@ Demonstrating semantic equivalence for every current test case.
 | 14 compute→copy→compute | cb_buf DMA-produce; compute_scratch compute-produce+DMA-consume(copy); copy_dst DMA-produce(copy)+compute-read; cb_out compute-produce+DMA-store | DMA: load, copy, store; compute: wait/reserve/linalg/push/pop ×2. ✓ |
 | fanout (file 2) | cb_in DMA-produce, two compute consumers same nest | one `wait` before first, one `pop` after last. ✓ |
 | fanout_unsupported | cb_in consumers in two distinct nests | `commonParentBlock` fails → diagnostic. ✓ (Message text will change; see §8.) |
-| semaphore_wait ×2 | as labelled | `semaphore_wait` tagged `both`, replicated, order preserved; CB ops as above. ✓ |
+| semaphore_wait ×2 | as labelled | non-mutating `semaphore_wait` tagged `both`, replicated, order preserved; reset waits run on data movement; CB ops as above. ✓ |
 
 ## 7. Risks and open questions
 
@@ -372,7 +374,8 @@ contract at each boundary. Provisional RUN lines:
 - aliased load/store: op left in implicit form, tagged
   `d2m.thread = #d2m.thread<compute>`.
 - compute op (`linalg.generic` + `tile_exp`): tagged `compute`.
-- `semaphore_wait` (no reset): tagged `both`; with reset: `expected-error`.
+- `semaphore_wait` (no reset): tagged `both`; with reset: tagged
+  `datamovement` and not replicated.
 - `local_copy`: explicit-CB form, tagged `datamovement`.
 - negative: non-unified generic untouched.
 

--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -2474,6 +2474,63 @@ def D2M_RemoteStoreOp : D2M_GenericRegionDatamovementOp<"remote_store",
     }];
 }
 
+def D2M_CoreReadOp
+    : D2M_GenericRegionDatamovementOp<
+          "core_read",
+          [MemoryEffects<[MemRead, MemWrite]>, DestinationStyleOpInterface,
+           DeclareOpInterfaceMethods<
+               BufferizableOpInterface, ["bufferizesToMemoryRead",
+                                         "bufferizesToMemoryWrite", "bufferize",
+                                         "getAliasingValues", "getBufferType",
+                                         "hasTensorSemantics"]>,
+           D2M_SynchronizableOpInterface]> {
+  let summary = "D2M core-to-core local-L1 read.";
+  let description = [{
+      Reads an entire local L1 buffer from another core in the grid into this
+      core's local L1 buffer over the NoC. Both buffers must be local and have
+      identical shape and element type. The source buffer must have the same L1
+      offset on every core; `srcCore` selects the source core's logical `[y, x]`
+      coordinate.
+
+      Synchronization is the caller's responsibility: the source core must
+      publish the buffer before the read and must not overwrite it until the
+      transfer has completed.
+    }];
+
+  let arguments = (ins Arg<AnyRankedTensorOrMemRef,
+                           "remote core's local source buffer", [MemRead]>:$src,
+      Variadic<Index>:$srcCore,
+      Arg<AnyRankedTensorOrMemRef,
+          "this core's local destination buffer", [MemWrite]>:$dst);
+
+  let results = (outs Optional<AnyRankedTensorOrMemRef>:$result);
+
+  let assemblyFormat = [{
+      $src `core` `[` $srcCore `]` `into` $dst attr-dict
+      `:` type($src) `,` type($dst) (`->` qualified(type($result))^)?
+    }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+      MemRefType getSrcMemRefType() {
+        return cast<MemRefType>(getSrc().getType());
+      }
+      MemRefType getDstMemRefType() {
+        return cast<MemRefType>(getDst().getType());
+      }
+      mlir::MutableOperandRange getDpsInitsMutable() {
+        return getDstMutable();
+      }
+      bool isProducer(mlir::OpOperand &operand) {
+        return operand.get() == getDst();
+      }
+      bool isConsumer(mlir::OpOperand &operand) {
+        return operand.get() == getSrc();
+      }
+    }];
+}
+
 //===----------------------------------------------------------------------===//
 // D2M Generic Region Semaphore Ops (Used in TTMetal Lowering)
 //===----------------------------------------------------------------------===//
@@ -3134,6 +3191,28 @@ def D2M_MeshPositionOp : D2M_GenericRegionOp<"mesh_position", [ Pure ]> {
 
     let arguments = (ins ConfinedAttr<I64Attr, [IntMinValue<0>]>:$dim);
     let results = (outs Index:$result);
+}
+
+def D2M_IsRouterCoreOp : D2M_GenericRegionOp<"is_router_core", [Pure]> {
+  let summary = "Query whether this core is a fabric router core.";
+  let description = [{
+      Returns true on cores assigned to issue fabric operations by the enclosing
+      generic's fabric connection configuration. An empty router-core list means
+      the whole grid and therefore returns true.
+    }];
+  let results = (outs I1:$result);
+  let assemblyFormat = [{ attr-dict `:` type($result) }];
+}
+
+def D2M_RouterDirectionOp : D2M_GenericRegionOp<"router_direction", [Pure]> {
+  let summary = "Query this router core's link-direction slot index.";
+  let description = [{
+      Returns the matching router-core slot index. Slot i selects routing plane
+      i / cores_per_link and direction i % cores_per_link. Returns zero when no
+      router-core subset is configured and is undefined on non-router cores.
+    }];
+  let results = (outs Index:$result);
+  let assemblyFormat = [{ attr-dict `:` type($result) }];
 }
 
 

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -1094,8 +1094,10 @@ def D2MAssignThreads : Pass<"d2m-assign-threads", "::mlir::ModuleOp"> {
       thread it will be split into. All remote/`local_copy` ops -- including
       aliased ones -- are assigned to `datamovement` (the verifier requires
       remote ops to live on the datamovement thread); compute ops are assigned
-      to `compute`. Ops replicated into both threads (structural ops,
-      `semaphore_wait`) are left untagged.
+      to `compute`. Semaphore mutations, router-only waits, and
+      producer-release waits are assigned to `datamovement`; other semaphore
+      waits and structural ops are replicated into both threads and left
+      untagged.
 
     The annotations are an internal handoff consumed by `d2m-split-threads`.
   }];

--- a/include/ttmlir/Dialect/D2M/Utils/DMAUtils.h
+++ b/include/ttmlir/Dialect/D2M/Utils/DMAUtils.h
@@ -6,19 +6,11 @@
 #define TTMLIR_DIALECT_D2M_UTILS_DMAUTILS_H
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace mlir::tt::d2m::utils {
-
-// Recursively check that there are no illegal semaphore ops in a block and its
-// nested regions. Semaphore_inc, semaphore_set, and semaphore_wait with reset
-// are not supported in regions that will be replicated across multiple threads,
-// as all threads would execute the operation, creating a race condition on the
-// shared semaphore.
-LogicalResult checkForIllegalSemaphoreOps(Block *block);
 
 // Backends currently support only the WH/BH 2-DM core model. Reject Quasar and
 // any explicit DM core index beyond RiscV0/RiscV1 up front.

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -698,7 +698,7 @@ def TTCore_FabricConnectionConfigAttr: TTCore_Attr<"FabricConnectionConfig", "fa
   let assemblyFormat = "`<` `noc_index` `=` $noc_index `,` `topology` `=` $topology `,` `cluster_axis` `=` $cluster_axis `,` `routing_mode` `=` $routing_mode `,` `num_links` `=` $num_links (`,` `router_cores` `=` `[` $router_cores^ `]`)? `>`";
   let extraClassDeclaration = [{
     // Router cores is a flat list of (y, x) grid coordinate pairs, one per
-    // (link, direction) slot. Empty preserves the legacy whole-grid behavior.
+    // (link, direction) slot. An empty list assigns every grid core.
     unsigned getNumRouterSlots() const { return getRouterCores().size() / 2; }
   }];
   let genVerifyDecl = 1;

--- a/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
+++ b/include/ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.td
@@ -693,8 +693,15 @@ def TTCore_FabricConnectionConfigAttr: TTCore_Attr<"FabricConnectionConfig", "fa
                         "Topology":$topology,
                         "uint32_t":$cluster_axis,
                         "RoutingMode":$routing_mode,
-                        "uint32_t":$num_links);
-  let assemblyFormat = "`<` `noc_index` `=` $noc_index `,` `topology` `=` $topology `,` `cluster_axis` `=` $cluster_axis `,` `routing_mode` `=` $routing_mode `,` `num_links` `=` $num_links `>`";
+                        "uint32_t":$num_links,
+                        OptionalArrayRefParameter<"int64_t">:$router_cores);
+  let assemblyFormat = "`<` `noc_index` `=` $noc_index `,` `topology` `=` $topology `,` `cluster_axis` `=` $cluster_axis `,` `routing_mode` `=` $routing_mode `,` `num_links` `=` $num_links (`,` `router_cores` `=` `[` $router_cores^ `]`)? `>`";
+  let extraClassDeclaration = [{
+    // Router cores is a flat list of (y, x) grid coordinate pairs, one per
+    // (link, direction) slot. Empty preserves the legacy whole-grid behavior.
+    unsigned getNumRouterSlots() const { return getRouterCores().size() / 2; }
+  }];
+  let genVerifyDecl = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -216,4 +216,7 @@ table FabricConnectionConfig {
   cluster_axis: uint32;
   routing_mode: RoutingMode;
   num_links: uint32;
+  // Optional flat list of (y, x) worker coordinates that own fabric
+  // connections. Empty preserves the legacy whole-grid behavior.
+  router_cores: [int];
 }

--- a/include/ttmlir/Target/Common/types.fbs
+++ b/include/ttmlir/Target/Common/types.fbs
@@ -217,6 +217,6 @@ table FabricConnectionConfig {
   routing_mode: RoutingMode;
   num_links: uint32;
   // Optional flat list of (y, x) worker coordinates that own fabric
-  // connections. Empty preserves the legacy whole-grid behavior.
+  // connections. An empty list assigns every grid core.
   router_cores: [int];
 }

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_fabric_1d_routing.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_fabric_1d_routing.h
@@ -195,15 +195,14 @@ FORCE_INLINE McastRoutingParams get_mcast_params_line(
       static_cast<uint32_t>(topology.routing_directions[topology.axis].first);
   uint32_t bwd_dir =
       static_cast<uint32_t>(topology.routing_directions[topology.axis].second);
-  ASSERT(fwd_dir != eth_chan_directions::COUNT);
-  ASSERT(bwd_dir != eth_chan_directions::COUNT);
-
   if (range_fwd != 0) {
+    ASSERT(fwd_dir != eth_chan_directions::COUNT);
     result.params_per_direction[fwd_dir].active = true;
     result.params_per_direction[fwd_dir].mcast_command_header = {
         static_cast<uint8_t>(start_fwd), static_cast<uint8_t>(range_fwd)};
   }
   if (range_bwd != 0) {
+    ASSERT(bwd_dir != eth_chan_directions::COUNT);
     result.params_per_direction[bwd_dir].active = true;
     result.params_per_direction[bwd_dir].mcast_command_header = {
         static_cast<uint8_t>(start_bwd), static_cast<uint8_t>(range_bwd)};

--- a/include/ttmlir/Target/TTKernel/LLKs/experimental_fabric_topology_info.h
+++ b/include/ttmlir/Target/TTKernel/LLKs/experimental_fabric_topology_info.h
@@ -157,17 +157,11 @@ get_line_regions(int32_t my_idx, int32_t start_idx, int32_t end_idx,
   WAYPOINT("DA09");
   ASSERT(!(my_idx == start_idx && start_idx == end_idx));
 
-  // remove my_idx from endpoints since we don't send to ourselves
-  if (my_idx == start_idx) {
-    my_idx = (my_idx + 1) % size;
-  }
-  if (my_idx == end_idx) {
-    my_idx = (my_idx - 1 + size) % size;
-  }
-
   bool wraps = (start_idx > end_idx);
   if (!wraps) {
-    // Non-wrapped range: destinations are [start_idx..end_idx]
+    // Non-wrapped range: destinations are [start_idx..end_idx]. The
+    // forward/backward counts below already exclude the sender, so remapping
+    // an endpoint sender would invert its only valid direction on a line.
     if (my_idx < start_idx) {
       // Sender before range: forward only
       return {start_idx - my_idx, end_idx - start_idx + 1, 0, 0};
@@ -175,10 +169,18 @@ get_line_regions(int32_t my_idx, int32_t start_idx, int32_t end_idx,
       // Sender after range: backward only
       return {0, 0, my_idx - end_idx, end_idx - start_idx + 1};
     } else {
-      // Sender inside range: both directions
+      // Sender inside range (or at an endpoint): both directions
       return {1, end_idx - my_idx, 1, my_idx - start_idx};
     }
   } else {
+    // Remove the sender from wrapped endpoints.
+    if (my_idx == start_idx) {
+      my_idx = (my_idx + 1) % size;
+    }
+    if (my_idx == end_idx) {
+      my_idx = (my_idx - 1 + size) % size;
+    }
+
     // Wrapped range: destinations are [start_idx..size-1] and [0..end_idx]
     bool in_upper = (my_idx > start_idx && my_idx < size);
     bool in_lower = (my_idx > 0 && my_idx < end_idx);

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -2768,6 +2768,40 @@ private:
   const d2m::CBProducerConsumer *cbProducerConsumer;
 };
 
+// Read a whole uniform-offset local-L1 buffer from another worker core. This
+// bypasses device-layout addressing and maps directly to a NoC read.
+class D2MCoreReadRewriter : public OpConversionPattern<d2m::CoreReadOp> {
+public:
+  using OpConversionPattern<d2m::CoreReadOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::CoreReadOp op, d2m::CoreReadOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Location loc = op.getLoc();
+    auto chipDesc = ttcore::getOpChipDescAttr(op);
+
+    Value dstL1Addr =
+        rewriter.create<ttkernel::GetWritePtrOp>(loc, adaptor.getDst());
+    Value srcL1Addr =
+        rewriter.create<ttkernel::GetReadPtrOp>(loc, adaptor.getSrc());
+
+    auto srcType = op.getSrcMemRefType();
+    int64_t bytes = srcType.getNumElements() *
+                    ttcore::getElementSizeBytes(srcType.getElementType());
+    Value size = intConstant<int32_t>(rewriter, loc, bytes);
+    auto [virtY, virtX] = getVirtualCoordsFromLogicalCoords(
+        rewriter, loc, chipDesc, adaptor.getSrcCore());
+    NocEndpoint srcEndpoint{
+        ttcore::MemorySpace::DeviceL1, {virtX, virtY}, nullptr, srcL1Addr};
+    Value nocId = materializeKernelNocId(rewriter, op.getOperation());
+    createNocAsyncRead(rewriter, loc, srcEndpoint, dstL1Addr, size, nocId);
+    rewriter.create<ttkernel::NocAsyncReadBarrierOp>(loc, nocId);
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 class D2MDMAWriteRewriter : public OpConversionPattern<d2m::DMAWriteOp> {
 public:
   D2MDMAWriteRewriter(TypeConverter &typeConverter, MLIRContext *context,
@@ -3164,6 +3198,118 @@ public:
     Value virtDim = rewriter.create<mlir::affine::AffineApplyOp>(
         op.getLoc(), selectedMap, ValueRange{logicalY, logicalX});
     rewriter.replaceOp(op, virtDim);
+    return success();
+  }
+};
+} // namespace
+
+// Return the flat (y, x) router-core list for the generic whose thread owns
+// this operation. The generic still references its lowered thread function by
+// symbol at this point in the pipeline.
+static SmallVector<int64_t> getRouterCores(Operation *op) {
+  auto func = op->getParentOfType<func::FuncOp>();
+  if (!func) {
+    return {};
+  }
+
+  StringRef funcName = func.getSymName();
+  SmallVector<int64_t> routerCores;
+  if (auto module = op->getParentOfType<ModuleOp>()) {
+    module.walk([&](d2m::GenericOp generic) {
+      auto config = generic.getFabricConnectionConfigAttr();
+      if (!config) {
+        return WalkResult::advance();
+      }
+      for (Attribute thread : generic.getThreads()) {
+        auto symbol = mlir::cast<d2m::ThreadAttr>(thread).getKernelSymbol();
+        if (symbol && symbol.getLeafReference() == funcName) {
+          routerCores = llvm::to_vector(config.getRouterCores());
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    });
+  }
+  return routerCores;
+}
+
+namespace {
+class D2MIsRouterCoreRewriter
+    : public OpConversionPattern<d2m::IsRouterCoreOp> {
+public:
+  using OpConversionPattern<d2m::IsRouterCoreOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::IsRouterCoreOp op, d2m::IsRouterCoreOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Location loc = op.getLoc();
+    SmallVector<int64_t> routerCores = getRouterCores(op);
+    if (routerCores.empty()) {
+      rewriter.replaceOpWithNewOp<arith::ConstantOp>(
+          op, rewriter.getBoolAttr(true));
+      return success();
+    }
+
+    Value myY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
+    Value myX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+    Value result;
+    for (size_t index = 0; index + 1 < routerCores.size(); index += 2) {
+      Value routerY = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(routerCores[index]));
+      Value routerX = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(routerCores[index + 1]));
+      Value yMatches = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, myY, routerY);
+      Value xMatches = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, myX, routerX);
+      Value matches = rewriter.create<arith::AndIOp>(loc, yMatches, xMatches);
+      result =
+          result
+              ? rewriter.create<arith::OrIOp>(loc, result, matches).getResult()
+              : matches;
+    }
+    rewriter.replaceOp(op, result);
+    return success();
+  }
+};
+
+class D2MRouterDirectionRewriter
+    : public OpConversionPattern<d2m::RouterDirectionOp> {
+public:
+  using OpConversionPattern<d2m::RouterDirectionOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::RouterDirectionOp op,
+                  d2m::RouterDirectionOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    Location loc = op.getLoc();
+    SmallVector<int64_t> routerCores = getRouterCores(op);
+    Value result =
+        rewriter.create<arith::ConstantOp>(loc, rewriter.getIndexAttr(0));
+    if (routerCores.empty()) {
+      rewriter.replaceOp(op, result);
+      return success();
+    }
+
+    Value myY = rewriter.create<ttkernel::MyLogicalYOp>(loc);
+    Value myX = rewriter.create<ttkernel::MyLogicalXOp>(loc);
+    int numSlots = static_cast<int>(routerCores.size() / 2);
+    for (int slotIndex = numSlots - 1; slotIndex >= 0; --slotIndex) {
+      Value routerY = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(routerCores[2 * slotIndex]));
+      Value routerX = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(routerCores[2 * slotIndex + 1]));
+      Value yMatches = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, myY, routerY);
+      Value xMatches = rewriter.create<arith::CmpIOp>(
+          loc, arith::CmpIPredicate::eq, myX, routerX);
+      Value matches = rewriter.create<arith::AndIOp>(loc, yMatches, xMatches);
+      Value slot = rewriter.create<arith::ConstantOp>(
+          loc, rewriter.getIndexAttr(slotIndex));
+      result = rewriter.create<arith::SelectOp>(loc, matches, slot, result)
+                   .getResult();
+    }
+    rewriter.replaceOp(op, result);
     return success();
   }
 };
@@ -3997,6 +4143,8 @@ void populateD2MToTTKernelPatterns(
                ttkernel::D2MDMAWaitRewriter,
                ttkernel::D2MCoreIndexRewriter,
                ttkernel::D2MMeshPositionRewriter,
+               ttkernel::D2MIsRouterCoreRewriter,
+               ttkernel::D2MRouterDirectionRewriter,
                ttkernel::D2MNullTxRewriter,
                ttkernel::D2MIndexedRowCopyRewriter,
                ttkernel::MemRefCollapseRewriter,
@@ -4014,6 +4162,7 @@ void populateD2MToTTKernelPatterns(
       ttkernel::D2MDMAViaTensorAccessorRewriter<d2m::DMAWriteOp>>(
       typeConverter, ctx, tensorAccessorArgsChains, &cbProducerConsumer);
   patterns.add<ttkernel::D2MDMAReadRewriter>(typeConverter, ctx, &cbProducerConsumer);
+  patterns.add<ttkernel::D2MCoreReadRewriter>(typeConverter, ctx);
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);
 
   // Debug op patterns.

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -232,9 +232,8 @@ struct ConvertD2MToTTKernel
                   funcOp.getLoc())
               .getResult();
       if (funcHasRouterSubset(funcOp)) {
-        // Keep one connection open across the entire worker loop. Placing the
-        // lifecycle in the existing router branch would recreate and close it
-        // for every chunk, which prevents pipelined compute/CCL progress.
+        // Keep one connection open across every chunk so compute and fabric
+        // transfers can make pipelined progress.
         Value isRouter = builder.create<d2m::IsRouterCoreOp>(funcOp.getLoc());
         builder.create<scf::IfOp>(
             funcOp.getLoc(), isRouter,

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernelPass.cpp
@@ -184,32 +184,80 @@ struct ConvertD2MToTTKernel
     scf::populateSCFStructuralTypeConversionsAndLegality(typeConverter,
                                                          patterns, target);
 
-    // If there is any fabric related writes,
-    // insert fabric connection manager ops and setup fabric connections at the
-    // start of the function and close at the end.
-    bool fabric_write_present = false;
-    funcOp.walk([&](d2m::DMAWriteOp dmaWriteOp) {
-      if (dmaWriteOp.getStartDevice().size() > 0) {
-        fabric_write_present = true;
-        return WalkResult::interrupt();
+    auto isFabricOp = [](Operation *op) {
+      return llvm::isa<d2m::DeviceSynchronizeOp>(op) ||
+             (llvm::isa<d2m::DMAWriteOp>(op) &&
+              !llvm::cast<d2m::DMAWriteOp>(op).getStartDevice().empty()) ||
+             (llvm::isa<d2m::SemaphoreIncOp>(op) &&
+              !llvm::cast<d2m::SemaphoreIncOp>(op).getStartDevice().empty()) ||
+             (llvm::isa<d2m::SemaphoreSetOp>(op) &&
+              !llvm::cast<d2m::SemaphoreSetOp>(op).getStartDevice().empty());
+    };
+    auto funcHasRouterSubset = [](func::FuncOp func) {
+      StringRef name = func.getSymName();
+      bool found = false;
+      if (auto module = func->getParentOfType<ModuleOp>()) {
+        module.walk([&](d2m::GenericOp generic) {
+          auto config = generic.getFabricConnectionConfigAttr();
+          if (!config || config.getRouterCores().empty()) {
+            return WalkResult::advance();
+          }
+          for (Attribute thread : generic.getThreads()) {
+            auto symbol = llvm::cast<d2m::ThreadAttr>(thread).getKernelSymbol();
+            if (symbol && symbol.getLeafReference() == name) {
+              found = true;
+              return WalkResult::interrupt();
+            }
+          }
+          return WalkResult::advance();
+        });
       }
-      return WalkResult::advance();
+      return found;
+    };
+
+    SmallVector<Operation *> fabricOps;
+    funcOp.walk([&](Operation *op) {
+      if (isFabricOp(op)) {
+        fabricOps.push_back(op);
+      }
     });
 
-    if (fabric_write_present) {
+    if (!fabricOps.empty()) {
+      Block *anchor = &funcOp.getBody().front();
       OpBuilder builder(funcOp.getContext());
-      builder.setInsertionPointToStart(&funcOp.getBody().front());
+      builder.setInsertionPointToStart(anchor);
       auto fabricConnectionManager =
           builder
               .create<ttkernel::CreateFabricConnectionManagerOp>(
                   funcOp.getLoc())
               .getResult();
-      builder.create<ttkernel::SetupFabricConnectionsOp>(
-          funcOp.getLoc(), fabricConnectionManager);
-      Operation *terminator = funcOp.getBody().front().getTerminator();
-      builder.setInsertionPoint(terminator);
-      builder.create<ttkernel::CloseFabricConnectionsOp>(
-          funcOp.getLoc(), fabricConnectionManager);
+      if (funcHasRouterSubset(funcOp)) {
+        // Keep one connection open across the entire worker loop. Placing the
+        // lifecycle in the existing router branch would recreate and close it
+        // for every chunk, which prevents pipelined compute/CCL progress.
+        Value isRouter = builder.create<d2m::IsRouterCoreOp>(funcOp.getLoc());
+        builder.create<scf::IfOp>(
+            funcOp.getLoc(), isRouter,
+            [&](OpBuilder &thenBuilder, Location loc) {
+              thenBuilder.create<ttkernel::SetupFabricConnectionsOp>(
+                  loc, fabricConnectionManager);
+              thenBuilder.create<scf::YieldOp>(loc);
+            });
+        builder.setInsertionPoint(anchor->getTerminator());
+        builder.create<scf::IfOp>(
+            funcOp.getLoc(), isRouter,
+            [&](OpBuilder &thenBuilder, Location loc) {
+              thenBuilder.create<ttkernel::CloseFabricConnectionsOp>(
+                  loc, fabricConnectionManager);
+              thenBuilder.create<scf::YieldOp>(loc);
+            });
+      } else {
+        builder.create<ttkernel::SetupFabricConnectionsOp>(
+            funcOp.getLoc(), fabricConnectionManager);
+        builder.setInsertionPoint(anchor->getTerminator());
+        builder.create<ttkernel::CloseFabricConnectionsOp>(
+            funcOp.getLoc(), fabricConnectionManager);
+      }
     }
 
     if (failed(applyFullConversion(funcOp, target, std::move(patterns)))) {

--- a/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
+++ b/lib/Conversion/TTIRToD2M/TTIRToD2M.cpp
@@ -4565,7 +4565,8 @@ public:
         llvm::to_vector(ttcore::getGridShape(inputStreamResult));
     auto fabricConnectionConfig = ttcore::FabricConnectionConfigAttr::get(
         rewriter.getContext(), ttcore::NocIndex::Noc0, topology, clusterAxis,
-        ttcore::RoutingMode::UnidirRingTorus, num_links);
+        ttcore::RoutingMode::UnidirRingTorus, num_links,
+        /*router_cores=*/{});
     auto generic = rewriter.create<d2m::GenericOp>(
         loc, TypeRange(outputStreamResult), inputStreamResult,
         outputStreamResult, ValueRange({startSemaphore, endSemaphore}),

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -1646,6 +1646,107 @@ bool RemoteLoadOp::hasTensorSemantics() {
   return memrefIsTensor || resultIsTensor;
 }
 
+//===----------------------------------------------------------------------===//
+// CoreReadOp Bufferization Interface Implementation
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult CoreReadOp::verify() {
+  if (ttcore::hasDeviceLayout(getSrc())) {
+    return emitOpError("src must be a local buffer (no device layout)");
+  }
+  if (ttcore::hasDeviceLayout(getDst())) {
+    return emitOpError("dst must be a local buffer (no device layout)");
+  }
+  if (getSrcCore().size() != 2) {
+    return emitOpError("expected 2 srcCore coordinates (grid rank), got ")
+           << getSrcCore().size();
+  }
+
+  auto srcType = mlir::cast<ShapedType>(getSrc().getType());
+  auto dstType = mlir::cast<ShapedType>(getDst().getType());
+  if (srcType.getElementType() != dstType.getElementType()) {
+    return emitOpError("src and dst element types must match");
+  }
+  if (srcType.getShape() != dstType.getShape()) {
+    return emitOpError("src and dst shapes must match");
+  }
+  if (Value result = getResult();
+      result && result.getType() != getDst().getType()) {
+    return emitOpError("result type must match dst type");
+  }
+  return mlir::success();
+}
+
+bool CoreReadOp::bufferizesToMemoryRead(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getSrc();
+}
+
+bool CoreReadOp::bufferizesToMemoryWrite(
+    mlir::OpOperand &operand, const mlir::bufferization::AnalysisState &) {
+  return operand.get() == getDst();
+}
+
+mlir::bufferization::AliasingValueList
+CoreReadOp::getAliasingValues(mlir::OpOperand &operand,
+                              const mlir::bufferization::AnalysisState &) {
+  mlir::bufferization::AliasingValueList aliases;
+  Value result = getResult();
+  if (result && operand.get() == getDst()) {
+    aliases.addAlias({result, mlir::bufferization::BufferRelation::Equivalent});
+  }
+  return aliases;
+}
+
+mlir::FailureOr<mlir::bufferization::BufferLikeType>
+CoreReadOp::getBufferType(mlir::Value value,
+                          const mlir::bufferization::BufferizationOptions &,
+                          const mlir::bufferization::BufferizationState &,
+                          ::llvm::SmallVector<mlir::Value> &) {
+  if (value == getSrc() || value == getDst()) {
+    return ttcore::getBufferType(value.getType(), /*isView=*/false);
+  }
+  return mlir::failure();
+}
+
+mlir::LogicalResult
+CoreReadOp::bufferize(mlir::RewriterBase &rewriter,
+                      const mlir::bufferization::BufferizationOptions &options,
+                      mlir::bufferization::BufferizationState &state) {
+  Value result = getResult();
+  if (!result) {
+    return emitOpError("expected a result to bufferize");
+  }
+
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
+  mlir::FailureOr<Value> srcBuffer =
+      mlir::bufferization::getBuffer(rewriter, getSrc(), options, state);
+  if (failed(srcBuffer)) {
+    return srcBuffer;
+  }
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
+  mlir::FailureOr<Value> dstBuffer =
+      mlir::bufferization::getBuffer(rewriter, getDst(), options, state);
+  if (failed(dstBuffer)) {
+    return dstBuffer;
+  }
+
+  rewriter.create<CoreReadOp>(getLoc(), mlir::TypeRange{}, *srcBuffer,
+                              getSrcCore(), *dstBuffer);
+  auto toTensor = rewriter.create<bufferization::ToTensorOp>(
+      getLoc(), result.getType(), *dstBuffer);
+  rewriter.replaceAllUsesWith(result, toTensor.getResult());
+  rewriter.eraseOp(*this);
+  return mlir::success();
+}
+
+bool CoreReadOp::hasTensorSemantics() {
+  bool srcIsTensor = mlir::isa<RankedTensorType>(getSrc().getType());
+  Value result = getResult();
+  bool resultIsTensor = result && mlir::isa<RankedTensorType>(result.getType());
+  return srcIsTensor || resultIsTensor;
+}
+
 bool RemoteLoadOp::isNotConflicting(
     mlir::OpOperand *uRead, mlir::OpOperand *uConflictingWrite,
     const mlir::bufferization::AnalysisState &) {

--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -8,7 +8,6 @@
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/Analysis/Allocation/Utils.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
-#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "ttmlir/Dialect/D2M/Utils/Utils.h"
 #include "ttmlir/Dialect/D2M/Utils/VirtualGrid.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
@@ -2217,14 +2216,6 @@ MutableArrayRef<OpOperand> d2m::GenericOp::getInputsAndOutputsMutable() {
                              opGridMap, opGridShape, emitDiag);
     if (failed(blockFactorResult)) {
       return blockFactorResult;
-    }
-  }
-
-  // Unified form will be replicated across compute and datamovement threads.
-  // Reject semaphore ops that would create race conditions when replicated.
-  if (isUnifiedForm() && !this->getRegion(0).empty()) {
-    if (failed(utils::checkForIllegalSemaphoreOps(&getRegion(0).front()))) {
-      return failure();
     }
   }
 

--- a/lib/Dialect/D2M/Transforms/Allocate.cpp
+++ b/lib/Dialect/D2M/Transforms/Allocate.cpp
@@ -1253,6 +1253,14 @@ class D2MAllocate final : public impl::D2MAllocateBase<D2MAllocate> {
             if (!mlir::isa_and_nonnull<memref::AllocOp>(allocOp)) {
               return WalkResult::advance();
             }
+            // A core_read destination contains data gathered from a peer core.
+            // Aliasing it to the local output shard would make every gather
+            // destination share and overwrite that same shard.
+            if (llvm::any_of(allocOp->getUsers(), [](Operation *user) {
+                  return mlir::isa<CoreReadOp>(user);
+                })) {
+              return WalkResult::advance();
+            }
             rewriter.setInsertionPoint(allocOp);
             rewriter.replaceOpWithNewOp<d2m::OperandAliasOp>(
                 allocOp, allocOp->getResultTypes(), remoteStoreOp.getMemref());

--- a/lib/Dialect/D2M/Transforms/AssignThreads.cpp
+++ b/lib/Dialect/D2M/Transforms/AssignThreads.cpp
@@ -10,6 +10,7 @@
 #include "ttmlir/Dialect/D2M/Utils/CBUtils.h"
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
 
 namespace mlir::tt::d2m {
@@ -21,6 +22,16 @@ namespace {
 // The attribute used to record a leaf op's destination thread. Ops left without
 // this attribute are replicated into both threads by d2m-split-threads.
 static constexpr StringRef kThreadAttrName = "d2m.thread";
+
+static bool isInsideRouterRegion(Operation *op) {
+  for (auto ifOp = op->getParentOfType<scf::IfOp>(); ifOp;
+       ifOp = ifOp->getParentOfType<scf::IfOp>()) {
+    if (ifOp.getCondition().getDefiningOp<IsRouterCoreOp>()) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // Aliased remote ops carry no DMA transfer (the buffer is already in L1 via
 // operand_alias). These predicates are null-safe so they may be called on
@@ -47,14 +58,92 @@ static bool isAliasedLoad(RemoteLoadOp loadOp) {
 // explicit-CB form in place. Aliased remote ops are left implicit: they have no
 // DMA transfer and become compute-side CB obligations handled by
 // d2m-split-threads.
-static void lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
-                                    RewriterBase &rewriter) {
+static LogicalResult lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
+                                             RewriterBase &rewriter) {
   SmallVector<RemoteLoadOp> loads;
   SmallVector<RemoteStoreOp> stores;
   SmallVector<LocalCopyOp> localCopies;
+  SmallVector<CoreReadOp> coreReads;
+  SmallVector<SemaphoreIncOp> computeSignalIncs;
+  SmallVector<SemaphoreWaitOp> computeReleaseWaits;
   block->walk([&](RemoteLoadOp op) { loads.push_back(op); });
   block->walk([&](RemoteStoreOp op) { stores.push_back(op); });
   block->walk([&](LocalCopyOp op) { localCopies.push_back(op); });
+  block->walk([&](CoreReadOp op) { coreReads.push_back(op); });
+  block->walk([&](SemaphoreIncOp op) {
+    if (op->hasAttr("d2m.compute_signal")) {
+      computeSignalIncs.push_back(op);
+    }
+  });
+  block->walk([&](SemaphoreWaitOp op) {
+    if (op->hasAttr("d2m.compute_release")) {
+      computeReleaseWaits.push_back(op);
+    }
+  });
+
+  if ((!computeSignalIncs.empty() || !computeReleaseWaits.empty()) &&
+      coreReads.empty()) {
+    return generic.emitOpError(
+        "compute semaphore synchronization requires a core_read");
+  }
+
+  if (!computeReleaseWaits.empty() && computeSignalIncs.empty()) {
+    return generic.emitOpError(
+        "compute semaphore release requires a compute producer signal");
+  }
+
+  if (!coreReads.empty() && !computeSignalIncs.empty()) {
+    Value source = coreReads.front().getSrc();
+    if (llvm::any_of(coreReads,
+                     [&](CoreReadOp op) { return op.getSrc() != source; })) {
+      return generic.emitOpError(
+          "compute semaphore synchronization requires all core_read ops to "
+          "gather the same source");
+    }
+  }
+
+  auto markDatamovement = [&](Operation *op) {
+    op->setAttr(kThreadAttrName,
+                rewriter.getAttr<ThreadAttr>(ThreadType::Datamovement));
+  };
+
+  // A producer-done signal must not fire until compute has pushed the local
+  // buffer that the router will read. Acquire that buffer's CB before the
+  // signal, and retarget core_read to the acquired front pointer. Deliberately
+  // do not pop: the gather still needs the produced page to remain at the front
+  // while the router reads every worker's uniform L1 address.
+  Value fencedSrc;
+  Value fenceWaited;
+  if (!coreReads.empty() && !computeSignalIncs.empty()) {
+    fencedSrc = coreReads.front().getSrc();
+    unsigned fenceCBOperandIdx = generic.getOperandIndex(fencedSrc);
+    for (SemaphoreIncOp inc : computeSignalIncs) {
+      rewriter.setInsertionPoint(inc);
+      Value cb =
+          d2m::getOrCreateCB(rewriter, generic, block, fenceCBOperandIdx);
+      auto wait = rewriter.create<WaitOp>(inc.getLoc(), cb);
+      markDatamovement(wait);
+      fenceWaited = wait.getResult();
+      inc->removeAttr("d2m.compute_signal");
+    }
+  }
+
+  // Once the router acknowledges that it has copied this worker's result,
+  // release the producer CB. This balances the compute reserve/push inserted
+  // for each loop iteration and lets the next matmul chunk start while the
+  // router sends the gathered copy over fabric.
+  if (fencedSrc) {
+    unsigned fenceCBOperandIdx = generic.getOperandIndex(fencedSrc);
+    for (SemaphoreWaitOp wait : computeReleaseWaits) {
+      markDatamovement(wait);
+      wait->removeAttr("d2m.compute_release");
+      rewriter.setInsertionPointAfter(wait);
+      Value cb =
+          d2m::getOrCreateCB(rewriter, generic, block, fenceCBOperandIdx);
+      auto pop = rewriter.create<PopOp>(wait.getLoc(), cb);
+      markDatamovement(pop);
+    }
+  }
 
   for (RemoteLoadOp loadOp : loads) {
     if (loadOp.isExplicitCBForm() || isAliasedLoad(loadOp)) {
@@ -95,6 +184,31 @@ static void lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
     rewriter.eraseOp(storeOp);
   }
 
+  // core_read produces its destination CB on the datamovement thread. Wrap
+  // the NoC transfer in reserve/push so a following remote_store can consume
+  // the gathered buffer with its normal wait/pop protocol.
+  for (CoreReadOp coreReadOp : coreReads) {
+    Value dstBuffer = coreReadOp.getDst();
+    unsigned cbOperandIdx = generic.getOperandIndex(dstBuffer);
+    Value src = coreReadOp.getSrc();
+    if (fenceWaited && src == fencedSrc) {
+      src = fenceWaited;
+    }
+
+    rewriter.setInsertionPoint(coreReadOp);
+    Value cb = d2m::getOrCreateCB(rewriter, generic, block, cbOperandIdx);
+    auto reserve = rewriter.create<ReserveOp>(coreReadOp.getLoc(), cb);
+    auto read = rewriter.create<CoreReadOp>(coreReadOp.getLoc(), TypeRange{},
+                                            src, coreReadOp.getSrcCore(),
+                                            reserve.getResult());
+    auto push = rewriter.create<PushOp>(coreReadOp.getLoc(), cb);
+    markDatamovement(reserve);
+    markDatamovement(read);
+    markDatamovement(push);
+    coreReadOp->dropAllUses();
+    rewriter.eraseOp(coreReadOp);
+  }
+
   for (LocalCopyOp copyOp : localCopies) {
     if (copyOp.isExplicitCBForm()) {
       continue;
@@ -112,11 +226,14 @@ static void lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
     copyOp->dropAllUses();
     rewriter.eraseOp(copyOp);
   }
+
+  return success();
 }
 
 // Classify a leaf op in a unified region as belonging to a single thread.
 // Returns std::nullopt for ops that must be replicated into both threads
-// (structural/pure ops and semaphore_wait), which are left untagged.
+// (structural/pure ops and non-mutating semaphore_wait), which are left
+// untagged.
 //
 // All remote_load/store and local_copy are data-movement ops (the verifier
 // requires remote ops to live on the datamovement thread). Aliased remote ops
@@ -124,12 +241,19 @@ static void lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
 // remain in implicit form and d2m-insert-compute-cb inspects them to add the
 // matching compute-side CB synchronization, then erases them.
 static std::optional<ThreadType> classifyOp(Operation *op) {
-  if (mlir::isa<RemoteLoadOp, RemoteStoreOp, LocalCopyOp>(op)) {
+  if (mlir::isa<RemoteLoadOp, RemoteStoreOp, LocalCopyOp, CoreReadOp,
+                SemaphoreIncOp, SemaphoreSetOp>(op)) {
     return ThreadType::Datamovement;
   }
-  // semaphore_wait is replicated into both threads; leave untagged.
-  if (mlir::isa<SemaphoreWaitOp>(op)) {
-    return std::nullopt;
+  // Router-only waits guard data movement after compute has already published
+  // its result. Running them on compute as well adds a second waiter with no
+  // compute-side work to protect and can stall fabric progress on hardware.
+  // Resetting waits mutate shared state, so they also require one owner. Other
+  // waits remain replicated to preserve barriers that resume both threads.
+  if (auto wait = mlir::dyn_cast<SemaphoreWaitOp>(op)) {
+    return isInsideRouterRegion(op) || wait.getResetValue()
+               ? std::optional(ThreadType::Datamovement)
+               : std::nullopt;
   }
   if (mlir::isa<ShardDMAOpInterface, DeviceSynchronizeOp>(op)) {
     return ThreadType::Datamovement;
@@ -162,7 +286,10 @@ public:
       Block *block = &generic.getRegion(0).front();
       // Lower data-movement ops to explicit-CB form, then record each leaf op's
       // destination thread.
-      lowerDMAOpsToExplicitCB(generic, block, rewriter);
+      if (failed(lowerDMAOpsToExplicitCB(generic, block, rewriter))) {
+        signalPassFailure();
+        return;
+      }
       generic.getRegion(0).walk([&](Operation *op) {
         if (std::optional<ThreadType> thread = classifyOp(op)) {
           op->setAttr(kThreadAttrName, rewriter.getAttr<ThreadAttr>(*thread));

--- a/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertComputeCB.cpp
@@ -667,6 +667,23 @@ public:
         cbTransferDepth[getDMACBPort(generic, dma.getOperation())] =
             forDepth(dma.getOperation());
       });
+      // A compute-produced value gathered with core_read has no shard-DMA op
+      // on its source CB. AssignThreads inserts an explicit DM wait/pop pair
+      // instead; use that wait's loop depth as the producer cadence so compute
+      // reserves and pushes once per chunk rather than once around the entire
+      // loop.
+      dmBlock->walk([&](WaitOp wait) {
+        auto getCB = wait.getCb().getDefiningOp<GetCBOp>();
+        if (!getCB) {
+          return;
+        }
+        unsigned cbOperandIdx = getCB.getCbOperandIdx();
+        unsigned depth = forDepth(wait);
+        auto [it, inserted] = cbTransferDepth.try_emplace(cbOperandIdx, depth);
+        if (!inserted) {
+          it->second = std::max(it->second, depth);
+        }
+      });
       if (failed(insertCBOpsForCompute(computeBlock, rewriter, aliasedLoadCBs,
                                        aliasedStoreCBs, cbTransferDepth))) {
         signalPassFailure();

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -407,6 +407,28 @@ static std::optional<bool> isReductionBlockingLoop(Operation *loopOp) {
   return iteratorType == ttcore::IteratorType::Reduction;
 }
 
+// Return true if an output store of the enclosing generic has an index that
+// depends on `iv`. Such an IV selects distinct output chunks and is therefore
+// parallel, not a matmul reduction IV.
+static bool genericOutputStoreDependsOnIV(Operation *contextOp, Value iv) {
+  auto genericOp = contextOp->getParentOfType<GenericOp>();
+  if (!genericOp) {
+    return false;
+  }
+
+  bool dependent = false;
+  genericOp.walk([&](RemoteStoreOp storeOp) {
+    for (Value index : storeOp.getIndices()) {
+      if (valueDependsOnIV(index, iv)) {
+        dependent = true;
+        return WalkResult::interrupt();
+      }
+    }
+    return WalkResult::advance();
+  });
+  return dependent;
+}
+
 static SmallVector<Value> getGuardLoopIVs(Operation *loadOrStore,
                                           DstAccessKind kind,
                                           Operation *contextOp) {
@@ -421,7 +443,8 @@ static SmallVector<Value> getGuardLoopIVs(Operation *loadOrStore,
       }
     }
 
-    if (!accessDependsOnIV(loadOrStore, kind, loopIV)) {
+    if (!accessDependsOnIV(loadOrStore, kind, loopIV) &&
+        !genericOutputStoreDependsOnIV(loadOrStore, loopIV)) {
       guardIVs.push_back(loopIV);
     }
   }
@@ -535,9 +558,11 @@ Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
     if (isReduction.has_value() && !*isReduction) {
       continue;
     }
-    if (!isReduction.has_value() && anyOutputStoreDependsOnIV(copyInfos, iv)) {
-      // Non-blocking fallback: if this loop indexes the output, it is parallel,
-      // not a reduction.
+    if (!isReduction.has_value() &&
+        (anyOutputStoreDependsOnIV(copyInfos, iv) ||
+         genericOutputStoreDependsOnIV(acquireDstOp, iv))) {
+      // Non-blocking fallback: if this loop indexes either an in-region output
+      // copy or the generic output store, it is parallel, not a reduction.
       continue;
     }
 

--- a/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
+++ b/lib/Dialect/D2M/Transforms/InsertDstRegisterAccess/Shared.cpp
@@ -561,8 +561,7 @@ Value findClosestReductionLoopIVForL1Acc(Operation *acquireDstOp,
     if (!isReduction.has_value() &&
         (anyOutputStoreDependsOnIV(copyInfos, iv) ||
          genericOutputStoreDependsOnIV(acquireDstOp, iv))) {
-      // Non-blocking fallback: if this loop indexes either an in-region output
-      // copy or the generic output store, it is parallel, not a reduction.
+      // A loop that selects a distinct output is parallel, not a reduction.
       continue;
     }
 

--- a/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
@@ -189,12 +189,9 @@ static bool shouldKeepOpForThread(Operation *op,
 // Recursively erase DMA ops not assigned to this thread.
 // Also removes ops that become dead as a result.
 //
-// `keepBarrier` designates this thread as the owner of the CCL start barrier
-// (DeviceSynchronizeOp). The barrier has no CB, so it would otherwise survive
-// the clone-into-every-DM-thread and run once per thread. Each replica emits a
-// fabric semaphore increment and wait, so duplicate barriers can overshoot the
-// expected count and deadlock. Keep it on the thread that owns the guarded
-// cross-device store and erase it from every other DM thread.
+// A DeviceSynchronizeOp has no CB to drive thread filtering. `keepBarrier`
+// retains it only on the thread that owns the guarded cross-device store;
+// duplicate barriers can overshoot the fabric semaphore count and deadlock.
 static void filterOpsForThread(PatternRewriter &rewriter, Block *block,
                                const DenseSet<unsigned> &assignedCBs,
                                bool keepBarrier) {
@@ -266,9 +263,8 @@ public:
     }
     Block *dmBlock = &dmRegion.front();
 
-    // These operations have ordering or side effects that cannot be cloned
-    // across physical DM threads. Keep the whole region on one DM core until
-    // per-op thread ownership and cross-DM synchronization are available.
+    // Cloning these shared side effects across physical DM threads would
+    // duplicate synchronization or race on shared state.
     bool keepSingleDMThread = false;
     dmBlock->walk([&](Operation *op) {
       auto wait = dyn_cast<SemaphoreWaitOp>(op);
@@ -299,8 +295,7 @@ public:
     unsigned numThreadsToUse = std::min(
         static_cast<unsigned>(cbWorkloads.size()), numDatamovementThreads);
 
-    // Not enough CBs to warrant splitting but still need to assign a DM core on
-    // the existing single DM thread before returning failure.
+    // Assign a concrete DM core even when the region remains single-threaded.
     if (keepSingleDMThread || numThreadsToUse <= 1 || cbWorkloads.size() <= 1) {
       bool writesDRAM = llvm::any_of(dmaOps, [](const auto &entry) {
         auto store = mlir::dyn_cast_or_null<RemoteStoreOp>(entry.first);
@@ -332,10 +327,9 @@ public:
 
     assignDmCoreIndices(assignments, dmaOps, numDatamovementThreads);
 
-    // A CCL start barrier has no CB and must run exactly once per worker core.
-    // Pin it to the DM thread that owns the cross-device store it guards. The
-    // fallback preserves the pre-split behavior for barriers without a fabric
-    // store in the same generic.
+    // A CCL start barrier must run exactly once per worker core. The DM thread
+    // owning the first cross-device store owns the barrier; otherwise thread 0
+    // owns it.
     unsigned barrierOwnerIdx = 0;
     for (const auto &[op, cbIdx] : dmaOps) {
       auto store = mlir::dyn_cast<RemoteStoreOp>(op);
@@ -389,8 +383,7 @@ public:
         rewriter.clone(op, mapping);
       }
 
-      // Filter to keep only DMA ops for this thread's assigned CBs, and keep
-      // the CCL start barrier only on its designated owner thread.
+      // Keep this thread's assigned DMA ops and its owned CCL start barrier.
       filterOpsForThread(rewriter, newDMBlock, assignments[i].assignedCBs,
                          /*keepBarrier=*/i == barrierOwnerIdx);
     }

--- a/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
+++ b/lib/Dialect/D2M/Transforms/ScheduleDMA.cpp
@@ -7,7 +7,6 @@
 #include "ttmlir/Asserts.h"
 #include "ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.h"
 #include "ttmlir/Dialect/D2M/IR/D2MOps.h"
-#include "ttmlir/Dialect/D2M/Utils/DMAUtils.h"
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTCore/IR/Utils.h"
 
@@ -189,8 +188,16 @@ static bool shouldKeepOpForThread(Operation *op,
 
 // Recursively erase DMA ops not assigned to this thread.
 // Also removes ops that become dead as a result.
+//
+// `keepBarrier` designates this thread as the owner of the CCL start barrier
+// (DeviceSynchronizeOp). The barrier has no CB, so it would otherwise survive
+// the clone-into-every-DM-thread and run once per thread. Each replica emits a
+// fabric semaphore increment and wait, so duplicate barriers can overshoot the
+// expected count and deadlock. Keep it on the thread that owns the guarded
+// cross-device store and erase it from every other DM thread.
 static void filterOpsForThread(PatternRewriter &rewriter, Block *block,
-                               const DenseSet<unsigned> &assignedCBs) {
+                               const DenseSet<unsigned> &assignedCBs,
+                               bool keepBarrier) {
   bool changed = true;
   while (changed) {
     changed = false;
@@ -203,7 +210,15 @@ static void filterOpsForThread(PatternRewriter &rewriter, Block *block,
 
       // Recurse into nested loops.
       if (auto forOp = mlir::dyn_cast<scf::ForOp>(&op)) {
-        filterOpsForThread(rewriter, forOp.getBody(), assignedCBs);
+        filterOpsForThread(rewriter, forOp.getBody(), assignedCBs, keepBarrier);
+        continue;
+      }
+
+      if (mlir::isa<DeviceSynchronizeOp>(&op)) {
+        if (!keepBarrier && op.use_empty()) {
+          toErase.push_back(&op);
+          changed = true;
+        }
         continue;
       }
 
@@ -251,12 +266,19 @@ public:
     }
     Block *dmBlock = &dmRegion.front();
 
-    // Check that there are no illegal semaphore ops in the datamovement region.
-    // Replicating these across multiple threads would create a race condition
-    // on the shared semaphore.
-    if (failed(utils::checkForIllegalSemaphoreOps(dmBlock))) {
-      return failure();
-    }
+    // These operations have ordering or side effects that cannot be cloned
+    // across physical DM threads. Keep the whole region on one DM core until
+    // per-op thread ownership and cross-DM synchronization are available.
+    bool keepSingleDMThread = false;
+    dmBlock->walk([&](Operation *op) {
+      auto wait = dyn_cast<SemaphoreWaitOp>(op);
+      if (isa<SemaphoreIncOp, SemaphoreSetOp, CoreReadOp>(op) ||
+          (wait && wait.getResetValue())) {
+        keepSingleDMThread = true;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
 
     // Collect all DMA operations and their CB associations.
     SmallVector<std::pair<Operation *, unsigned>> dmaOps;
@@ -279,15 +301,20 @@ public:
 
     // Not enough CBs to warrant splitting but still need to assign a DM core on
     // the existing single DM thread before returning failure.
-    if (numThreadsToUse <= 1 || cbWorkloads.size() <= 1) {
+    if (keepSingleDMThread || numThreadsToUse <= 1 || cbWorkloads.size() <= 1) {
       bool writesDRAM = llvm::any_of(dmaOps, [](const auto &entry) {
         auto store = mlir::dyn_cast_or_null<RemoteStoreOp>(entry.first);
         return store && ttcore::getMemorySpace(store.getMemref()) ==
                             ttcore::MemorySpace::DeviceDRAM;
       });
+      bool usesFabric = llvm::any_of(dmaOps, [](const auto &entry) {
+        auto store = mlir::dyn_cast_or_null<RemoteStoreOp>(entry.first);
+        return store && !store.getStartDevice().empty();
+      });
       int32_t dmCoreIndex;
       if (numDatamovementThreads == 2) {
-        dmCoreIndex = writesDRAM ? 0 : 1;
+        // Fabric traffic on Wormhole uses NoC0, whose default DM core is 1.
+        dmCoreIndex = usesFabric ? 1 : (writesDRAM ? 0 : 1);
       } else {
         dmCoreIndex = 0;
       }
@@ -304,6 +331,25 @@ public:
         assignCBsToThreads(cbWorkloads, numThreadsToUse);
 
     assignDmCoreIndices(assignments, dmaOps, numDatamovementThreads);
+
+    // A CCL start barrier has no CB and must run exactly once per worker core.
+    // Pin it to the DM thread that owns the cross-device store it guards. The
+    // fallback preserves the pre-split behavior for barriers without a fabric
+    // store in the same generic.
+    unsigned barrierOwnerIdx = 0;
+    for (const auto &[op, cbIdx] : dmaOps) {
+      auto store = mlir::dyn_cast<RemoteStoreOp>(op);
+      if (!store || store.getStartDevice().empty()) {
+        continue;
+      }
+      for (unsigned i = 0; i < numThreadsToUse; ++i) {
+        if (assignments[i].assignedCBs.contains(cbIdx)) {
+          barrierOwnerIdx = i;
+          break;
+        }
+      }
+      break;
+    }
 
     // Create new thread attributes: N datamovement threads + 1 compute thread.
     SmallVector<Attribute> threads;
@@ -343,8 +389,10 @@ public:
         rewriter.clone(op, mapping);
       }
 
-      // Filter to keep only DMA ops for this thread's assigned CBs.
-      filterOpsForThread(rewriter, newDMBlock, assignments[i].assignedCBs);
+      // Filter to keep only DMA ops for this thread's assigned CBs, and keep
+      // the CCL start barrier only on its designated owner thread.
+      filterOpsForThread(rewriter, newDMBlock, assignments[i].assignedCBs,
+                         /*keepBarrier=*/i == barrierOwnerIdx);
     }
 
     // Clone the compute region to the new generic (not move, to preserve SSA).

--- a/lib/Dialect/D2M/Transforms/SplitThreads.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitThreads.cpp
@@ -238,7 +238,17 @@ static void collectComputeOpsToErase(Block *block,
       collectComputeOpsToErase(forOp.getBody(), eraseSet);
       continue;
     }
-    bool isDMAOp = isa<ShardDMAOpInterface, DeviceSynchronizeOp>(&op);
+    if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
+      for (Region &region : ifOp->getRegions()) {
+        if (!region.empty()) {
+          collectComputeOpsToErase(&region.front(), eraseSet);
+        }
+      }
+      continue;
+    }
+    bool isDMAOp =
+        isa<ShardDMAOpInterface, DeviceSynchronizeOp, SemaphoreIncOp,
+            SemaphoreSetOp, CoreReadOp, ReserveOp, PushOp, WaitOp, PopOp>(&op);
     bool isReplicated = isa<SemaphoreWaitOp>(&op);
     if (!isDMAOp && !isReplicated) {
       eraseSet.insert(&op);
@@ -338,10 +348,6 @@ public:
       return failure();
     }
     Block *originalBlock = &originalRegion.front();
-
-    if (failed(utils::checkForIllegalSemaphoreOps(originalBlock))) {
-      return failure();
-    }
 
     // Create new 2-region GenericOp: datamovement + compute.
     auto newGeneric = rewriter.create<GenericOp>(

--- a/lib/Dialect/D2M/Utils/DMAUtils.cpp
+++ b/lib/Dialect/D2M/Utils/DMAUtils.cpp
@@ -12,42 +12,6 @@
 
 namespace mlir::tt::d2m::utils {
 
-LogicalResult checkForIllegalSemaphoreOps(Block *block) {
-  for (Operation &op : block->getOperations()) {
-    if (isa<SemaphoreIncOp>(&op)) {
-      return op.emitError()
-             << "semaphore_inc is not supported in regions that will be "
-                "replicated across multiple threads, as all threads would "
-                "increment the semaphore, creating a race condition on the "
-                "shared semaphore.";
-    }
-    if (isa<SemaphoreSetOp>(&op)) {
-      return op.emitError()
-             << "semaphore_set is not supported in regions that will be "
-                "replicated across multiple threads, as all threads would "
-                "set the semaphore, creating a race condition on the "
-                "shared semaphore.";
-    }
-    if (auto waitOp = dyn_cast<SemaphoreWaitOp>(&op)) {
-      if (waitOp.getResetValue()) {
-        return waitOp.emitError()
-               << "semaphore_wait with reset is not supported in regions that "
-                  "will be replicated across multiple threads, as all threads "
-                  "would execute the reset, creating a race condition on the "
-                  "shared semaphore.";
-      }
-    }
-    for (Region &region : op.getRegions()) {
-      if (!region.empty()) {
-        if (failed(checkForIllegalSemaphoreOps(&region.front()))) {
-          return failure();
-        }
-      }
-    }
-  }
-  return success();
-}
-
 static LogicalResult checkBackendDmCoreSupport(Operation *rootOp,
                                                ModuleOp moduleOp,
                                                llvm::StringRef backend) {

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -1381,6 +1381,30 @@ MetalLayoutAttr::getMemRefType(mlir::RankedTensorType tensorType) {
   return ::mlir::success();
 }
 
+::mlir::LogicalResult FabricConnectionConfigAttr::verify(
+    ::llvm::function_ref<::mlir::InFlightDiagnostic()> emitError,
+    NocIndex nocIndex, Topology topology, uint32_t clusterAxis,
+    RoutingMode routingMode, uint32_t numLinks,
+    ::llvm::ArrayRef<int64_t> routerCores) {
+  (void)nocIndex;
+  (void)topology;
+  (void)clusterAxis;
+
+  if (routerCores.size() % 2 != 0) {
+    return emitError() << "router_cores must contain (y, x) coordinate pairs";
+  }
+  if (llvm::any_of(routerCores,
+                   [](int64_t coordinate) { return coordinate < 0; })) {
+    return emitError() << "router_cores coordinates must be non-negative";
+  }
+
+  uint64_t coresPerLink = routingMode == RoutingMode::UnidirRingTorus ? 2 : 1;
+  if (routerCores.size() / 2 > numLinks * coresPerLink) {
+    return emitError() << "router_cores exceeds the configured routing slots";
+  }
+  return ::mlir::success();
+}
+
 // Get effective stride (use provided or calculate from shape)
 llvm::SmallVector<int64_t>
 MetalLayoutAttr::getShardStride(RankedTensorType tensorType) const {

--- a/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
+++ b/lib/Target/TTMetal/TTMetalToFlatbuffer.cpp
@@ -987,12 +987,16 @@ static flatbuffers::Offset<target::FabricConnectionConfig>
 fabricConnectionConfigToFlatbuffer(
     FlatbufferObjectCache &cache,
     ttcore::FabricConnectionConfigAttr fabricConnectionConfig) {
+  std::vector<int32_t> routerCores(
+      fabricConnectionConfig.getRouterCores().begin(),
+      fabricConnectionConfig.getRouterCores().end());
   return target::CreateFabricConnectionConfig(
       *cache.fbb, toFlatbuffer(cache, fabricConnectionConfig.getNocIndex()),
       toFlatbuffer(cache, fabricConnectionConfig.getTopology()),
       fabricConnectionConfig.getClusterAxis(),
       toFlatbuffer(cache, fabricConnectionConfig.getRoutingMode()),
-      fabricConnectionConfig.getNumLinks());
+      fabricConnectionConfig.getNumLinks(),
+      cache.fbb->CreateVector(routerCores));
 }
 
 static flatbuffers::Offset<target::metal::KernelConfig>

--- a/runtime/lib/common/fabric_config.cpp
+++ b/runtime/lib/common/fabric_config.cpp
@@ -202,8 +202,7 @@ appendFabricConfigArgs(
   // update number of topology args
   rtArgsVec[num_topology_arg_idx] = (rtArgsVec.size() - num_topology_arg_idx);
 
-  // Insert fabric connection args only for configured router cores. An empty
-  // list preserves the legacy whole-grid behavior.
+  // An empty router-core list assigns fabric connections to the whole grid.
   std::vector<tt::tt_metal::CoreCoord> cores;
   const auto *routerCores = fabricConnectionConfig->router_cores();
   if (routerCores && routerCores->size() >= 2) {

--- a/runtime/lib/common/fabric_config.cpp
+++ b/runtime/lib/common/fabric_config.cpp
@@ -202,9 +202,19 @@ appendFabricConfigArgs(
   // update number of topology args
   rtArgsVec[num_topology_arg_idx] = (rtArgsVec.size() - num_topology_arg_idx);
 
-  // insert fabric connection args (device and core specific)
-  std::vector<tt::tt_metal::CoreCoord> cores =
-      tt::tt_metal::corerange_to_cores(coreRangeSet);
+  // Insert fabric connection args only for configured router cores. An empty
+  // list preserves the legacy whole-grid behavior.
+  std::vector<tt::tt_metal::CoreCoord> cores;
+  const auto *routerCores = fabricConnectionConfig->router_cores();
+  if (routerCores && routerCores->size() >= 2) {
+    for (flatbuffers::uoffset_t index = 0; index + 1 < routerCores->size();
+         index += 2) {
+      cores.emplace_back(/*x=*/(*routerCores)[index + 1],
+                         /*y=*/(*routerCores)[index]);
+    }
+  } else {
+    cores = tt::tt_metal::corerange_to_cores(coreRangeSet);
+  }
   LOG_ASSERT(cores.size() <= num_links * cores_per_link, "Number of cores (",
              cores.size(),
              ") to connect to fabric routers exceeds number of routing "

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -1000,8 +1000,10 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
             deviceCoord, meshDevice, rtArgsVec, coreRangeSet);
 
         for (auto core : tt::tt_metal::corerange_to_cores(coreRangeSet)) {
+          auto it = fabricConfigArgs.find(core);
           tt_metal::SetRuntimeArgs(program, handle, core,
-                                   fabricConfigArgs[core]);
+                                   it != fabricConfigArgs.end() ? it->second
+                                                                : rtArgsVec);
         }
       } else {
         tt_metal::SetRuntimeArgs(program, handle, coreRangeSet, rtArgsVec);

--- a/test/d2m-jit/lit/ccl_overlap.py
+++ b/test/d2m-jit/lit/ccl_overlap.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2 1 2>&1 | FileCheck %s
+# RUN: %python %s 1 2 2>&1 | FileCheck %s
+# RUN: %python %s 2 2 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""Lower a chunked matmul + all-gather through the complete backend."""
+
+import sys
+
+import torch
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import (
+    _Builder,
+    _emit_returns_and_finalise,
+    _pipeline_passes,
+)
+from ttmlir.passmanager import PassManager
+
+
+@d2m.kernel
+def chunked_matmul_all_gather(lhs, rhs, output, start_sem, end_sem, num_chunks):
+    dy = mesh_position(0)
+    dx = mesh_position(1)
+    cy = core_index(0)
+    cx = core_index(1)
+    device_synchronize(
+        start_sem,
+        start_device=[dy, 0],
+        mcast_shape=[1, 2],
+        num_receivers=1,
+        core_indices=[cy, cx],
+    )
+    for chunk in range(num_chunks):
+        a = remote_load(lhs, [cy * num_chunks + chunk, cx])
+        b = remote_load(rhs, [cy * num_chunks + chunk, cx])
+        c = a @ b
+        remote_store(
+            output,
+            [cy * 2 * num_chunks + dx * num_chunks + chunk, cx],
+            c,
+            start_device=[dy, 0],
+            device_mcast_shape=[1, 2],
+            semaphore=end_sem,
+            semaphore_indices=[cy, cx],
+        )
+    semaphore_wait(end_sem, 2 * num_chunks)
+
+
+num_chunks = int(sys.argv[1])
+assert num_chunks in (1, 2)
+worker_grid_size = int(sys.argv[2])
+assert worker_grid_size in (1, 2)
+grid_y = worker_grid_size
+grid_x = worker_grid_size
+d2m.mesh((1, 2), topology=("linear", "linear"))
+block_tiles = 4
+block_elements = block_tiles * 32
+input_layout = d2m.Layout(
+    shape=(grid_y * num_chunks * block_elements, grid_x * block_elements),
+    dtype=d2m.float32,
+    block_shape=[block_tiles, block_tiles],
+    grid_shape=[grid_y, grid_x],
+)
+output_layout = d2m.Layout(
+    shape=(grid_y * 2 * num_chunks * block_elements, grid_x * block_elements),
+    dtype=d2m.float32,
+    block_shape=[block_tiles, block_tiles],
+    grid_shape=[grid_y, grid_x],
+)
+full_lhs = torch.randn(
+    grid_y * num_chunks * block_elements,
+    2 * grid_x * block_elements,
+)
+full_rhs = torch.randn(
+    grid_y * num_chunks * block_elements,
+    2 * grid_x * block_elements,
+)
+lhs = d2m.mesh_shard(
+    full_lhs,
+    input_layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+rhs = d2m.mesh_shard(
+    full_rhs,
+    input_layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+output = d2m.empty(output_layout)
+chunked_matmul_all_gather(
+    lhs,
+    rhs,
+    output,
+    d2m.global_semaphore(grid_shape=(8, 8)),
+    d2m.global_semaphore(grid_shape=(8, 8)),
+    num_chunks,
+    grid=(grid_y, grid_x),
+    fabric=d2m.fabric_config(
+        cluster_axis=1,
+        topology="linear",
+        num_links=grid_y * grid_x,
+    ),
+)
+gathered = d2m.mesh_gather(
+    output,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [gathered])
+pipeline = (
+    "builtin.module("
+    "ttcore-register-device{mock-system-desc-arch=wormhole_b0 "
+    "mesh-shape=1,2 mesh-topology=linear,linear}," + ",".join(_pipeline_passes()) + ")"
+)
+PassManager.parse(pipeline, context=builder.ctx).run(builder.module.operation)
+builder.module.operation.verify()
+lowered = str(builder.module)
+num_setups = lowered.count("experimental::setup_fabric_connections")
+num_closes = lowered.count("experimental::close_fabric_connections")
+num_writes = lowered.count("experimental::fabric_mcast_fast_write_any_len")
+num_fabric_sem_incs = lowered.count("experimental::fabric_mcast_sem_inc")
+assert num_setups == 1, num_setups
+assert num_closes == 1, num_closes
+assert num_writes == 1, num_writes
+assert num_fabric_sem_incs == 2, num_fabric_sem_incs
+
+fabric_enqueue = next(
+    line
+    for line in lowered.splitlines()
+    if '"ttmetal.enqueue_program"' in line and "fabricConnectionConfig" in line
+)
+assert fabric_enqueue.count("#ttmetal.noc_config<") == 2, fabric_enqueue
+assert fabric_enqueue.count("#ttmetal.compute_config<") == 1, fabric_enqueue
+expected_core_range = f"#ttmetal.core_range<0x0, {grid_y}x{grid_x}>"
+assert fabric_enqueue.count(expected_core_range) == 3, fabric_enqueue
+assert "dm_core = 1, noc0" in fabric_enqueue, fabric_enqueue
+assert "dm_core = 0, noc1" in fabric_enqueue, fabric_enqueue
+
+# The chunk loop indexes distinct generic outputs. It must not be mistaken for
+# a matmul reduction loop, which would accumulate chunk t onto chunk t-1.
+assert "llk_pack_reconfig_l1_acc" not in lowered, lowered
+print("chunked matmul all-gather lowering: ok")
+_Builder.reset()
+
+
+# CHECK: chunked matmul all-gather lowering: ok

--- a/test/d2m-jit/lit/ccl_router_multicore.py
+++ b/test/d2m-jit/lit/ccl_router_multicore.py
@@ -6,6 +6,8 @@
 # RUN: %python %s 2 2 2>&1 | FileCheck %s
 # RUN: %python %s 1 1 2>&1 | FileCheck %s
 # RUN: %python %s 1 1 2 2>&1 | FileCheck %s
+# RUN: %python %s 4 4 2 2>&1 | FileCheck %s
+# RUN: %python %s 4 4 2 bf16 2>&1 | FileCheck %s
 # REQUIRES: d2m-jit
 
 """Lower multicore matmul + router-core all-gather end to end."""
@@ -60,7 +62,7 @@ def router_matmul_all_gather(
             dx = mesh_position(1)
             for ty in range(grid_y):
                 for tx in range(grid_x):
-                    gathered = empty([4, 4])
+                    gathered = empty_like(c)
                     gathered = core_read(gathered, c, core=[ty, tx])
                     semaphore_inc(consumed, 1, core=[ty, tx])
                     remote_store(
@@ -82,8 +84,12 @@ def router_matmul_all_gather(
 grid_y = int(sys.argv[1])
 grid_x = int(sys.argv[2])
 num_chunks = int(sys.argv[3]) if len(sys.argv) > 3 else 1
-assert (grid_y, grid_x) in ((1, 1), (2, 1), (2, 2))
+dtype_name = sys.argv[4] if len(sys.argv) > 4 else "fp32"
+assert (grid_y, grid_x) in ((1, 1), (2, 1), (2, 2), (4, 4))
 assert num_chunks in (1, 2)
+assert dtype_name in ("fp32", "bf16")
+layout_dtype = d2m.float32 if dtype_name == "fp32" else d2m.bfloat16
+torch_dtype = torch.float32 if dtype_name == "fp32" else torch.bfloat16
 num_workers = grid_y * grid_x
 end_count = 2 * num_workers
 block_tiles = 4
@@ -91,23 +97,25 @@ block_elements = block_tiles * 32
 d2m.mesh((1, 2), topology=("linear", "linear"))
 input_layout = d2m.Layout(
     shape=(grid_y * num_chunks * block_elements, grid_x * block_elements),
-    dtype=d2m.float32,
+    dtype=layout_dtype,
     block_shape=[block_tiles, block_tiles],
     grid_shape=[grid_y * num_chunks, grid_x],
 )
 output_layout = d2m.Layout(
     shape=(2 * grid_y * num_chunks * block_elements, grid_x * block_elements),
-    dtype=d2m.float32,
+    dtype=layout_dtype,
     block_shape=[block_tiles, block_tiles],
     grid_shape=[2 * grid_y * num_chunks, grid_x],
 )
 full_lhs = torch.randn(
     grid_y * num_chunks * block_elements,
     2 * grid_x * block_elements,
+    dtype=torch_dtype,
 )
 full_rhs = torch.randn(
     grid_y * num_chunks * block_elements,
     2 * grid_x * block_elements,
+    dtype=torch_dtype,
 )
 lhs = d2m.mesh_shard(
     full_lhs,

--- a/test/d2m-jit/lit/ccl_router_multicore.py
+++ b/test/d2m-jit/lit/ccl_router_multicore.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python %s 2 1 2>&1 | FileCheck %s
+# RUN: %python %s 2 2 2>&1 | FileCheck %s
+# RUN: %python %s 1 1 2>&1 | FileCheck %s
+# RUN: %python %s 1 1 2 2>&1 | FileCheck %s
+# REQUIRES: d2m-jit
+
+"""Lower multicore matmul + router-core all-gather end to end."""
+
+import sys
+
+import torch
+
+import d2m_jit as d2m
+from d2m_jit._src.builder import (
+    _Builder,
+    _emit_returns_and_finalise,
+    _pipeline_passes,
+)
+from ttmlir.passmanager import PassManager
+
+
+@d2m.kernel
+def router_matmul_all_gather(
+    lhs,
+    rhs,
+    output,
+    start_sem,
+    ready,
+    consumed,
+    end_sem,
+    num_chunks,
+    grid_y,
+    grid_x,
+    num_workers,
+    end_count,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+
+    for chunk in range(num_chunks):
+        a = remote_load(lhs, [cy * num_chunks + chunk, cx])
+        b = remote_load(rhs, [cy * num_chunks + chunk, cx])
+        c = a @ b
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+
+        if is_router_core():
+            dy = mesh_position(0)
+            device_synchronize(
+                start_sem,
+                start_device=[dy, 0],
+                mcast_shape=[1, 2],
+                num_receivers=1,
+                core_indices=[cy, cx],
+            )
+            semaphore_wait(ready, (chunk + 1) * num_workers)
+            dx = mesh_position(1)
+            for ty in range(grid_y):
+                for tx in range(grid_x):
+                    gathered = empty([4, 4])
+                    gathered = core_read(gathered, c, core=[ty, tx])
+                    semaphore_inc(consumed, 1, core=[ty, tx])
+                    remote_store(
+                        output,
+                        [
+                            dx * grid_y * num_chunks + ty * num_chunks + chunk,
+                            tx,
+                        ],
+                        gathered,
+                        start_device=[dy, 0],
+                        device_mcast_shape=[1, 2],
+                        semaphore=end_sem,
+                        semaphore_indices=[cy, 0],
+                    )
+            semaphore_wait(end_sem, (chunk + 1) * end_count)
+        semaphore_wait(consumed, chunk + 1, compute=True)
+
+
+grid_y = int(sys.argv[1])
+grid_x = int(sys.argv[2])
+num_chunks = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+assert (grid_y, grid_x) in ((1, 1), (2, 1), (2, 2))
+assert num_chunks in (1, 2)
+num_workers = grid_y * grid_x
+end_count = 2 * num_workers
+block_tiles = 4
+block_elements = block_tiles * 32
+d2m.mesh((1, 2), topology=("linear", "linear"))
+input_layout = d2m.Layout(
+    shape=(grid_y * num_chunks * block_elements, grid_x * block_elements),
+    dtype=d2m.float32,
+    block_shape=[block_tiles, block_tiles],
+    grid_shape=[grid_y * num_chunks, grid_x],
+)
+output_layout = d2m.Layout(
+    shape=(2 * grid_y * num_chunks * block_elements, grid_x * block_elements),
+    dtype=d2m.float32,
+    block_shape=[block_tiles, block_tiles],
+    grid_shape=[2 * grid_y * num_chunks, grid_x],
+)
+full_lhs = torch.randn(
+    grid_y * num_chunks * block_elements,
+    2 * grid_x * block_elements,
+)
+full_rhs = torch.randn(
+    grid_y * num_chunks * block_elements,
+    2 * grid_x * block_elements,
+)
+lhs = d2m.mesh_shard(
+    full_lhs,
+    input_layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+rhs = d2m.mesh_shard(
+    full_rhs,
+    input_layout,
+    shard_dims=[0, 1],
+    shard_shape=[1, 2],
+)
+output = d2m.empty(output_layout)
+router_matmul_all_gather(
+    lhs,
+    rhs,
+    output,
+    d2m.global_semaphore(grid_shape=(8, 8)),
+    d2m.global_semaphore(grid_shape=(8, 8), init=0),
+    d2m.global_semaphore(grid_shape=(8, 8), init=0),
+    d2m.global_semaphore(grid_shape=(8, 8)),
+    num_chunks,
+    grid_y,
+    grid_x,
+    num_workers,
+    end_count,
+    grid=(grid_y, grid_x),
+    fabric=d2m.fabric_config(
+        cluster_axis=1,
+        topology="linear",
+        router_cores=[(0, 0)],
+    ),
+)
+
+builder = _Builder.get()
+_emit_returns_and_finalise(builder, [output])
+pipeline = (
+    "builtin.module("
+    "ttcore-register-device{mock-system-desc-arch=wormhole_b0 "
+    "mesh-shape=1,2 mesh-topology=linear,linear}," + ",".join(_pipeline_passes()) + ")"
+)
+pm = PassManager.parse(pipeline, context=builder.ctx)
+pm.run(builder.module.operation)
+builder.module.operation.verify()
+lowered = str(builder.module)
+num_setups = lowered.count("experimental::setup_fabric_connections")
+num_closes = lowered.count("experimental::close_fabric_connections")
+assert num_setups == 1, num_setups
+assert num_closes == 1, num_closes
+assert "async_read(unicast_ep" in lowered
+assert "experimental::fabric_mcast_fast_write_any_len" in lowered
+assert "experimental::fabric_mcast_sem_inc" in lowered
+compute_start = lowered.index("func.func private @compute_kernel5")
+compute_end = lowered.index("func.func private @", compute_start + 1)
+assert "experimental::semaphore_wait" not in lowered[compute_start:compute_end]
+print("multicore router matmul all-gather lowering: ok")
+_Builder.reset()
+
+
+# CHECK: multicore router matmul all-gather lowering: ok

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -12,6 +12,7 @@ import torch
 
 import d2m_jit as d2m
 from d2m_jit._src.builder import _Builder
+from utils import assert_pcc
 
 try:
     from _ttmlir_runtime import binary, runtime
@@ -158,6 +159,90 @@ def test_mesh_compute_round_trip_1x2():
     assert (torch.sigmoid(full) - result).abs().max().item() < 0.05
 
 
+@d2m.kernel
+def _matmul_core_read_gather(lhs, rhs, output, ready):
+    cy = core_index(0)
+    cx = core_index(1)
+    a = remote_load(lhs, [cy, cx])
+    b = remote_load(rhs, [cy, cx])
+    c = a @ b
+    semaphore_inc(ready, 1, core=[0, 0], compute=True)
+    if cy == 0:
+        semaphore_wait(ready, 2)
+        own = empty([4, 4])
+        own = core_read(own, c, core=[0, 0])
+        peer = empty([4, 4])
+        peer = core_read(peer, c, core=[1, 0])
+        remote_store(output, [0, 0], own)
+        remote_store(output, [1, 0], peer)
+
+
+@requires_mesh
+def test_matmul_core_read_gather():
+    """Isolate a multi-tile compute-to-DM producer fence without fabric."""
+    layout = d2m.Layout(
+        shape=(256, 128),
+        dtype=d2m.float32,
+        block_shape=[4, 4],
+        grid_shape=[2, 1],
+    )
+    lhs = torch.randn(256, 128, dtype=torch.float32) * 0.125
+    rhs = torch.randn(256, 128, dtype=torch.float32) * 0.125
+    output = d2m.empty(layout)
+    _matmul_core_read_gather(
+        d2m.to_layout(lhs, layout),
+        d2m.to_layout(rhs, layout),
+        output,
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
+        grid=(2, 1),
+    )
+    result = output.to_host()
+    expected = torch.cat([lhs[:128] @ rhs[:128], lhs[128:] @ rhs[128:]], dim=0)
+    assert result.shape == expected.shape
+    assert_pcc(expected, result, threshold=0.99)
+
+
+@d2m.kernel
+def _chunked_matmul_core_read_gather(lhs, rhs, output, ready, consumed):
+    for chunk in range(2):
+        a = remote_load(lhs, [chunk, 0])
+        b = remote_load(rhs, [chunk, 0])
+        c = a @ b
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+        semaphore_wait(ready, chunk + 1)
+        gathered = empty([4, 4])
+        gathered = core_read(gathered, c, core=[0, 0])
+        semaphore_inc(consumed, 1, core=[0, 0])
+        remote_store(output, [chunk, 0], gathered)
+        semaphore_wait(consumed, chunk + 1, compute=True)
+
+
+@requires_mesh
+def test_chunked_matmul_core_read_gather():
+    """Isolate producer-CB release and reuse across two chunks."""
+    layout = d2m.Layout(
+        shape=(256, 128),
+        dtype=d2m.float32,
+        block_shape=[4, 4],
+        grid_shape=[2, 1],
+    )
+    lhs = torch.randn(256, 128, dtype=torch.float32) * 0.125
+    rhs = torch.randn(256, 128, dtype=torch.float32) * 0.125
+    output = d2m.empty(layout)
+    _chunked_matmul_core_read_gather(
+        d2m.to_layout(lhs, layout),
+        d2m.to_layout(rhs, layout),
+        output,
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
+        grid=(1, 1),
+    )
+    result = output.to_host()
+    expected = torch.cat([lhs[:128] @ rhs[:128], lhs[128:] @ rhs[128:]], dim=0)
+    assert result.shape == expected.shape
+    assert_pcc(expected, result, threshold=0.99)
+
+
 @requires_fabric_mesh
 def test_all_gather_round_trip_1x2():
     @d2m.kernel
@@ -229,3 +314,262 @@ def test_all_gather_round_trip_1x2():
     expected = torch.cat([gathered, gathered], dim=1)
     assert result.shape == expected.shape
     assert (expected - result).abs().max().item() < 0.05
+
+
+@d2m.kernel
+def _multicore_all_gather_1x2(
+    input_, output, start_sem, ready, end_sem, grid_y, grid_x, worker_count
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    value = remote_load(input_, [cy, cx])
+    semaphore_inc(ready, 1, core=[0, 0])
+    if is_router_core():
+        dy = mesh_position(0)
+        device_synchronize(
+            start_sem,
+            start_device=[dy, 0],
+            mcast_shape=[1, 2],
+            num_receivers=1,
+            core_indices=[cy, cx],
+        )
+        semaphore_wait(ready, worker_count)
+        dx = mesh_position(1)
+        for ty in range(grid_y):
+            for tx in range(grid_x):
+                gathered = empty([2, 2])
+                gathered = core_read(gathered, value, core=[ty, tx])
+                remote_store(
+                    output,
+                    [dx * grid_y + ty, tx],
+                    gathered,
+                    start_device=[dy, 0],
+                    device_mcast_shape=[1, 2],
+                    semaphore=end_sem,
+                    semaphore_indices=[cy, 0],
+                )
+        semaphore_wait(end_sem, 2 * worker_count)
+
+
+@requires_fabric_mesh
+def test_multicore_all_gather_round_trip_1x2():
+    """Gather worker blocks through one router core and one fabric link."""
+    torch.manual_seed(0)
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    grid_y, grid_x = (2, 1)
+    block_tiles = 2
+    block_elements = block_tiles * 32
+    input_layout = d2m.Layout(
+        shape=(grid_y * block_elements, grid_x * block_elements),
+        dtype=d2m.float32,
+        block_shape=[block_tiles, block_tiles],
+        grid_shape=[grid_y, grid_x],
+    )
+    output_layout = d2m.Layout(
+        shape=(grid_y * 2 * block_elements, grid_x * block_elements),
+        dtype=d2m.float32,
+        block_shape=[block_tiles, block_tiles],
+        grid_shape=[2 * grid_y, grid_x],
+    )
+    full = torch.randn(
+        grid_y * block_elements, 2 * grid_x * block_elements, dtype=torch.float32
+    )
+    input_ = d2m.mesh_shard(
+        full,
+        input_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    output = d2m.empty(output_layout)
+    _multicore_all_gather_1x2(
+        input_,
+        output,
+        d2m.global_semaphore(),
+        d2m.global_semaphore(init=0),
+        d2m.global_semaphore(),
+        grid_y,
+        grid_x,
+        grid_y * grid_x,
+        grid=(grid_y, grid_x),
+        fabric=d2m.fabric_config(
+            cluster_axis=1,
+            topology="linear",
+            router_cores=[(0, 0)],
+        ),
+    )
+    result = d2m.mesh_gather(
+        output,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    ).to_host()
+
+    gathered_blocks = []
+    for device in range(2):
+        for cy in range(grid_y):
+            row = slice(cy * block_elements, (cy + 1) * block_elements)
+            col = slice(
+                device * grid_x * block_elements,
+                (device + 1) * grid_x * block_elements,
+            )
+            gathered_blocks.append(full[row, col])
+    gathered = torch.cat(gathered_blocks, dim=0)
+    expected = torch.cat([gathered, gathered], dim=1)
+
+    assert result.shape == expected.shape
+    assert_pcc(expected, result, threshold=0.99)
+
+
+@d2m.kernel
+def _chunked_matmul_all_gather_1x2(
+    lhs,
+    rhs,
+    output,
+    start_sem,
+    ready,
+    consumed,
+    end_sem,
+    num_chunks,
+    grid_y,
+    grid_x,
+    worker_count,
+):
+    # Every worker computes; one router gathers the results and uses fabric.
+    cy = core_index(0)
+    cx = core_index(1)
+    for chunk in range(num_chunks):
+        a = remote_load(lhs, [cy * num_chunks + chunk, cx])
+        b = remote_load(rhs, [cy * num_chunks + chunk, cx])
+        c = a @ b
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+        if is_router_core():
+            dy = mesh_position(0)
+            device_synchronize(
+                start_sem,
+                start_device=[dy, 0],
+                mcast_shape=[1, 2],
+                num_receivers=1,
+                core_indices=[cy, cx],
+            )
+            semaphore_wait(ready, (chunk + 1) * worker_count)
+            dx = mesh_position(1)
+            for ty in range(grid_y):
+                for tx in range(grid_x):
+                    gathered = empty([4, 4])
+                    gathered = core_read(gathered, c, core=[ty, tx])
+                    semaphore_inc(consumed, 1, core=[ty, tx])
+                    remote_store(
+                        output,
+                        [
+                            dx * grid_y * num_chunks + ty * num_chunks + chunk,
+                            tx,
+                        ],
+                        gathered,
+                        start_device=[dy, 0],
+                        device_mcast_shape=[1, 2],
+                        semaphore=end_sem,
+                        semaphore_indices=[cy, 0],
+                    )
+            semaphore_wait(end_sem, (chunk + 1) * 2 * worker_count)
+        semaphore_wait(consumed, chunk + 1, compute=True)
+
+
+@requires_fabric_mesh
+@pytest.mark.parametrize("num_chunks", [1, 2])
+@pytest.mark.parametrize(
+    "worker_grid",
+    [(1, 1), (2, 1), (2, 2)],
+    ids=["single-core", "multicore-2x1", "multicore-2x2"],
+)
+def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
+    """Overlap chunk t's fabric send with chunk t+1's compute across devices."""
+    torch.manual_seed(0)
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    grid_y, grid_x = worker_grid
+    block_tiles = 4
+    block_elements = block_tiles * 32
+    input_layout = d2m.Layout(
+        shape=(grid_y * num_chunks * block_elements, grid_x * block_elements),
+        dtype=d2m.float32,
+        block_shape=[block_tiles, block_tiles],
+        grid_shape=[grid_y * num_chunks, grid_x],
+    )
+    output_layout = d2m.Layout(
+        shape=(grid_y * 2 * num_chunks * block_elements, grid_x * block_elements),
+        dtype=d2m.float32,
+        block_shape=[block_tiles, block_tiles],
+        grid_shape=[2 * grid_y * num_chunks, grid_x],
+    )
+    full_lhs = (
+        torch.randn(
+            grid_y * num_chunks * block_elements,
+            2 * grid_x * block_elements,
+            dtype=torch.float32,
+        )
+        * 0.125
+    )
+    full_rhs = torch.randn(
+        grid_y * num_chunks * block_elements,
+        2 * grid_x * block_elements,
+        dtype=torch.float32,
+    )
+    full_rhs *= 0.125
+    lhs = d2m.mesh_shard(
+        full_lhs,
+        input_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    rhs = d2m.mesh_shard(
+        full_rhs,
+        input_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    output = d2m.empty(output_layout)
+    _chunked_matmul_all_gather_1x2(
+        lhs,
+        rhs,
+        output,
+        d2m.global_semaphore(),
+        d2m.global_semaphore(init=0),
+        d2m.global_semaphore(init=0),
+        d2m.global_semaphore(),
+        num_chunks,
+        grid_y,
+        grid_x,
+        grid_y * grid_x,
+        grid=worker_grid,
+        fabric=d2m.fabric_config(
+            cluster_axis=1,
+            topology="linear",
+            router_cores=[(0, 0)],
+        ),
+    )
+    result = d2m.mesh_gather(
+        output,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    ).to_host()
+
+    gathered_blocks = []
+    for device in range(2):
+        for cy in range(grid_y):
+            for chunk in range(num_chunks):
+                row_index = cy * num_chunks + chunk
+                row = slice(
+                    row_index * block_elements, (row_index + 1) * block_elements
+                )
+                row_blocks = []
+                for cx in range(grid_x):
+                    col_index = device * grid_x + cx
+                    col = slice(
+                        col_index * block_elements,
+                        (col_index + 1) * block_elements,
+                    )
+                    row_blocks.append(full_lhs[row, col] @ full_rhs[row, col])
+                gathered_blocks.append(torch.cat(row_blocks, dim=1))
+    gathered = torch.cat(gathered_blocks, dim=0)
+    expected = torch.cat([gathered, gathered], dim=1)
+
+    assert result.shape == expected.shape
+    assert_pcc(expected, result, threshold=0.99)

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -433,7 +433,6 @@ def _chunked_matmul_all_gather_1x2(
     grid_x,
     worker_count,
 ):
-    # Every worker computes; one router gathers the results and uses fabric.
     cy = core_index(0)
     cx = core_index(1)
     for chunk in range(num_chunks):

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -454,7 +454,7 @@ def _chunked_matmul_all_gather_1x2(
             dx = mesh_position(1)
             for ty in range(grid_y):
                 for tx in range(grid_x):
-                    gathered = empty([4, 4])
+                    gathered = empty_like(c)
                     gathered = core_read(gathered, c, core=[ty, tx])
                     semaphore_inc(consumed, 1, core=[ty, tx])
                     remote_store(
@@ -477,25 +477,33 @@ def _chunked_matmul_all_gather_1x2(
 @pytest.mark.parametrize("num_chunks", [1, 2])
 @pytest.mark.parametrize(
     "worker_grid",
-    [(1, 1), (2, 1), (2, 2)],
-    ids=["single-core", "multicore-2x1", "multicore-2x2"],
+    [(1, 1), (2, 1), (2, 2), (4, 4)],
+    ids=[
+        "single-core",
+        "multicore-2x1",
+        "multicore-2x2",
+        "saturation-4x4",
+    ],
 )
 def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
     """Overlap chunk t's fabric send with chunk t+1's compute across devices."""
     torch.manual_seed(0)
     d2m.mesh((1, 2), topology=("linear", "linear"))
     grid_y, grid_x = worker_grid
+    saturation = worker_grid == (4, 4)
+    layout_dtype = d2m.bfloat16 if saturation else d2m.float32
+    torch_dtype = torch.bfloat16 if saturation else torch.float32
     block_tiles = 4
     block_elements = block_tiles * 32
     input_layout = d2m.Layout(
         shape=(grid_y * num_chunks * block_elements, grid_x * block_elements),
-        dtype=d2m.float32,
+        dtype=layout_dtype,
         block_shape=[block_tiles, block_tiles],
         grid_shape=[grid_y * num_chunks, grid_x],
     )
     output_layout = d2m.Layout(
         shape=(grid_y * 2 * num_chunks * block_elements, grid_x * block_elements),
-        dtype=d2m.float32,
+        dtype=layout_dtype,
         block_shape=[block_tiles, block_tiles],
         grid_shape=[2 * grid_y * num_chunks, grid_x],
     )
@@ -503,14 +511,14 @@ def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
         torch.randn(
             grid_y * num_chunks * block_elements,
             2 * grid_x * block_elements,
-            dtype=torch.float32,
+            dtype=torch_dtype,
         )
         * 0.125
     )
     full_rhs = torch.randn(
         grid_y * num_chunks * block_elements,
         2 * grid_x * block_elements,
-        dtype=torch.float32,
+        dtype=torch_dtype,
     )
     full_rhs *= 0.125
     lhs = d2m.mesh_shard(

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
@@ -81,11 +81,8 @@ module attributes {ttcore.system_desc = #system_desc} {
     return
   }
 
-  // Test 2: semaphore_wait with reset and no remote ops (aliased operands)
-  // Verifies:
-  // - semaphore_wait with reset is assigned only to datamovement
-  // - aliased load converted to CB ops in compute
-  // - DMA region has semaphore_wait with reset but no remote ops
+  // A resetting wait must remain on data movement even when no remote DMA
+  // survives, because both threads must not mutate the shared semaphore.
   // CHECK-LABEL: func.func @test_semaphore_wait_reset_no_remote
   // CHECK: d2m.generic
   // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
@@ -94,7 +91,6 @@ module attributes {ttcore.system_desc = #system_desc} {
     %cb_in = d2m.operand_alias %arg0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     %cb_out = d2m.operand_alias %alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
 
-    // Datamovement region: semaphore_wait with reset, no remote ops
     // CHECK: ^datamovement0
     // CHECK: scf.for
     // CHECK: scf.for
@@ -104,7 +100,6 @@ module attributes {ttcore.system_desc = #system_desc} {
     // CHECK-NOT: linalg.generic
     // CHECK-NOT: d2m.pop
 
-    // Compute region: aliased CB ops, no semaphore mutation
     // CHECK: ^compute0
     // CHECK: scf.for
     // CHECK: scf.for

--- a/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/split_unified_thread_semaphore_wait.mlir
@@ -1,13 +1,8 @@
 // RUN: ttmlir-opt --ttcore-register-device --d2m-split-unified-thread %s 2>&1 | FileCheck %s
 
-// This test file verifies that d2m.semaphore_wait ops (without reset values) are
-// properly replicated when splitting a unified thread into datamovement and compute
-// regions.
-//
-// IMPORTANT: d2m.semaphore_wait with reset values are NOT supported in unified thread
-// form. The pass will emit an error if a semaphore_wait with reset is encountered,
-// because replicating the reset across both threads would break synchronization.
-// Use separate d2m.semaphore_set ops if reset functionality is needed.
+// This test verifies that non-mutating d2m.semaphore_wait ops are replicated
+// when splitting a unified thread, while waits that reset a semaphore run only
+// on the datamovement thread.
 
 #l1 = #ttcore.memory_space<l1>
 #dram = #ttcore.memory_space<dram>
@@ -86,34 +81,34 @@ module attributes {ttcore.system_desc = #system_desc} {
     return
   }
 
-  // Test 2: semaphore_wait with no remote ops (aliased operands)
+  // Test 2: semaphore_wait with reset and no remote ops (aliased operands)
   // Verifies:
-  // - semaphore_wait is replicated into both regions even with no remote ops
+  // - semaphore_wait with reset is assigned only to datamovement
   // - aliased load converted to CB ops in compute
-  // - DMA region has semaphore_wait but no remote ops
-  // CHECK-LABEL: func.func @test_semaphore_wait_no_remote
+  // - DMA region has semaphore_wait with reset but no remote ops
+  // CHECK-LABEL: func.func @test_semaphore_wait_reset_no_remote
   // CHECK: d2m.generic
   // CHECK-SAME: threads = [#d2m.thread<datamovement>, #d2m.thread<compute>]
-  func.func @test_semaphore_wait_no_remote(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
+  func.func @test_semaphore_wait_reset_no_remote(%arg0: memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>) {
     %alloc = memref.alloc() {address = 1024 : i64, alignment = 16 : i64} : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
     %cb_in = d2m.operand_alias %arg0 : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
     %cb_out = d2m.operand_alias %alloc : memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1> -> memref<2x4x!ttcore.tile<32x32, f32>, #l1>
 
-    // Datamovement region: semaphore_wait replicated, no remote ops
+    // Datamovement region: semaphore_wait with reset, no remote ops
     // CHECK: ^datamovement0
     // CHECK: scf.for
     // CHECK: scf.for
-    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}} reset %{{.*}}
     // CHECK-NOT: d2m.remote_load
     // CHECK-NOT: d2m.wait
     // CHECK-NOT: linalg.generic
     // CHECK-NOT: d2m.pop
 
-    // Compute region: semaphore_wait + aliased CB ops
+    // Compute region: aliased CB ops, no semaphore mutation
     // CHECK: ^compute0
     // CHECK: scf.for
     // CHECK: scf.for
-    // CHECK: d2m.semaphore_wait %{{.*}}, %{{.*}}
+    // CHECK-NOT: d2m.semaphore_wait
     // CHECK: d2m.reserve %{{.*}}
     // CHECK: d2m.push %{{.*}}
     // CHECK: d2m.wait %{{.*}}
@@ -129,7 +124,7 @@ module attributes {ttcore.system_desc = #system_desc} {
       %c1 = arith.constant 1 : index
       scf.for %arg1 = %c0 to %c1 step %c1 {
         scf.for %arg2 = %c0 to %c1 step %c1 {
-          d2m.semaphore_wait %sem0, %c1 : !d2m.local_semaphore
+          d2m.semaphore_wait %sem0, %c1 reset %c0 : !d2m.local_semaphore
           d2m.remote_load %cb_in %arg0[%c0, %c0] : memref<2x4x!ttcore.tile<32x32, f32>, #l1>, memref<2x4x2x4x!ttcore.tile<32x32, f32>, #ttcore.shard<16384x4096, 1>, #l1>
           linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%cb_in : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) outs(%cb_out : memref<2x4x!ttcore.tile<32x32, f32>, #l1>) {
           ^bb0(%in: !ttcore.tile<32x32, f32>, %out: !ttcore.tile<32x32, f32>):

--- a/test/ttmlir/Dialect/TTCore/fabric_connection_config_attr.mlir
+++ b/test/ttmlir/Dialect/TTCore/fabric_connection_config_attr.mlir
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt %s | ttmlir-opt | FileCheck %s
+
+// CHECK-DAG: #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 1, routing_mode = bidir_line_mesh, num_links = 1>
+#legacy = #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 1, routing_mode = bidir_line_mesh, num_links = 1>
+
+// CHECK-DAG: #ttcore.fabric_connection_config<noc_index = noc1, topology = ring, cluster_axis = 0, routing_mode = unidir_ring_torus, num_links = 1, router_cores = [0, 0, 1, 0]>
+#routed = #ttcore.fabric_connection_config<noc_index = noc1, topology = ring, cluster_axis = 0, routing_mode = unidir_ring_torus, num_links = 1, router_cores = [0, 0, 1, 0]>
+
+module attributes {ttcore.legacy = #legacy, ttcore.routed = #routed} {}

--- a/test/ttmlir/Dialect/TTCore/fabric_connection_config_attr.mlir
+++ b/test/ttmlir/Dialect/TTCore/fabric_connection_config_attr.mlir
@@ -5,9 +5,9 @@
 // RUN: ttmlir-opt %s | ttmlir-opt | FileCheck %s
 
 // CHECK-DAG: #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 1, routing_mode = bidir_line_mesh, num_links = 1>
-#legacy = #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 1, routing_mode = bidir_line_mesh, num_links = 1>
+#all_cores = #ttcore.fabric_connection_config<noc_index = noc0, topology = linear, cluster_axis = 1, routing_mode = bidir_line_mesh, num_links = 1>
 
 // CHECK-DAG: #ttcore.fabric_connection_config<noc_index = noc1, topology = ring, cluster_axis = 0, routing_mode = unidir_ring_torus, num_links = 1, router_cores = [0, 0, 1, 0]>
 #routed = #ttcore.fabric_connection_config<noc_index = noc1, topology = ring, cluster_axis = 0, routing_mode = unidir_ring_torus, num_links = 1, router_cores = [0, 0, 1, 0]>
 
-module attributes {ttcore.legacy = #legacy, ttcore.routed = #routed} {}
+module attributes {ttcore.all_cores = #all_cores, ttcore.routed = #routed} {}

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -102,7 +102,14 @@ def _to_runtime_data_type(dtype):
 class FabricConfig:
     """Host-side description of a generic's 1D fabric connection."""
 
-    __slots__ = ("cluster_axis", "topology", "routing", "noc", "num_links")
+    __slots__ = (
+        "cluster_axis",
+        "topology",
+        "routing",
+        "noc",
+        "num_links",
+        "router_cores",
+    )
 
     _ROUTING_BY_TOPOLOGY = {
         "linear": "bidir_line_mesh",
@@ -116,6 +123,7 @@ class FabricConfig:
         routing=None,
         noc="noc0",
         num_links=1,
+        router_cores=None,
     ):
         if (
             not isinstance(cluster_axis, int)
@@ -152,24 +160,60 @@ class FabricConfig:
                 f"fabric num_links must be a positive integer, got {num_links!r}"
             )
 
+        router_cores = [] if router_cores is None else list(router_cores)
+        flattened_router_cores = []
+        seen_router_cores = set()
+        for coordinate in router_cores:
+            if (
+                not isinstance(coordinate, (list, tuple))
+                or len(coordinate) != 2
+                or any(
+                    not isinstance(value, int) or isinstance(value, bool) or value < 0
+                    for value in coordinate
+                )
+            ):
+                raise ValueError(
+                    "fabric router_cores entries must be non-negative (y, x) "
+                    f"integer pairs, got {coordinate!r}"
+                )
+            coordinate = tuple(coordinate)
+            if coordinate in seen_router_cores:
+                raise ValueError(
+                    f"fabric router_cores contains duplicate core {coordinate!r}"
+                )
+            seen_router_cores.add(coordinate)
+            flattened_router_cores.extend(coordinate)
+
+        cores_per_link = 2 if routing == "unidir_ring_torus" else 1
+        if len(router_cores) > num_links * cores_per_link:
+            raise ValueError(
+                "fabric router_cores exceeds the configured routing slots: "
+                f"{len(router_cores)} cores for {num_links * cores_per_link} slots"
+            )
+
         self.cluster_axis = cluster_axis
         self.topology = topology
         self.routing = routing
         self.noc = noc
         self.num_links = num_links
+        self.router_cores = tuple(flattened_router_cores)
 
     @property
     def runtime_mode(self):
         return "FABRIC_1D_RING" if self.topology == "ring" else "FABRIC_1D"
 
     def build_attr(self, ctx):
+        router_cores = ""
+        if self.router_cores:
+            values = ", ".join(str(value) for value in self.router_cores)
+            router_cores = f", router_cores = [{values}]"
         return Attribute.parse(
             "#ttcore.fabric_connection_config<"
             f"noc_index = {self.noc}, "
             f"topology = {self.topology}, "
             f"cluster_axis = {self.cluster_axis}, "
             f"routing_mode = {self.routing}, "
-            f"num_links = {self.num_links}>",
+            f"num_links = {self.num_links}{router_cores}>",
             ctx,
         )
 
@@ -180,9 +224,17 @@ def fabric_config(
     routing=None,
     noc="noc0",
     num_links=1,
+    router_cores=None,
 ):
     """Create a validated 1D fabric configuration for a kernel call."""
-    return FabricConfig(cluster_axis, topology, routing, noc, num_links)
+    return FabricConfig(
+        cluster_axis,
+        topology,
+        routing,
+        noc,
+        num_links,
+        router_cores,
+    )
 
 
 # --- Builder singleton -------------------------------------------------------
@@ -2003,6 +2055,13 @@ def _emit_kernel_generic(
                 "supported inside a pattern rewrite or d2m.spatial",
                 cause=TypeError(),
             )
+        for y, x in zip(fabric.router_cores[::2], fabric.router_cores[1::2]):
+            if y >= grid[0] or x >= grid[1]:
+                raise _call_error(
+                    f"fabric router core {(y, x)} is outside kernel grid "
+                    f"{tuple(grid)}",
+                    cause=ValueError(),
+                )
         b.enable_fabric(fabric)
         fabric_attr = fabric.build_attr(b.ctx)
 

--- a/tools/d2m-jit/_src/sim/ops.py
+++ b/tools/d2m-jit/_src/sim/ops.py
@@ -316,6 +316,11 @@ def zeros(shape):
     return SimBlock(torch.zeros(bm, bn, TILE, TILE, dtype=torch.float32))
 
 
+def empty_like(input):
+    """Kernel-body uninitialized block matching `input`."""
+    return SimBlock(torch.empty_like(input.tiles), input.reduced_axes)
+
+
 def matmul(lhs, rhs, transpose_b=False):
     a = lhs.to_2d()
     b = rhs.to_2d()
@@ -435,8 +440,9 @@ SIM_OPS.update(
         "remote_load": remote_load,
         "remote_store": remote_store,
         "Semaphore": Semaphore,
-        # Free function only -- there is no `!tensor.zeros` method form.
+        # Free functions only -- there are no method forms for these ops.
         "zeros": zeros,
+        "empty_like": empty_like,
     }
 )
 

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -995,6 +995,13 @@ def _empty_op(shape):
     return tensor.empty(list(shape), tile_ty)
 
 
+@syntax("empty_like")
+def _empty_like_op(input):
+    """Kernel-body uninitialized L1 scratch block matching `input`."""
+    block_ty = input.type
+    return tensor.empty(list(block_ty.shape), block_ty.element_type)
+
+
 def _bool_attr_from_ast(node):
     if isinstance(node, ast.Constant) and isinstance(node.value, bool):
         return node.value

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -328,6 +328,36 @@ def remote_store(
     )
 
 
+@syntax("core_read")
+def core_read(dst, src, *, core):
+    """Read another core's local L1 ``src`` buffer into local ``dst``.
+
+    The source core is selected by logical ``[y, x]`` coordinates. Both
+    buffers must have the same shape and uniform L1 placement across the grid.
+    The caller is responsible for publishing and protecting the source with
+    semaphores.
+    """
+    dst = _as_value(dst)
+    src = _as_value(src)
+    return d2m.core_read(dst.type, src, _idx_list(core), dst)
+
+
+@syntax("semaphore_inc")
+def semaphore_inc(semaphore, value, core=None, mcast=None, compute=False):
+    """Increment a local or global semaphore.
+
+    ``compute=True`` marks a producer-done signal. The update remains on the
+    datamovement thread but is fenced behind the compute output gathered by a
+    subsequent ``core_read``.
+    """
+    op = d2m.semaphore_inc(
+        semaphore, _asindex(value), _idx_list(core), _idx_list(mcast), [], []
+    )
+    if compute:
+        op.operation.attributes["d2m.compute_signal"] = UnitAttr.get()
+    return op
+
+
 @syntax(
     "core_index",
     args_as_attr=[_i64_attr_from_literal],
@@ -342,9 +372,31 @@ def mesh_position(dim):
     return d2m.mesh_position(dim)
 
 
+@syntax("is_router_core")
+def is_router_core():
+    """Return true on cores selected by ``fabric_config(router_cores=...)``."""
+    return d2m.is_router_core()
+
+
+@syntax("router_direction")
+def router_direction():
+    """Return this router core's link-direction slot index."""
+    return d2m.router_direction()
+
+
 @syntax("semaphore_wait")
-def semaphore_wait(semaphore, value, reset=None):
-    return d2m.semaphore_wait(semaphore, _asindex(value), reset_value=_asindex(reset))
+def semaphore_wait(semaphore, value, reset=None, compute=False):
+    """Wait for a semaphore, optionally releasing a gathered compute result.
+
+    ``compute=True`` pairs this acknowledgment with the local compute result
+    gathered by ``core_read``. Once the acknowledgment arrives, the data-
+    movement thread releases that result so compute can reuse its circular
+    buffer for the next chunk.
+    """
+    op = d2m.semaphore_wait(semaphore, _asindex(value), reset_value=_asindex(reset))
+    if compute:
+        op.operation.attributes["d2m.compute_release"] = UnitAttr.get()
+    return op
 
 
 @syntax(
@@ -1407,23 +1459,34 @@ class Semaphore:
             ast_self, _asindex(value), _asindex(core), _asindex(mcast)
         )
 
-    def inc(ast_self, value, core=None, mcast=None):
-        return d2m.semaphore_inc(
+    def inc(ast_self, value, core=None, mcast=None, compute=False):
+        """Increment the semaphore, optionally after compute has produced data.
+
+        ``compute=True`` marks a producer-done signal. The update remains on
+        the datamovement thread but is fenced behind the local compute output
+        that a ``core_read`` gathers.
+        """
+        op = d2m.semaphore_inc(
             ast_self, _asindex(value), _asindex(core), _asindex(mcast)
         )
+        if compute:
+            op.operation.attributes["d2m.compute_signal"] = UnitAttr.get()
+        return op
 
-    def wait(ast_self, value, reset=None):
-        return d2m.semaphore_wait(
-            ast_self, _asindex(value), reset_value=_asindex(reset)
-        )
+    def wait(ast_self, value, reset=None, compute=False):
+        op = d2m.semaphore_wait(ast_self, _asindex(value), reset_value=_asindex(reset))
+        if compute:
+            op.operation.attributes["d2m.compute_release"] = UnitAttr.get()
+        return op
 
 
 @syntax("!d2m.global_semaphore")
 class GlobalSemaphoreOps:
-    def wait(ast_self, value, reset=None):
-        return d2m.semaphore_wait(
-            ast_self, _asindex(value), reset_value=_asindex(reset)
-        )
+    def wait(ast_self, value, reset=None, compute=False):
+        op = d2m.semaphore_wait(ast_self, _asindex(value), reset_value=_asindex(reset))
+        if compute:
+            op.operation.attributes["d2m.compute_release"] = UnitAttr.get()
+        return op
 
 
 # --- Block-level eltwise helper -------------------------------------------


### PR DESCRIPTION
## Summary

- add an optional router-core subset to D2M fabric configuration and carry it through MLIR, flatbuffer serialization, and runtime argument setup
- add router-owned NoC gather support so a designated core can collect blocks produced across a worker grid before issuing inter-device traffic
- preserve scheduling and synchronization constraints required to overlap multicore compute with CCL
- cover one-core, multicore, saturated, serialized, and overlapped lowering/runtime configurations

## Stack

Depends on #9181. The next draft adds the profiling primitives used to inspect overlap.

## Validation

- `ccl_overlap.py` and `ccl_router_multicore.py` lit coverage
- D2M transform, fabric-attribute, and mesh API tests
- N300 two-chip multicore correctness runs completed before the stack split
- reconstructed stack passes `pre-commit run --all-files`

Split from #9170 so the compiler/runtime mechanism can be reviewed separately from performance workloads.