### PR TITLE
[D2M] Add BF16 multichip overlap benchmarks

### DIFF
--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -1280,6 +1280,7 @@ void MCQExecutor::execute(const target::metal::FinishCommand *) {
 }
 
 void MCQExecutor::execute(const target::metal::MeshShardCommand *command) {
+  ZoneScopedN("MeshShardCommand");
   LOG_ASSERT(command->src()->desc()->buffer_detail_type() ==
                  tt::target::metal::BufferDetail::SystemBuffer,
              "MeshShardCommand requires system memory as input");

--- a/test/d2m-jit/llama_down_projection_workload.py
+++ b/test/d2m-jit/llama_down_projection_workload.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Llama 3 8B prefill down projection with two-way tensor parallelism."""
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+import d2m_jit as d2m
+
+
+@dataclass(frozen=True)
+class WorkloadConfig:
+    m: int = 576
+    k: int = 14336
+    n: int = 4096
+    grid_y: int = 6
+    grid_x: int = 8
+    seed: int = 0
+
+    m_block_tiles: int = 1
+    k_block_tiles: int = 56
+    n_block_tiles: int = 4
+    k_segments: int = 8
+
+    def __post_init__(self):
+        if self.m_block_tiles != 1 or self.n_block_tiles != 4:
+            raise ValueError("the kernels require 32x128 output blocks")
+        if self.k_segments != 8:
+            raise ValueError("the kernels require eight K segments")
+        if self.k % self.k_segments:
+            raise ValueError("the contraction dimension must split into eight segments")
+        dimensions = (
+            (self.m, self.m_block_elements * self.grid_y, "m"),
+            (self.k_segment_elements, self.k_block_elements, "K segment"),
+            (self.n, self.n_block_elements * self.grid_x, "n"),
+        )
+        for size, divisor, name in dimensions:
+            if size % divisor:
+                raise ValueError(f"{name}={size} must be divisible by {divisor}")
+        if self.k_blocks_per_segment > 8:
+            raise ValueError("a K segment must fit across one worker-grid dimension")
+        if self.n_blocks > 32:
+            raise ValueError("the staged weight conversion supports at most 32 blocks")
+
+    @property
+    def m_block_elements(self):
+        return self.m_block_tiles * 32
+
+    @property
+    def k_block_elements(self):
+        return self.k_block_tiles * 32
+
+    @property
+    def n_block_elements(self):
+        return self.n_block_tiles * 32
+
+    @property
+    def m_blocks(self):
+        return self.m // self.m_block_elements
+
+    @property
+    def n_blocks(self):
+        return self.n // self.n_block_elements
+
+    @property
+    def m_blocks_per_core(self):
+        return self.m_blocks // self.grid_y
+
+    @property
+    def n_blocks_per_core(self):
+        return self.n_blocks // self.grid_x
+
+    @property
+    def output_blocks_per_core(self):
+        return self.m_blocks_per_core * self.n_blocks_per_core
+
+    @property
+    def k_segment_elements(self):
+        return self.k // self.k_segments
+
+    @property
+    def k_blocks_per_segment(self):
+        return self.k_segment_elements // self.k_block_elements
+
+
+def make_operands(config):
+    generator = torch.Generator()
+    generator.manual_seed(config.seed)
+    activations = torch.randn(
+        config.m,
+        config.k,
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.25)
+    weight = torch.randn(
+        config.k,
+        config.n,
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.015625)
+    return activations, weight
+
+
+def golden(activations, weight):
+    return torch.matmul(activations.float(), weight.float()).to(torch.bfloat16)
+
+
+def _layout(shape, block_shape, grid_shape=None):
+    return d2m.Layout(
+        shape=shape,
+        dtype=d2m.bfloat16,
+        block_shape=block_shape,
+        grid_shape=grid_shape,
+        mem_space="dram",
+    )
+
+
+@d2m.kernel
+def single_chip_down_projection(
+    activations,
+    weight,
+    output,
+    m_blocks_per_core,
+    n_blocks_per_core,
+    k_blocks,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        for n_slot in range(n_blocks_per_core):
+            n_block = cx * n_blocks_per_core + n_slot
+            acc = zeros([1, 4], dtype="bf16")
+            for k_block in range(k_blocks):
+                lhs = remote_load(activations, [m_block, k_block])
+                rhs = remote_load(weight, [k_block, n_block])
+                acc += lhs @ rhs
+            remote_store(output, [m_block, n_block], acc)
+
+
+@d2m.kernel
+def place_activation_segment(
+    source,
+    destination,
+    k_block_offset,
+    m_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        block = remote_load(source, [m_block, cx])
+        remote_store(destination, [m_block, k_block_offset + cx], block)
+
+
+@d2m.kernel
+def place_weight_segment(
+    source,
+    destination,
+    k_block_offset,
+    n_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for n_slot in range(n_blocks_per_core):
+        n_block = cx * n_blocks_per_core + n_slot
+        block = remote_load(source, [cy, n_block])
+        remote_store(destination, [k_block_offset + cy, n_block], block)
+
+
+@d2m.kernel
+def serialized_two_chip_down_projection(
+    activations,
+    weight,
+    partials,
+    start_sem,
+    ready,
+    consumed,
+    fabric_done,
+    transfer_done,
+    m_blocks,
+    m_blocks_per_core,
+    n_blocks_per_core,
+    k_blocks,
+    grid_y,
+    grid_x,
+    worker_count,
+    output_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    if is_router_core():
+        dy = mesh_position(0)
+        device_synchronize(
+            start_sem,
+            start_device=[dy, 0],
+            mcast_shape=[1, 2],
+            num_receivers=1,
+            core_indices=[cy, cx],
+        )
+    for item in range(output_blocks_per_core):
+        m_slot = item // n_blocks_per_core
+        n_slot = item % n_blocks_per_core
+        m_block = cy * m_blocks_per_core + m_slot
+        n_block = cx * n_blocks_per_core + n_slot
+        acc = zeros([1, 4], dtype="bf16")
+        for k_block in range(k_blocks):
+            lhs = remote_load(activations, [m_block, k_block])
+            rhs = remote_load(weight, [k_block, n_block])
+            acc += lhs @ rhs
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+
+        if is_router_core():
+            dy = mesh_position(0)
+            semaphore_wait(ready, (item + 1) * worker_count)
+            dx = mesh_position(1)
+            for ty in range(grid_y):
+                target_m = ty * m_blocks_per_core + m_slot
+                for tx in range(grid_x):
+                    target_n = tx * n_blocks_per_core + n_slot
+                    partial = empty_like(acc)
+                    partial = core_read(partial, acc, core=[ty, tx])
+                    semaphore_inc(consumed, 1, core=[ty, tx])
+                    remote_store(
+                        partials,
+                        [dx * m_blocks + target_m, target_n],
+                        partial,
+                        start_device=[dy, 0],
+                        device_mcast_shape=[1, 2],
+                        semaphore=fabric_done,
+                        semaphore_indices=[cy, cx],
+                    )
+            semaphore_wait(fabric_done, (item + 1) * 2 * worker_count)
+            for ty in range(grid_y):
+                for tx in range(grid_x):
+                    semaphore_inc(transfer_done, 1, core=[ty, tx])
+        semaphore_wait(consumed, item + 1, compute=True)
+        semaphore_wait(transfer_done, item + 1)
+
+
+@d2m.kernel
+def overlapped_two_chip_down_projection(
+    activations,
+    weight,
+    partials,
+    start_sem,
+    ready,
+    consumed,
+    fabric_done,
+    m_blocks,
+    m_blocks_per_core,
+    n_blocks_per_core,
+    k_blocks,
+    grid_y,
+    grid_x,
+    worker_count,
+    output_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    if is_router_core():
+        dy = mesh_position(0)
+        device_synchronize(
+            start_sem,
+            start_device=[dy, 0],
+            mcast_shape=[1, 2],
+            num_receivers=1,
+            core_indices=[cy, cx],
+        )
+    for item in range(output_blocks_per_core):
+        m_slot = item // n_blocks_per_core
+        n_slot = item % n_blocks_per_core
+        m_block = cy * m_blocks_per_core + m_slot
+        n_block = cx * n_blocks_per_core + n_slot
+        acc = zeros([1, 4], dtype="bf16")
+        for k_block in range(k_blocks):
+            lhs = remote_load(activations, [m_block, k_block])
+            rhs = remote_load(weight, [k_block, n_block])
+            acc += lhs @ rhs
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+
+        if is_router_core():
+            dy = mesh_position(0)
+            semaphore_wait(ready, (item + 1) * worker_count)
+            dx = mesh_position(1)
+            for ty in range(grid_y):
+                target_m = ty * m_blocks_per_core + m_slot
+                for tx in range(grid_x):
+                    target_n = tx * n_blocks_per_core + n_slot
+                    partial = empty_like(acc)
+                    partial = core_read(partial, acc, core=[ty, tx])
+                    semaphore_inc(consumed, 1, core=[ty, tx])
+                    remote_store(
+                        partials,
+                        [dx * m_blocks + target_m, target_n],
+                        partial,
+                        start_device=[dy, 0],
+                        device_mcast_shape=[1, 2],
+                        semaphore=fabric_done,
+                        semaphore_indices=[cy, cx],
+                    )
+            semaphore_wait(fabric_done, (item + 1) * 2 * worker_count)
+        semaphore_wait(consumed, item + 1, compute=True)
+
+
+@d2m.kernel
+def reduce_two_chip_partials(
+    partials,
+    output,
+    m_blocks,
+    m_blocks_per_core,
+    n_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        for n_slot in range(n_blocks_per_core):
+            n_block = cx * n_blocks_per_core + n_slot
+            first = remote_load(partials, [m_block, n_block])
+            second = remote_load(partials, [m_blocks + m_block, n_block])
+            remote_store(output, [m_block, n_block], first + second)
+
+
+def _stage_k_segments(config, activation_sources, weight_sources, k_elements):
+    k_blocks = k_elements // config.k_block_elements
+    activation_layout = _layout(
+        (config.m, k_elements),
+        [config.m_block_tiles, config.k_block_tiles],
+        (config.grid_y, math.gcd(k_blocks, config.grid_x)),
+    )
+    weight_layout = _layout(
+        (k_elements, config.n),
+        [config.k_block_tiles, config.n_block_tiles],
+        (math.gcd(k_blocks, 8), config.grid_x),
+    )
+    staged_activations = d2m.empty(activation_layout)
+    staged_weight = d2m.empty(weight_layout)
+    activation_grid = (config.grid_y, config.k_blocks_per_segment)
+    weight_grid = (config.k_blocks_per_segment, config.grid_x)
+    for segment, (activation, weight) in enumerate(
+        zip(activation_sources, weight_sources)
+    ):
+        k_block_offset = segment * config.k_blocks_per_segment
+        place_activation_segment(
+            activation,
+            staged_activations,
+            k_block_offset,
+            config.m_blocks_per_core,
+            grid=activation_grid,
+            kernel_io_in_dram=True,
+        )
+        place_weight_segment(
+            weight,
+            staged_weight,
+            k_block_offset,
+            config.n_blocks_per_core,
+            grid=weight_grid,
+            kernel_io_in_dram=True,
+        )
+    return staged_activations, staged_weight, k_blocks
+
+
+def run_single_chip(config, activations, weight):
+    d2m.mesh((1, 1), topology=("linear", "linear"))
+    grid = (config.grid_y, config.grid_x)
+    segment_activation_layout = _layout(
+        (config.m, config.k_segment_elements),
+        [config.m_block_tiles, config.k_block_tiles],
+    )
+    segment_weight_layout = _layout(
+        (config.k_segment_elements, config.n),
+        [config.k_block_tiles, config.n_block_tiles],
+        (2, config.n_blocks),
+    )
+    output_layout = _layout(
+        (config.m, config.n),
+        [config.m_block_tiles, config.n_block_tiles],
+        grid,
+    )
+    segment_size = config.k_segment_elements
+    activation_sources = []
+    weight_sources = []
+    for segment in range(config.k_segments):
+        start = segment * segment_size
+        stop = start + segment_size
+        activation_sources.append(
+            d2m.to_layout(
+                activations[:, start:stop].contiguous(),
+                segment_activation_layout,
+            )
+        )
+        weight_sources.append(
+            d2m.to_layout(weight[start:stop, :], segment_weight_layout)
+        )
+    staged_activations, staged_weight, k_blocks = _stage_k_segments(
+        config,
+        activation_sources,
+        weight_sources,
+        config.k,
+    )
+    output = d2m.empty(output_layout)
+    single_chip_down_projection(
+        staged_activations,
+        staged_weight,
+        output,
+        config.m_blocks_per_core,
+        config.n_blocks_per_core,
+        k_blocks,
+        grid=grid,
+        kernel_io_in_dram=True,
+    )
+    return output.to_host()
+
+
+def run_two_chip(config, activations, weight, overlap):
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    grid = (config.grid_y, config.grid_x)
+    segment_activation_layout = _layout(
+        (config.m, config.k_segment_elements),
+        [config.m_block_tiles, config.k_block_tiles],
+    )
+    segment_weight_layout = _layout(
+        (config.k_segment_elements, config.n),
+        [config.k_block_tiles, config.n_block_tiles],
+        (2, config.n_blocks),
+    )
+    partial_layout = _layout(
+        (2 * config.m, config.n),
+        [config.m_block_tiles, config.n_block_tiles],
+        grid,
+    )
+    output_layout = _layout(
+        (config.m, config.n),
+        [config.m_block_tiles, config.n_block_tiles],
+        grid,
+    )
+    segment_size = config.k_segment_elements
+    activation_sources = []
+    weight_sources = []
+    for local_segment in range(config.k_segments // 2):
+        low_start = local_segment * segment_size
+        high_start = low_start + config.k // 2
+        packed_activations = torch.cat(
+            (
+                activations[:, low_start : low_start + segment_size],
+                activations[:, high_start : high_start + segment_size],
+            ),
+            dim=1,
+        )
+        packed_weight = torch.cat(
+            (
+                weight[low_start : low_start + segment_size, :],
+                weight[high_start : high_start + segment_size, :],
+            ),
+            dim=0,
+        )
+        activation_sources.append(
+            d2m.mesh_shard(
+                packed_activations,
+                segment_activation_layout,
+                shard_dims=[-1, 1],
+                shard_shape=[1, 2],
+            )
+        )
+        weight_sources.append(
+            d2m.mesh_shard(
+                packed_weight,
+                segment_weight_layout,
+                shard_dims=[-1, 0],
+                shard_shape=[2, 1],
+            )
+        )
+    local_activations, local_weight, local_k_blocks = _stage_k_segments(
+        config,
+        activation_sources,
+        weight_sources,
+        config.k // 2,
+    )
+    partials = d2m.empty(partial_layout)
+    output = d2m.empty(output_layout)
+    start_sem = d2m.global_semaphore(grid_shape=(8, 8))
+    ready = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+    consumed = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+    fabric_done = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+    common_args = (
+        local_activations,
+        local_weight,
+        partials,
+        start_sem,
+        ready,
+        consumed,
+        fabric_done,
+    )
+    shape_args = (
+        config.m_blocks,
+        config.m_blocks_per_core,
+        config.n_blocks_per_core,
+        local_k_blocks,
+        config.grid_y,
+        config.grid_x,
+        config.grid_y * config.grid_x,
+        config.output_blocks_per_core,
+    )
+    kernel_options = {
+        "grid": grid,
+        "fabric": d2m.fabric_config(
+            cluster_axis=1,
+            topology="linear",
+            router_cores=[(0, 0)],
+        ),
+        "kernel_io_in_dram": True,
+    }
+    if overlap:
+        overlapped_two_chip_down_projection(
+            *common_args,
+            *shape_args,
+            **kernel_options,
+        )
+    else:
+        serialized_two_chip_down_projection(
+            *common_args,
+            d2m.global_semaphore(grid_shape=(8, 8), init=0),
+            *shape_args,
+            **kernel_options,
+        )
+    reduce_two_chip_partials(
+        partials,
+        output,
+        config.m_blocks,
+        config.m_blocks_per_core,
+        config.n_blocks_per_core,
+        grid=grid,
+        kernel_io_in_dram=True,
+    )
+    replicated = d2m.mesh_gather(
+        output,
+        shard_dims=[-1, 0],
+        shard_shape=[2, 1],
+    )
+    return replicated.to_host()[: config.m]

--- a/test/d2m-jit/multichip_overlap_benchmark.py
+++ b/test/d2m-jit/multichip_overlap_benchmark.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare equal-work single-chip matmul with two-chip matmul + all-gather."""
+
+import argparse
+import collections
+import contextlib
+import csv
+import os
+import pathlib
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import time
+
+
+def _tracy_tool(name):
+    tt_metal_home = pathlib.Path(os.environ["TT_METAL_HOME"])
+    candidates = (
+        tt_metal_home / name,
+        tt_metal_home / "build" / "tools" / "profiler" / "bin" / name,
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"{name} was not found under {tt_metal_home}")
+
+
+def _available_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@contextlib.contextmanager
+def _capture_tracy(trace_path, port):
+    capture = subprocess.Popen(
+        [
+            str(_tracy_tool("tracy-capture")),
+            "-o",
+            str(trace_path),
+            "-f",
+            "-p",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(0.1)
+    if capture.poll() is not None:
+        output, _ = capture.communicate()
+        raise RuntimeError(f"tracy-capture exited before the workload:\n{output}")
+    try:
+        yield
+    finally:
+        capture.send_signal(signal.SIGINT)
+        try:
+            output, _ = capture.communicate(timeout=20)
+        except subprocess.TimeoutExpired:
+            capture.kill()
+            output, _ = capture.communicate()
+        if capture.returncode not in (0, -signal.SIGINT):
+            raise RuntimeError(f"tracy-capture failed:\n{output}")
+
+
+def _export_tracy(trace_path):
+    csv_path = trace_path.with_suffix(".csv")
+    with csv_path.open("w", encoding="utf-8", newline="") as output:
+        subprocess.run(
+            [str(_tracy_tool("tracy-csvexport")), "-u", str(trace_path)],
+            check=True,
+            stdout=output,
+        )
+    return csv_path
+
+
+def _summarize_tracy(csv_path, measured_iterations):
+    selected = {
+        "submit": [],
+        "EnqueueProgramCommand": [],
+        "FinishCommand": [],
+        "EnqueueReadBufferCommand": [],
+    }
+    with csv_path.open(encoding="utf-8", newline="") as input_file:
+        for row in csv.DictReader(input_file):
+            name = row["name"]
+            if name in selected:
+                selected[name].append(int(row["exec_time_ns"]))
+    for name, samples in selected.items():
+        samples = samples[-measured_iterations:]
+        if samples:
+            mean_us = sum(samples) / len(samples) / 1_000
+            print(
+                f"tracy {name}: count={len(samples)} "
+                f"mean_us={mean_us:.1f} min_us={min(samples) / 1_000:.1f} "
+                f"max_us={max(samples) / 1_000:.1f}"
+            )
+
+
+def _device_kernel_ns(profile_csv, warmup, iterations):
+    events_by_host_id = collections.defaultdict(list)
+    with profile_csv.open(encoding="utf-8", newline="") as input_file:
+        header = input_file.readline()
+        match = re.search(r"CHIP_FREQ\[MHz\]:\s*(\d+)", header)
+        if match is None:
+            raise ValueError(f"chip frequency is missing from {profile_csv}")
+        frequency_mhz = float(match.group(1))
+        for raw_row in csv.DictReader(input_file):
+            row = {key.strip().lower(): value for key, value in raw_row.items()}
+            if row["zone name"].endswith("-KERNEL"):
+                events_by_host_id[row["run host id"]].append(
+                    (int(row["time[cycles since reset]"]), row["type"])
+                )
+
+    captured_runs = warmup + iterations
+    measured_durations = []
+    for events in events_by_host_id.values():
+        events.sort()
+        if len(events) % captured_runs:
+            raise ValueError("device profiler events do not divide into iterations")
+        events_per_run = len(events) // captured_runs
+        for run_index in range(warmup, captured_runs):
+            run_events = events[
+                run_index * events_per_run : (run_index + 1) * events_per_run
+            ]
+            starts = [cycle for cycle, kind in run_events if kind == "ZONE_START"]
+            ends = [cycle for cycle, kind in run_events if kind == "ZONE_END"]
+            if starts and ends:
+                measured_durations.append(max(ends) - min(starts))
+    if not measured_durations:
+        return None
+    return max(measured_durations) * 1_000 / frequency_mhz
+
+
+def _pcc(actual, expected):
+    import torch
+
+    values = torch.stack((actual.float().flatten(), expected.float().flatten()))
+    return torch.corrcoef(values)[0, 1].item()
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("single", "two-chip"))
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--k-tiles", type=int, default=24)
+    parser.add_argument("--compute-repeats", type=int, default=6)
+    parser.add_argument("--tracy-file", type=pathlib.Path)
+    parser.add_argument("--device-profile-dir", type=pathlib.Path)
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    if args.iterations < 1 or args.warmup < 0:
+        raise ValueError("iterations must be positive and warmup must be non-negative")
+
+    trace_context = contextlib.nullcontext()
+    if args.tracy_file:
+        args.tracy_file.parent.mkdir(parents=True, exist_ok=True)
+        port = _available_port()
+        os.environ["TRACY_PORT"] = str(port)
+        trace_context = _capture_tracy(args.tracy_file, port)
+
+    if args.device_profile_dir:
+        args.device_profile_dir.mkdir(parents=True, exist_ok=True)
+        shutil.rmtree(args.device_profile_dir / ".logs", ignore_errors=True)
+        kernel_cache = args.device_profile_dir / "kernel-cache"
+        shutil.rmtree(kernel_cache, ignore_errors=True)
+        os.environ["TT_METAL_PROFILER_DIR"] = str(args.device_profile_dir)
+        os.environ["TT_METAL_CACHE"] = str(kernel_cache)
+        os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
+        os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+
+    with trace_context:
+        import multichip_overlap_workload as workload
+        from d2m_jit._src.builder import _Builder
+
+        if args.device_profile_dir:
+            from d2m_jit._src.config import config as d2m_config
+
+            d2m_config.enable_perf_trace = True
+
+        config = workload.WorkloadConfig(
+            k_tiles=args.k_tiles,
+            compute_repeats=args.compute_repeats,
+        )
+        output_blocks = 2 * config.grid_y * config.grid_x * config.num_chunks
+        effective_k = config.k_elements * (config.compute_repeats + 1)
+        print(
+            f"workload: mode={args.mode} computed_output_blocks={output_blocks} "
+            f"block={config.block_elements}x{config.block_elements} "
+            f"effective_k={effective_k}",
+            flush=True,
+        )
+        run = (
+            workload.run_single_chip if args.mode == "single" else workload.run_two_chip
+        )
+        result = expected = None
+        warmup_context = contextlib.nullcontext()
+        if args.device_profile_dir:
+            from autotuner.autotuner import _silence_native_output
+
+            warmup_context = _silence_native_output(
+                str(args.device_profile_dir / "native_compile.log")
+            )
+        with warmup_context:
+            for _ in range(args.warmup):
+                _Builder.reset()
+                result, expected = run(config)
+        for iteration in range(args.iterations):
+            _Builder.reset()
+            result, expected = run(config)
+            print(
+                f"iteration={iteration + 1} mode={args.mode} "
+                f"pcc={_pcc(result, expected):.6f}",
+                flush=True,
+            )
+        _Builder.reset()
+
+    if args.tracy_file:
+        tracy_csv = _export_tracy(args.tracy_file)
+        _summarize_tracy(tracy_csv, args.iterations)
+        print(f"tracy trace: {args.tracy_file}")
+        print(f"tracy zones: {tracy_csv}")
+    if args.device_profile_dir:
+        profile_csv = args.device_profile_dir / ".logs" / "profile_log_device.csv"
+        kernel_ns = _device_kernel_ns(profile_csv, args.warmup, args.iterations)
+        print(f"device longest_kernel_ns={kernel_ns}")
+        print(f"device profile: {profile_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/d2m-jit/multichip_overlap_benchmark.py
+++ b/test/d2m-jit/multichip_overlap_benchmark.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compare equal-work single-chip matmul with two-chip matmul + all-gather."""
+"""Profile a BF16 Llama 3 8B down projection with two-way tensor parallelism."""
 
 import argparse
 import collections
@@ -81,24 +81,53 @@ def _export_tracy(trace_path):
 
 def _summarize_tracy(csv_path, measured_iterations):
     selected = {
-        "submit": [],
+        "MeshShardCommand": [],
         "EnqueueProgramCommand": [],
         "FinishCommand": [],
         "EnqueueReadBufferCommand": [],
     }
+    submits = []
     with csv_path.open(encoding="utf-8", newline="") as input_file:
         for row in csv.DictReader(input_file):
             name = row["name"]
+            start_ns = int(row["ns_since_start"])
+            duration_ns = int(row["exec_time_ns"])
+            if name == "submit":
+                submits.append((start_ns, duration_ns))
             if name in selected:
-                selected[name].append(int(row["exec_time_ns"]))
-    for name, samples in selected.items():
-        samples = samples[-measured_iterations:]
-        if samples:
-            mean_us = sum(samples) / len(samples) / 1_000
+                selected[name].append((start_ns, duration_ns))
+
+    submits = sorted(submits)[-measured_iterations:]
+    submit_durations = [duration for _, duration in submits]
+    if submit_durations:
+        print(
+            f"tracy submit: count={len(submit_durations)} "
+            f"mean_us={sum(submit_durations) / len(submit_durations) / 1_000:.1f} "
+            f"min_us={min(submit_durations) / 1_000:.1f} "
+            f"max_us={max(submit_durations) / 1_000:.1f}"
+        )
+    for name, zones in selected.items():
+        counts = []
+        totals = []
+        for submit_start, submit_duration in submits:
+            durations = [
+                duration
+                for start, duration in zones
+                if submit_start <= start < submit_start + submit_duration
+            ]
+            counts.append(len(durations))
+            totals.append(sum(durations))
+        if totals and any(counts):
+            count = (
+                str(counts[0])
+                if len(set(counts)) == 1
+                else f"{min(counts)}-{max(counts)}"
+            )
             print(
-                f"tracy {name}: count={len(samples)} "
-                f"mean_us={mean_us:.1f} min_us={min(samples) / 1_000:.1f} "
-                f"max_us={max(samples) / 1_000:.1f}"
+                f"tracy {name}: count_per_submit={count} "
+                f"mean_total_us={sum(totals) / len(totals) / 1_000:.1f} "
+                f"min_total_us={min(totals) / 1_000:.1f} "
+                f"max_total_us={max(totals) / 1_000:.1f}"
             )
 
 
@@ -146,11 +175,18 @@ def _pcc(actual, expected):
 
 def _parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("mode", choices=("single", "two-chip"))
+    parser.add_argument(
+        "mode",
+        choices=("single", "two-chip-serialized", "two-chip-overlap"),
+    )
     parser.add_argument("--iterations", type=int, default=3)
     parser.add_argument("--warmup", type=int, default=1)
-    parser.add_argument("--k-tiles", type=int, default=24)
-    parser.add_argument("--compute-repeats", type=int, default=6)
+    parser.add_argument("--m", type=int, default=576)
+    parser.add_argument("--k", type=int, default=14336)
+    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--grid-y", type=int, default=6)
+    parser.add_argument("--grid-x", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--tracy-file", type=pathlib.Path)
     parser.add_argument("--device-profile-dir", type=pathlib.Path)
     return parser.parse_args()
@@ -179,7 +215,7 @@ def main():
         os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
 
     with trace_context:
-        import multichip_overlap_workload as workload
+        import llama_down_projection_workload as workload
         from d2m_jit._src.builder import _Builder
 
         if args.device_profile_dir:
@@ -188,21 +224,34 @@ def main():
             d2m_config.enable_perf_trace = True
 
         config = workload.WorkloadConfig(
-            k_tiles=args.k_tiles,
-            compute_repeats=args.compute_repeats,
+            m=args.m,
+            k=args.k,
+            n=args.n,
+            grid_y=args.grid_y,
+            grid_x=args.grid_x,
+            seed=args.seed,
         )
-        output_blocks = 2 * config.grid_y * config.grid_x * config.num_chunks
-        effective_k = config.k_elements * (config.compute_repeats + 1)
+        activations, weight = workload.make_operands(config)
+        expected = workload.golden(activations, weight)
+        global_flops = 2 * config.m * config.k * config.n
         print(
-            f"workload: mode={args.mode} computed_output_blocks={output_blocks} "
-            f"block={config.block_elements}x{config.block_elements} "
-            f"effective_k={effective_k}",
+            f"workload: llama3-8b-down-projection mode={args.mode} dtype=bf16 "
+            f"shape={config.m}x{config.k}x{config.n} "
+            f"grid={config.grid_y}x{config.grid_x} "
+            f"global_flops={global_flops}",
             flush=True,
         )
-        run = (
-            workload.run_single_chip if args.mode == "single" else workload.run_two_chip
-        )
-        result = expected = None
+        if args.mode == "single":
+            run = lambda: workload.run_single_chip(config, activations, weight)
+        else:
+            overlap = args.mode == "two-chip-overlap"
+            run = lambda: workload.run_two_chip(
+                config,
+                activations,
+                weight,
+                overlap=overlap,
+            )
+        result = None
         warmup_context = contextlib.nullcontext()
         if args.device_profile_dir:
             from autotuner.autotuner import _silence_native_output
@@ -213,10 +262,10 @@ def main():
         with warmup_context:
             for _ in range(args.warmup):
                 _Builder.reset()
-                result, expected = run(config)
+                result = run()
         for iteration in range(args.iterations):
             _Builder.reset()
-            result, expected = run(config)
+            result = run()
             print(
                 f"iteration={iteration + 1} mode={args.mode} "
                 f"pcc={_pcc(result, expected):.6f}",

--- a/test/d2m-jit/multichip_overlap_workload.py
+++ b/test/d2m-jit/multichip_overlap_workload.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import torch
+
+import d2m_jit as d2m
+
+
+@dataclass(frozen=True)
+class WorkloadConfig:
+    grid_y: int = 4
+    grid_x: int = 4
+    num_chunks: int = 2
+    block_tiles: int = 4
+    k_tiles: int = 24
+    compute_repeats: int = 6
+    seed: int = 0
+
+    @property
+    def block_elements(self):
+        return self.block_tiles * 32
+
+    @property
+    def k_elements(self):
+        return self.k_tiles * 32
+
+
+@d2m.kernel
+def single_chip_matmuls(lhs, rhs, output, num_items, compute_repeats):
+    cy = core_index(0)
+    cx = core_index(1)
+    for item in range(num_items):
+        a = remote_load(lhs, [cy * num_items + item, cx])
+        b = remote_load(rhs, [cy * num_items + item, cx])
+        acc = a @ b
+        for repeat in range(compute_repeats):
+            acc += a @ b
+        remote_store(output, [cy * num_items + item, cx], acc)
+
+
+@d2m.kernel
+def two_chip_matmul_all_gather(
+    lhs,
+    rhs,
+    output,
+    start_sem,
+    ready,
+    consumed,
+    end_sem,
+    num_chunks,
+    grid_y,
+    grid_x,
+    worker_count,
+    compute_repeats,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for chunk in range(num_chunks):
+        a = remote_load(lhs, [cy * num_chunks + chunk, cx])
+        b = remote_load(rhs, [cy * num_chunks + chunk, cx])
+        acc = a @ b
+        for repeat in range(compute_repeats):
+            acc += a @ b
+        semaphore_inc(ready, 1, core=[0, 0], compute=True)
+        if is_router_core():
+            dy = mesh_position(0)
+            device_synchronize(
+                start_sem,
+                start_device=[dy, 0],
+                mcast_shape=[1, 2],
+                num_receivers=1,
+                core_indices=[cy, cx],
+            )
+            semaphore_wait(ready, (chunk + 1) * worker_count)
+            dx = mesh_position(1)
+            for ty in range(grid_y):
+                for tx in range(grid_x):
+                    gathered = empty_like(acc)
+                    gathered = core_read(gathered, acc, core=[ty, tx])
+                    semaphore_inc(consumed, 1, core=[ty, tx])
+                    remote_store(
+                        output,
+                        [
+                            dx * grid_y * num_chunks + ty * num_chunks + chunk,
+                            tx,
+                        ],
+                        gathered,
+                        start_device=[dy, 0],
+                        device_mcast_shape=[1, 2],
+                        semaphore=end_sem,
+                        semaphore_indices=[cy, 0],
+                    )
+            semaphore_wait(end_sem, (chunk + 1) * 2 * worker_count)
+        semaphore_wait(consumed, chunk + 1, compute=True)
+
+
+def _layout(rows, columns, block_shape):
+    return d2m.Layout(
+        shape=(rows * block_shape[0] * 32, columns * block_shape[1] * 32),
+        dtype=d2m.bfloat16,
+        block_shape=block_shape,
+        grid_shape=[rows, columns],
+        mem_space="dram",
+    )
+
+
+def _blocked_matmuls(lhs, rhs, config, block_rows, block_columns):
+    output = torch.empty(
+        block_rows * config.block_elements,
+        block_columns * config.block_elements,
+    )
+    for by in range(block_rows):
+        row = slice(
+            by * config.block_elements,
+            (by + 1) * config.block_elements,
+        )
+        rhs_row = slice(by * config.k_elements, (by + 1) * config.k_elements)
+        for bx in range(block_columns):
+            column = slice(
+                bx * config.block_elements,
+                (bx + 1) * config.block_elements,
+            )
+            lhs_column = slice(
+                bx * config.k_elements,
+                (bx + 1) * config.k_elements,
+            )
+            output[row, column] = (config.compute_repeats + 1) * (
+                lhs[row, lhs_column] @ rhs[rhs_row, column]
+            )
+    return output
+
+
+def run_single_chip(config):
+    torch.manual_seed(config.seed)
+    d2m.mesh((1, 1), topology=("linear", "linear"))
+    num_items = 2 * config.num_chunks
+    block_rows = config.grid_y * num_items
+    lhs_layout = _layout(
+        block_rows,
+        config.grid_x,
+        [config.block_tiles, config.k_tiles],
+    )
+    rhs_layout = _layout(
+        block_rows,
+        config.grid_x,
+        [config.k_tiles, config.block_tiles],
+    )
+    output_layout = _layout(
+        block_rows,
+        config.grid_x,
+        [config.block_tiles, config.block_tiles],
+    )
+    lhs_host = torch.randn(lhs_layout.logical_shape, dtype=torch.bfloat16) * 0.125
+    rhs_host = torch.randn(rhs_layout.logical_shape, dtype=torch.bfloat16) * 0.125
+    output = d2m.empty(output_layout)
+    single_chip_matmuls(
+        d2m.to_layout(lhs_host, lhs_layout),
+        d2m.to_layout(rhs_host, rhs_layout),
+        output,
+        num_items,
+        config.compute_repeats,
+        grid=(config.grid_y, config.grid_x),
+        kernel_io_in_dram=True,
+    )
+    result = output.to_host()
+    expected = _blocked_matmuls(
+        lhs_host,
+        rhs_host,
+        config,
+        block_rows,
+        config.grid_x,
+    )
+    return result, expected
+
+
+def run_two_chip(config):
+    torch.manual_seed(config.seed)
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    input_rows = config.grid_y * config.num_chunks
+    lhs_layout = _layout(
+        input_rows,
+        config.grid_x,
+        [config.block_tiles, config.k_tiles],
+    )
+    rhs_layout = _layout(
+        input_rows,
+        config.grid_x,
+        [config.k_tiles, config.block_tiles],
+    )
+    output_layout = _layout(
+        2 * input_rows,
+        config.grid_x,
+        [config.block_tiles, config.block_tiles],
+    )
+    lhs_host = (
+        torch.randn(
+            lhs_layout.logical_shape[0],
+            2 * lhs_layout.logical_shape[1],
+            dtype=torch.bfloat16,
+        )
+        * 0.125
+    )
+    rhs_host = (
+        torch.randn(
+            rhs_layout.logical_shape[0],
+            2 * rhs_layout.logical_shape[1],
+            dtype=torch.bfloat16,
+        )
+        * 0.125
+    )
+    lhs = d2m.mesh_shard(
+        lhs_host,
+        lhs_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    rhs = d2m.mesh_shard(
+        rhs_host,
+        rhs_layout,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    )
+    output = d2m.empty(output_layout)
+    two_chip_matmul_all_gather(
+        lhs,
+        rhs,
+        output,
+        d2m.global_semaphore(grid_shape=(8, 8)),
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
+        d2m.global_semaphore(grid_shape=(8, 8), init=0),
+        d2m.global_semaphore(grid_shape=(8, 8)),
+        config.num_chunks,
+        config.grid_y,
+        config.grid_x,
+        config.grid_y * config.grid_x,
+        config.compute_repeats,
+        grid=(config.grid_y, config.grid_x),
+        fabric=d2m.fabric_config(
+            cluster_axis=1,
+            topology="linear",
+            router_cores=[(0, 0)],
+        ),
+        kernel_io_in_dram=True,
+    )
+    result = d2m.mesh_gather(
+        output,
+        shard_dims=[0, 1],
+        shard_shape=[1, 2],
+    ).to_host()
+
+    gathered_blocks = []
+    for device in range(2):
+        for cy in range(config.grid_y):
+            for chunk in range(config.num_chunks):
+                row_index = cy * config.num_chunks + chunk
+                row = slice(
+                    row_index * config.block_elements,
+                    (row_index + 1) * config.block_elements,
+                )
+                row_blocks = []
+                for cx in range(config.grid_x):
+                    column_index = device * config.grid_x + cx
+                    column = slice(
+                        column_index * config.block_elements,
+                        (column_index + 1) * config.block_elements,
+                    )
+                    lhs_column = slice(
+                        column_index * config.k_elements,
+                        (column_index + 1) * config.k_elements,
+                    )
+                    rhs_row = slice(
+                        row_index * config.k_elements,
+                        (row_index + 1) * config.k_elements,
+                    )
+                    row_blocks.append(
+                        (config.compute_repeats + 1)
+                        * (lhs_host[row, lhs_column] @ rhs_host[rhs_row, column])
+                    )
+                gathered_blocks.append(torch.cat(row_blocks, dim=1))
+    gathered = torch.cat(gathered_blocks, dim=0)
+    expected = torch.cat([gathered, gathered], dim=1)
+    return result, expected

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -39,6 +39,16 @@ def matmul_multi_k_kernel(lhs, rhs, out, k_blocks):
 
 
 @d2m.kernel
+def matmul_multi_k_bf16_kernel(lhs, rhs, out, k_blocks):
+    c = zeros([1, 1], dtype="bf16")
+    for k in range(k_blocks):
+        a = remote_load(lhs, [0, k])
+        b = remote_load(rhs, [k, 0])
+        c += a @ b
+    remote_store(out, [0, 0], c)
+
+
+@d2m.kernel
 def matmul_tiled_multi_k_kernel(lhs, rhs, out, m_blocks, n_blocks, k_blocks):
     for m in range(m_blocks):
         for n in range(n_blocks):
@@ -139,6 +149,39 @@ def test_matmul_correctness_multi_k_loop_carried_accumulator():
         assert_pcc(lhs @ rhs, out_d.to_host(), threshold=0.99)
     finally:
         d2m.config.use_tile_matmul = old_use_tile_matmul
+
+
+def test_matmul_correctness_multi_k_bf16_accumulator():
+    torch.manual_seed(0)
+    lhs = torch.randn(32, 64, dtype=torch.bfloat16) * 0.125
+    rhs = torch.randn(64, 32, dtype=torch.bfloat16) * 0.125
+    lhs_layout = d2m.Layout(
+        shape=(32, 64),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    rhs_layout = d2m.Layout(
+        shape=(64, 32),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    out_layout = d2m.Layout(
+        shape=(32, 32),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    out = d2m.empty(out_layout)
+    matmul_multi_k_bf16_kernel(
+        d2m.to_layout(lhs, lhs_layout),
+        d2m.to_layout(rhs, rhs_layout),
+        out,
+        2,
+        grid=(1, 1),
+    )
+    assert_pcc(lhs.float() @ rhs.float(), out.to_host().float(), threshold=0.99)
 
 
 def test_matmul_correctness_tiled_mnk_loop_carried_accumulator():

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -51,6 +51,11 @@ requires_fabric_mesh = pytest.mark.skipif(
     ),
 )
 
+requires_fabric_stress = pytest.mark.skipif(
+    os.environ.get("D2M_JIT_RUN_FABRIC_STRESS") != "1",
+    reason="requires D2M_JIT_RUN_FABRIC_STRESS=1 to opt into fabric stress tests",
+)
+
 
 def test_mesh_configuration():
     d2m.mesh((1, 2), topology=("linear", "ring"))
@@ -472,26 +477,16 @@ def _chunked_matmul_all_gather_1x2(
         semaphore_wait(consumed, chunk + 1, compute=True)
 
 
-@requires_fabric_mesh
-@pytest.mark.parametrize("num_chunks", [1, 2])
-@pytest.mark.parametrize(
-    "worker_grid",
-    [(1, 1), (2, 1), (2, 2), (4, 4)],
-    ids=[
-        "single-core",
-        "multicore-2x1",
-        "multicore-2x2",
-        "saturation-4x4",
-    ],
-)
-def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
-    """Overlap chunk t's fabric send with chunk t+1's compute across devices."""
-    torch.manual_seed(0)
+def _run_chunked_matmul_all_gather(
+    num_chunks,
+    worker_grid,
+    layout_dtype,
+    torch_dtype,
+    seed,
+):
+    torch.manual_seed(seed)
     d2m.mesh((1, 2), topology=("linear", "linear"))
     grid_y, grid_x = worker_grid
-    saturation = worker_grid == (4, 4)
-    layout_dtype = d2m.bfloat16 if saturation else d2m.float32
-    torch_dtype = torch.bfloat16 if saturation else torch.float32
     block_tiles = 4
     block_elements = block_tiles * 32
     input_layout = d2m.Layout(
@@ -580,3 +575,82 @@ def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
 
     assert result.shape == expected.shape
     assert_pcc(expected, result, threshold=0.99)
+
+
+@requires_fabric_mesh
+@pytest.mark.parametrize("num_chunks", [1, 2])
+@pytest.mark.parametrize(
+    "worker_grid",
+    [(1, 1), (2, 1), (2, 2), (4, 4)],
+    ids=[
+        "single-core",
+        "multicore-2x1",
+        "multicore-2x2",
+        "saturation-4x4",
+    ],
+)
+def test_chunked_matmul_all_gather_round_trip_1x2(num_chunks, worker_grid):
+    """Overlap chunk t's fabric send with chunk t+1's compute across devices."""
+    saturation = worker_grid == (4, 4)
+    _run_chunked_matmul_all_gather(
+        num_chunks,
+        worker_grid,
+        d2m.bfloat16 if saturation else d2m.float32,
+        torch.bfloat16 if saturation else torch.float32,
+        seed=0,
+    )
+
+
+@requires_fabric_mesh
+@requires_fabric_stress
+@pytest.mark.parametrize(
+    "num_chunks,worker_grid,layout_dtype,torch_dtype,seed",
+    [
+        pytest.param(
+            2,
+            (1, 1),
+            d2m.float32,
+            torch.float32,
+            3,
+            id="alternate-seed-fp32",
+        ),
+        pytest.param(
+            2,
+            (2, 2),
+            d2m.bfloat16,
+            torch.bfloat16,
+            7,
+            id="multichunk-bf16",
+        ),
+        pytest.param(
+            1,
+            (4, 8),
+            d2m.bfloat16,
+            torch.bfloat16,
+            11,
+            id="wide-grid-bf16",
+        ),
+        pytest.param(
+            2,
+            (8, 2),
+            d2m.float32,
+            torch.float32,
+            19,
+            id="tall-grid-fp32",
+        ),
+    ],
+)
+def test_chunked_matmul_all_gather_stress_1x2(
+    num_chunks,
+    worker_grid,
+    layout_dtype,
+    torch_dtype,
+    seed,
+):
+    _run_chunked_matmul_all_gather(
+        num_chunks,
+        worker_grid,
+        layout_dtype,
+        torch_dtype,
+        seed,
+    )

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -654,3 +654,19 @@ def test_chunked_matmul_all_gather_stress_1x2(
         torch_dtype,
         seed,
     )
+
+
+@requires_fabric_mesh
+@pytest.mark.parametrize("overlap", [False, True], ids=["serialized", "overlapped"])
+def test_llama_down_projection_all_reduce_1x2(overlap):
+    from llama_down_projection_workload import (
+        WorkloadConfig,
+        golden,
+        make_operands,
+        run_two_chip,
+    )
+
+    config = WorkloadConfig(m=128, k=14336, n=256, grid_y=2, grid_x=2)
+    activations, weight = make_operands(config)
+    result = run_two_chip(config, activations, weight, overlap=overlap)
+    assert_pcc(golden(activations, weight), result, threshold=0.99)

--- a/test/d2m-jit/test_multichip_overlap_benchmark.py
+++ b/test/d2m-jit/test_multichip_overlap_benchmark.py
@@ -2,7 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from multichip_overlap_benchmark import _device_kernel_ns
+import torch
+
+from multichip_overlap_benchmark import _device_kernel_ns, _summarize_tracy
+from llama_down_projection_workload import WorkloadConfig, golden, make_operands
+
+
+def test_down_projection_tensor_parallel_partition_matches_dense_matmul():
+    config = WorkloadConfig(m=128, k=14336, n=256, grid_y=2, grid_x=2)
+    activations, weight = make_operands(config)
+    segment_size = config.k_segment_elements
+    partials = []
+    for device in range(2):
+        partial = torch.zeros((config.m, config.n), dtype=torch.float32)
+        for local_segment in range(config.k_segments // 2):
+            segment = device * config.k_segments // 2 + local_segment
+            start = segment * segment_size
+            stop = start + segment_size
+            partial += activations[:, start:stop].float() @ weight[start:stop].float()
+        partials.append(partial)
+    partial_sum = partials[0] + partials[1]
+    expected = golden(activations, weight).float()
+    pcc = torch.corrcoef(torch.stack((partial_sum.flatten(), expected.flatten())))[
+        0, 1
+    ].item()
+
+    assert tuple(activations.shape) == (config.m, config.k)
+    assert tuple(weight.shape) == (config.k, config.n)
+    assert tuple(partial_sum.shape) == (config.m, config.n)
+    assert pcc > 0.999
 
 
 def test_device_kernel_ns_excludes_warmup(tmp_path):
@@ -19,3 +47,23 @@ def test_device_kernel_ns_excludes_warmup(tmp_path):
     )
 
     assert _device_kernel_ns(profile_csv, warmup=1, iterations=1) == 130
+
+
+def test_tracy_summary_aggregates_zones_per_submit(tmp_path, capsys):
+    tracy_csv = tmp_path / "trace.csv"
+    tracy_csv.write_text(
+        "name,src_file,src_line,zone_name,zone_text,ns_since_start,"
+        "exec_time_ns,thread,special_parent_text\n"
+        "submit,,, , ,100,1000,1,\n"
+        "MeshShardCommand,,, , ,150,100,1,\n"
+        "MeshShardCommand,,, , ,300,200,1,\n"
+        "submit,,, , ,1200,2000,1,\n"
+        "MeshShardCommand,,, , ,1300,400,1,\n"
+        "MeshShardCommand,,, , ,1800,600,1,\n"
+    )
+
+    _summarize_tracy(tracy_csv, measured_iterations=1)
+
+    output = capsys.readouterr().out
+    assert "tracy submit: count=1 mean_us=2.0" in output
+    assert "MeshShardCommand: count_per_submit=2 mean_total_us=1.0" in output

--- a/test/d2m-jit/test_multichip_overlap_benchmark.py
+++ b/test/d2m-jit/test_multichip_overlap_benchmark.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from multichip_overlap_benchmark import _device_kernel_ns
+
+
+def test_device_kernel_ns_excludes_warmup(tmp_path):
+    profile_csv = tmp_path / "profile_log_device.csv"
+    profile_csv.write_text(
+        "ARCH: wormhole_b0, CHIP_FREQ[MHz]: 1000, Max Compute Cores: 64\n"
+        "PCIe slot,core_x,core_y,RISC processor type,timer_id,"
+        "time[cycles since reset],data,run host ID,trace id,trace id counter,"
+        "zone name,type,source line,source file,meta data\n"
+        "0,1,1,TRISC,1,100,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,200,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+        "0,1,1,TRISC,1,1000,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,1130,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+    )
+
+    assert _device_kernel_ns(profile_csv, warmup=1, iterations=1) == 130

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -413,16 +413,20 @@ D2M_JIT_RUN_FABRIC_STRESS=1 \
 pytest test/d2m-jit/test_mesh.py
 ```
 
-The equal-work single-chip versus two-chip matmul/all-gather workload can
-capture host/runtime Tracy zones when the runtime was built with
-`TT_RUNTIME_ENABLE_PERF_TRACE=ON`:
+The BF16 Llama 3 8B prefill down-projection benchmark compares the same dense
+`576x14336 @ 14336x4096` operation on one chip and with two-way K-sharded
+tensor parallelism. The two-chip modes provide serialized and overlapped
+matmul/all-reduce schedules. They can capture host/runtime Tracy zones when the
+runtime was built with `TT_RUNTIME_ENABLE_PERF_TRACE=ON`:
 
 ```bash
 export SYSTEM_DESC_PATH=/path/to/two-chip.ttsys
 python test/d2m-jit/multichip_overlap_benchmark.py single \
   --tracy-file /tmp/d2m-overlap/single.tracy
-python test/d2m-jit/multichip_overlap_benchmark.py two-chip \
-  --tracy-file /tmp/d2m-overlap/two-chip.tracy
+python test/d2m-jit/multichip_overlap_benchmark.py two-chip-serialized \
+  --tracy-file /tmp/d2m-overlap/two-chip-serialized.tracy
+python test/d2m-jit/multichip_overlap_benchmark.py two-chip-overlap \
+  --tracy-file /tmp/d2m-overlap/two-chip-overlap.tracy
 ```
 
 Pass `--device-profile-dir DIR` to collect the matching tt-metal device

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -404,6 +404,31 @@ The Python module installs to `<build>/python_packages/d2m_jit/`.
 RNG is deterministic per test. `test/d2m-jit/utils.py` provides
 `assert_pcc(golden, actual)` and `arange_tile(...)` helpers.
 
+Fabric execution and its larger grid/dtype/seed matrix are opt-in:
+
+```bash
+SYSTEM_DESC_PATH=/path/to/two-chip.ttsys \
+D2M_JIT_RUN_FABRIC_TESTS=1 \
+D2M_JIT_RUN_FABRIC_STRESS=1 \
+pytest test/d2m-jit/test_mesh.py
+```
+
+The equal-work single-chip versus two-chip matmul/all-gather workload can
+capture host/runtime Tracy zones when the runtime was built with
+`TT_RUNTIME_ENABLE_PERF_TRACE=ON`:
+
+```bash
+export SYSTEM_DESC_PATH=/path/to/two-chip.ttsys
+python test/d2m-jit/multichip_overlap_benchmark.py single \
+  --tracy-file /tmp/d2m-overlap/single.tracy
+python test/d2m-jit/multichip_overlap_benchmark.py two-chip \
+  --tracy-file /tmp/d2m-overlap/two-chip.tracy
+```
+
+Pass `--device-profile-dir DIR` to collect the matching tt-metal device
+timeline. Tracy summaries exclude warmup iterations; the device summary reports
+the longest kernel envelope in the captured warmup and measured iterations.
+
 ## Pipeline
 
 `to_host` runs the following passes on the open module before flatbuffering:

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -1006,11 +1006,15 @@ def _shape_literal(node):
     )
 
 
-@syntax("zeros", args_as_attr=[_shape_literal])
-def _zeros_op(shape):
+@syntax(
+    "zeros",
+    args_as_attr=[_shape_literal],
+    kwargs_as_attr={"dtype": _const_value},
+)
+def _zeros_op(shape, dtype="fp32"):
     """Kernel-body zero-initialized tile block."""
     ctx = get_default_loc_context()
-    tile_ty = ttcore.ir.TileType.get(ctx, 32, 32, float32)
+    tile_ty = ttcore.ir.TileType.get(ctx, 32, 32, _to_data_type(dtype))
     block_ty = RankedTensorType.get(list(shape), tile_ty)
     return _zeros_block(block_ty)
 


### PR DESCRIPTION
## Summary

- add serialized and overlapped two-chip CCL/matmul stress workloads
- add a realistic BF16 Llama down-projection workload with tensor-parallel local matmul partials and an inter-device reduction
- compare single-chip, serialized two-chip, and overlapped two-chip execution with correctness and timing reports
- cover workload geometry, timing aggregation, and supported matmul/mesh layouts

## Stack

Depends on #9183. The next draft scales the same mechanism to the complete Llama 3 8B prefill MLP.

## Validation

- `pytest -q test/d2m-jit/test_multichip_overlap_benchmark.py` (7 passed on the reconstructed stack)
- exact BF16 serialized/overlapped N300 smoke runs completed before the split
- reconstructed stack passes `pre-commit run --all-files`

Split from #9170 so workload construction and benchmark methodology can be reviewed apart from the underlying compiler/runtime support.