### PR TITLE
[D2M] Scale multichip overlap to full Llama MLP

### DIFF
--- a/lib/Dialect/D2M/IR/D2MOps.cpp
+++ b/lib/Dialect/D2M/IR/D2MOps.cpp
@@ -372,7 +372,8 @@ d2m::MeshShardOp::getBufferType(
   auto shardShapeArray = getShardShape();
   auto shardType = getShardType();
   if (shardType != mlir::tt::ttcore::MeshShardType::Replicate &&
-      ttmlir::utils::volume(shardShapeArray) == 1) {
+      ttmlir::utils::volume(shardShapeArray) == 1 &&
+      getInput().getType() == getResult().getType()) {
     return getInput();
   }
 

--- a/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
+++ b/lib/Dialect/D2M/Transforms/PythonRewritesPass.cpp
@@ -130,23 +130,21 @@ public:
 
   void runOnOperation() override {
     if (modulePaths.empty()) {
-      // No-op when invoked without any patterns.
       return;
     }
 
     ModuleOp module = getOperation();
 
-    // Step 1: print the host module to text with locations preserved.
     std::string inputText;
     {
       llvm::raw_string_ostream os(inputText);
       OpPrintingFlags flags;
       flags.enableDebugInfo(/*enable=*/true, /*pretty=*/false);
-      // Generic form is portable across C++/Python MLIR runtimes.
+      // Generic form is portable across C++/Python MLIR runtimes, while debug
+      // info preserves semantic location metadata through the text boundary.
       module.print(os, flags);
     }
 
-    // Step 2: call into Python.
     ensurePythonInitialized();
     PyGIL gil;
 
@@ -205,9 +203,8 @@ public:
     }
     std::string outputText(resultUtf8, resultUtf8 + resultLen);
 
-    // Step 3: parse the result back into the host context, replace
-    // module body. We keep the GIL held through the parse — it's
-    // synchronous and our pass doesn't expect parallelism here.
+    // Keep the GIL through the synchronous parse because the pass does not
+    // permit concurrent Python rewrites.
     OwningOpRef<ModuleOp> newModule =
         parseSourceString<ModuleOp>(outputText, &getContext());
 
@@ -220,27 +217,19 @@ public:
       return;
     }
 
-    // Swap bodies: erase the host module's body ops, splice in the
-    // re-parsed module's body. Both modules have a single block in
-    // their region.
     Block &dst = module.getBodyRegion().front();
     Block &src = newModule->getBodyRegion().front();
 
-    // Erase existing ops; iterating backwards because erase mutates the
-    // list. Skip the implicit terminator if any (ModuleOp doesn't have
-    // one).
     for (auto it = dst.rbegin(); it != dst.rend();) {
       Operation &op = *it;
       ++it;
       op.erase();
     }
-    // Splice the source's ops to the destination.
     auto &srcOps = src.getOperations();
     while (!srcOps.empty()) {
       Operation &op = srcOps.front();
       op.moveBefore(&dst, dst.end());
     }
-    // newModule is now empty; drop it.
   }
 
 private:

--- a/runtime/include/tt/runtime/runtime.h
+++ b/runtime/include/tt/runtime/runtime.h
@@ -158,8 +158,8 @@ void setTensorRetain(Tensor tensor, bool retain);
 // that writes or aliases the corresponding device input while reuse is
 // enabled. The Tensor and its copies must also remain alive until all using
 // submissions have completed. Clearing the flag is also forbidden while a
-// using submission is in flight. Currently implemented for single-device
-// programs in the local TTMetal runtime.
+// using submission is in flight. Retained representations are scoped to the
+// executable, program, input destination, and persistent TTMetal device.
 bool getTensorReusable(Tensor tensor);
 void setTensorReusable(Tensor &tensor, bool reusable);
 TensorReuseStats getTensorReuseStats(Tensor tensor);

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -33,6 +33,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -47,6 +48,7 @@ namespace {
 struct CachedKernelBinding {
   tt_metal::KernelHandle handle;
   tt_metal::CoreRangeSet coreRangeSet;
+  std::vector<std::uint32_t> compileArgs;
   std::vector<std::uint32_t> commonRuntimeArgs;
   std::vector<std::uint32_t> runtimeArgs;
 };
@@ -56,34 +58,18 @@ struct CachedCircularBufferBinding {
   std::uint32_t bufferGlobalId;
 };
 
-struct CachedMeshWorkloadState {
+struct CachedProgramBinding {
   std::vector<CachedKernelBinding> kernels;
   std::vector<CachedCircularBufferBinding> circularBuffers;
 };
 
+struct CachedMeshWorkloadState {
+  std::unordered_map<distributed::MeshCoordinateRange, CachedProgramBinding>
+      programs;
+};
+
 using CachedMeshWorkload = tt_metal::program_cache::detail::CachedMeshWorkload<
     CachedMeshWorkloadState>;
-
-bool hasDynamicCompileTimeBindings(
-    const target::metal::EnqueueProgramCommand *command) {
-  for (const target::metal::KernelConfig *kernelConfig :
-       *command->program()->kernels()) {
-    const auto *compileArgs = kernelConfig->args()->ct_args();
-    if (!compileArgs) {
-      continue;
-    }
-
-    for (const target::metal::KernelArg *kernelArg : *compileArgs) {
-      if (kernelArg->arg_type() ==
-              target::metal::KernelArgType::KernelArgBufferAddress ||
-          kernelArg->arg_type() ==
-              target::metal::KernelArgType::KernelArgGlobalSemaphore) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
 
 struct ReusableInputKey {
   std::uint32_t deviceId;
@@ -451,9 +437,6 @@ MCQExecutor::MCQExecutor(
     }
     if (reusableInputCache &&
         hostBuffers.find(ref->global_id()) != hostBuffers.end()) {
-      LOG_ASSERT(meshDevice->num_devices() == 1,
-                 "Reusable D2M inputs currently require a single-device "
-                 "program");
       hostBufferInputProvenance.try_emplace(
           ref->global_id(),
           ProgramInputProvenance{currentInputIndex,
@@ -535,8 +518,15 @@ void MCQExecutor::analyzeReusableInputs(
     }
     case target::metal::CommandType::MeshShardCommand: {
       const auto *meshShard = command->type_as_MeshShardCommand();
-      markHostUse(meshShard->src());
-      provenance.erase(meshShard->dst()->global_id());
+      auto source = provenance.find(meshShard->src()->global_id());
+      if (source == provenance.end()) {
+        provenance.erase(meshShard->dst()->global_id());
+        break;
+      }
+      provenance.insert_or_assign(meshShard->dst()->global_id(),
+                                  source->second);
+      plans.at(source->second.inputIndex)
+          .derivedHostBufferIds.insert(meshShard->dst()->global_id());
       break;
     }
     case target::metal::CommandType::ReturnCommand: {
@@ -550,6 +540,8 @@ void MCQExecutor::analyzeReusableInputs(
       break;
     }
   }
+
+  hostBufferInputProvenance = provenance;
 
   for (const auto &[inputIndex, plan] : plans) {
     if (!plan.input.cache || plan.requiresHostMaterialization ||
@@ -839,52 +831,66 @@ void MCQExecutor::refreshCachedMeshWorkload(
     CachedMeshWorkload &cached,
     const target::metal::EnqueueProgramCommand *command) {
   auto &programs = cached.workload.get_programs();
-  LOG_ASSERT(programs.size() == 1,
-             "Cached non-fabric workloads must contain exactly one program");
-  tt_metal::Program &program = programs.begin()->second;
-  LOG_ASSERT(cached.shared_variables.kernels.size() ==
-                 command->program()->kernels()->size(),
-             "Cached kernel binding count mismatch");
+  LOG_ASSERT(programs.size() == cached.shared_variables.programs.size(),
+             "Cached program binding count mismatch");
 
-  std::function<std::uint32_t(std::uint32_t)> preserveLocalSemaphores;
-  for (std::size_t i = 0; i < cached.shared_variables.kernels.size(); ++i) {
-    const target::metal::KernelConfig *kernelConfig =
-        command->program()->kernels()->Get(i);
-    const CachedKernelBinding &binding = cached.shared_variables.kernels[i];
+  for (auto &[range, program] : programs) {
+    const CachedProgramBinding &programBinding =
+        cached.shared_variables.programs.at(range);
+    LOG_ASSERT(programBinding.kernels.size() ==
+                   command->program()->kernels()->size(),
+               "Cached kernel binding count mismatch");
 
-    std::vector<std::uint32_t> commonRuntimeArgs = refreshRuntimeArgs(
-        binding.commonRuntimeArgs, kernelConfig->args()->crt_args(),
-        command->arg_refs_type(), command->arg_refs(), meshBuffers,
-        global_semaphores, local_semaphore_initializer, command->cbs(),
-        deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
-    tt_metal::RuntimeArgsData &cachedCommonRuntimeArgs =
-        tt_metal::GetCommonRuntimeArgs(program, binding.handle);
-    LOG_ASSERT(cachedCommonRuntimeArgs.size() == commonRuntimeArgs.size(),
-               "Cached common runtime argument count mismatch");
-    std::copy(commonRuntimeArgs.begin(), commonRuntimeArgs.end(),
-              cachedCommonRuntimeArgs.data());
+    std::function<std::uint32_t(std::uint32_t)> preserveLocalSemaphores;
+    for (std::size_t i = 0; i < programBinding.kernels.size(); ++i) {
+      const target::metal::KernelConfig *kernelConfig =
+          command->program()->kernels()->Get(i);
+      const CachedKernelBinding &binding = programBinding.kernels[i];
 
-    std::vector<std::uint32_t> runtimeArgs = refreshRuntimeArgs(
-        binding.runtimeArgs, kernelConfig->args()->rt_args(),
-        command->arg_refs_type(), command->arg_refs(), meshBuffers,
-        global_semaphores, local_semaphore_initializer, command->cbs(),
-        deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
-    for (const tt_metal::CoreCoord core :
-         tt_metal::corerange_to_cores(binding.coreRangeSet)) {
-      tt_metal::RuntimeArgsData &cachedRuntimeArgs =
-          tt_metal::GetRuntimeArgs(program, binding.handle, core);
-      LOG_ASSERT(cachedRuntimeArgs.size() == runtimeArgs.size(),
-                 "Cached runtime argument count mismatch");
-      std::copy(runtimeArgs.begin(), runtimeArgs.end(),
-                cachedRuntimeArgs.data());
+      std::vector<std::uint32_t> compileArgs = processCompileArgs(
+          kernelConfig->args()->ct_args(), command->arg_refs_type(),
+          command->arg_refs(), meshBuffers, global_semaphores,
+          local_semaphore_initializer, command->cbs(), deviceAddressValidator,
+          std::function<std::uint32_t(std::uint32_t)>(), hostBuffers,
+          &binding.compileArgs);
+      LOG_ASSERT(compileArgs == binding.compileArgs,
+                 "Cached compile-time kernel arguments changed between "
+                 "submissions");
+
+      std::vector<std::uint32_t> commonRuntimeArgs = refreshRuntimeArgs(
+          binding.commonRuntimeArgs, kernelConfig->args()->crt_args(),
+          command->arg_refs_type(), command->arg_refs(), meshBuffers,
+          global_semaphores, local_semaphore_initializer, command->cbs(),
+          deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
+      tt_metal::RuntimeArgsData &cachedCommonRuntimeArgs =
+          tt_metal::GetCommonRuntimeArgs(program, binding.handle);
+      LOG_ASSERT(cachedCommonRuntimeArgs.size() == commonRuntimeArgs.size(),
+                 "Cached common runtime argument count mismatch");
+      std::copy(commonRuntimeArgs.begin(), commonRuntimeArgs.end(),
+                cachedCommonRuntimeArgs.data());
+
+      std::vector<std::uint32_t> runtimeArgs = refreshRuntimeArgs(
+          binding.runtimeArgs, kernelConfig->args()->rt_args(),
+          command->arg_refs_type(), command->arg_refs(), meshBuffers,
+          global_semaphores, local_semaphore_initializer, command->cbs(),
+          deviceAddressValidator, preserveLocalSemaphores, hostBuffers);
+      for (const tt_metal::CoreCoord core :
+           tt_metal::corerange_to_cores(binding.coreRangeSet)) {
+        tt_metal::RuntimeArgsData &cachedRuntimeArgs =
+            tt_metal::GetRuntimeArgs(program, binding.handle, core);
+        LOG_ASSERT(cachedRuntimeArgs.size() >= runtimeArgs.size(),
+                   "Cached runtime argument count mismatch");
+        std::copy(runtimeArgs.begin(), runtimeArgs.end(),
+                  cachedRuntimeArgs.data());
+      }
     }
-  }
 
-  for (const CachedCircularBufferBinding &binding :
-       cached.shared_variables.circularBuffers) {
-    const auto &meshBuffer = meshBuffers.at(binding.bufferGlobalId);
-    tt_metal::UpdateDynamicCircularBufferAddress(
-        program, binding.handle, *meshBuffer->get_reference_buffer());
+    for (const CachedCircularBufferBinding &binding :
+         programBinding.circularBuffers) {
+      const auto &meshBuffer = meshBuffers.at(binding.bufferGlobalId);
+      tt_metal::UpdateDynamicCircularBufferAddress(
+          program, binding.handle, *meshBuffer->get_reference_buffer());
+    }
   }
 }
 
@@ -916,20 +922,26 @@ void MCQExecutor::enqueueMeshWorkload(distributed::MeshWorkload &workload,
 void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
                           const char *loc, const char *debugInfo) {
   ZoneScopedN("EnqueueProgramCommand");
+  if (loc) {
+    std::string_view zoneText(loc);
+    constexpr std::string_view namePrefix = "loc(\"";
+    constexpr std::string_view nameSuffix = "\")";
+    if (zoneText.size() >= namePrefix.size() + nameSuffix.size() &&
+        zoneText.substr(0, namePrefix.size()) == namePrefix &&
+        zoneText.substr(zoneText.size() - nameSuffix.size()) == nameSuffix) {
+      zoneText = zoneText.substr(namePrefix.size(), zoneText.size() -
+                                                        namePrefix.size() -
+                                                        nameSuffix.size());
+    }
+    ZoneText(zoneText.data(), zoneText.size());
+  }
   LOG_TRACE(logger::LogRuntimeTTMetalCommand, "Executing program: ", loc, "\n",
             debugInfo);
 
   const std::uint32_t commandIndex = nextEnqueueProgramIndex++;
   auto &programCache = meshDevice->get_program_cache();
 
-  // Cached bindings describe one Program. Multi-device and fabric workloads
-  // need per-Program binding state before they can be refreshed safely. Buffer
-  // and global semaphore addresses baked into kernels can change between
-  // submissions, so those programs must be rebuilt.
-  const bool cacheEligible = programCache.is_enabled() &&
-                             meshDevice->num_devices() == 1 &&
-                             !command->fabric_connection_config() &&
-                             !hasDynamicCompileTimeBindings(command);
+  const bool cacheEligible = programCache.is_enabled();
   tt_metal::program_cache::detail::ProgramCacheKey programKey;
   if (cacheEligible) {
     programKey = createProgramCacheKey(command, commandIndex);
@@ -951,6 +963,7 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
   auto meshWorkload = distributed::MeshWorkload();
   auto deviceRange = distributed::MeshCoordinateRange(meshDevice->shape());
   for (auto deviceCoord : deviceRange) {
+    CachedProgramBinding cacheProgramBinding;
     tt_metal::Program program = tt_metal::CreateProgram();
     for (const target::metal::KernelConfig *kernelConfig :
          *command->program()->kernels()) {
@@ -967,13 +980,17 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
         return tt_metal::CreateSemaphore(program, coreRangeSet, initialValue);
       };
 
+      auto materializedKernelConfig = createKernelConfig(
+          kernelConfig, command->arg_refs_type(), command->arg_refs(),
+          meshBuffers, global_semaphores, local_semaphore_initializer,
+          command->cbs(), deviceAddressValidator, createSemaphore, hostBuffers);
+      const std::vector<std::uint32_t> &compileArgs = std::visit(
+          [](const auto &config) -> const std::vector<std::uint32_t> & {
+            return config.compile_args;
+          },
+          materializedKernelConfig);
       tt_metal::KernelHandle handle = createKernel(
-          program, kernelSourceString, coreRangeSet,
-          createKernelConfig(kernelConfig, command->arg_refs_type(),
-                             command->arg_refs(), meshBuffers,
-                             global_semaphores, local_semaphore_initializer,
-                             command->cbs(), deviceAddressValidator,
-                             createSemaphore, hostBuffers),
+          program, kernelSourceString, coreRangeSet, materializedKernelConfig,
           currentProgramName, debugInfo, kernelConfig->debug_info()->c_str(),
           kernelConfig->loc() ? kernelConfig->loc()->c_str() : nullptr);
 
@@ -1010,9 +1027,9 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       }
 
       if (cacheEligible) {
-        cacheState.kernels.push_back({handle, coreRangeSet,
-                                      std::move(commonRtArgsVec),
-                                      std::move(rtArgsVec)});
+        cacheProgramBinding.kernels.push_back(
+            {handle, coreRangeSet, compileArgs, std::move(commonRtArgsVec),
+             std::move(rtArgsVec)});
       }
     }
 
@@ -1040,18 +1057,22 @@ void MCQExecutor::execute(const target::metal::EnqueueProgramCommand *command,
       tt_metal::CBHandle handle =
           tt_metal::CreateCircularBuffer(program, coreRangeSet, config);
       if (cacheEligible) {
-        cacheState.circularBuffers.push_back(
+        cacheProgramBinding.circularBuffers.push_back(
             {handle, cbRef->buffer_ref()->global_id()});
       }
     }
 
-    // fabric connected cores all have separate runtime args so we add a
-    // separate program for each device
-    if (command->fabric_connection_config()) {
-      meshWorkload.add_program(distributed::MeshCoordinateRange(deviceCoord),
-                               std::move(program));
-    } else {
-      meshWorkload.add_program(deviceRange, std::move(program));
+    // Fabric connection arguments are device-specific, so fabric workloads
+    // need one Program per device.
+    distributed::MeshCoordinateRange programRange =
+        command->fabric_connection_config()
+            ? distributed::MeshCoordinateRange(deviceCoord)
+            : deviceRange;
+    if (cacheEligible) {
+      cacheState.programs.emplace(programRange, std::move(cacheProgramBinding));
+    }
+    meshWorkload.add_program(programRange, std::move(program));
+    if (!command->fabric_connection_config()) {
       break;
     }
   }
@@ -1281,6 +1302,9 @@ void MCQExecutor::execute(const target::metal::FinishCommand *) {
 
 void MCQExecutor::execute(const target::metal::MeshShardCommand *command) {
   ZoneScopedN("MeshShardCommand");
+  if (skippedHostBufferIds.contains(command->dst()->global_id())) {
+    return;
+  }
   LOG_ASSERT(command->src()->desc()->buffer_detail_type() ==
                  tt::target::metal::BufferDetail::SystemBuffer,
              "MeshShardCommand requires system memory as input");

--- a/runtime/lib/ttmetal/executor_utils.h
+++ b/runtime/lib/ttmetal/executor_utils.h
@@ -176,8 +176,8 @@ createMeshBufferForShardedMetalBuffer(
         toShape(distributionSpec->shard_shape_in_pages()), std::move(cores));
     if (!refAddress) {
       // An owning allocation must be sized from the distribution spec. When
-      // both forms are present, Metal's allocation path currently prioritizes
-      // the legacy shard spec, which describes only one shard per core and can
+      // both forms are present, Metal's allocation path prioritizes the shard
+      // spec. That spec describes only one shard per core and can
       // under-allocate buffers that place multiple shards on each core.
       return tt_metal::BufferShardingArgs(std::move(metalDistributionSpec));
     }

--- a/runtime/lib/ttmetal/meshshard_utils.cpp
+++ b/runtime/lib/ttmetal/meshshard_utils.cpp
@@ -162,8 +162,10 @@ shardHostBuffer(const tt_metal::HostBuffer &hostBuffer,
 
   // replicate - use the host buffer for all shards in distributed buffer.
   if (meshShardType == target::MeshShardType::Replicate) {
-    LOG_ASSERT(meshShardDims.size() == 1 && meshShardDims[0] == -1,
-               "Replicate shard type should have a single dimension set to -1");
+    LOG_ASSERT(!meshShardDims.empty() &&
+                   std::all_of(meshShardDims.begin(), meshShardDims.end(),
+                               [](int64_t dim) { return dim == -1; }),
+               "Replicate shard type should only contain -1 shard dimensions");
     auto distributedBuffer = tt_metal::DistributedHostBuffer::create(meshShape);
     for (const auto &coord :
          tt_metal::distributed::MeshCoordinateRange(meshShape)) {

--- a/runtime/lib/ttmetal/runtime.cpp
+++ b/runtime/lib/ttmetal/runtime.cpp
@@ -329,6 +329,7 @@ tt::target::Arch getArch() {
 size_t getNumAvailableDevices() { return tt_metal::GetNumAvailableDevices(); }
 
 Device openMeshDevice(const MeshDeviceOptions &options) {
+  ZoneScopedN("D2MPrepareDevice");
   std::optional<tt_metal::distributed::MeshShape> meshShape = std::nullopt;
   if (options.meshShape.has_value()) {
     LOG_ASSERT(options.meshShape.value().size() == 2,
@@ -368,6 +369,7 @@ Device openMeshDevice(const MeshDeviceOptions &options) {
 }
 
 void closeMeshDevice(Device parentMesh) {
+  ZoneScopedN("D2MReleaseDevice");
   tt_metal::distributed::MeshDevice &metalMeshDevice =
       parentMesh.as<tt_metal::distributed::MeshDevice>(DeviceRuntime::TTMetal);
 
@@ -589,6 +591,7 @@ getMemoryView(Device deviceHandle) {
 }
 
 void setFabricConfig(tt::runtime::FabricConfig config) {
+  ZoneScopedN("D2MConfigureFabric");
   ::tt::tt_fabric::SetFabricConfig(common::toMetalFabricConfig(config));
   RuntimeContext::instance().setCurrentFabricConfig(config);
 }
@@ -607,6 +610,7 @@ void wait(Tensor tensor, std::optional<uint8_t> cqId) {
 }
 
 void wait(const std::vector<Tensor> &tensors, std::optional<uint8_t> cqId) {
+  ZoneScopedN("D2MWait");
   for (Tensor tensor : tensors) {
     ::tt::runtime::ttmetal::wait(tensor);
   }
@@ -633,6 +637,7 @@ uint32_t getNumShards(Tensor tensor) {
 }
 
 std::vector<Tensor> toHost(Tensor tensor, bool untilize, bool blocking) {
+  ZoneScopedN("D2MReadback");
   ::tt::runtime::ttmetal::wait(tensor);
   std::visit(
       utils::overloaded{
@@ -736,6 +741,7 @@ void memcpy(void *dst, Tensor src,
 }
 
 void memcpy(Tensor dst, Tensor src) {
+  ZoneScopedN("D2MHostCopy");
   auto &metalDst = dst.as<MetalTensor>(DeviceRuntime::TTMetal);
   auto &dstDesc = std::get<TensorDesc>(metalDst);
   std::visit(
@@ -1094,15 +1100,12 @@ DistributedHostBuffer getDistributedHostBuffer(Tensor tensor) {
 std::vector<Tensor> submit(Device deviceHandle, Binary executableHandle,
                            std::uint32_t programIndex,
                            std::vector<Tensor> &inputs) {
+  ZoneScopedN("D2MInvoke");
   const target::metal::TTMetalBinary &fbb = *getBinary(executableHandle);
   const target::metal::Program *program = fbb.programs()->Get(programIndex);
   tt_metal::distributed::MeshDevice &meshDevice =
       deviceHandle.as<tt_metal::distributed::MeshDevice>(
           DeviceRuntime::TTMetal);
-  const bool hasReusableInput =
-      std::any_of(inputs.begin(), inputs.end(), getTensorReusable);
-  LOG_ASSERT(!hasReusableInput || meshDevice.num_devices() == 1,
-             "Reusable D2M inputs currently require a single-device handle");
   if (meshDevice.num_rows() != 1 || meshDevice.num_cols() != 1) {
     LOG_WARNING("D2M runtime multi-device support is experimental. mesh = [",
                 meshDevice.num_rows(), ", ", meshDevice.num_cols(), "]");

--- a/test/d2m-jit/lit/mesh_shard.py
+++ b/test/d2m-jit/lit/mesh_shard.py
@@ -27,21 +27,33 @@ shard = d2m.mesh_shard(
     shard_shape=[1, 2],
 )
 gathered = d2m.mesh_gather(shard)
+replicated_full = torch.zeros((64, 64), dtype=torch.float32)
+replicated = d2m.mesh_shard(
+    replicated_full,
+    layout,
+    shard_dims=[-1, -1],
+    shard_shape=[1, 1],
+)
+gathered_replicated = d2m.mesh_gather(replicated)
 
 builder = _Builder.get()
 assert builder._mesh_shape == [1, 2]
 assert builder._mesh_topology == ["linear", "ring"]
 assert shard.mesh.full_shape == [64, 128]
-_emit_returns_and_finalise(builder, [gathered])
+_emit_returns_and_finalise(builder, [gathered, gathered_replicated])
 builder.module.operation.verify()
 print(builder.module)
 _Builder.reset()
 
 
 # CHECK: module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>}
-# CHECK: func.func @main(%{{.*}}: tensor<64x128xf32>) -> tensor<64x128xf32>
+# CHECK: func.func @main(%{{.*}}: tensor<64x128xf32>, %{{.*}}: tensor<64x64xf32>) -> (tensor<64x128xf32>, tensor<64x64xf32>)
 # CHECK: shard_direction = #ttcore.shard_direction<full_to_shard>
 # CHECK-SAME: tensor<64x128xf32> -> tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">>
+# CHECK: shard_type = #ttcore.shard_type<replicate>
+# CHECK-SAME: tensor<64x64xf32> -> tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">>
 # CHECK: tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">>
 # CHECK: shard_direction = #ttcore.shard_direction<shard_to_full>
 # CHECK-SAME: tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">> -> tensor<64x128xf32>
+# CHECK: shard_type = #ttcore.shard_type<replicate>
+# CHECK-SAME: tensor<64x64xf32, #ttcore.tensor_mesh<"mesh">> -> tensor<64x64xf32>

--- a/test/d2m-jit/llama_down_projection_workload.py
+++ b/test/d2m-jit/llama_down_projection_workload.py
@@ -365,7 +365,7 @@ def _stage_k_segments(config, activation_sources, weight_sources, k_elements):
     return staged_activations, staged_weight, k_blocks
 
 
-def run_single_chip(config, activations, weight):
+def build_single_chip(config, activations, weight):
     d2m.mesh((1, 1), topology=("linear", "linear"))
     grid = (config.grid_y, config.grid_x)
     segment_activation_layout = _layout(
@@ -385,6 +385,7 @@ def run_single_chip(config, activations, weight):
     segment_size = config.k_segment_elements
     activation_sources = []
     weight_sources = []
+    reusable_weights = []
     for segment in range(config.k_segments):
         start = segment * segment_size
         stop = start + segment_size
@@ -394,9 +395,9 @@ def run_single_chip(config, activations, weight):
                 segment_activation_layout,
             )
         )
-        weight_sources.append(
-            d2m.to_layout(weight[start:stop, :], segment_weight_layout)
-        )
+        weight_segment = weight[start:stop, :]
+        reusable_weights.append(weight_segment)
+        weight_sources.append(d2m.to_layout(weight_segment, segment_weight_layout))
     staged_activations, staged_weight, k_blocks = _stage_k_segments(
         config,
         activation_sources,
@@ -414,10 +415,20 @@ def run_single_chip(config, activations, weight):
         grid=grid,
         kernel_io_in_dram=True,
     )
+    return output, tuple(reusable_weights)
+
+
+def run_single_chip(config, activations, weight):
+    output, _ = build_single_chip(config, activations, weight)
     return output.to_host()
 
 
-def run_two_chip(config, activations, weight, overlap):
+def prepare_single_chip(config, activations, weight):
+    output, reusable_weights = build_single_chip(config, activations, weight)
+    return d2m.prepare(output, reusable_inputs=reusable_weights)
+
+
+def build_two_chip(config, activations, weight, overlap):
     d2m.mesh((1, 2), topology=("linear", "linear"))
     grid = (config.grid_y, config.grid_x)
     segment_activation_layout = _layout(
@@ -442,6 +453,7 @@ def run_two_chip(config, activations, weight, overlap):
     segment_size = config.k_segment_elements
     activation_sources = []
     weight_sources = []
+    reusable_weights = []
     for local_segment in range(config.k_segments // 2):
         low_start = local_segment * segment_size
         high_start = low_start + config.k // 2
@@ -459,6 +471,7 @@ def run_two_chip(config, activations, weight, overlap):
             ),
             dim=0,
         )
+        reusable_weights.append(packed_weight)
         activation_sources.append(
             d2m.mesh_shard(
                 packed_activations,
@@ -539,7 +552,17 @@ def run_two_chip(config, activations, weight, overlap):
     )
     replicated = d2m.mesh_gather(
         output,
-        shard_dims=[-1, 0],
-        shard_shape=[2, 1],
+        shard_dims=[-1, -1],
+        shard_shape=[1, 1],
     )
-    return replicated.to_host()[: config.m]
+    return replicated, tuple(reusable_weights)
+
+
+def run_two_chip(config, activations, weight, overlap):
+    output, _ = build_two_chip(config, activations, weight, overlap)
+    return output.to_host()
+
+
+def prepare_two_chip(config, activations, weight, overlap):
+    output, reusable_weights = build_two_chip(config, activations, weight, overlap)
+    return d2m.prepare(output, reusable_inputs=reusable_weights)

--- a/test/d2m-jit/llama_mlp_workload.py
+++ b/test/d2m-jit/llama_mlp_workload.py
@@ -1,0 +1,550 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""BF16 Llama 3 8B prefill MLP with two-way tensor parallelism."""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+import d2m_jit as d2m
+
+from llama_down_projection_workload import (
+    overlapped_two_chip_down_projection,
+    reduce_two_chip_partials,
+    serialized_two_chip_down_projection,
+    single_chip_down_projection,
+)
+
+
+@dataclass(frozen=True)
+class WorkloadConfig:
+    m: int = 576
+    hidden: int = 4096
+    intermediate: int = 14336
+    grid_y: int = 6
+    grid_x: int = 8
+    seed: int = 0
+
+    m_block_tiles: int = 1
+    projection_k_block_tiles: int = 16
+    projection_n_block_tiles: int = 4
+    down_k_block_tiles: int = 14
+
+    def __post_init__(self):
+        if self.m_block_tiles != 1 or self.projection_n_block_tiles != 4:
+            raise ValueError("the kernels require 32x128 output blocks")
+        if self.intermediate % 2:
+            raise ValueError("intermediate must be divisible across two chips")
+        dimensions = (
+            (self.m, self.m_block_elements * self.grid_y, "m"),
+            (self.hidden, self.projection_k_block_elements, "hidden"),
+            (
+                self.hidden,
+                self.projection_k_block_elements * self.grid_x,
+                "hidden",
+            ),
+            (self.hidden, self.hidden_block_elements * self.grid_x, "hidden"),
+            (
+                self.local_intermediate,
+                self.projection_n_block_elements * self.grid_x,
+                "local intermediate",
+            ),
+            (
+                self.local_intermediate,
+                self.down_k_block_elements * self.grid_x,
+                "local intermediate",
+            ),
+        )
+        for size, divisor, name in dimensions:
+            if size % divisor:
+                raise ValueError(f"{name}={size} must be divisible by {divisor}")
+
+    @property
+    def local_intermediate(self):
+        return self.intermediate // 2
+
+    @property
+    def m_block_elements(self):
+        return self.m_block_tiles * 32
+
+    @property
+    def projection_k_block_elements(self):
+        return self.projection_k_block_tiles * 32
+
+    @property
+    def projection_n_block_elements(self):
+        return self.projection_n_block_tiles * 32
+
+    @property
+    def down_k_block_elements(self):
+        return self.down_k_block_tiles * 32
+
+    @property
+    def hidden_block_elements(self):
+        return self.projection_n_block_elements
+
+    @property
+    def m_blocks(self):
+        return self.m // self.m_block_elements
+
+    @property
+    def n_blocks(self):
+        return self.hidden // self.hidden_block_elements
+
+    @property
+    def m_blocks_per_core(self):
+        return self.m_blocks // self.grid_y
+
+    @property
+    def n_blocks_per_core(self):
+        return self.n_blocks // self.grid_x
+
+    @property
+    def output_blocks_per_core(self):
+        return self.m_blocks_per_core * self.n_blocks_per_core
+
+
+def make_operands(config):
+    generator = torch.Generator()
+    generator.manual_seed(config.seed)
+    hidden_states = torch.randn(
+        config.m, config.hidden, dtype=torch.bfloat16, generator=generator
+    ).mul_(0.125)
+    gate_weight = torch.randn(
+        config.hidden,
+        config.intermediate,
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.0625)
+    up_weight = torch.randn(
+        config.hidden,
+        config.intermediate,
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.0625)
+    down_weight = torch.randn(
+        config.intermediate,
+        config.hidden,
+        dtype=torch.bfloat16,
+        generator=generator,
+    ).mul_(0.015625)
+    residual = torch.randn(
+        config.m, config.hidden, dtype=torch.bfloat16, generator=generator
+    ).mul_(0.125)
+    return hidden_states, gate_weight, up_weight, down_weight, residual
+
+
+def golden(hidden_states, gate_weight, up_weight, down_weight, residual):
+    gate = torch.matmul(hidden_states.float(), gate_weight.float()).to(torch.bfloat16)
+    up = torch.matmul(hidden_states.float(), up_weight.float()).to(torch.bfloat16)
+    activated = (F.silu(gate.float()) * up.float()).to(torch.bfloat16)
+    down = torch.matmul(activated.float(), down_weight.float()).to(torch.bfloat16)
+    return (down + residual).to(torch.bfloat16)
+
+
+def _layout(shape, block_shape, grid_shape, tiled=True):
+    return d2m.Layout(
+        shape=shape,
+        dtype=d2m.bfloat16,
+        block_shape=block_shape,
+        grid_shape=grid_shape,
+        tiled=tiled,
+        mem_space="dram",
+    )
+
+
+def _weight_grid(block_rows, block_columns):
+    def grid_extent(blocks):
+        return max(extent for extent in range(1, 9) if blocks % extent == 0)
+
+    return grid_extent(block_rows), grid_extent(block_columns)
+
+
+@d2m.kernel
+def tilize_weight(
+    source,
+    destination,
+    row_blocks_per_core,
+    column_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for row_slot in range(row_blocks_per_core):
+        row_block = cy * row_blocks_per_core + row_slot
+        for column_slot in range(column_blocks_per_core):
+            column_block = cx * column_blocks_per_core + column_slot
+            block = remote_load(source, [row_block, column_block])
+            remote_store(
+                destination,
+                [row_block, column_block],
+                tilize_block(block),
+            )
+
+
+@d2m.kernel
+def local_projection(
+    hidden_states,
+    weight,
+    output,
+    m_blocks_per_core,
+    n_blocks_per_core,
+    k_blocks,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        for n_slot in range(n_blocks_per_core):
+            n_block = cx * n_blocks_per_core + n_slot
+            acc = zeros([1, 4], dtype="bf16")
+            for k_block in range(k_blocks):
+                lhs = remote_load(hidden_states, [m_block, k_block])
+                rhs = remote_load(weight, [k_block, n_block])
+                acc += lhs @ rhs
+            remote_store(output, [m_block, n_block], acc)
+
+
+@d2m.kernel
+def gated_activation(gate, up, output, m_blocks_per_core, n_blocks_per_core):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        for n_slot in range(n_blocks_per_core):
+            n_block = cx * n_blocks_per_core + n_slot
+            gate_block = remote_load(gate, [m_block, n_block])
+            up_block = remote_load(up, [m_block, n_block])
+            remote_store(output, [m_block, n_block], silu(gate_block) * up_block)
+
+
+@d2m.kernel
+def add_residual(
+    projected,
+    residual,
+    output,
+    m_blocks_per_core,
+    n_blocks_per_core,
+):
+    cy = core_index(0)
+    cx = core_index(1)
+    for m_slot in range(m_blocks_per_core):
+        m_block = cy * m_blocks_per_core + m_slot
+        for n_slot in range(n_blocks_per_core):
+            n_block = cx * n_blocks_per_core + n_slot
+            projected_block = remote_load(projected, [m_block, n_block])
+            residual_block = remote_load(residual, [m_block, n_block])
+            remote_store(output, [m_block, n_block], projected_block + residual_block)
+
+
+def _layouts(config, intermediate):
+    grid = (config.grid_y, config.grid_x)
+    hidden_layout = _layout(
+        (config.m, config.hidden),
+        [config.m_block_tiles, config.projection_k_block_tiles],
+        grid,
+    )
+    projection_weight_grid = _weight_grid(
+        config.hidden // config.projection_k_block_elements,
+        intermediate // config.projection_n_block_elements,
+    )
+    projection_weight_host_layout = _layout(
+        (config.hidden, intermediate),
+        [
+            config.projection_k_block_elements,
+            config.projection_n_block_elements,
+        ],
+        projection_weight_grid,
+        tiled=False,
+    )
+    projection_weight_layout = _layout(
+        (config.hidden, intermediate),
+        [config.projection_k_block_tiles, config.projection_n_block_tiles],
+        projection_weight_grid,
+    )
+    projection_output_layout = _layout(
+        (config.m, intermediate),
+        [config.m_block_tiles, config.projection_n_block_tiles],
+        grid,
+    )
+    down_activation_layout = _layout(
+        (config.m, intermediate),
+        [config.m_block_tiles, config.down_k_block_tiles],
+        grid,
+    )
+    down_weight_grid = _weight_grid(
+        intermediate // config.down_k_block_elements,
+        config.hidden // config.projection_n_block_elements,
+    )
+    down_weight_host_layout = _layout(
+        (intermediate, config.hidden),
+        [config.down_k_block_elements, config.projection_n_block_elements],
+        down_weight_grid,
+        tiled=False,
+    )
+    down_weight_layout = _layout(
+        (intermediate, config.hidden),
+        [config.down_k_block_tiles, config.projection_n_block_tiles],
+        down_weight_grid,
+    )
+    output_layout = _layout(
+        (config.m, config.hidden),
+        [config.m_block_tiles, config.projection_n_block_tiles],
+        grid,
+    )
+    return (
+        hidden_layout,
+        projection_weight_host_layout,
+        projection_weight_layout,
+        projection_output_layout,
+        down_activation_layout,
+        down_weight_host_layout,
+        down_weight_layout,
+        output_layout,
+    )
+
+
+def _tilize_weight(source, layout):
+    output = d2m.empty(layout)
+    grid_y, grid_x = layout.grid_shape
+    block_rows, block_columns = layout.blocked_grid_shape
+    tilize_weight(
+        source,
+        output,
+        block_rows // grid_y,
+        block_columns // grid_x,
+        grid=(grid_y, grid_x),
+        kernel_io_in_dram=True,
+    )
+    return output
+
+
+def _build_local_mlp(
+    config,
+    hidden_states,
+    gate_weight,
+    up_weight,
+    down_weight,
+    residual,
+    two_chip,
+    overlap,
+):
+    grid = (config.grid_y, config.grid_x)
+    intermediate = config.local_intermediate if two_chip else config.intermediate
+    (
+        hidden_layout,
+        projection_weight_host_layout,
+        projection_weight_layout,
+        projection_output_layout,
+        down_activation_layout,
+        down_weight_host_layout,
+        down_weight_layout,
+        output_layout,
+    ) = _layouts(config, intermediate)
+
+    if two_chip:
+        hidden_device = d2m.mesh_shard(
+            hidden_states,
+            hidden_layout,
+            shard_dims=[-1, -1],
+            shard_shape=[1, 1],
+        )
+        gate_source = d2m.mesh_shard(
+            gate_weight,
+            projection_weight_host_layout,
+            shard_dims=[-1, 1],
+            shard_shape=[1, 2],
+        )
+        up_source = d2m.mesh_shard(
+            up_weight,
+            projection_weight_host_layout,
+            shard_dims=[-1, 1],
+            shard_shape=[1, 2],
+        )
+        down_source = d2m.mesh_shard(
+            down_weight,
+            down_weight_host_layout,
+            shard_dims=[-1, 0],
+            shard_shape=[2, 1],
+        )
+        residual_device = d2m.mesh_shard(
+            residual,
+            output_layout,
+            shard_dims=[-1, -1],
+            shard_shape=[1, 1],
+        )
+    else:
+        hidden_device = d2m.to_layout(hidden_states, hidden_layout)
+        gate_source = d2m.to_layout(gate_weight, projection_weight_host_layout)
+        up_source = d2m.to_layout(up_weight, projection_weight_host_layout)
+        down_source = d2m.to_layout(down_weight, down_weight_host_layout)
+        residual_device = d2m.to_layout(residual, output_layout)
+
+    gate_device = _tilize_weight(gate_source, projection_weight_layout)
+    up_device = _tilize_weight(up_source, projection_weight_layout)
+    down_device = _tilize_weight(down_source, down_weight_layout)
+
+    projection_n_blocks_per_core = (
+        intermediate // config.projection_n_block_elements // config.grid_x
+    )
+    projection_k_blocks = config.hidden // config.projection_k_block_elements
+    gate_output = d2m.empty(projection_output_layout)
+    up_output = d2m.empty(projection_output_layout)
+    for weight_device, projection_output in (
+        (gate_device, gate_output),
+        (up_device, up_output),
+    ):
+        local_projection(
+            hidden_device,
+            weight_device,
+            projection_output,
+            config.m_blocks_per_core,
+            projection_n_blocks_per_core,
+            projection_k_blocks,
+            grid=grid,
+            kernel_io_in_dram=True,
+        )
+
+    activated = d2m.empty(projection_output_layout)
+    gated_activation(
+        gate_output,
+        up_output,
+        activated,
+        config.m_blocks_per_core,
+        projection_n_blocks_per_core,
+        grid=grid,
+        kernel_io_in_dram=True,
+    )
+    down_activations = (
+        activated
+        if config.projection_n_block_tiles == config.down_k_block_tiles
+        else d2m.to_layout(activated, down_activation_layout)
+    )
+    down_k_blocks = intermediate // config.down_k_block_elements
+
+    if not two_chip:
+        projected = d2m.empty(output_layout)
+        single_chip_down_projection(
+            down_activations,
+            down_device,
+            projected,
+            config.m_blocks_per_core,
+            config.n_blocks_per_core,
+            down_k_blocks,
+            grid=grid,
+            kernel_io_in_dram=True,
+        )
+    else:
+        partial_layout = _layout(
+            (2 * config.m, config.hidden),
+            [config.m_block_tiles, config.projection_n_block_tiles],
+            grid,
+        )
+        partials = d2m.empty(partial_layout)
+        start_sem = d2m.global_semaphore(grid_shape=(8, 8))
+        ready = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+        consumed = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+        fabric_done = d2m.global_semaphore(grid_shape=(8, 8), init=0)
+        common_args = (
+            down_activations,
+            down_device,
+            partials,
+            start_sem,
+            ready,
+            consumed,
+            fabric_done,
+        )
+        shape_args = (
+            config.m_blocks,
+            config.m_blocks_per_core,
+            config.n_blocks_per_core,
+            down_k_blocks,
+            config.grid_y,
+            config.grid_x,
+            config.grid_y * config.grid_x,
+            config.output_blocks_per_core,
+        )
+        kernel_options = {
+            "grid": grid,
+            "fabric": d2m.fabric_config(
+                cluster_axis=1,
+                topology="linear",
+                router_cores=[(0, 0)],
+            ),
+            "kernel_io_in_dram": True,
+        }
+        if overlap:
+            overlapped_two_chip_down_projection(
+                *common_args,
+                *shape_args,
+                **kernel_options,
+            )
+        else:
+            serialized_two_chip_down_projection(
+                *common_args,
+                d2m.global_semaphore(grid_shape=(8, 8), init=0),
+                *shape_args,
+                **kernel_options,
+            )
+        projected = d2m.empty(output_layout)
+        reduce_two_chip_partials(
+            partials,
+            projected,
+            config.m_blocks,
+            config.m_blocks_per_core,
+            config.n_blocks_per_core,
+            grid=grid,
+            kernel_io_in_dram=True,
+        )
+
+    output = d2m.empty(output_layout)
+    add_residual(
+        projected,
+        residual_device,
+        output,
+        config.m_blocks_per_core,
+        config.n_blocks_per_core,
+        grid=grid,
+        kernel_io_in_dram=True,
+    )
+    if two_chip:
+        output = d2m.mesh_gather(
+            output,
+            shard_dims=[-1, -1],
+            shard_shape=[1, 1],
+        )
+    return output
+
+
+def build_single_chip(config, operands):
+    d2m.mesh((1, 1), topology=("linear", "linear"))
+    output = _build_local_mlp(config, *operands, two_chip=False, overlap=False)
+    return output, operands[1:4]
+
+
+def build_two_chip(config, operands, overlap):
+    d2m.mesh((1, 2), topology=("linear", "linear"))
+    output = _build_local_mlp(config, *operands, two_chip=True, overlap=overlap)
+    return output, operands[1:4]
+
+
+def run_single_chip(config, operands):
+    output, _ = build_single_chip(config, operands)
+    return output.to_host()
+
+
+def run_two_chip(config, operands, overlap):
+    output, _ = build_two_chip(config, operands, overlap)
+    return output.to_host()
+
+
+def prepare_single_chip(config, operands):
+    output, reusable_weights = build_single_chip(config, operands)
+    return d2m.prepare(output, reusable_inputs=reusable_weights)
+
+
+def prepare_two_chip(config, operands, overlap):
+    output, reusable_weights = build_two_chip(config, operands, overlap)
+    return d2m.prepare(output, reusable_inputs=reusable_weights)

--- a/test/d2m-jit/multichip_overlap_benchmark.py
+++ b/test/d2m-jit/multichip_overlap_benchmark.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Profile a BF16 Llama 3 8B down projection with two-way tensor parallelism."""
+"""Profile BF16 Llama 3 8B tensor parallelism at realistic host boundaries."""
 
 import argparse
 import collections
@@ -82,11 +82,22 @@ def _export_tracy(trace_path):
 def _summarize_tracy(csv_path, measured_iterations):
     selected = {
         "MeshShardCommand": [],
+        "EnqueueWriteBufferCommand": [],
         "EnqueueProgramCommand": [],
         "FinishCommand": [],
         "EnqueueReadBufferCommand": [],
     }
     submits = []
+    invokes = []
+    programs = []
+    lifecycle_zones = {
+        "D2MPrepareDevice": [],
+        "D2MConfigureFabric": [],
+        "D2MReleaseDevice": [],
+        "D2MWait": [],
+        "D2MReadback": [],
+        "D2MHostCopy": [],
+    }
     with csv_path.open(encoding="utf-8", newline="") as input_file:
         for row in csv.DictReader(input_file):
             name = row["name"]
@@ -94,14 +105,23 @@ def _summarize_tracy(csv_path, measured_iterations):
             duration_ns = int(row["exec_time_ns"])
             if name == "submit":
                 submits.append((start_ns, duration_ns))
+            if name == "D2MInvoke":
+                invokes.append((start_ns, duration_ns))
+            if name == "EnqueueProgramCommand":
+                programs.append((start_ns, duration_ns, row["zone_text"].strip()))
             if name in selected:
                 selected[name].append((start_ns, duration_ns))
+            if name in lifecycle_zones:
+                lifecycle_zones[name].append(duration_ns)
 
-    submits = sorted(submits)[-measured_iterations:]
-    submit_durations = [duration for _, duration in submits]
+    anchors = invokes if invokes else submits
+    anchor_name = "D2MInvoke" if invokes else "submit"
+    anchor_label = "invoke" if invokes else "submit"
+    anchors = sorted(anchors)[-measured_iterations:]
+    submit_durations = [duration for _, duration in anchors]
     if submit_durations:
         print(
-            f"tracy submit: count={len(submit_durations)} "
+            f"tracy {anchor_name}: count={len(submit_durations)} "
             f"mean_us={sum(submit_durations) / len(submit_durations) / 1_000:.1f} "
             f"min_us={min(submit_durations) / 1_000:.1f} "
             f"max_us={max(submit_durations) / 1_000:.1f}"
@@ -109,7 +129,7 @@ def _summarize_tracy(csv_path, measured_iterations):
     for name, zones in selected.items():
         counts = []
         totals = []
-        for submit_start, submit_duration in submits:
+        for submit_start, submit_duration in anchors:
             durations = [
                 duration
                 for start, duration in zones
@@ -124,15 +144,47 @@ def _summarize_tracy(csv_path, measured_iterations):
                 else f"{min(counts)}-{max(counts)}"
             )
             print(
-                f"tracy {name}: count_per_submit={count} "
+                f"tracy {name}: count_per_{anchor_label}={count} "
                 f"mean_total_us={sum(totals) / len(totals) / 1_000:.1f} "
                 f"min_total_us={min(totals) / 1_000:.1f} "
                 f"max_total_us={max(totals) / 1_000:.1f}"
             )
+    for label in sorted({label for _, _, label in programs}):
+        counts = []
+        totals = []
+        for invoke_start, invoke_duration in anchors:
+            durations = [
+                duration
+                for start, duration, program_label in programs
+                if program_label == label
+                and invoke_start <= start < invoke_start + invoke_duration
+            ]
+            counts.append(len(durations))
+            totals.append(sum(durations))
+        if any(counts):
+            count = (
+                str(counts[0])
+                if len(set(counts)) == 1
+                else f"{min(counts)}-{max(counts)}"
+            )
+            print(
+                f"tracy program {label or '<unattributed>'}: "
+                f"count_per_{anchor_label}={count} "
+                f"mean_total_us={sum(totals) / len(totals) / 1_000:.1f}"
+            )
+    for name, durations in lifecycle_zones.items():
+        if durations:
+            samples = durations[-measured_iterations:]
+            print(
+                f"tracy {name}: count={len(samples)} "
+                f"mean_us={sum(samples) / len(samples) / 1_000:.1f} "
+                f"min_us={min(samples) / 1_000:.1f} "
+                f"max_us={max(samples) / 1_000:.1f}"
+            )
 
 
-def _device_kernel_ns(profile_csv, warmup, iterations):
-    events_by_host_id = collections.defaultdict(list)
+def _device_program_intervals(profile_csv, warmup, iterations):
+    events_by_program = collections.defaultdict(list)
     with profile_csv.open(encoding="utf-8", newline="") as input_file:
         header = input_file.readline()
         match = re.search(r"CHIP_FREQ\[MHz\]:\s*(\d+)", header)
@@ -142,13 +194,14 @@ def _device_kernel_ns(profile_csv, warmup, iterations):
         for raw_row in csv.DictReader(input_file):
             row = {key.strip().lower(): value for key, value in raw_row.items()}
             if row["zone name"].endswith("-KERNEL"):
-                events_by_host_id[row["run host id"]].append(
+                device = row.get("device id") or row.get("pcie slot") or "unknown"
+                events_by_program[(device, row["run host id"])].append(
                     (int(row["time[cycles since reset]"]), row["type"])
                 )
 
     captured_runs = warmup + iterations
-    measured_durations = []
-    for events in events_by_host_id.values():
+    intervals_by_device_run = collections.defaultdict(list)
+    for (device, _), events in events_by_program.items():
         events.sort()
         if len(events) % captured_runs:
             raise ValueError("device profiler events do not divide into iterations")
@@ -160,10 +213,59 @@ def _device_kernel_ns(profile_csv, warmup, iterations):
             starts = [cycle for cycle, kind in run_events if kind == "ZONE_START"]
             ends = [cycle for cycle, kind in run_events if kind == "ZONE_END"]
             if starts and ends:
-                measured_durations.append(max(ends) - min(starts))
+                intervals_by_device_run[(device, run_index)].append(
+                    (min(starts), max(ends))
+                )
+
+    return frequency_mhz, intervals_by_device_run
+
+
+def _device_kernel_ns(profile_csv, warmup, iterations):
+    frequency_mhz, intervals_by_device_run = _device_program_intervals(
+        profile_csv, warmup, iterations
+    )
+    measured_durations = [
+        end - start
+        for intervals in intervals_by_device_run.values()
+        for start, end in intervals
+    ]
     if not measured_durations:
         return None
     return max(measured_durations) * 1_000 / frequency_mhz
+
+
+def _device_timing_samples(profile_csv, warmup, iterations):
+    frequency_mhz, intervals_by_device_run = _device_program_intervals(
+        profile_csv, warmup, iterations
+    )
+    critical_path_ns = []
+    active_program_ns = []
+    for run_index in range(warmup, warmup + iterations):
+        device_timings = []
+        for (device, interval_run), intervals in intervals_by_device_run.items():
+            if interval_run != run_index:
+                continue
+            device_timings.append(
+                (
+                    max(end for _, end in intervals)
+                    - min(start for start, _ in intervals),
+                    sum(end - start for start, end in intervals),
+                )
+            )
+        if device_timings:
+            critical_cycles, active_cycles = max(
+                device_timings, key=lambda timing: timing[0]
+            )
+            critical_path_ns.append(critical_cycles * 1_000 / frequency_mhz)
+            active_program_ns.append(active_cycles * 1_000 / frequency_mhz)
+    return {
+        "critical_path_ns": critical_path_ns,
+        "active_program_ns": active_program_ns,
+    }
+
+
+def _device_critical_path_ns(profile_csv, warmup, iterations):
+    return _device_timing_samples(profile_csv, warmup, iterations)["critical_path_ns"]
 
 
 def _pcc(actual, expected):
@@ -179,11 +281,21 @@ def _parse_args():
         "mode",
         choices=("single", "two-chip-serialized", "two-chip-overlap"),
     )
+    parser.add_argument(
+        "--workload",
+        choices=("down-projection", "full-mlp"),
+        default="full-mlp",
+    )
+    parser.add_argument(
+        "--lifecycle",
+        choices=("rebuilt", "prepared"),
+        default="prepared",
+    )
     parser.add_argument("--iterations", type=int, default=3)
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--m", type=int, default=576)
-    parser.add_argument("--k", type=int, default=14336)
-    parser.add_argument("--n", type=int, default=4096)
+    parser.add_argument("--hidden", type=int, default=4096)
+    parser.add_argument("--intermediate", type=int, default=14336)
     parser.add_argument("--grid-y", type=int, default=6)
     parser.add_argument("--grid-x", type=int, default=8)
     parser.add_argument("--seed", type=int, default=0)
@@ -208,49 +320,80 @@ def main():
         args.device_profile_dir.mkdir(parents=True, exist_ok=True)
         shutil.rmtree(args.device_profile_dir / ".logs", ignore_errors=True)
         kernel_cache = args.device_profile_dir / "kernel-cache"
-        shutil.rmtree(kernel_cache, ignore_errors=True)
         os.environ["TT_METAL_PROFILER_DIR"] = str(args.device_profile_dir)
         os.environ["TT_METAL_CACHE"] = str(kernel_cache)
         os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
         os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
 
     with trace_context:
-        import llama_down_projection_workload as workload
         from d2m_jit._src.builder import _Builder
+
+        if args.workload == "full-mlp":
+            import llama_mlp_workload as workload
+        else:
+            import llama_down_projection_workload as workload
 
         if args.device_profile_dir:
             from d2m_jit._src.config import config as d2m_config
 
             d2m_config.enable_perf_trace = True
 
-        config = workload.WorkloadConfig(
-            m=args.m,
-            k=args.k,
-            n=args.n,
-            grid_y=args.grid_y,
-            grid_x=args.grid_x,
-            seed=args.seed,
-        )
-        activations, weight = workload.make_operands(config)
-        expected = workload.golden(activations, weight)
-        global_flops = 2 * config.m * config.k * config.n
+        if args.workload == "full-mlp":
+            config = workload.WorkloadConfig(
+                m=args.m,
+                hidden=args.hidden,
+                intermediate=args.intermediate,
+                grid_y=args.grid_y,
+                grid_x=args.grid_x,
+                seed=args.seed,
+            )
+            operands = workload.make_operands(config)
+            expected = workload.golden(*operands)
+            global_flops = 6 * config.m * config.hidden * config.intermediate
+            shape = f"m={config.m} hidden={config.hidden} intermediate={config.intermediate}"
+        else:
+            config = workload.WorkloadConfig(
+                m=args.m,
+                k=args.intermediate,
+                n=args.hidden,
+                grid_y=args.grid_y,
+                grid_x=args.grid_x,
+                seed=args.seed,
+            )
+            operands = workload.make_operands(config)
+            expected = workload.golden(*operands)
+            global_flops = 2 * config.m * config.k * config.n
+            shape = f"m={config.m} k={config.k} n={config.n}"
         print(
-            f"workload: llama3-8b-down-projection mode={args.mode} dtype=bf16 "
-            f"shape={config.m}x{config.k}x{config.n} "
+            f"workload: llama3-8b-{args.workload} mode={args.mode} "
+            f"lifecycle={args.lifecycle} dtype=bf16 {shape} "
             f"grid={config.grid_y}x{config.grid_x} "
             f"global_flops={global_flops}",
             flush=True,
         )
-        if args.mode == "single":
-            run = lambda: workload.run_single_chip(config, activations, weight)
+        overlap = args.mode == "two-chip-overlap"
+        if args.workload == "full-mlp":
+            if args.mode == "single":
+                run = lambda: workload.run_single_chip(config, operands)
+                prepare = lambda: workload.prepare_single_chip(config, operands)
+            else:
+                run = lambda: workload.run_two_chip(config, operands, overlap)
+                prepare = lambda: workload.prepare_two_chip(config, operands, overlap)
+        elif args.mode == "single":
+            run = lambda: workload.run_single_chip(config, *operands)
+            prepare = lambda: workload.prepare_single_chip(config, *operands)
         else:
-            overlap = args.mode == "two-chip-overlap"
-            run = lambda: workload.run_two_chip(
-                config,
-                activations,
-                weight,
-                overlap=overlap,
-            )
+            run = lambda: workload.run_two_chip(config, *operands, overlap)
+            prepare = lambda: workload.prepare_two_chip(config, *operands, overlap)
+
+        def normalize(result):
+            if tuple(result.shape) != tuple(expected.shape):
+                raise ValueError(
+                    f"result shape {tuple(result.shape)} does not match "
+                    f"golden shape {tuple(expected.shape)}"
+                )
+            return result
+
         result = None
         warmup_context = contextlib.nullcontext()
         if args.device_profile_dir:
@@ -259,19 +402,59 @@ def main():
             warmup_context = _silence_native_output(
                 str(args.device_profile_dir / "native_compile.log")
             )
-        with warmup_context:
-            for _ in range(args.warmup):
+        if args.lifecycle == "rebuilt":
+            with warmup_context:
+                for _ in range(args.warmup):
+                    _Builder.reset()
+                    result = normalize(run())
+            for iteration in range(args.iterations):
                 _Builder.reset()
-                result = run()
-        for iteration in range(args.iterations):
+                begin = time.perf_counter_ns()
+                result = normalize(run())
+                total_ms = (time.perf_counter_ns() - begin) / 1_000_000
+                print(
+                    f"iteration={iteration + 1} mode={args.mode} "
+                    f"pcc={_pcc(result, expected):.6f} total_ms={total_ms:.3f}",
+                    flush=True,
+                )
             _Builder.reset()
-            result = run()
-            print(
-                f"iteration={iteration + 1} mode={args.mode} "
-                f"pcc={_pcc(result, expected):.6f}",
-                flush=True,
-            )
-        _Builder.reset()
+        else:
+            _Builder.reset()
+            begin = time.perf_counter_ns()
+            executable = prepare()
+            prepare_ms = (time.perf_counter_ns() - begin) / 1_000_000
+            print(f"prepare_ms={prepare_ms:.3f}", flush=True)
+            try:
+                with warmup_context:
+                    for _ in range(args.warmup):
+                        result = normalize(executable.run()[0])
+                for iteration in range(args.iterations):
+                    total_begin = time.perf_counter_ns()
+                    begin = time.perf_counter_ns()
+                    submitted = executable.submit()
+                    submit_ms = (time.perf_counter_ns() - begin) / 1_000_000
+                    begin = time.perf_counter_ns()
+                    executable.wait(submitted)
+                    wait_ms = (time.perf_counter_ns() - begin) / 1_000_000
+                    begin = time.perf_counter_ns()
+                    result = normalize(executable.readback(submitted)[0])
+                    readback_ms = (time.perf_counter_ns() - begin) / 1_000_000
+                    total_ms = (time.perf_counter_ns() - total_begin) / 1_000_000
+                    print(
+                        f"iteration={iteration + 1} mode={args.mode} "
+                        f"pcc={_pcc(result, expected):.6f} "
+                        f"submit_ms={submit_ms:.3f} wait_ms={wait_ms:.3f} "
+                        f"readback_ms={readback_ms:.3f} total_ms={total_ms:.3f}",
+                        flush=True,
+                    )
+                print(
+                    f"program_cache_entries={executable.program_cache_entries} "
+                    f"input_reuse_stats={executable.input_reuse_stats}",
+                    flush=True,
+                )
+            finally:
+                executable.close()
+            _Builder.reset()
 
     if args.tracy_file:
         tracy_csv = _export_tracy(args.tracy_file)
@@ -281,7 +464,21 @@ def main():
     if args.device_profile_dir:
         profile_csv = args.device_profile_dir / ".logs" / "profile_log_device.csv"
         kernel_ns = _device_kernel_ns(profile_csv, args.warmup, args.iterations)
+        timing_samples = _device_timing_samples(
+            profile_csv, args.warmup, args.iterations
+        )
         print(f"device longest_kernel_ns={kernel_ns}")
+        critical_samples = timing_samples["critical_path_ns"]
+        active_samples = timing_samples["active_program_ns"]
+        if critical_samples:
+            print(
+                "device critical_path_ns="
+                f"{critical_samples} mean_ns={sum(critical_samples) / len(critical_samples)}"
+            )
+            print(
+                "device active_program_ns="
+                f"{active_samples} mean_ns={sum(active_samples) / len(active_samples)}"
+            )
         print(f"device profile: {profile_csv}")
 
 

--- a/test/d2m-jit/test_matmul.py
+++ b/test/d2m-jit/test_matmul.py
@@ -95,6 +95,24 @@ def test_matmul_compiles_and_runs():
     assert result.dtype == torch.float32
 
 
+def test_kernel_call_has_profiler_location():
+    lhs = torch.eye(64, dtype=torch.float32)
+    rhs = torch.eye(64, dtype=torch.float32)
+    layout = _make_layout()
+    output = d2m.empty(layout)
+    matmul_kernel(
+        d2m.to_layout(lhs, layout),
+        d2m.to_layout(rhs, layout),
+        output,
+        1,
+        1,
+        grid=(2, 2),
+    )
+
+    assert output.value.owner.name == "d2m.generic"
+    assert str(output.value.owner.location) == 'loc("matmul_kernel")'
+
+
 def test_matmul_correctness_single_tile_multicore():
     """Per-shard 32x32 matmul: each core's shard is exactly one tile, so
     the kernel emits a single `tile_matmul` per shard. Comparing against
@@ -182,6 +200,51 @@ def test_matmul_correctness_multi_k_bf16_accumulator():
         grid=(1, 1),
     )
     assert_pcc(lhs.float() @ rhs.float(), out.to_host().float(), threshold=0.99)
+
+
+def test_prepared_matmul_reuses_program_and_immutable_rhs():
+    torch.manual_seed(0)
+    lhs = torch.randn(32, 64, dtype=torch.bfloat16) * 0.125
+    rhs = torch.randn(64, 32, dtype=torch.bfloat16) * 0.125
+    lhs_layout = d2m.Layout(
+        shape=(32, 64),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    rhs_layout = d2m.Layout(
+        shape=(64, 32),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    out_layout = d2m.Layout(
+        shape=(32, 32),
+        dtype=d2m.bfloat16,
+        block_shape=[1, 1],
+        grid_shape=[1, 1],
+    )
+    out = d2m.empty(out_layout)
+    matmul_multi_k_bf16_kernel(
+        d2m.to_layout(lhs, lhs_layout),
+        d2m.to_layout(rhs, rhs_layout),
+        out,
+        2,
+        grid=(1, 1),
+    )
+    executable = d2m.prepare(out, reusable_inputs=(rhs,))
+    try:
+        first_expected = lhs.float() @ rhs.float()
+        first = executable.run()[0]
+        lhs.copy_(torch.linspace(-0.25, 0.25, lhs.numel()).reshape_as(lhs))
+        second_expected = lhs.float() @ rhs.float()
+        second = executable.run()[0]
+        assert_pcc(first_expected, first.float(), threshold=0.99)
+        assert_pcc(second_expected, second.float(), threshold=0.99)
+        assert executable.program_cache_entries > 0
+        assert list(executable.input_reuse_stats.values())[0]["cache_hits"] == 1
+    finally:
+        executable.close()
 
 
 def test_matmul_correctness_tiled_mnk_loop_carried_accumulator():

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -670,3 +670,41 @@ def test_llama_down_projection_all_reduce_1x2(overlap):
     activations, weight = make_operands(config)
     result = run_two_chip(config, activations, weight, overlap=overlap)
     assert_pcc(golden(activations, weight), result, threshold=0.99)
+
+
+@requires_fabric_mesh
+@pytest.mark.parametrize("overlap", [False, True], ids=["serialized", "overlapped"])
+def test_prepared_llama_mlp_1x2(overlap):
+    from llama_mlp_workload import (
+        WorkloadConfig,
+        golden,
+        make_operands,
+        prepare_two_chip,
+    )
+
+    config = WorkloadConfig(
+        m=128,
+        hidden=512,
+        intermediate=1024,
+        grid_y=2,
+        grid_x=2,
+        projection_k_block_tiles=8,
+        down_k_block_tiles=4,
+    )
+    operands = make_operands(config)
+    executable = prepare_two_chip(config, operands, overlap)
+    try:
+        first = executable.run()[0]
+        assert tuple(first.shape) == (config.m, config.hidden)
+        assert_pcc(golden(*operands), first, threshold=0.99)
+        cache_entries = executable.program_cache_entries
+        second = executable.run()[0]
+        assert tuple(second.shape) == (config.m, config.hidden)
+        assert_pcc(golden(*operands), second, threshold=0.99)
+        assert executable.program_cache_entries == cache_entries
+        assert cache_entries > 0
+        assert all(
+            stats["cache_hits"] == 1 for stats in executable.input_reuse_stats.values()
+        )
+    finally:
+        executable.close()

--- a/test/d2m-jit/test_multichip_overlap_benchmark.py
+++ b/test/d2m-jit/test_multichip_overlap_benchmark.py
@@ -4,8 +4,18 @@
 
 import torch
 
-from multichip_overlap_benchmark import _device_kernel_ns, _summarize_tracy
+from multichip_overlap_benchmark import (
+    _device_critical_path_ns,
+    _device_kernel_ns,
+    _device_timing_samples,
+    _summarize_tracy,
+)
 from llama_down_projection_workload import WorkloadConfig, golden, make_operands
+from llama_mlp_workload import (
+    WorkloadConfig as MlpWorkloadConfig,
+    golden as mlp_golden,
+    make_operands as make_mlp_operands,
+)
 
 
 def test_down_projection_tensor_parallel_partition_matches_dense_matmul():
@@ -33,6 +43,36 @@ def test_down_projection_tensor_parallel_partition_matches_dense_matmul():
     assert pcc > 0.999
 
 
+def test_mlp_tensor_parallel_partition_matches_dense_mlp():
+    config = MlpWorkloadConfig(
+        m=128,
+        hidden=512,
+        intermediate=1024,
+        grid_y=2,
+        grid_x=2,
+        projection_k_block_tiles=8,
+        down_k_block_tiles=4,
+    )
+    hidden, gate_weight, up_weight, down_weight, residual = make_mlp_operands(config)
+    partials = []
+    for device in range(2):
+        begin = device * config.local_intermediate
+        end = begin + config.local_intermediate
+        gate = (hidden.float() @ gate_weight[:, begin:end].float()).to(torch.bfloat16)
+        up = (hidden.float() @ up_weight[:, begin:end].float()).to(torch.bfloat16)
+        activated = (torch.nn.functional.silu(gate.float()) * up.float()).to(
+            torch.bfloat16
+        )
+        partials.append(activated.float() @ down_weight[begin:end].float())
+    actual = (partials[0] + partials[1]).to(torch.bfloat16) + residual
+    expected = mlp_golden(hidden, gate_weight, up_weight, down_weight, residual)
+    pcc = torch.corrcoef(
+        torch.stack((actual.float().flatten(), expected.float().flatten()))
+    )[0, 1].item()
+
+    assert pcc > 0.999
+
+
 def test_device_kernel_ns_excludes_warmup(tmp_path):
     profile_csv = tmp_path / "profile_log_device.csv"
     profile_csv.write_text(
@@ -49,6 +89,46 @@ def test_device_kernel_ns_excludes_warmup(tmp_path):
     assert _device_kernel_ns(profile_csv, warmup=1, iterations=1) == 130
 
 
+def test_device_critical_path_spans_every_program(tmp_path):
+    profile_csv = tmp_path / "profile_log_device.csv"
+    profile_csv.write_text(
+        "ARCH: wormhole_b0, CHIP_FREQ[MHz]: 1000, Max Compute Cores: 64\n"
+        "device id,core_x,core_y,RISC processor type,timer_id,"
+        "time[cycles since reset],data,run host ID,trace id,trace id counter,"
+        "zone name,type,source line,source file,meta data\n"
+        "0,1,1,TRISC,1,100,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,200,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+        "0,1,1,TRISC,1,300,0,8,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,450,0,8,,,TRISC-KERNEL,ZONE_END,0,,\n"
+        "0,1,1,TRISC,1,1000,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,1130,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+        "0,1,1,TRISC,1,1200,0,8,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,1400,0,8,,,TRISC-KERNEL,ZONE_END,0,,\n"
+    )
+
+    timings = _device_timing_samples(profile_csv, warmup=1, iterations=1)
+    assert timings == {
+        "critical_path_ns": [400],
+        "active_program_ns": [330],
+    }
+
+
+def test_device_critical_path_compares_per_device_spans(tmp_path):
+    profile_csv = tmp_path / "profile_log_device.csv"
+    profile_csv.write_text(
+        "ARCH: wormhole_b0, CHIP_FREQ[MHz]: 1000, Max Compute Cores: 64\n"
+        "PCIe slot,core_x,core_y,RISC processor type,timer_id,"
+        "time[cycles since reset],data,run host ID,trace id,trace id counter,"
+        "zone name,type,source line,source file,meta data\n"
+        "0,1,1,TRISC,1,100,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "0,1,1,TRISC,1,400,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+        "1,1,1,TRISC,1,10000,0,7,,,TRISC-KERNEL,ZONE_START,0,,\n"
+        "1,1,1,TRISC,1,10200,0,7,,,TRISC-KERNEL,ZONE_END,0,,\n"
+    )
+
+    assert _device_critical_path_ns(profile_csv, warmup=0, iterations=1) == [300]
+
+
 def test_tracy_summary_aggregates_zones_per_submit(tmp_path, capsys):
     tracy_csv = tmp_path / "trace.csv"
     tracy_csv.write_text(
@@ -60,6 +140,8 @@ def test_tracy_summary_aggregates_zones_per_submit(tmp_path, capsys):
         "submit,,, , ,1200,2000,1,\n"
         "MeshShardCommand,,, , ,1300,400,1,\n"
         "MeshShardCommand,,, , ,1800,600,1,\n"
+        "EnqueueProgramCommand,,,,local_projection,1400,300,1,\n"
+        "EnqueueProgramCommand,,,,local_projection,1900,200,1,\n"
     )
 
     _summarize_tracy(tracy_csv, measured_iterations=1)
@@ -67,3 +149,6 @@ def test_tracy_summary_aggregates_zones_per_submit(tmp_path, capsys):
     output = capsys.readouterr().out
     assert "tracy submit: count=1 mean_us=2.0" in output
     assert "MeshShardCommand: count_per_submit=2 mean_total_us=1.0" in output
+    assert (
+        "tracy program local_projection: count_per_submit=2 mean_total_us=0.5" in output
+    )

--- a/test/python/golden/d2m/test_program_cache.py
+++ b/test/python/golden/d2m/test_program_cache.py
@@ -91,9 +91,9 @@ def test_repeated_submission_with_dynamic_inputs(
     cold_cache_entries = device.get_num_program_cache_entries()
     assert cold_cache_entries > 0
 
-    # Normal lowering refreshes cached bindings. Forced compile-time lowering
-    # rebuilds programs whose kernels bake in allocation-dependent addresses,
-    # while address-independent programs in the command queue remain eligible.
+    # Both forms reuse programs because the binary-scoped allocation plan keeps
+    # compile-time addresses stable across submissions; runtime bindings are
+    # refreshed for the normal lowering.
     warm_lhs = torch.linspace(-1.0, 1.0, shape[0] * shape[1], dtype=dtype).reshape(
         shape
     )

--- a/test/ttmlir/Dialect/D2M/mesh_shard_canonicalize.mlir
+++ b/test/ttmlir/Dialect/D2M/mesh_shard_canonicalize.mlir
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt %s --canonicalize | FileCheck %s
+
+module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
+  func.func @preserve_mesh_annotation(%arg0: tensor<32x32xbf16>) -> tensor<32x32xbf16, #ttcore.tensor_mesh<"mesh">> {
+    %0 = d2m.mesh_shard %arg0 {shard_dims = array<i64: -1, -1>, shard_direction = #ttcore.shard_direction<full_to_shard>, shard_shape = array<i64: 1, 1>, shard_type = #ttcore.shard_type<devices>} : tensor<32x32xbf16> -> tensor<32x32xbf16, #ttcore.tensor_mesh<"mesh">>
+    return %0 : tensor<32x32xbf16, #ttcore.tensor_mesh<"mesh">>
+  }
+}
+
+// CHECK-LABEL: func.func @preserve_mesh_annotation
+// CHECK: d2m.mesh_shard

--- a/tools/d2m-jit/README.md
+++ b/tools/d2m-jit/README.md
@@ -110,11 +110,19 @@ MLIR `Context`, `Module`, and an open `func.func`. Every call to
 ops to that open function. The graph **is** the MLIR module — there is no
 separate Python-side IR.
 
-The builder lifecycle is:
+The one-shot builder lifecycle is:
 
 1. Lazy-created on the first lazy-tensor construction.
 2. Reset by `to_host(*lts)`: emits returns, runs the pass pipeline, executes
    the resulting flatbuffer on a mesh device, drops the module.
+
+For repeated execution, `d2m.prepare(*lts, reusable_inputs=...)` runs the
+compiler pipeline once and opens a persistent mesh with TT-Metal's program
+cache enabled. The returned `PreparedExecutable` supports `submit`, `wait`,
+`readback`, and `run`; close it explicitly or use it as a context manager.
+Torch tensors listed in `reusable_inputs` are immutable for the executable's
+lifetime: their converted device buffers are retained after the first run and
+rebound on later runs.
 
 After reset, every `LazyTensor` produced by the dropped builder generation is
 "spent":
@@ -177,6 +185,7 @@ kernel body.
 | `d2m.permute(lt, *dims)` | `torch.permute`-style positional permutation. |
 | `d2m.reshape(lt, *new_shape)` | `torch.reshape`-style logical-shape change. A single `-1` dim is inferred from the others. Currently a host roundtrip (`to_host` -> `torch.reshape` -> `to_layout`); pays a DRAM transfer. Use for shape changes not expressible as a `view`. |
 | `d2m.spatial(inputs, outputs, grid_ranges, region_builders)` | Emit a `d2m.spatial` wrapper around one `@d2m.kernel` call per disjoint core range. |
+| `d2m.prepare(*lts, reusable_inputs=())` | Compile once and return a persistent `PreparedExecutable` for repeated submissions. |
 | `d2m.to_host(*lts)` | Compile and execute; return a tuple of `torch.Tensor`s. Resets the builder. |
 | `LazyTensor.to_host()` | Sugar for `to_host(self)[0]`. |
 
@@ -413,11 +422,13 @@ D2M_JIT_RUN_FABRIC_STRESS=1 \
 pytest test/d2m-jit/test_mesh.py
 ```
 
-The BF16 Llama 3 8B prefill down-projection benchmark compares the same dense
-`576x14336 @ 14336x4096` operation on one chip and with two-way K-sharded
-tensor parallelism. The two-chip modes provide serialized and overlapped
-matmul/all-reduce schedules. They can capture host/runtime Tracy zones when the
-runtime was built with `TT_RUNTIME_ENABLE_PERF_TRACE=ON`:
+The BF16 Llama 3 8B prefill benchmark defaults to the full gated MLP at
+`M=576`, hidden size `4096`, and intermediate size `14336`. Its two-chip modes
+column-shard the gate/up projections, keep the gated activation local, then
+row-shard the down projection and compare serialized and overlapped all-reduce
+schedules. `--workload down-projection` selects the isolated down projection.
+The default prepared lifecycle separates one-time compilation/device setup
+from steady-state invocation and retains the three immutable weights:
 
 ```bash
 export SYSTEM_DESC_PATH=/path/to/two-chip.ttsys
@@ -430,8 +441,10 @@ python test/d2m-jit/multichip_overlap_benchmark.py two-chip-overlap \
 ```
 
 Pass `--device-profile-dir DIR` to collect the matching tt-metal device
-timeline. Tracy summaries exclude warmup iterations; the device summary reports
-the longest kernel envelope in the captured warmup and measured iterations.
+timeline. Tracy reports the prepare, invoke, wait, and readback lifecycle zones
+and command composition for measured iterations. The device summary excludes
+warmup and reports the longest individual kernel, summed program activity on
+the critical chip, and the end-to-end kernel schedule span for each invocation.
 
 ## Pipeline
 

--- a/tools/d2m-jit/_src/builder.py
+++ b/tools/d2m-jit/_src/builder.py
@@ -1198,7 +1198,8 @@ def mesh(shape, topology=None):
 
 
 def _emit_mesh_shard(b, value, dst_ty, direction, shard_dims, shard_shape):
-    shard_type = Attribute.parse("#ttcore.shard_type<devices>", b.ctx)
+    shard_type_name = "replicate" if all(dim == -1 for dim in shard_dims) else "devices"
+    shard_type = Attribute.parse(f"#ttcore.shard_type<{shard_type_name}>", b.ctx)
     shard_direction = Attribute.parse(f"#ttcore.shard_direction<{direction}>", b.ctx)
     return d2m.mesh_shard(
         dst_ty,
@@ -1747,81 +1748,184 @@ def _maybe_enable_perf_trace():
     )
 
 
-def _execute(b: _Builder, lts):
-    """Serialize to flatbuffer, run on a mesh device, return torch tensors."""
-    if runtime is None or binary is None:
-        raise RuntimeError("ttmlir runtime is not available in this build")
-    _maybe_enable_perf_trace()
-    bin_capsule = ttmetal_to_flatbuffer_bin(b.module)
-    fbb = binary.load_binary_from_capsule(bin_capsule)
-    if config.save_flatbuffer_path:
-        fbb.store(config.save_flatbuffer_path)
-        print(f"[d2m-jit] flatbuffer written to {config.save_flatbuffer_path}")
-    program_index = 0
-    device_options = runtime.MeshDeviceOptions()
-    device_options.mesh_shape = fbb.get_program_mesh_shape(program_index)
-    runtime.set_compatible_device_runtime(fbb)
+class PreparedExecutable:
+    """Compiled D2M graph with a persistent mesh device and runtime inputs."""
 
-    # Marshal inputs from the torch tensors / scalars gathered during graph build.
-    rt_inputs = []
-    for t in b.host_tensors:
-        if isinstance(t, int) and not isinstance(t, bool):
-            rt_inputs.append(runtime.create_scalar_tensor(t))
-            continue
-        rt_inputs.append(
-            runtime.create_borrowed_host_tensor(
-                t.data_ptr(),
-                list(t.shape),
-                list(t.stride()),
-                t.element_size(),
-                _to_runtime_data_type(t.dtype),
+    def __init__(self, builder, outputs, reusable_inputs):
+        if runtime is None or binary is None:
+            raise RuntimeError("ttmlir runtime is not available in this build")
+        _maybe_enable_perf_trace()
+        bin_capsule = ttmetal_to_flatbuffer_bin(builder.module)
+        self.binary = binary.load_binary_from_capsule(bin_capsule)
+        runtime.set_compatible_device_runtime(self.binary)
+        if config.save_flatbuffer_path:
+            self.binary.store(config.save_flatbuffer_path)
+            print(f"[d2m-jit] flatbuffer written to {config.save_flatbuffer_path}")
+
+        self.program_index = 0
+        self._host_tensors = tuple(builder.host_tensors)
+        reusable_ids = {id(tensor) for tensor in reusable_inputs}
+        available_ids = {
+            id(tensor)
+            for tensor in self._host_tensors
+            if not (isinstance(tensor, int) and not isinstance(tensor, bool))
+        }
+        missing = reusable_ids - available_ids
+        if missing:
+            raise ValueError(
+                "reusable_inputs must contain tensors used to build this graph"
             )
-        )
 
-    # Allocate output torch tensors and borrowed host wrappers.
-    out_torch = []
-    rt_outputs = []
-    for lt in lts:
-        torch_dtype = _ttcore_to_torch_dtype(lt.layout.dtype)
-        output_shape = (
-            lt.mesh.full_shape if lt.mesh is not None else lt.layout.logical_shape
-        )
-        t_out = torch.empty(list(output_shape), dtype=torch_dtype)
-        out_torch.append(t_out)
-        rt_outputs.append(
-            runtime.create_borrowed_host_tensor(
-                t_out.data_ptr(),
-                list(t_out.shape),
-                list(t_out.stride()),
-                t_out.element_size(),
-                _to_runtime_data_type(t_out.dtype),
+        self.runtime_inputs = []
+        self._reusable_input_indices = []
+        for index, tensor in enumerate(self._host_tensors):
+            if isinstance(tensor, int) and not isinstance(tensor, bool):
+                runtime_input = runtime.create_scalar_tensor(tensor)
+            else:
+                runtime_input = runtime.create_borrowed_host_tensor(
+                    tensor.data_ptr(),
+                    list(tensor.shape),
+                    list(tensor.stride()),
+                    tensor.element_size(),
+                    _to_runtime_data_type(tensor.dtype),
+                )
+                if id(tensor) in reusable_ids:
+                    runtime_input.set_reusable(True)
+                    self._reusable_input_indices.append(index)
+            self.runtime_inputs.append(runtime_input)
+
+        self._output_specs = []
+        for output in outputs:
+            output_shape = (
+                output.mesh.full_shape
+                if output.mesh is not None
+                else output.layout.logical_shape
             )
-        )
-
-    device = None
-    fabric_enabled = False
-    try:
-        if b._fabric_runtime_mode is not None:
-            runtime.set_fabric_config(
-                getattr(runtime.FabricConfig, b._fabric_runtime_mode)
+            self._output_specs.append(
+                (tuple(output_shape), _ttcore_to_torch_dtype(output.layout.dtype))
             )
-            fabric_enabled = True
 
-        device = runtime.open_mesh_device(device_options)
-        submitted = runtime.submit(device, fbb, program_index, rt_inputs)
-        runtime.wait(submitted)
-        for i, rt_out in enumerate(submitted):
-            host_view = runtime.to_host(rt_out, untilize=True)[0]
-            runtime.memcpy(rt_outputs[i], host_view)
-            runtime.deallocate_tensor(rt_out, force=True)
-        return out_torch
-    finally:
+        device_options = runtime.MeshDeviceOptions()
+        device_options.mesh_shape = self.binary.get_program_mesh_shape(
+            self.program_index
+        )
+        device_options.enable_program_cache = True
+        self.device = None
+        self._fabric_enabled = builder._fabric_runtime_mode is not None
         try:
-            if device is not None:
-                runtime.close_mesh_device(device)
-        finally:
-            if fabric_enabled:
+            if self._fabric_enabled:
+                runtime.set_fabric_config(
+                    getattr(runtime.FabricConfig, builder._fabric_runtime_mode)
+                )
+            self.device = runtime.open_mesh_device(device_options)
+        except Exception:
+            if self._fabric_enabled:
                 runtime.set_fabric_config(runtime.FabricConfig.DISABLED)
+            raise
+
+    def submit(self):
+        if self.device is None:
+            raise RuntimeError("prepared executable is closed")
+        return runtime.submit(
+            self.device,
+            self.binary,
+            self.program_index,
+            self.runtime_inputs,
+        )
+
+    def wait(self, submitted):
+        runtime.wait(submitted)
+
+    def readback(self, submitted):
+        outputs = []
+        for runtime_output, (shape, dtype) in zip(
+            submitted, self._output_specs, strict=True
+        ):
+            output = torch.empty(shape, dtype=dtype)
+            runtime_host = runtime.create_borrowed_host_tensor(
+                output.data_ptr(),
+                list(output.shape),
+                list(output.stride()),
+                output.element_size(),
+                _to_runtime_data_type(output.dtype),
+            )
+            host_view = runtime.to_host(runtime_output, untilize=True)[0]
+            runtime.memcpy(runtime_host, host_view)
+            runtime.deallocate_tensor(runtime_output, force=True)
+            outputs.append(output)
+        return tuple(outputs)
+
+    def run(self, readback=True):
+        submitted = self.submit()
+        self.wait(submitted)
+        if readback:
+            return self.readback(submitted)
+        for runtime_output in submitted:
+            runtime.deallocate_tensor(runtime_output, force=True)
+        return ()
+
+    @property
+    def program_cache_entries(self):
+        if self.device is None:
+            raise RuntimeError("prepared executable is closed")
+        return self.device.get_num_program_cache_entries()
+
+    @property
+    def input_reuse_stats(self):
+        return {
+            index: self.runtime_inputs[index].get_reuse_stats()
+            for index in self._reusable_input_indices
+        }
+
+    def close(self):
+        if self.device is None:
+            return
+        try:
+            runtime.close_mesh_device(self.device)
+        finally:
+            self.device = None
+            if self._fabric_enabled:
+                runtime.set_fabric_config(runtime.FabricConfig.DISABLED)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+
+def prepare(*lts: LazyTensor, reusable_inputs=()):
+    """Compile a lazy graph once for repeated execution on one open mesh."""
+    if not lts:
+        raise ValueError("prepare requires at least one LazyTensor")
+
+    builder = _get_scope()
+    if not isinstance(builder, _Builder):
+        raise RuntimeError("prepare() requires the top-level lazy builder")
+    resolved = [lt._resolve() for lt in lts]
+    for index, output in enumerate(resolved):
+        if output.is_view:
+            raise ValueError(
+                f"prepare: argument {index} is a view; convert it to a concrete "
+                "layout before preparing the graph"
+            )
+    assert all(output.generation == builder.generation for output in resolved)
+
+    _emit_returns_and_finalise(builder, resolved)
+    builder.module.operation.verify()
+    _run_pipeline(builder)
+    executable = PreparedExecutable(builder, resolved, tuple(reusable_inputs))
+    _Builder.reset()
+    return executable
+
+
+def _execute(b: _Builder, lts):
+    """Compile and execute a graph once, returning materialized torch tensors."""
+    executable = PreparedExecutable(b, lts, ())
+    try:
+        return list(executable.run())
+    finally:
+        executable.close()
 
 
 def to_host(*lts: LazyTensor):
@@ -2190,8 +2294,12 @@ def _emit_kernel_generic(
         compiler.visit(kernel._ast)
         compiler.module.operation.verify()
 
+    # The generic's name location survives lowering into the runtime command
+    # and identifies the kernel call in host and device profiler timelines.
+    kernel_loc = Location.name(kernel.fn.__name__, context=b.ctx)
+
     # Emit the GenericOp + splice the kernel body.
-    with b.ctx, b.loc, b.insert_point:
+    with b.ctx, kernel_loc, b.insert_point:
         # Scalars come from func args; semaphores reuse their host-scope
         # create_global_semaphore results.
         additional = [
@@ -2233,6 +2341,7 @@ def _emit_kernel_generic(
             threads,
             1,  # num_regions
             fabricConnectionConfig=fabric_attr,
+            loc=kernel_loc,
         )
 
         region = generic.regions[0]

--- a/tools/d2m-jit/api.py
+++ b/tools/d2m-jit/api.py
@@ -30,7 +30,9 @@ from ._src.builder import (
     GlobalSemaphore,
     LazyTensor,
     MeshShard,
+    PreparedExecutable,
     fabric_config,
+    prepare,
     reduction_layout,
     arange,
     view_layout,
@@ -50,7 +52,6 @@ from ._src.rewrite import (
     infer_layout,
     apply_patterns,
 )
-
 
 # --- Backend dispatch (config.backend) --------------------------------------
 #
@@ -1032,6 +1033,25 @@ def _empty_like_op(input):
     """Kernel-body uninitialized L1 scratch block matching `input`."""
     block_ty = input.type
     return tensor.empty(list(block_ty.shape), block_ty.element_type)
+
+
+@syntax("tilize_block")
+def _tilize_block_op(input):
+    """Convert one row-major BF16 block to a block of 32x32 tiles."""
+    if not isinstance(input.type.element_type, BF16Type):
+        raise TypeError(
+            "tilize_block currently requires BF16 input, got "
+            f"{input.type.element_type}"
+        )
+    shape = list(input.type.shape)
+    if len(shape) != 2 or any(dim % 32 for dim in shape):
+        raise ValueError(
+            "tilize_block requires a rank-2 shape divisible by 32, got " f"{shape}"
+        )
+    tile_ty = ttcore.ir.TileType.get(input.context, 32, 32, ttcore.DataType.BFloat16)
+    result_ty = RankedTensorType.get([dim // 32 for dim in shape], tile_ty)
+    output = tensor.empty(list(result_ty.shape), result_ty.element_type)
+    return _as_value(d2m.tile_tilize_block(result_ty, input, output))
 
 
 def _bool_attr_from_ast(node):


### PR DESCRIPTION
## Summary

- scale the cached BF16 workload to the complete Llama 3 8B prefill MLP: gate/up projections, SiLU gating, row-sharded down projection, inter-device reduction, and residual add
- stream large DRAM weights through legal block-sized tilization and preserve replicated mesh-shard semantics through compiler/runtime lowering
- use prepared execution, program caching, and immutable weight reuse from #9096/#9156
- report single-chip, serialized two-chip, and overlapped two-chip correctness and end-to-end performance

## Representative N300 result

| Mode | Mean wall time | Effective throughput | PCC |
| --- | ---: | ---: | ---: |
| Single chip | 93.266 ms | 2.176 TFLOP/s | 0.999636 |
| Two-chip serialized | 87.193 ms | 2.327 TFLOP/s | 0.999641 |
| Two-chip overlapped | 85.277 ms | 2.380 TFLOP/s | 0.999641 |

## Stack

Depends on #9184. The final draft contains the block-level timeline and raw fabric saturation experiments.

## Validation

- `pytest -q test/d2m-jit/test_multichip_overlap_benchmark.py` (7 passed on the reconstructed stack)
- prepared full-MLP and down-projection N300 correctness/performance runs completed before the split
- reconstructed stack passes `pre-commit run --all-files`

Split from #9170 so the full-model scaling changes can be reviewed independently.