### PR TITLE
[D2M] Add semantic profile regions and device timestamps

### DIFF
--- a/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
+++ b/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
@@ -3570,6 +3570,24 @@ def D2M_PrintOp : D2M_GenericRegionOp<"print", [MemoryEffects<[MemRead, MemWrite
     }];
 }
 
+def D2M_ProfileEventOp : D2M_GenericRegionOp<"profile_event",
+  [MemoryEffects<[MemRead, MemWrite]>]> {
+    let summary = "Record a named device-profiler timestamp.";
+    let description = [{
+        Emits a `DeviceTimestampedData` event on one physical thread of a split
+        D2M kernel. Repeated events inside a loop retain their name, core, and
+        timestamp in the tt-metal device-profiler log. Callers can pair `.begin`
+        and `.end` labels to reconstruct block-level timelines without adding
+        C++ scopes around generated temporaries.
+
+        `thread` is 0 for compute and 1 for data movement.
+    }];
+
+    let arguments = (ins StrAttr:$label, I32Attr:$thread);
+    let assemblyFormat = "`(` $label `,` $thread `)` attr-dict";
+    let hasVerifier = 1;
+}
+
 def D2M_OperandAliasOp : D2M_GenericRegionOp<"operand_alias", [
     MemoryEffects<[MemRead, MemWrite]>
   ]> {

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/EmitC/IR/EmitC.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -4014,6 +4015,21 @@ public:
     return success();
   }
 };
+
+class D2MProfileEventOpRewriter
+    : public OpConversionPattern<d2m::ProfileEventOp> {
+public:
+  using OpConversionPattern<d2m::ProfileEventOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(d2m::ProfileEventOp op, d2m::ProfileEventOpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    std::string source =
+        "DeviceTimestampedData(\"" + op.getLabel().str() + "\", 0);";
+    rewriter.replaceOpWithNewOp<mlir::emitc::VerbatimOp>(op, source);
+    return success();
+  }
+};
 } // namespace
 
 } // namespace mlir::tt::ttkernel
@@ -4166,7 +4182,8 @@ void populateD2MToTTKernelPatterns(
   patterns.add<ttkernel::D2MDMAWriteRewriter>(typeConverter, ctx, &cbProducerConsumer);
 
   // Debug op patterns.
-  patterns.add<ttkernel::D2MPrintOpRewriter>(typeConverter, ctx);
+  patterns.add<ttkernel::D2MPrintOpRewriter,
+               ttkernel::D2MProfileEventOpRewriter>(typeConverter, ctx);
 
   // This is needed to lower affine apply ops that may be generated when
   // `d2m.core_index` is used with a `phys_to_virt_map`.

--- a/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MGenericRegionOps.cpp
@@ -15,6 +15,8 @@
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include <limits>
 
 #define GET_OP_CLASSES
@@ -43,6 +45,21 @@ bufferizeCBOp(OpTy op, mlir::RewriterBase &rewriter,
 void AcquireDstOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
   setNameFn(getResult(), "dst");
+}
+
+LogicalResult ProfileEventOp::verify() {
+  StringRef label = getLabel();
+  if (label.empty() || !llvm::all_of(label, [](char c) {
+        return llvm::isAlnum(c) || c == '_' || c == '-' || c == '.';
+      })) {
+    return emitOpError(
+        "label must contain only ASCII letters, digits, '_', '-', or '.'");
+  }
+  if (getThread() != static_cast<int32_t>(ThreadType::Compute) &&
+      getThread() != static_cast<int32_t>(ThreadType::Datamovement)) {
+    return emitOpError("thread must be 0 (compute) or 1 (data movement)");
+  }
+  return success();
 }
 
 // Helper to extract element type from ranked tensor or memref

--- a/lib/Dialect/D2M/Transforms/AssignThreads.cpp
+++ b/lib/Dialect/D2M/Transforms/AssignThreads.cpp
@@ -241,6 +241,9 @@ static LogicalResult lowerDMAOpsToExplicitCB(GenericOp generic, Block *block,
 // remain in implicit form and d2m-insert-compute-cb inspects them to add the
 // matching compute-side CB synchronization, then erases them.
 static std::optional<ThreadType> classifyOp(Operation *op) {
+  if (auto profile = mlir::dyn_cast<ProfileEventOp>(op)) {
+    return static_cast<ThreadType>(profile.getThread());
+  }
   if (mlir::isa<RemoteLoadOp, RemoteStoreOp, LocalCopyOp, CoreReadOp,
                 SemaphoreIncOp, SemaphoreSetOp>(op)) {
     return ThreadType::Datamovement;

--- a/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
+++ b/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
@@ -136,11 +136,12 @@ public:
 
     ModuleOp module = getOperation();
 
-    // Step 1: print the host module to text.
+    // Step 1: print the host module to text with locations preserved.
     std::string inputText;
     {
       llvm::raw_string_ostream os(inputText);
       OpPrintingFlags flags;
+      flags.enableDebugInfo(/*enable=*/true, /*pretty=*/false);
       // Generic form is portable across C++/Python MLIR runtimes.
       module.print(os, flags);
     }
@@ -182,8 +183,9 @@ public:
       PyList_SET_ITEM(pathsList.get(), static_cast<Py_ssize_t>(i), path);
     }
 
-    PyRef resultPy(PyObject_CallFunctionObjArgs(applyText.get(), inputPy.get(),
-                                                pathsList.get(), nullptr));
+    PyRef resultPy(PyObject_CallFunctionObjArgs(
+        applyText.get(), inputPy.get(), pathsList.get(),
+        /*preserveDebugInfo=*/Py_True, nullptr));
     if (!resultPy) {
       emitPyError("d2m_jit apply_patterns_text raised");
       return;

--- a/lib/Dialect/D2M/Transforms/SplitThreads.cpp
+++ b/lib/Dialect/D2M/Transforms/SplitThreads.cpp
@@ -246,9 +246,13 @@ static void collectComputeOpsToErase(Block *block,
       }
       continue;
     }
+    auto profile = dyn_cast<ProfileEventOp>(&op);
     bool isDMAOp =
         isa<ShardDMAOpInterface, DeviceSynchronizeOp, SemaphoreIncOp,
-            SemaphoreSetOp, CoreReadOp, ReserveOp, PushOp, WaitOp, PopOp>(&op);
+            SemaphoreSetOp, CoreReadOp, ReserveOp, PushOp, WaitOp, PopOp>(
+            &op) ||
+        (profile &&
+         profile.getThread() == static_cast<int32_t>(ThreadType::Datamovement));
     bool isReplicated = isa<SemaphoreWaitOp>(&op);
     if (!isDMAOp && !isReplicated) {
       eraseSet.insert(&op);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -53,6 +53,7 @@ declare_mlir_dialect_python_bindings(
   SOURCES dialects/d2m.py
   DIALECT_NAME d2m
   DEPENDS ${CMAKE_SOURCE_DIR}/include/ttmlir/Dialect/D2M/IR/D2MOps.td
+          ${CMAKE_SOURCE_DIR}/include/ttmlir/Dialect/D2M/IR/D2MGenericRegionOps.td
 )
 
 declare_mlir_dialect_python_bindings(

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -911,10 +911,6 @@ void MCQExecutor::enqueueMeshWorkload(distributed::MeshWorkload &workload,
   }
 
   distributed::EnqueueMeshWorkload(*mcq, workload, blockingCQ);
-
-  if (perf::Env::get().enablePerfTrace) {
-    ::tt::tt_metal::ReadMeshDeviceProfilerResults(*meshDevice);
-  }
 }
 
 void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -891,6 +891,10 @@ void MCQExecutor::refreshCachedMeshWorkload(
 void MCQExecutor::enqueueMeshWorkload(distributed::MeshWorkload &workload,
                                       const char *loc) {
   if (perf::Env::get().enablePerfTrace) {
+    if (loc) {
+      perf::Env::get().tracyLogOpLocation(std::string(loc));
+    }
+
     auto devices = meshDevice->get_devices();
     auto meshShape = meshDevice->shape();
 

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -14,6 +14,7 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/common/runtime_context.h"
 #include "tt/runtime/detail/ttmetal/ttmetal.h"
+#include "tt/runtime/perf.h"
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"
 #include "tt/runtime/utils.h"
@@ -1153,6 +1154,12 @@ std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
 
     LOG_ASSERT(outputs.size() == program->outputs()->size(),
                "Outputs size mismatch");
+  }
+
+  // A profiler read synchronizes the mesh, so defer it until every program in
+  // the submission has been enqueued to preserve inter-program overlap.
+  if (perf::Env::get().enablePerfTrace) {
+    tt::runtime::ttmetal::readDeviceProfilerResults(deviceHandle);
   }
 
   return outputs;

--- a/test/d2m-jit/lit/ccl_overlap.py
+++ b/test/d2m-jit/lit/ccl_overlap.py
@@ -38,7 +38,10 @@ def chunked_matmul_all_gather(lhs, rhs, output, start_sem, end_sem, num_chunks):
     for chunk in range(num_chunks):
         a = remote_load(lhs, [cy * num_chunks + chunk, cx])
         b = remote_load(rhs, [cy * num_chunks + chunk, cx])
+        profile_event("d2m.chunk.compute.begin", "compute")
         c = a @ b
+        profile_event("d2m.chunk.compute.end", "compute")
+        profile_event("d2m.chunk.fabric.begin", "datamovement")
         remote_store(
             output,
             [cy * 2 * num_chunks + dx * num_chunks + chunk, cx],
@@ -48,6 +51,7 @@ def chunked_matmul_all_gather(lhs, rhs, output, start_sem, end_sem, num_chunks):
             semaphore=end_sem,
             semaphore_indices=[cy, cx],
         )
+        profile_event("d2m.chunk.fabric.end", "datamovement")
     semaphore_wait(end_sem, 2 * num_chunks)
 
 
@@ -143,6 +147,15 @@ expected_core_range = f"#ttmetal.core_range<0x0, {grid_y}x{grid_x}>"
 assert fabric_enqueue.count(expected_core_range) == 3, fabric_enqueue
 assert "dm_core = 1, noc0" in fabric_enqueue, fabric_enqueue
 assert "dm_core = 0, noc1" in fabric_enqueue, fabric_enqueue
+profile_markers = {
+    "d2m.chunk.compute.begin": 1,
+    "d2m.chunk.compute.end": 1,
+    "d2m.chunk.fabric.begin": 2,
+    "d2m.chunk.fabric.end": 2,
+}
+for marker, expected_count in profile_markers.items():
+    assert lowered.count(marker) == expected_count, marker
+assert lowered.count("DeviceTimestampedData") == sum(profile_markers.values()), lowered
 
 # The chunk loop indexes distinct generic outputs. It must not be mistaken for
 # a matmul reduction loop, which would accumulate chunk t onto chunk t-1.

--- a/test/d2m-jit/lit/python_rewrites_pass.py
+++ b/test/d2m-jit/lit/python_rewrites_pass.py
@@ -30,7 +30,7 @@ import tempfile
 TTIR_INPUT = """\
 module {
   func.func @forward(%x: tensor<32x32xf32>) -> tensor<32x32xf32> {
-    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32>
+    %r = "ttir.exp"(%x) : (tensor<32x32xf32>) -> tensor<32x32xf32> loc(fused<{tt.profile.region = "test.exp"}>["input.mlir":1:1])
     return %r : tensor<32x32xf32>
   }
 }
@@ -68,6 +68,7 @@ def main():
         result = subprocess.run(
             [
                 ttmlir_opt,
+                "--mlir-print-debuginfo",
                 f"--d2m-python-rewrites=module-path={pattern_file}",
                 tmp_path,
             ],
@@ -91,3 +92,4 @@ if __name__ == "__main__":
 # CHECK:        d2m.generic
 # CHECK:        d2m.tile_exp
 # CHECK:        return %{{.*}} : tensor<32x32xf32>
+# CHECK:        tt.profile.region = "test.exp"

--- a/test/d2m-jit/runner.py
+++ b/test/d2m-jit/runner.py
@@ -292,7 +292,7 @@ def assert_pcc(golden, actual, threshold: float = 0.99):
 # ----------------------------------------------------------------------
 
 
-def run_rewrite(spec: PatternTest) -> str:
+def run_rewrite(spec: PatternTest, *, preserve_debug_info: bool = False) -> str:
     """Apply just this pattern file's rewrites to the spec's TTIR module.
 
     Uses ``apply_patterns_text``, which snapshots/clears/restores the global
@@ -305,7 +305,11 @@ def run_rewrite(spec: PatternTest) -> str:
         raise ValueError(
             f"PatternTest {spec.name!r} has no source_file (discovery sets it)"
         )
-    return apply_patterns_text(spec.ttir, [spec.source_file])
+    return apply_patterns_text(
+        spec.ttir,
+        [spec.source_file],
+        preserve_debug_info=preserve_debug_info,
+    )
 
 
 def _filecheck_bin() -> str:
@@ -483,8 +487,7 @@ def compile_spec_to_fbb(spec: PatternTest):
     from _ttmlir_runtime import binary as _rt_binary
     from d2m_jit._src.builder import _get_system_desc_path, _pipeline_passes
 
-    # run_rewrite already applies *only* this file's pattern(s), in isolation.
-    rewritten = run_rewrite(spec)
+    rewritten = run_rewrite(spec, preserve_debug_info=True)
     ctx = ir.Context()
     ctx.load_all_available_dialects()
     module = ir.Module.parse(rewritten, ctx)

--- a/test/python/golden/d2m/test_profile_region_loc.py
+++ b/test/python/golden/d2m/test_profile_region_loc.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify TTMetal enqueue-program location serialization preserves semantic tags."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+import _ttmlir_runtime as tt_runtime
+from ttmlir.ir import Context, Location, Module
+from ttmlir.passmanager import PassManager
+from ttmlir.passes import ttmetal_to_flatbuffer_bin
+
+pytestmark = pytest.mark.frontend("ttir")
+
+# The finish location ensures the enqueue-program location is selected.
+_PROFILE_REGION_MLIR = """\
+module {
+  func.func @test_profile_region_loc(%arg0: i32) {
+    "ttmetal.enqueue_program"(%arg0) <{
+      cb_ports = array<i64>,
+      kernelConfigs = [
+        #ttmetal.noc_config<@scalar_kernel,
+          #ttmetal.core_range<0x0, 1x1>,
+          #ttmetal.kernel_args<ct_args = [<scalar[0]>]>,
+          dm_core = 1, noc0>
+      ],
+      operandSegmentSizes = array<i32: 1, 0>
+    }> : (i32) -> () loc(fused<{tt.profile.region = "test.region"}>["tagged.mlir":1:1])
+    "ttmetal.finish"() : () -> () loc("finish.mlir":2:2)
+    return
+  }
+  func.func private @scalar_kernel() attributes {
+    ttkernel.arg_spec = #ttkernel.arg_spec<
+      ct_args = [<arg_type = scalar, operand_index = 0>]>,
+    ttkernel.thread = #ttkernel.thread<noc>
+  } {
+    return
+  }
+}
+"""
+
+_PROFILE_REGION_MLIR_LEGACY = _PROFILE_REGION_MLIR.replace(
+    "dm_core = 1, noc0>", "noc0>"
+)
+
+
+def _parse_json(raw: str) -> object:
+    return json.loads(re.sub(r"\binf\b", "Infinity", re.sub(r"\bnan\b", "NaN", raw)))
+
+
+def _walk(value):
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _parse_module(mlir: str) -> Module:
+    ctx = Context()
+    loc = Location.unknown(ctx)
+    with ctx, loc:
+        module = Module.parse(mlir)
+    pm = PassManager.parse(
+        "builtin.module("
+        "ttcore-register-device,"
+        "ttcore-mark-functions-as-forward,"
+        "ttcore-wrap-device-module"
+        ")",
+        ctx,
+    )
+    pm.run(module.operation)
+    return module
+
+
+@pytest.mark.parametrize("target", ["ttmetal"])
+def test_ttmetal_enqueue_program_serializes_profile_region(target: str):
+    """FlatBuffer Command.loc for enqueue-program retains tt.profile.region."""
+    last_error = None
+    module = None
+    for mlir in (_PROFILE_REGION_MLIR, _PROFILE_REGION_MLIR_LEGACY):
+        try:
+            module = _parse_module(mlir)
+            break
+        except Exception as exc:  # noqa: BLE001 - retry alternate assembly syntax
+            last_error = exc
+    if module is None:
+        raise last_error
+
+    capsule = ttmetal_to_flatbuffer_bin(module)
+    fbb = tt_runtime.binary.load_binary_from_capsule(capsule)
+    data = _parse_json(fbb.as_json())
+
+    enqueue_locs = []
+    finish_locs = []
+    for node in _walk(data):
+        if not isinstance(node, dict):
+            continue
+        type_type = str(node.get("type_type", ""))
+        if "EnqueueProgram" in type_type:
+            enqueue_locs.append(node.get("loc"))
+        if type_type.endswith("FinishCommand") or type_type == "FinishCommand":
+            finish_locs.append(node.get("loc"))
+
+    assert enqueue_locs, "expected at least one EnqueueProgramCommand"
+    assert any(
+        isinstance(loc, str) and 'tt.profile.region = "test.region"' in loc
+        for loc in enqueue_locs
+    ), enqueue_locs
+    assert any(
+        isinstance(loc, str) and "finish.mlir" in loc for loc in finish_locs
+    ), finish_locs

--- a/test/python/test_d2m_preserve_debug_info.py
+++ b/test/python/test_d2m_preserve_debug_info.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# REQUIRES: d2m-jit
+# RUN: %python -m pytest -q %s
+
+"""Verify d2m-jit text rewrite APIs can preserve MLIR debug locations."""
+
+from __future__ import annotations
+
+from d2m_jit._src.rewrite import apply_patterns_text
+
+_INPUT = """\
+module {
+  func.func @forward(%arg0: f32) -> f32 {
+    %0 = arith.addf %arg0, %arg0 : f32 loc(fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1])
+    return %0 : f32
+  }
+}
+"""
+
+
+def test_apply_patterns_text_drops_debug_info_by_default():
+    out = apply_patterns_text(_INPUT, pattern_paths=[])
+    assert "tt.profile.region" not in out
+    assert "arith.addf" in out
+
+
+def test_apply_patterns_text_preserve_debug_info_keeps_profile_region():
+    out = apply_patterns_text(_INPUT, pattern_paths=[], preserve_debug_info=True)
+    assert 'tt.profile.region = "decoder.sdpa"' in out
+    # Round-trip: re-parse and confirm the region is still attached.
+    out2 = apply_patterns_text(out, pattern_paths=[], preserve_debug_info=True)
+    assert 'tt.profile.region = "decoder.sdpa"' in out2

--- a/test/python/test_profile_regions.py
+++ b/test/python/test_profile_regions.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# RUN: %python -m pytest -q %s
+
+"""Unit tests for semantic profile-region extraction and CSV export."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PROFILE_REGIONS_PATH = _REPO_ROOT / "tools" / "ttrt" / "common" / "profile_regions.py"
+
+
+def _load_profile_regions():
+    # Load by path so these tests do not require importing the full ttrt package.
+    spec = importlib.util.spec_from_file_location(
+        "profile_regions", _PROFILE_REGIONS_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+profile_regions = _load_profile_regions()
+PROFILE_REGIONS_COLUMN = profile_regions.PROFILE_REGIONS_COLUMN
+annotate_ops_perf_csv = profile_regions.annotate_ops_perf_csv
+annotate_ops_perf_rows = profile_regions.annotate_ops_perf_rows
+extract_profile_regions = profile_regions.extract_profile_regions
+extract_device_op_global_call_count = (
+    profile_regions.extract_device_op_global_call_count
+)
+format_profile_regions = profile_regions.format_profile_regions
+profile_regions_from_loc = profile_regions.profile_regions_from_loc
+
+
+def test_extract_single_fused_region():
+    loc = 'loc(fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1])'
+    assert extract_profile_regions(loc) == ["decoder.sdpa"]
+
+
+def test_extract_quoted_attr_name():
+    loc = 'loc(fused<{"tt.profile.region" = "decoder.mlp"}>[...])'
+    assert extract_profile_regions(loc) == ["decoder.mlp"]
+
+
+def test_extract_nested_fused_and_callsite_order():
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.mlp"}>'
+        '[fused<{tt.profile.region = "decoder.sdpa"}>["a.mlir":1:1], '
+        'callsite("b.mlir":2:2 at fused<{tt.profile.region = "decoder.attn"}>'
+        '["c.mlir":3:3])])'
+    )
+    assert extract_profile_regions(loc) == [
+        "decoder.mlp",
+        "decoder.sdpa",
+        "decoder.attn",
+    ]
+
+
+def test_extract_deduplicates_preserving_order():
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.sdpa"}>'
+        '[fused<{tt.profile.region = "decoder.mlp"}>[...], '
+        'fused<{tt.profile.region = "decoder.sdpa"}>[...]])'
+    )
+    assert extract_profile_regions(loc) == ["decoder.sdpa", "decoder.mlp"]
+
+
+def test_extract_multiple_regions_on_one_op():
+    # Fusion may retain several contributing semantic labels on one emit.
+    loc = (
+        'loc(fused<{tt.profile.region = "decoder.qkv"}>'
+        '[fused<{tt.profile.region = "decoder.sdpa"}>[...]])'
+    )
+    assert extract_profile_regions(loc) == ["decoder.qkv", "decoder.sdpa"]
+    assert format_profile_regions(extract_profile_regions(loc)) == (
+        "decoder.qkv;decoder.sdpa"
+    )
+
+
+def test_untagged_location_yields_empty():
+    assert extract_profile_regions('loc("file.mlir":10:4)') == []
+    assert extract_profile_regions("loc(unknown)") == []
+    assert extract_profile_regions(None) == []
+    assert extract_profile_regions("") == []
+    assert profile_regions_from_loc('loc("file.mlir":10:4)') == ""
+
+
+def test_extract_device_op_global_call_count_current_tracy_format():
+    multiline = (
+        '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
+        "6579250399439280527, 0, false, 2048 ->"
+    )
+    single_line = (
+        '`TT_DNN_DEVICE_OP: "TilizeDeviceOperation", '
+        "6579250399439280527, 0, false, 3072`;12167960701"
+    )
+    assert extract_device_op_global_call_count(multiline) == 2048
+    assert extract_device_op_global_call_count(single_line) == 3072
+    assert extract_device_op_global_call_count("MLIR_OP_LOCATION;loc(unknown)") is None
+
+
+def test_annotate_rows_preserves_loc():
+    rows = [
+        {
+            "GLOBAL CALL COUNT": "1",
+            "LOC": 'loc(fused<{tt.profile.region = "decoder.sdpa"}>[...])',
+        },
+        {
+            "GLOBAL CALL COUNT": "2",
+            "LOC": 'loc("untagged.mlir":1:1)',
+        },
+    ]
+    annotated = annotate_ops_perf_rows(rows)
+    assert annotated[0]["LOC"] == rows[0]["LOC"]
+    assert annotated[0][PROFILE_REGIONS_COLUMN] == "decoder.sdpa"
+    assert annotated[1]["LOC"] == rows[1]["LOC"]
+    assert annotated[1][PROFILE_REGIONS_COLUMN] == ""
+
+
+def test_annotate_ops_perf_csv_from_synthetic_tracy_style_input(tmp_path):
+    input_csv = tmp_path / "ops_perf_results.csv"
+    output_csv = tmp_path / "ops_perf_annotated.csv"
+    with open(input_csv, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=[
+                "GLOBAL CALL COUNT",
+                "OP CODE",
+                "DEVICE KERNEL DURATION [ns]",
+                "LOC",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "GLOBAL CALL COUNT": "7",
+                "OP CODE": "ttnn.add",
+                "DEVICE KERNEL DURATION [ns]": "1000",
+                "LOC": (
+                    'loc(fused<{tt.profile.region = "decoder.sdpa"}>' '["x.mlir":1:1])'
+                ),
+            }
+        )
+        writer.writerow(
+            {
+                "GLOBAL CALL COUNT": "8",
+                "OP CODE": "ttnn.matmul",
+                "DEVICE KERNEL DURATION [ns]": "2000",
+                "LOC": 'loc("y.mlir":2:2)',
+            }
+        )
+
+    annotate_ops_perf_csv(str(input_csv), str(output_csv))
+
+    with open(output_csv, "r", newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert PROFILE_REGIONS_COLUMN in reader.fieldnames
+        assert "LOC" in reader.fieldnames
+        rows = list(reader)
+
+    assert rows[0]["LOC"].startswith("loc(fused<{tt.profile.region")
+    assert rows[0][PROFILE_REGIONS_COLUMN] == "decoder.sdpa"
+    assert rows[1]["LOC"] == 'loc("y.mlir":2:2)'
+    assert rows[1][PROFILE_REGIONS_COLUMN] == ""

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -1718,8 +1718,8 @@ _g_perf_trace_enabled = False
 
 
 def _maybe_enable_perf_trace():
-    """Flip the perf::Env singleton so the ttmetal executor dumps device
-    profiler results after each workload. Must run before the first submit in
+    """Flip the perf::Env singleton so the ttmetal runtime dumps device
+    profiler results after each submission. Must run before the first submit in
     the process (the singleton is seeded on first access). Idempotent.
 
     Device-side capture is controlled by tt-metal env vars that must be present

--- a/tools/d2m-jit/_src/rewrite.py
+++ b/tools/d2m-jit/_src/rewrite.py
@@ -395,7 +395,11 @@ def _build_pdl_text(patterns: Sequence[_Pattern]) -> str:
     return f"module {{\n{body}\n}}\n"
 
 
-def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
+def apply_patterns_text(
+    input_text: str,
+    pattern_paths: Sequence[str],
+    preserve_debug_info: bool = False,
+) -> str:
     """Text-IO entrypoint for the d2m-jit pattern framework.
 
     Parses `input_text` (textual MLIR) in a fresh ir.Context, imports each
@@ -407,6 +411,9 @@ def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
     the C++/Python "two MLIRs" problem (ttmlir-opt is statically linked
     against MLIR while ttmlir's Python bindings have their own shared
     copy, so capsule pointers can't cross the boundary safely).
+
+    When `preserve_debug_info` is true, the rewritten module retains location
+    metadata. The default output omits debug locations.
 
     Pattern registration is process-global; we snapshot and restore so
     repeated calls don't accumulate stale entries.
@@ -433,6 +440,8 @@ def apply_patterns_text(input_text: str, pattern_paths: Sequence[str]) -> str:
 
         apply_patterns(module)
         module.operation.verify()
+        if preserve_debug_info:
+            return module.operation.get_asm(enable_debug_info=True)
         return str(module)
     finally:
         _registry.clear()

--- a/tools/d2m-jit/_src/sim/ops.py
+++ b/tools/d2m-jit/_src/sim/ops.py
@@ -122,6 +122,14 @@ def remote_store(dst, indices, src):
     )
 
 
+def tilize_block(input):
+    return input
+
+
+def profile_event(label, thread):
+    pass
+
+
 # --- elementwise helpers -----------------------------------------------------
 
 
@@ -439,6 +447,8 @@ SIM_OPS.update(
         "core_index": core_index,
         "remote_load": remote_load,
         "remote_store": remote_store,
+        "tilize_block": tilize_block,
+        "profile_event": profile_event,
         "Semaphore": Semaphore,
         # Free functions only -- there are no method forms for these ops.
         "zeros": zeros,

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -710,6 +710,34 @@ def _const_value(node):
     )
 
 
+@syntax(
+    "profile_event",
+    args_as_attr=[_const_value, _const_value],
+)
+def profile_event(label, thread):
+    """Record a named device-profiler timestamp on one kernel thread.
+
+    Use `.begin` and `.end` label suffixes for events that form an interval.
+    The event is inert unless tt-metal device profiling is enabled.
+    """
+    if (
+        not isinstance(label, str)
+        or not label
+        or not label.isascii()
+        or any(not (character.isalnum() or character in "_.-") for character in label)
+    ):
+        raise ValueError(
+            "profile label must contain only ASCII letters, digits, '_', '-', or '.'"
+        )
+    thread_values = {"compute": 0, "datamovement": 1}
+    if thread not in thread_values:
+        raise ValueError("profile thread must be 'compute' or 'datamovement'")
+    return d2m.profile_event(
+        StringAttr.get(label),
+        IntegerAttr.get(IntegerType.get_signless(32), thread_values[thread]),
+    )
+
+
 def _tile_elem_type(block):
     """Return the !ttcore.tile element type of a tile-tensor block, or
     raise a clear error if `block` isn't a tile tensor."""

--- a/tools/ttrt/CMakeLists.txt
+++ b/tools/ttrt/CMakeLists.txt
@@ -60,6 +60,7 @@ declare_mlir_python_sources(TTRTSources
     common/callback.py
     common/check.py
     common/perf.py
+    common/profile_regions.py
     common/query.py
     common/read.py
     common/run.py

--- a/tools/ttrt/common/perf.py
+++ b/tools/ttrt/common/perf.py
@@ -14,6 +14,11 @@ import csv
 import ast
 
 from ttrt.common.util import *
+from ttrt.common.profile_regions import (
+    PROFILE_REGIONS_COLUMN,
+    annotate_row_with_profile_regions,
+    extract_device_op_global_call_count,
+)
 
 
 class Perf:
@@ -586,19 +591,11 @@ class Perf:
 
                                     # Process the collected block. Find it's global call count and add it to the loc
                                     for bline in block:
-                                        parts = bline.split(",")
-                                        # Strip and split part[3] on semicolon or space, and grab the number
-                                        num_part = parts[3].strip()
-                                        digits = ""
-                                        for c in num_part:
-                                            if c.isdigit():
-                                                digits += c
-                                            else:
-                                                break
                                         global_call_count = (
-                                            int(digits) if digits else None
+                                            extract_device_op_global_call_count(bline)
                                         )
-                                        call_count_mapping[global_call_count] = data
+                                        if global_call_count is not None:
+                                            call_count_mapping[global_call_count] = data
 
                         return call_count_mapping
 
@@ -627,6 +624,7 @@ class Perf:
                         reader = csv.DictReader(infile)
                         fieldnames = reader.fieldnames + [
                             "LOC",
+                            PROFILE_REGIONS_COLUMN,
                             "CONST_EVAL_OP",
                             "INPUT_LAYOUT_CONVERSION_OP",
                             "PROGRAM_METADATA",
@@ -646,6 +644,8 @@ class Perf:
                                 ]
                             else:
                                 row["LOC"] = "loc(unknown)"
+
+                            annotate_row_with_profile_regions(row)
 
                             # Append the const_eval_op column with its const_eval_op data
                             if (

--- a/tools/ttrt/common/profile_regions.py
+++ b/tools/ttrt/common/profile_regions.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract semantic profile regions from MLIR location strings.
+
+Region labels are attached to high-level ops as fused-location metadata:
+
+    loc(fused<{tt.profile.region = "decoder.sdpa"}>[...])
+
+After lowering and fusion, an emitted op may carry an ordered,
+de-duplicated set of labels from multiple source regions. This module
+parses those labels from the printed location text that already flows
+through FlatBuffer ``loc`` / ``loc_info`` and Tracy ``MLIR_OP_LOCATION``.
+"""
+
+from __future__ import annotations
+
+import csv
+import re
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+PROFILE_REGION_ATTR = "tt.profile.region"
+PROFILE_REGIONS_COLUMN = "PROFILE_REGIONS"
+
+# Matches both quoted and bare dictionary keys:
+#   tt.profile.region = "decoder.sdpa"
+#   "tt.profile.region" = "decoder.sdpa"
+_REGION_PATTERN = re.compile(
+    r'(?:"tt\.profile\.region"|tt\.profile\.region)\s*=\s*"((?:\\.|[^"\\])*)"'
+)
+
+# GLOBAL CALL COUNT is the final comma-separated field before either ``->``
+# (multiline op text) or the closing backtick (single-line op text). Earlier
+# fields vary with the profiler metadata and cannot be indexed reliably.
+_DEVICE_OP_CALL_COUNT_PATTERN = re.compile(
+    r"TT_DNN_DEVICE_OP:.*?,\s*(\d+)\s*(?:->|`(?:;|$))"
+)
+
+
+def extract_profile_regions(loc: Optional[str]) -> List[str]:
+    """Return ordered, de-duplicated ``tt.profile.region`` labels from ``loc``.
+
+    Nested fused and callsite locations are handled by scanning the printed
+    location left-to-right, which matches MLIR's pre-order print of fused
+    metadata before child locations. Operations without the attribute yield
+    an empty list.
+    """
+    if not loc:
+        return []
+
+    regions: List[str] = []
+    seen = set()
+    for match in _REGION_PATTERN.finditer(loc):
+        region = bytes(match.group(1), "utf-8").decode("unicode_escape")
+        if region in seen:
+            continue
+        seen.add(region)
+        regions.append(region)
+    return regions
+
+
+def extract_device_op_global_call_count(line: str) -> Optional[int]:
+    """Extract ``GLOBAL CALL COUNT`` from a Tracy TT_DNN_DEVICE_OP line."""
+    match = _DEVICE_OP_CALL_COUNT_PATTERN.search(line)
+    return int(match.group(1)) if match else None
+
+
+def format_profile_regions(regions: Sequence[str]) -> str:
+    """Join region labels for the ``PROFILE_REGIONS`` CSV column."""
+    return ";".join(regions)
+
+
+def profile_regions_from_loc(loc: Optional[str]) -> str:
+    """Convenience: extract and format regions from a location string."""
+    return format_profile_regions(extract_profile_regions(loc))
+
+
+def annotate_row_with_profile_regions(
+    row: MutableMapping[str, str], loc_column: str = "LOC"
+) -> None:
+    """Set ``PROFILE_REGIONS`` on ``row`` from its ``LOC`` column."""
+    row[PROFILE_REGIONS_COLUMN] = profile_regions_from_loc(row.get(loc_column))
+
+
+def annotate_ops_perf_rows(
+    rows: Iterable[Mapping[str, str]], loc_column: str = "LOC"
+) -> List[dict]:
+    """Return copies of profiler rows with ``PROFILE_REGIONS`` populated."""
+    annotated: List[dict] = []
+    for row in rows:
+        out = dict(row)
+        annotate_row_with_profile_regions(out, loc_column=loc_column)
+        annotated.append(out)
+    return annotated
+
+
+def annotate_ops_perf_csv(
+    input_csv_path: str,
+    output_csv_path: str,
+    loc_column: str = "LOC",
+) -> None:
+    """Rewrite an ops-perf CSV, adding ``PROFILE_REGIONS`` from ``LOC``.
+
+    Existing columns, including ``LOC``, are preserved unchanged.
+    """
+    with open(input_csv_path, mode="r", newline="", encoding="utf-8") as infile:
+        reader = csv.DictReader(infile)
+        if reader.fieldnames is None:
+            raise ValueError(f"CSV has no header: {input_csv_path}")
+        if loc_column not in reader.fieldnames:
+            raise ValueError(f"CSV missing {loc_column!r} column: {input_csv_path}")
+
+        fieldnames = list(reader.fieldnames)
+        if PROFILE_REGIONS_COLUMN not in fieldnames:
+            fieldnames.append(PROFILE_REGIONS_COLUMN)
+
+        rows = annotate_ops_perf_rows(reader, loc_column=loc_column)
+
+    with open(output_csv_path, mode="w", newline="", encoding="utf-8") as outfile:
+        writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)


### PR DESCRIPTION
## Summary

- preserve semantic MLIR name locations through D2M rewriting and attach them to TT-Metal program submissions
- report named profile regions through ttrt performance tooling
- add a `profile_event` D2M primitive that lowers to device timestamp markers on the selected data-movement or compute thread
- defer device-profiler readback until the complete D2M submission has finished, preserving inter-program overlap
- cover location preservation, profile-region extraction, and timestamp lowering

## Stack

Depends on #9182. The next drafts use this infrastructure to characterize the overlap workloads.

## Validation

- profile/debug-info Python tests and D2M rewrite lit coverage
- device timestamp coverage in `ccl_overlap.py`
- reconstructed stack passes `pre-commit run --all-files`

Split from #9170 so profiling infrastructure is reviewable without the benchmark-specific reporting code.