### PR TITLE
[StableHLO] Support 3D scaled_dot_product_attention in lowering and sharding rule

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -1656,7 +1656,8 @@ public:
 //
 // Operand/attribute mapping:
 //   - Operands: [query, key, value] or [query, key, value, attention_mask].
-//     Shapes are passed through unchanged; the TTIR generic verifier enforces
+//     4D shapes are passed through unchanged; 3D query/key/value are promoted
+//     to 4D with a unit head dim. The TTIR generic verifier enforces
 //     [B, Hq, Sq, D] / [B, Hkv, Sk, D] / [1|B, 1|Hq, Sq, Sk] layouts.
 //   - Attributes: only `is_causal` and `scale` are forwarded from the
 //     composite. Other attributes that PyTorch SDPA may set
@@ -1707,12 +1708,41 @@ static LogicalResult convertToTTIRScaledDotProductAttention(
     }
   }
 
+  auto queryType = mlir::cast<RankedTensorType>(operands[0].getType());
+  int64_t queryRank = queryType.getRank();
+  if (queryRank != 3 && queryRank != 4) {
+    return rewriter.notifyMatchFailure(srcOp, "query rank must be 3 or 4");
+  }
+  bool needsHeadDim = queryRank == 3;
+  if (needsHeadDim) {
+    for (Value operand : operands.take_front(3)) {
+      if (mlir::cast<RankedTensorType>(operand.getType()).getRank() != 3) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "query, key and value must all have the same rank");
+      }
+    }
+  }
+
+  auto insertHeadDim = [&](Value value) -> Value {
+    auto type = mlir::cast<RankedTensorType>(value.getType());
+    SmallVector<int64_t> shape(type.getShape().begin(), type.getShape().end());
+    shape.insert(shape.begin() + 1, 1);
+    auto promotedType = RankedTensorType::get(shape, type.getElementType());
+    return rewriter.create<ttir::ReshapeOp>(
+        srcOp->getLoc(), promotedType, value,
+        rewriter.getI32ArrayAttr(llvm::to_vector_of<int32_t>(shape)));
+  };
+
   // The first 3 operands are always query, key, value. A 4th operand
   // (attention_mask) is present only when is_causal is false.
   bool hasAttnMask = !isCausal && numOperands == 4;
   SmallVector<Value> sdpaOperands = {operands[0], operands[1], operands[2]};
+  if (needsHeadDim) {
+    for (Value &operand : sdpaOperands) {
+      operand = insertHeadDim(operand);
+    }
+  }
   if (hasAttnMask) {
-    // Left-pad mask with unit dims to 4D — matches PyTorch broadcast semantics.
     Value mask = operands[3];
     auto maskType = mlir::cast<RankedTensorType>(mask.getType());
     int64_t maskRank = maskType.getRank();
@@ -1720,7 +1750,12 @@ static LogicalResult convertToTTIRScaledDotProductAttention(
       return rewriter.notifyMatchFailure(srcOp,
                                          "attention_mask rank must be <= 4");
     }
-    if (maskRank < 4) {
+    if (needsHeadDim && maskRank == 3) {
+      // A [B, Sq, Sk] mask takes the head dim in the same position as query.
+      mask = insertHeadDim(mask);
+    } else if (maskRank < 4) {
+      // Left-pad mask with unit dims to 4D — matches PyTorch broadcast
+      // semantics.
       SmallVector<int64_t> paddedShape(4 - maskRank, 1);
       paddedShape.append(maskType.getShape().begin(),
                          maskType.getShape().end());
@@ -1739,8 +1774,25 @@ static LogicalResult convertToTTIRScaledDotProductAttention(
   namedAttrs.push_back(rewriter.getNamedAttr(
       "operandSegmentSizes", rewriter.getDenseI32ArrayAttr(segmentSizes)));
 
-  rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
-      srcOp, outputType, sdpaOperands, namedAttrs);
+  if (!needsHeadDim) {
+    rewriter.replaceOpWithNewOp<ttir::ScaledDotProductAttentionOp>(
+        srcOp, outputType, sdpaOperands, namedAttrs);
+    return success();
+  }
+
+  SmallVector<int64_t> promotedShape(outputType.getShape().begin(),
+                                     outputType.getShape().end());
+  promotedShape.insert(promotedShape.begin() + 1, 1);
+  auto promotedOutputType =
+      RankedTensorType::get(promotedShape, outputType.getElementType());
+
+  Value sdpaResult = rewriter.create<ttir::ScaledDotProductAttentionOp>(
+      srcOp->getLoc(), promotedOutputType, sdpaOperands, namedAttrs);
+
+  rewriter.replaceOpWithNewOp<ttir::ReshapeOp>(
+      srcOp, outputType, sdpaResult,
+      rewriter.getI32ArrayAttr(
+          llvm::to_vector_of<int32_t>(outputType.getShape())));
   return success();
 }
 

--- a/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RegisterCustomShardingRule.cpp
@@ -177,6 +177,42 @@ getSDPAShardingRule(mlir::stablehlo::CustomCallOp op) {
     return mlir::sdy::OpShardingRuleAttr();
   }
 
+  // 3D SDPA is [B, S, D], a single implicit head. S and D are the
+  // softmax/contraction axes, so only batch can be sharded.
+  if (qType.getRank() == 3) {
+    if (kType.getRank() != 3 || vType.getRank() != 3 ||
+        outType.getRank() != 3) {
+      op.getOperation()->emitWarning()
+          << "SDPA requires Q/K/V/Out to have the same rank";
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+
+    ArrayRef<int64_t> qShape3D = qType.getShape();
+    if (qShape3D != outType.getShape() ||
+        kType.getShape() != vType.getShape() || qShape3D != kType.getShape()) {
+      op.getOperation()->emitWarning()
+          << "SDPA shape validation failed: incompatible Q/K/V/Out dimensions";
+      return mlir::sdy::OpShardingRuleAttr();
+    }
+
+    int64_t numOperands3D = op.getNumOperands();
+    sdy::OpShardingRuleBuilder builder3D(op);
+    auto makeOpDims3D = [&](int64_t dim) -> SmallVector<int64_t> {
+      SmallVector<int64_t> dims(numOperands3D, sdy::kNullDim);
+      dims[0] = dim;
+      dims[1] = dim;
+      dims[2] = dim;
+      return dims;
+    };
+    builder3D.addFactor(makeOpDims3D(0), {0}, qShape3D[0],
+                        sdy::FactorType::kPassThrough);
+    builder3D.addFactor(makeOpDims3D(1), {1}, qShape3D[1],
+                        sdy::FactorType::kNeedReplication);
+    builder3D.addFactor(makeOpDims3D(2), {2}, qShape3D[2],
+                        sdy::FactorType::kNeedReplication);
+    return builder3D.build();
+  }
+
   // SDPA operates on 4D tensors: [B, H, S, D]
   if (qType.getRank() != 4 || kType.getRank() != 4 || vType.getRank() != 4 ||
       outType.getRank() != 4) {

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa_rank3.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa_rank3.mlir
@@ -1,0 +1,83 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // 3D query/key/value must take a unit head dim at index 1, with the result
+  // reshaped back to 3D.
+  func.func @sdpa_rank3(
+      %q: tensor<1x4096x1024xbf16>,
+      %k: tensor<1x4096x1024xbf16>,
+      %v: tensor<1x4096x1024xbf16>) -> tensor<1x4096x1024xbf16> {
+    // CHECK-LABEL: func.func @sdpa_rank3(
+    // CHECK: %[[Q4D:[0-9]+]] = "ttir.reshape"(%arg0)
+    // CHECK-SAME: shape = [1 : i32, 1 : i32, 4096 : i32, 1024 : i32]
+    // CHECK-SAME: (tensor<1x4096x1024xbf16>{{.*}}) -> tensor<1x1x4096x1024xbf16>
+    // CHECK: %[[K4D:[0-9]+]] = "ttir.reshape"(%arg1)
+    // CHECK-SAME: -> tensor<1x1x4096x1024xbf16>
+    // CHECK: %[[V4D:[0-9]+]] = "ttir.reshape"(%arg2)
+    // CHECK-SAME: -> tensor<1x1x4096x1024xbf16>
+    // CHECK: %[[SDPA:[0-9]+]] = "ttir.scaled_dot_product_attention"(%[[Q4D]], %[[K4D]], %[[V4D]])
+    // CHECK-SAME: -> tensor<1x1x4096x1024xbf16>
+    // CHECK: "ttir.reshape"(%[[SDPA]])
+    // CHECK-SAME: shape = [1 : i32, 4096 : i32, 1024 : i32]
+    // CHECK-SAME: (tensor<1x1x4096x1024xbf16>{{.*}}) -> tensor<1x4096x1024xbf16>
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl_rank3
+    } : (tensor<1x4096x1024xbf16>, tensor<1x4096x1024xbf16>, tensor<1x4096x1024xbf16>) -> tensor<1x4096x1024xbf16>
+    return %0 : tensor<1x4096x1024xbf16>
+  }
+
+  // A 3D mask alongside 3D q/k/v takes the head dim at index 1, not a left pad.
+  func.func @sdpa_rank3_mask(
+      %q: tensor<2x4096x1024xbf16>,
+      %k: tensor<2x4096x1024xbf16>,
+      %v: tensor<2x4096x1024xbf16>,
+      %mask: tensor<2x4096x4096xbf16>) -> tensor<2x4096x1024xbf16> {
+    // CHECK-LABEL: func.func @sdpa_rank3_mask(
+    // CHECK: %[[MASK4D:[0-9]+]] = "ttir.reshape"(%arg3)
+    // CHECK-SAME: shape = [2 : i32, 1 : i32, 4096 : i32, 4096 : i32]
+    // CHECK-SAME: (tensor<2x4096x4096xbf16>{{.*}}) -> tensor<2x1x4096x4096xbf16>
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: %[[MASK4D]]
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v, %mask {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl_rank3_mask
+    } : (tensor<2x4096x1024xbf16>, tensor<2x4096x1024xbf16>, tensor<2x4096x1024xbf16>, tensor<2x4096x4096xbf16>) -> tensor<2x4096x1024xbf16>
+    return %0 : tensor<2x4096x1024xbf16>
+  }
+
+  // 4D query/key/value must pass through unchanged — no extra reshape inserted.
+  func.func @sdpa_rank4(
+      %q: tensor<1x1x4096x1024xbf16>,
+      %k: tensor<1x1x4096x1024xbf16>,
+      %v: tensor<1x1x4096x1024xbf16>) -> tensor<1x1x4096x1024xbf16> {
+    // CHECK-LABEL: func.func @sdpa_rank4(
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.scaled_dot_product_attention"
+    %0 = stablehlo.composite "tenstorrent.scaled_dot_product_attention" %q, %k, %v {
+        composite_attributes = {is_causal = false},
+        decomposition = @sdpa_impl_rank4
+    } : (tensor<1x1x4096x1024xbf16>, tensor<1x1x4096x1024xbf16>, tensor<1x1x4096x1024xbf16>) -> tensor<1x1x4096x1024xbf16>
+    return %0 : tensor<1x1x4096x1024xbf16>
+  }
+
+  func.func private @sdpa_impl_rank3(
+      %arg0: tensor<1x4096x1024xbf16>, %arg1: tensor<1x4096x1024xbf16>,
+      %arg2: tensor<1x4096x1024xbf16>) -> tensor<1x4096x1024xbf16> {
+    return %arg0 : tensor<1x4096x1024xbf16>
+  }
+
+  func.func private @sdpa_impl_rank3_mask(
+      %arg0: tensor<2x4096x1024xbf16>, %arg1: tensor<2x4096x1024xbf16>,
+      %arg2: tensor<2x4096x1024xbf16>, %arg3: tensor<2x4096x4096xbf16>) -> tensor<2x4096x1024xbf16> {
+    return %arg0 : tensor<2x4096x1024xbf16>
+  }
+
+  func.func private @sdpa_impl_rank4(
+      %arg0: tensor<1x1x4096x1024xbf16>, %arg1: tensor<1x1x4096x1024xbf16>,
+      %arg2: tensor<1x1x4096x1024xbf16>) -> tensor<1x1x4096x1024xbf16> {
+    return %arg0 : tensor<1x1x4096x1024xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa_rank3.mlir
+++ b/test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa_rank3.mlir
@@ -1,0 +1,31 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt -split-input-file --stablehlo-pipeline -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+// CHECK-LABEL: module @SDPA_Rank3_Sharding_Batch
+module @SDPA_Rank3_Sharding_Batch attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<2x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<2x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<2x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{\22_axis_0\22}, {}, {}]>"}, mhlo.sharding = "{devices=[2,1,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}) -> tensor<2x32x128xbf16> {
+    // Batch is kPassThrough, so it shards without any collective.
+    // CHECK-NOT: stablehlo.all_gather
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x32x128xbf16>, tensor<1x32x128xbf16>, tensor<1x32x128xbf16>
+    // CHECK-SAME: -> tensor<1x32x128xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "False"}} : (tensor<2x32x128xbf16>, tensor<2x32x128xbf16>, tensor<2x32x128xbf16>) -> tensor<2x32x128xbf16>
+    return %0 : tensor<2x32x128xbf16>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module @SDPA_Rank3_Sharding_Sequence
+module @SDPA_Rank3_Sharding_Sequence attributes {mhlo.cross_program_prefetches = [], mhlo.frontend_attributes = {xla.sdy.meshes = "{mesh = #sdy.mesh<[\22_axis_0\22=2]>}"}, mhlo.input_output_alias = [], mhlo.is_dynamic = false, mhlo.use_auto_spmd_partitioning = false} {
+  func.func @main(%arg0: tensor<1x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "query"}, %arg1: tensor<1x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "key"}, %arg2: tensor<1x32x128xbf16> {mhlo.frontend_attributes = {xla.sdy.sharding = "#sdy.sharding<@mesh, [{}, {\22_axis_0\22}, {}]>"}, mhlo.sharding = "{devices=[1,2,1]<=[2]}", ttcore.argument_type = #ttcore.argument_type<input>, ttir.name = "value"}) -> tensor<1x32x128xbf16> {
+    // Sequence must be gathered back to full length before the custom call.
+    // CHECK: stablehlo.custom_call @tt.scaled_dot_product_attention
+    // CHECK-SAME: tensor<1x32x128xbf16>, tensor<1x32x128xbf16>, tensor<1x32x128xbf16>
+    // CHECK-SAME: -> tensor<1x32x128xbf16>
+    %0 = stablehlo.custom_call @tt.scaled_dot_product_attention(%arg0, %arg1, %arg2) {api_version = 0 : i32, mhlo.frontend_attributes = {is_causal = "False"}} : (tensor<1x32x128xbf16>, tensor<1x32x128xbf16>, tensor<1x32x128xbf16>) -> tensor<1x32x128xbf16>
+    return %0 : tensor<1x32x128xbf16>
+  }
+}


### PR DESCRIPTION
## Ticket
- fixes https://github.com/tenstorrent/tt-xla/issues/5914

## Problem Description

- The `stablehlo.composite "tenstorrent.scaled_dot_product_attention"` lowering passes query/key/value through unchanged. `torch.nn.functional.scaled_dot_product_attention` accepts rank-3 `(B, S, E)` input, but `ttir.scaled_dot_product_attention` requires 4D `[B, Hq, Sq, D]`, so single-head attention blocks that never materialize a head dimension fail to convert.
- HunyuanImage 2.1's VAE decoder mid-block attention is single-head and reshapes to `(B, H*W, C)` before calling SDPA, emitting a `1x4096x1024` composite that is rejected during SHLO -> TTIR conversion.
- On the multi-chip path the composite becomes a `stablehlo.custom_call` so Shardy can propagate through it, and `getSDPAShardingRule` only handles rank 4. Rank 3 falls back to `buildPointwise`, which lets the sequence dim be sharded.


## What's Changed

- Promote rank-3 query/key/value to 4D in `convertToTTIRScaledDotProductAttention` (covers both the composite and sharded `custom_call` paths), then reshape the result back
- The unit dim is inserted at index 1 (after batch), since `ttir.scaled_dot_product_attention` reads its shape positionally as `[B, Hq, Sq, D]`.
- A rank-3 mask is promoted the same way rather than left-padded, keeping the batch dim at index 0 (previously correct only for `B == 1`); other ranks rejected via `notifyMatchFailure`, 4D unchanged
- Added a rank-3 branch to `getSDPAShardingRule`: batch is `kPassThrough`, sequence and hidden are `kNeedReplication`, so the sequence dim is gathered instead of sharded
- Added `test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdpa_rank3.mlir`: rank-3 promotion, mask alignment at `B = 2`, 4D pass-through regression
- Added `test/ttmlir/Dialect/StableHLO/register_custom_sharding_rule/custom_op_sdpa_rank3.mlir`: batch-sharded and sequence-sharded rank-3 cases

## Checklist
- [x] Verified changes through local testing on sanity & model in BH

### Logs

- [aug7_HunyuanImage_2_1_decoder_before_fix.log](https://github.com/user-attachments/files/30822212/aug7_HunyuanImage_2_1_decoder.log)
- [aug10_sanity_mc_before_fix.log](https://github.com/user-attachments/files/30895054/aug10_sanity_mc_bf.log)
- [aug10_sanity_sc_before_fix.log](https://github.com/user-attachments/files/30895053/aug10_sanity_sc_bf.log)
- [aug10_HunyuanImage_2_1_decoder_after_fix.log](https://github.com/user-attachments/files/30895254/aug10_HunyuanImage_2_1_decoder_after_fix.log)
- [aug10_sanity_mc_after_fix.log](https://github.com/user-attachments/files/30895256/aug10_sanity_mc_af.log)
- [aug10_sanity_sc_after_fix.log](https://github.com/user-attachments/files/30895257/aug10_sanity_sc_af.log)

