### PR TITLE
[trace] eliminate slot allocations during (re)capture

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -3717,6 +3717,23 @@ def TTNN_WriteTensorOp : TTNN_InplaceOp<"write_tensor", [OpModelExempt]> {
   let hasVerifier = 1;
 }
 
+def TTNN_CopyOp : TTNN_InplaceOp<"copy", [OpModelExempt]> {
+  let summary = "Device to device copy op.";
+  let description = [{
+    Copies `src` into the pre-allocated device tensor `dst`. Both tensors must be
+    on device and have identical types.
+
+    Inputs:
+      - `src` AnyRankedTensor: The device tensor to copy from.
+      - `dst` AnyRankedTensor: The pre-allocated device tensor to copy into.
+  }];
+
+  let arguments = (ins AnyRankedTensor:$src,
+                       Arg<AnyRankedTensor, "destination tensor", [MemWrite]>:$dst);
+
+  let hasVerifier = 1;
+}
+
 def TTNN_BeginTraceCaptureOp : TTNN_MemoryEffectOp<"begin_trace_capture", [OpModelExempt]> {
   let summary = "Begin trace capture.";
   let description = [{
@@ -3783,10 +3800,23 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
   let description = [{
     Captures or executes the trace. Will have read/write memory effects on the cached trace data.
     If the trace data exists (meaning the trace was captured previously), it will be executed with
-    the execute_callee function. Otherwise, the trace will be captured with the capture_callee function.
+    the execute_callee function. Otherwise, the trace is captured.
+
+    Capturing is split across two functions so that the persistent input/output slots are
+    allocated only once - on the very first capture - and reused for every recapture:
+      - `allocate_slots_callee` allocates the persistent device input/output slots. It runs
+        exactly once per trace.
+      - `capture_callee` takes those slots as arguments and captures the trace against them.
+
+    A cached trace that has gone stale is recaptured by invoking `capture_callee` again with the
+    same slots. Because the slots are never reallocated, a recapture leaves the device allocator
+    state untouched and therefore cannot invalidate any other cached trace. The initial capture and
+    every recapture run the identical program, so anything established by the first capture (compiled
+    programs, program cache entries) holds for every recapture by construction.
 
     Inputs:
       - `device` TTNN_Device: The device where the trace was captured.
+      - `allocate_slots_callee` FlatSymbolRefAttr: The symbol of the slot allocation function.
       - `capture_callee` FlatSymbolRefAttr: The symbol of the capture trace function.
       - `execute_callee` FlatSymbolRefAttr: The symbol of the execute trace function.
       - `inputs` Variadic<AnyRankedTensor>: The input tensors to the trace function.
@@ -3796,12 +3826,22 @@ def TTNN_CaptureOrExecuteTraceOp : TTNN_MemoryEffectOp<"capture_or_execute_trace
   }];
 
   let arguments = (ins TTNN_Device:$device,
+                       FlatSymbolRefAttr:$allocate_slots_callee,
                        FlatSymbolRefAttr:$capture_callee,
                        FlatSymbolRefAttr:$execute_callee,
                        Variadic<AnyRankedTensor>:$inputs,
                        Variadic<TTNN_GlobalSemaphore>:$semaphore_inputs);
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
+
+  let extraClassDeclaration = [{
+    // Partitions the trace input indices into device-resident inputs (already
+    // in device memory, acting as their own persistent slots) and host-staged
+    // inputs. The runtime makes the same split from the storage type recorded
+    // in the flatbuffer, so the two must agree.
+    std::pair<llvm::SmallVector<size_t>, llvm::SmallVector<size_t>>
+    partitionInputIndices();
+  }];
 
   let hasVerifier = 1;
 }

--- a/include/ttmlir/Dialect/TTNN/Types/Types.h
+++ b/include/ttmlir/Dialect/TTNN/Types/Types.h
@@ -19,6 +19,8 @@ inline constexpr int64_t LAYER_NORM_SUM_X_OFFSET = TILE_WIDTH;
 inline constexpr std::array<uint32_t, 2> VALID_CQ_IDS = {0, 1};
 inline constexpr llvm::StringLiteral g_TTNNHoistGenericViaD2MAttrName =
     "ttnn.hoist_generic_via_d2m";
+inline constexpr llvm::StringLiteral g_TTNNAllocateSlotsTracePrefix =
+    "allocate_slots_";
 inline constexpr llvm::StringLiteral g_TTNNCaptureTracePrefix =
     "run_and_capture_";
 inline constexpr llvm::StringLiteral g_TTNNExecuteTracePrefix = "execute_";

--- a/include/ttmlir/FunctionTypes.h
+++ b/include/ttmlir/FunctionTypes.h
@@ -39,8 +39,15 @@ enum class FunctionType {
   /// for tracing.
   TraceMain,
 
-  /// Trace run and capture function - a function that runs and captures
-  /// a trace for later execution.
+  /// Trace allocate-slots function - allocates the persistent device buffers
+  /// (input and output slots) that a captured trace reads from and writes to.
+  /// Runs exactly once per trace; the slots then outlive every capture of it.
+  TraceAllocateSlots,
+
+  /// Trace run and capture function - runs and captures a trace against slots
+  /// that were allocated by the TraceAllocateSlots function and are passed in
+  /// as arguments. Used for both the initial capture and any later recapture
+  /// of a stale trace.
   TraceRunAndCapture,
 
   /// Trace execute function - a function that executes a previously
@@ -82,6 +89,8 @@ constexpr inline llvm::StringLiteral kForwardCPUDeclarationValue =
     "forward_cpu_declaration";
 constexpr inline llvm::StringLiteral kConstEvalValue = "const_eval";
 constexpr inline llvm::StringLiteral kTraceMainValue = "trace_main";
+constexpr inline llvm::StringLiteral kTraceAllocateSlotsValue =
+    "trace_allocate_slots";
 constexpr inline llvm::StringLiteral kTraceRunAndCaptureValue =
     "trace_run_and_capture";
 constexpr inline llvm::StringLiteral kTraceExecuteValue = "trace_execute";
@@ -115,6 +124,8 @@ inline llvm::StringRef getFunctionTypeValue(FunctionType type) {
     return detail::kConstEvalValue;
   case FunctionType::TraceMain:
     return detail::kTraceMainValue;
+  case FunctionType::TraceAllocateSlots:
+    return detail::kTraceAllocateSlotsValue;
   case FunctionType::TraceRunAndCapture:
     return detail::kTraceRunAndCaptureValue;
   case FunctionType::TraceExecute:
@@ -150,6 +161,9 @@ parseFunctionTypeValue(llvm::StringRef value) {
   }
   if (value == detail::kTraceMainValue) {
     return FunctionType::TraceMain;
+  }
+  if (value == detail::kTraceAllocateSlotsValue) {
+    return FunctionType::TraceAllocateSlots;
   }
   if (value == detail::kTraceRunAndCaptureValue) {
     return FunctionType::TraceRunAndCapture;
@@ -244,6 +258,11 @@ inline bool isTraceMainFunc(mlir::func::FuncOp funcOp) {
   return hasFunctionType(funcOp, FunctionType::TraceMain);
 }
 
+/// Returns true if the function is marked as a trace allocate-slots function.
+inline bool isTraceAllocateSlotsFunc(mlir::func::FuncOp funcOp) {
+  return hasFunctionType(funcOp, FunctionType::TraceAllocateSlots);
+}
+
 /// Returns true if the function is marked as a trace run and capture function.
 inline bool isTraceRunAndCaptureFunc(mlir::func::FuncOp funcOp) {
   return hasFunctionType(funcOp, FunctionType::TraceRunAndCapture);
@@ -255,10 +274,10 @@ inline bool isTraceExecuteFunc(mlir::func::FuncOp funcOp) {
 }
 
 /// Returns true if the function is any trace function (TraceMain,
-/// TraceRunAndCapture, or TraceExecute).
+/// TraceAllocateSlots, TraceRunAndCapture, or TraceExecute).
 inline bool isTraceFunc(mlir::func::FuncOp funcOp) {
-  return isTraceMainFunc(funcOp) || isTraceRunAndCaptureFunc(funcOp) ||
-         isTraceExecuteFunc(funcOp);
+  return isTraceMainFunc(funcOp) || isTraceAllocateSlotsFunc(funcOp) ||
+         isTraceRunAndCaptureFunc(funcOp) || isTraceExecuteFunc(funcOp);
 }
 
 /// Returns true if the function is marked as a kernel function.

--- a/include/ttmlir/Target/TTNN/operations/data_movement.fbs
+++ b/include/ttmlir/Target/TTNN/operations/data_movement.fbs
@@ -133,3 +133,8 @@ table WriteTensorOp {
   blocking: bool;
   cq_id: uint32;
 }
+
+table CopyOp {
+  src: tt.target.ttnn.TensorRef;
+  dst: tt.target.ttnn.TensorRef;
+}

--- a/include/ttmlir/Target/TTNN/operations/trace.fbs
+++ b/include/ttmlir/Target/TTNN/operations/trace.fbs
@@ -26,6 +26,7 @@ table CaptureOrExecuteTraceOp {
   device: tt.target.DeviceRef;
   capture_program_id: uint32;
   execute_program_id: uint32;
+  allocate_slots_program_id: uint32;
   inputs: [tt.target.ttnn.TensorRef];
   outputs: [tt.target.ttnn.TensorRef];
   semaphore_inputs: [tt.target.ttnn.GlobalSemaphoreRef];

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -165,6 +165,7 @@ union OpType {
   CreateGlobalSemaphoreOp,
   ResetGlobalSemaphoreOp,
   AllocateMoeComputeSemaphoreOp,
+  CopyOp,
 }
 
 table Operation {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -5130,6 +5130,38 @@ public:
 } // namespace
 
 namespace {
+class CopyOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<mlir::tt::ttnn::CopyOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return mlir::tt::ttnn::CopyOp::getOperationName().str();
+  }
+  std::string getPrefixSwapPattern() const override { return "ttnn::copy"; }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::CopyOp>::TTNNToEmitCBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::CopyOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::CopyOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getSrc()),
+        emitter.emit(srcOp.getDst()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
+namespace {
 class BeginTraceCaptureOpConversionPattern
     : public TTNNToEmitCBaseOpConversionPattern<
           mlir::tt::ttnn::BeginTraceCaptureOp> {
@@ -5367,41 +5399,42 @@ public:
       rewriter.create<emitc::AssignOp>(
           loc, getGlobalVariable(rewriter, loc, isFirstCall), falseC);
 
-      // v = capture_callee(args...)
+      // Slot allocation and capture are separate programs: allocation runs once
+      // and yields the persistent slots, then capture is invoked against them.
+      // Standalone code has no trace cache, so it only ever captures once, but
+      // it follows the same two-step shape as the runtime.
+      //
+      // v = allocate_slots_callee(device-resident args...)
       auto autoTy = emitc::OpaqueType::get(ctx, "auto");
-      auto captureTuple = rewriter.create<emitc::CallOpaqueOp>(
-          loc, autoTy, srcOp.getCaptureCallee(), nullptr, nullptr,
-          block->getArguments());
+      auto [deviceResidentIndices, hostStagedIndices] =
+          srcOp.partitionInputIndices();
+      llvm::SmallVector<mlir::Value> deviceResidentArgs;
+      llvm::SmallVector<mlir::Value> hostStagedArgs;
+      for (size_t i : deviceResidentIndices) {
+        deviceResidentArgs.push_back(block->getArgument(i));
+      }
+      for (size_t i : hostStagedIndices) {
+        hostStagedArgs.push_back(block->getArgument(i));
+      }
 
-      // trace_id = std::get<0>(v);
-      auto getTraceId = rewriter.create<emitc::CallOpaqueOp>(
-          loc, traceId.getType(), "::std::get", /*args=*/nullptr,
-          /*template_args=*/
-          rewriter.getArrayAttr({rewriter.getI32IntegerAttr(0)}),
-          captureTuple.getResult(0));
-      rewriter.create<emitc::AssignOp>(
-          loc, getGlobalVariable(rewriter, loc, traceId),
-          getTraceId.getResult(0));
+      auto slotsTuple = rewriter.create<emitc::CallOpaqueOp>(
+          loc, autoTy, srcOp.getAllocateSlotsCallee(), nullptr, nullptr,
+          deviceResidentArgs);
 
-      // input_i = std::get<inputBaseIndex + i>(v)
-      const size_t inputBaseIndex = 1;
+      // input_i = std::get<i>(v); output_i = std::get<nInputs + i>(v)
       for (size_t i = 0; i < traceInputVariable.size(); ++i) {
         auto getResult = rewriter.create<emitc::CallOpaqueOp>(
             loc, traceInputVariable[i].getType(), "::std::get",
             /*args=*/nullptr,
             /*template_args=*/
-            rewriter.getArrayAttr(
-                {rewriter.getI32IntegerAttr(inputBaseIndex + i)}),
-            ValueRange{captureTuple.getResult(0)});
+            rewriter.getArrayAttr({rewriter.getI32IntegerAttr(i)}),
+            ValueRange{slotsTuple.getResult(0)});
         rewriter.create<emitc::AssignOp>(
             loc, getGlobalVariable(rewriter, loc, traceInputVariable[i]),
             getResult.getResult(0));
       }
 
-      // output_i = std::get<traceOutputBaseIndex + i>(v)
-      // Output slots also serve as the actual outputs for the first invocation.
-      const size_t traceOutputBaseIndex =
-          inputBaseIndex + traceInputVariable.size();
+      const size_t traceOutputBaseIndex = traceInputVariable.size();
       for (size_t i = 0; i < traceOutputVariable.size(); ++i) {
         auto getResult = rewriter.create<emitc::CallOpaqueOp>(
             loc, traceOutputVariable[i].getType(), "::std::get",
@@ -5409,7 +5442,7 @@ public:
             /*template_args=*/
             rewriter.getArrayAttr(
                 {rewriter.getI32IntegerAttr(traceOutputBaseIndex + i)}),
-            captureTuple.getResult(0));
+            slotsTuple.getResult(0));
         rewriter.create<emitc::AssignOp>(
             loc, getGlobalVariable(rewriter, loc, traceOutputVariable[i]),
             getResult.getResult(0));
@@ -5419,6 +5452,22 @@ public:
         rewriter.create<emitc::AssignOp>(loc, returnVariable[i],
                                          getResult.getResult(0));
       }
+
+      // trace_id = capture_callee(host-staged args..., slots...)
+      llvm::SmallVector<mlir::Value> captureArgs(hostStagedArgs);
+      for (auto &inputVariable : traceInputVariable) {
+        captureArgs.push_back(loadGlobalVariable(rewriter, loc, inputVariable));
+      }
+      for (auto &outputVariable : traceOutputVariable) {
+        captureArgs.push_back(
+            loadGlobalVariable(rewriter, loc, outputVariable));
+      }
+      auto captureCall = rewriter.create<emitc::CallOpaqueOp>(
+          loc, traceId.getType(), srcOp.getCaptureCallee(), nullptr, nullptr,
+          captureArgs);
+      rewriter.create<emitc::AssignOp>(
+          loc, getGlobalVariable(rewriter, loc, traceId),
+          captureCall.getResult(0));
 
       rewriter.create<emitc::YieldOp>(loc);
     }
@@ -6076,6 +6125,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
   // Trace ops
   //
   patterns.add<WriteTensorOpConversionPattern>(typeConverter, ctx);
+  patterns.add<CopyOpConversionPattern>(typeConverter, ctx);
   patterns.add<BeginTraceCaptureOpConversionPattern>(typeConverter, ctx);
   patterns.add<EndTraceCaptureOpConversionPattern>(typeConverter, ctx);
   patterns.add<CaptureOrExecuteTraceOpConversionPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -5038,6 +5038,40 @@ public:
 };
 } // namespace
 
+// CopyOp conversion pattern
+//
+namespace {
+class CopyOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<mlir::tt::ttnn::CopyOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return mlir::tt::ttnn::CopyOp::getOperationName().str();
+  }
+  std::string getPrefixSwapPattern() const override { return "ttnn.copy"; }
+
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::CopyOp>::TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::CopyOp copyOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    ttnn_to_emitpy::EmitPyTTNNEmitter<mlir::tt::ttnn::CopyOp> emitter(
+        copyOp, adaptor, rewriter);
+
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(copyOp.getSrc()),
+        emitter.emit(copyOp.getDst()),
+    };
+
+    emitter.replaceOp(*this, args);
+
+    return success();
+  }
+};
+} // namespace
+
 // BeginTraceCaptureOp conversion pattern
 //
 namespace {
@@ -5286,28 +5320,35 @@ public:
           loc, rewriter.getStringAttr(firstCallGlobalName),
           falseVal.getResult());
 
-      // result = capture_callee(input_0_arg, ..., input_n_arg)
+      // Slot allocation and capture are separate programs: allocation runs once
+      // and yields the persistent slots, then capture is invoked against them.
+      // Standalone code has no trace cache, so it only ever captures once, but
+      // it follows the same two-step shape as the runtime.
+      //
+      // slots = allocate_slots_callee(device-resident args...)
+      auto [deviceResidentIndices, hostStagedIndices] =
+          captureOrExecuteOp.partitionInputIndices();
+      llvm::SmallVector<mlir::Value> deviceResidentArgs;
+      llvm::SmallVector<mlir::Value> hostStagedArgs;
+      for (size_t i : deviceResidentIndices) {
+        deviceResidentArgs.push_back(block->getArgument(i));
+      }
+      for (size_t i : hostStagedIndices) {
+        hostStagedArgs.push_back(block->getArgument(i));
+      }
+
       auto tensorListType = emitpy::OpaqueType::get(ctx, "[ttnn.Tensor]");
-      auto captureResult = rewriter.create<emitpy::CallOpaqueOp>(
-          loc, tensorListType, captureOrExecuteOp.getCaptureCallee().str(),
-          block->getArguments());
+      auto slotsResult = rewriter.create<emitpy::CallOpaqueOp>(
+          loc, tensorListType,
+          captureOrExecuteOp.getAllocateSlotsCallee().str(),
+          deviceResidentArgs);
 
-      // trace_id = result[0]
-      auto idx0 =
-          rewriter.create<emitpy::LiteralOp>(loc, rewriter.getIndexType(), "0");
-      auto traceIdVal = rewriter.create<emitpy::SubscriptOp>(
-          loc, intType, captureResult.getResult(0), idx0.getResult());
-      rewriter.create<emitpy::AssignGlobalOp>(
-          loc, rewriter.getStringAttr(traceIdGlobalName),
-          traceIdVal.getResult());
-
-      // input_i = result[1 + i]
-      const size_t inputBaseIndex = 1;
+      // input_i = slots[i]
       for (size_t i = 0; i < inputGlobals.size(); ++i) {
         auto idx = rewriter.create<emitpy::LiteralOp>(
-            loc, rewriter.getIndexType(), std::to_string(inputBaseIndex + i));
+            loc, rewriter.getIndexType(), std::to_string(i));
         auto inputVal = rewriter.create<emitpy::SubscriptOp>(
-            loc, inputTypes[i], captureResult.getResult(0), idx.getResult());
+            loc, inputTypes[i], slotsResult.getResult(0), idx.getResult());
         rewriter.create<emitpy::AssignGlobalOp>(
             loc,
             rewriter.getStringAttr(inputGlobalPrefix + std::to_string(i) +
@@ -5315,19 +5356,32 @@ public:
             inputVal.getResult());
       }
 
-      // output_i = result[1 + numInputs + i]
-      const size_t outputBaseIndex = inputBaseIndex + inputGlobals.size();
+      // output_i = slots[numInputs + i]
+      const size_t outputBaseIndex = inputGlobals.size();
       for (size_t i = 0; i < outputGlobals.size(); ++i) {
         auto idx = rewriter.create<emitpy::LiteralOp>(
             loc, rewriter.getIndexType(), std::to_string(outputBaseIndex + i));
         auto outputVal = rewriter.create<emitpy::SubscriptOp>(
-            loc, resultTypes[i], captureResult.getResult(0), idx.getResult());
+            loc, resultTypes[i], slotsResult.getResult(0), idx.getResult());
         rewriter.create<emitpy::AssignGlobalOp>(
             loc,
             rewriter.getStringAttr(outputGlobalPrefix + std::to_string(i) +
                                    traceNameSuffix),
             outputVal.getResult());
       }
+
+      // trace_id = capture_callee(host-staged args..., slots...)
+      // The global references are already in scope, and reading them after the
+      // assignments above yields the freshly allocated slots.
+      llvm::SmallVector<mlir::Value> captureArgs(hostStagedArgs);
+      llvm::append_range(captureArgs, inputRefs);
+      llvm::append_range(captureArgs, outputRefs);
+      auto captureResult = rewriter.create<emitpy::CallOpaqueOp>(
+          loc, intType, captureOrExecuteOp.getCaptureCallee().str(),
+          captureArgs);
+      rewriter.create<emitpy::AssignGlobalOp>(
+          loc, rewriter.getStringAttr(traceIdGlobalName),
+          captureResult.getResult(0));
     }
 
     // ELSE block: execute path.
@@ -5688,6 +5742,7 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   // Trace ops
   //
   patterns.add<WriteTensorOpConversionPattern>(typeConverter, ctx);
+  patterns.add<CopyOpConversionPattern>(typeConverter, ctx);
   patterns.add<BeginTraceCaptureOpConversionPattern>(typeConverter, ctx);
   patterns.add<EndTraceCaptureOpConversionPattern>(typeConverter, ctx);
   patterns.add<ExecuteTraceOpConversionPattern>(typeConverter, ctx);

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -5436,6 +5436,33 @@ verifyReduceProdOp(tt::ttnn::ProdOp *reduceOp,
 }
 
 //===----------------------------------------------------------------------===//
+// CopyOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult CopyOp::verify() {
+  auto srcType = ::mlir::cast<RankedTensorType>(this->getSrc().getType());
+  auto dstType = ::mlir::cast<RankedTensorType>(this->getDst().getType());
+
+  // tt-metal's copy op requires both operands to be device tensors, and with a
+  // pre-allocated output it derives the output spec from the destination.
+  // Rather than replicate its compatibility rules, require the types to be
+  // identical: that is all the trace hoisting pass ever produces, and it keeps
+  // any mistake a compile-time error instead of a mid-trace-capture TT_FATAL.
+  if (!utils::isTensorOnDevice(srcType)) {
+    return emitOpError() << "Source tensor must be on device memory";
+  }
+  if (!utils::isTensorOnDevice(dstType)) {
+    return emitOpError() << "Destination tensor must be on device memory";
+  }
+  if (srcType != dstType) {
+    return emitOpError() << "Source and destination tensor types must match, "
+                         << "but got " << srcType << " and " << dstType;
+  }
+
+  return ::mlir::success();
+}
+
+//===----------------------------------------------------------------------===//
 // TraceOps
 //===----------------------------------------------------------------------===//
 
@@ -5544,8 +5571,92 @@ void CaptureOrExecuteTraceOp::getEffects(
                        TraceResource::get());
 }
 
+std::pair<llvm::SmallVector<size_t>, llvm::SmallVector<size_t>>
+CaptureOrExecuteTraceOp::partitionInputIndices() {
+  llvm::SmallVector<size_t> deviceResidentIndices;
+  llvm::SmallVector<size_t> hostStagedIndices;
+  for (auto [i, input] : llvm::enumerate(getInputs())) {
+    auto tensorType = mlir::cast<RankedTensorType>(input.getType());
+    if (utils::isTensorOnDevice(tensorType)) {
+      deviceResidentIndices.push_back(i);
+    } else {
+      hostStagedIndices.push_back(i);
+    }
+  }
+  return {std::move(deviceResidentIndices), std::move(hostStagedIndices)};
+}
+
 ::mlir::LogicalResult CaptureOrExecuteTraceOp::verify() {
-  // Verify that the callee exists
+  auto opInputs = this->getInputs();
+  auto opSemaphoreInputs = this->getSemaphoreInputs();
+  auto opOutputs = this->getResults();
+
+  // An input already on device acts as its own persistent slot and is handed
+  // to the allocation program, while an input in system memory is staged into
+  // a freshly allocated slot by the capture program.
+  auto [deviceResidentIndices, hostStagedIndices] = partitionInputIndices();
+  llvm::SmallVector<mlir::Type> deviceResidentInputTypes;
+  llvm::SmallVector<mlir::Type> hostStagedInputTypes;
+  for (size_t i : deviceResidentIndices) {
+    deviceResidentInputTypes.push_back(opInputs[i].getType());
+  }
+  for (size_t i : hostStagedIndices) {
+    hostStagedInputTypes.push_back(opInputs[i].getType());
+  }
+
+  // Verify the slot allocation function: it takes the device-resident inputs
+  // and returns one slot per trace input followed by one slot per trace output.
+  FlatSymbolRefAttr allocateSlotsCalleeAttr =
+      this->getAllocateSlotsCalleeAttr();
+  func::FuncOp allocateSlotsFuncOp =
+      SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+          *this, allocateSlotsCalleeAttr);
+  if (!allocateSlotsFuncOp) {
+    return emitOpError() << "'" << allocateSlotsCalleeAttr.getValue()
+                         << "' does not reference a function";
+  }
+
+  auto allocateSlotsInputTypes =
+      allocateSlotsFuncOp.getFunctionType().getInputs();
+  if (allocateSlotsInputTypes.size() != deviceResidentInputTypes.size()) {
+    return emitOpError() << "Slot allocation function '"
+                         << allocateSlotsCalleeAttr.getValue() << "' must take "
+                         << deviceResidentInputTypes.size()
+                         << " arguments (the device-resident inputs), but has "
+                         << allocateSlotsInputTypes.size();
+  }
+  for (size_t i = 0; i < deviceResidentInputTypes.size(); ++i) {
+    if (allocateSlotsInputTypes[i] != deviceResidentInputTypes[i]) {
+      return emitOpError() << "Slot allocation function argument " << i
+                           << " type mismatch: expected "
+                           << deviceResidentInputTypes[i] << ", but got "
+                           << allocateSlotsInputTypes[i];
+    }
+  }
+
+  auto slotTypes = allocateSlotsFuncOp.getFunctionType().getResults();
+  size_t expectedSlots = opInputs.size() + opOutputs.size();
+  if (slotTypes.size() != expectedSlots) {
+    return emitOpError() << "Slot allocation function '"
+                         << allocateSlotsCalleeAttr.getValue()
+                         << "' must return " << expectedSlots << " slots ("
+                         << opInputs.size() << " input slots + "
+                         << opOutputs.size() << " output slots), but returns "
+                         << slotTypes.size();
+  }
+  for (size_t i = 0; i < opOutputs.size(); ++i) {
+    if (slotTypes[opInputs.size() + i] != opOutputs[i].getType()) {
+      return emitOpError() << "Slot allocation function output slot " << i
+                           << " type mismatch: expected "
+                           << opOutputs[i].getType() << ", but got "
+                           << slotTypes[opInputs.size() + i];
+    }
+  }
+
+  // Verify the capture function. Its arguments are, in order: the host-staged
+  // inputs, every slot the allocation function returned, then the semaphores.
+  // The runtime forwards those slots straight through, both on the initial
+  // capture and on every recapture, so the types must match exactly.
   FlatSymbolRefAttr captureCalleeAttr = this->getCaptureCalleeAttr();
   func::FuncOp captureFuncOp =
       SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(*this,
@@ -5555,39 +5666,66 @@ void CaptureOrExecuteTraceOp::getEffects(
                          << "' does not reference a function";
   }
 
-  // Verify that the input arguments to this op match the capture_callee
-  // function's arguments.
   auto captureInputTypes = captureFuncOp.getFunctionType().getInputs();
-  auto opInputs = this->getInputs();
-  auto opSemaphoreInputs = this->getSemaphoreInputs();
-  size_t expectedCaptureInputs = opInputs.size() + opSemaphoreInputs.size();
-
+  size_t expectedCaptureInputs =
+      hostStagedInputTypes.size() + slotTypes.size() + opSemaphoreInputs.size();
   if (captureInputTypes.size() != expectedCaptureInputs) {
-    return emitOpError()
-           << "Number of input arguments (inputs + semaphore_inputs = "
-           << opInputs.size() << " + " << opSemaphoreInputs.size() << " = "
-           << expectedCaptureInputs << ") does not match capture function '"
-           << captureCalleeAttr.getValue() << "' input count ("
-           << captureInputTypes.size() << ")";
+    return emitOpError() << "Capture function '" << captureCalleeAttr.getValue()
+                         << "' must take " << expectedCaptureInputs
+                         << " arguments (" << hostStagedInputTypes.size()
+                         << " host-staged inputs + " << slotTypes.size()
+                         << " slots + " << opSemaphoreInputs.size()
+                         << " semaphores), but has "
+                         << captureInputTypes.size();
   }
 
-  for (size_t i = 0; i < opInputs.size(); ++i) {
-    if (opInputs[i].getType() != captureInputTypes[i]) {
-      return emitOpError() << "Input argument " << i << " type mismatch: "
-                           << "expected " << captureInputTypes[i]
-                           << " from capture function, but got "
-                           << opInputs[i].getType();
+  for (size_t i = 0; i < hostStagedInputTypes.size(); ++i) {
+    if (captureInputTypes[i] != hostStagedInputTypes[i]) {
+      return emitOpError() << "Capture function host-staged input argument "
+                           << i << " type mismatch: expected "
+                           << hostStagedInputTypes[i] << ", but got "
+                           << captureInputTypes[i];
+    }
+  }
+
+  for (size_t i = 0; i < slotTypes.size(); ++i) {
+    size_t captureIdx = hostStagedInputTypes.size() + i;
+    if (captureInputTypes[captureIdx] != slotTypes[i]) {
+      return emitOpError() << "Capture function slot argument " << i
+                           << " type mismatch: expected " << slotTypes[i]
+                           << " from slot allocation function, but got "
+                           << captureInputTypes[captureIdx];
     }
   }
 
   for (size_t i = 0; i < opSemaphoreInputs.size(); ++i) {
-    size_t captureIdx = opInputs.size() + i;
-    if (opSemaphoreInputs[i].getType() != captureInputTypes[captureIdx]) {
+    size_t captureIdx = hostStagedInputTypes.size() + slotTypes.size() + i;
+    if (captureInputTypes[captureIdx] != opSemaphoreInputs[i].getType()) {
       return emitOpError() << "Semaphore input argument " << i
                            << " type mismatch: "
                            << "expected " << captureInputTypes[captureIdx]
                            << " from capture function, but got "
                            << opSemaphoreInputs[i].getType();
+    }
+  }
+
+  auto captureResultTypes = captureFuncOp.getFunctionType().getResults();
+  if (captureResultTypes.size() != 1) {
+    return emitOpError() << "Capture function '" << captureCalleeAttr.getValue()
+                         << "' must return exactly one trace_id value, but "
+                            "returns "
+                         << captureResultTypes.size();
+  }
+  {
+    auto captureTraceIdType =
+        mlir::dyn_cast<mlir::RankedTensorType>(captureResultTypes[0]);
+    if (!captureTraceIdType || captureTraceIdType.getRank() != 0 ||
+        !mlir::isa_and_present<ttnn::TraceIdAttr>(
+            captureTraceIdType.getEncoding())) {
+      return emitOpError() << "Capture function '"
+                           << captureCalleeAttr.getValue()
+                           << "' must return a trace_id tensor (scalar ui32 "
+                              "with TraceIdAttr encoding)";
     }
   }
 
@@ -5608,24 +5746,12 @@ void CaptureOrExecuteTraceOp::getEffects(
                          << "' does not reference a function";
   }
 
-  // Verify that the outputs of this op match the trace function's outputs
-  auto traceOutputTypes = traceFuncOp.getFunctionType().getResults();
-  auto opOutputs = this->getResults();
-
-  if (traceOutputTypes.size() != opOutputs.size()) {
-    return emitOpError() << "Number of output results (" << opOutputs.size()
-                         << ") does not match trace function '"
-                         << traceFuncCalleeAttr.getValue() << "' output count ("
-                         << traceOutputTypes.size() << ")";
-  }
-
-  for (size_t i = 0; i < opOutputs.size(); ++i) {
-    if (opOutputs[i].getType() != traceOutputTypes[i]) {
-      return emitOpError() << "Output result " << i << " type mismatch: "
-                           << "expected " << traceOutputTypes[i]
-                           << " from trace function, but got "
-                           << opOutputs[i].getType();
-    }
+  // The trace function stores its results into the output slots rather than
+  // returning them.
+  if (traceFuncOp.getFunctionType().getNumResults() != 0) {
+    return emitOpError() << "Trace function '" << traceFuncCalleeAttr.getValue()
+                         << "' must return no results; it stores its outputs "
+                            "into the output slot arguments";
   }
 
   for (BlockArgument arg : traceFuncOp.getArguments()) {

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -14,6 +14,8 @@
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 #include "ttmlir/FunctionTypes.h"
 #include "ttmlir/Utils.h"
+#include "llvm/ADT/Sequence.h"
+#include <algorithm>
 #include <atomic>
 
 namespace mlir::tt::ttnn {
@@ -77,12 +79,20 @@ private:
     return traceFuncName;
   }
 
+  TraceSmallString getAllocateSlotsTraceFuncName(func::FuncOp funcOp,
+                                                 uint64_t traceFuncIndex) {
+    TraceSmallString allocateSlotsTraceFuncName;
+    allocateSlotsTraceFuncName.append(g_TTNNAllocateSlotsTracePrefix);
+    allocateSlotsTraceFuncName.append(getTraceFuncName(funcOp, traceFuncIndex));
+    return allocateSlotsTraceFuncName;
+  }
+
   TraceSmallString getCaptureTraceFuncName(func::FuncOp funcOp,
                                            uint64_t traceFuncIndex) {
-    TraceSmallString runAndCaptureTraceFuncName;
-    runAndCaptureTraceFuncName.append(g_TTNNCaptureTracePrefix);
-    runAndCaptureTraceFuncName.append(getTraceFuncName(funcOp, traceFuncIndex));
-    return runAndCaptureTraceFuncName;
+    TraceSmallString captureTraceFuncName;
+    captureTraceFuncName.append(g_TTNNCaptureTracePrefix);
+    captureTraceFuncName.append(getTraceFuncName(funcOp, traceFuncIndex));
+    return captureTraceFuncName;
   }
 
   TraceSmallString getExecuteTraceFuncName(func::FuncOp funcOp,
@@ -244,8 +254,79 @@ private:
     return inputAttrs;
   }
 
-  // Creates the trace function
-  ::mlir::LogicalResult
+  // Describes the trace-main function: the hoisted computation's boundary
+  // values, the device-resident/host-staged partition of its tensor inputs,
+  // and the persistent slot types derived from them. Computed once when the
+  // trace-main function is created; the slot allocation, capture, and execute
+  // functions - and the trace op itself - all derive their signatures from
+  // it, which is what keeps them mutually consistent. All indices refer to
+  // trace-main's [tensor inputs][output slots][semaphores] argument order,
+  // with device-resident tensors grouped before host-staged ones.
+  struct TraceMainFuncInfo {
+    // The trace-main function itself.
+    func::FuncOp traceFunc;
+    // Values of the original function feeding the trace, device-resident
+    // tensors first, then host-staged tensors, then semaphores.
+    llvm::SmallVector<mlir::Value> boundaryInputs;
+    // Values of the original function that the trace produces.
+    llvm::SmallVector<mlir::Value> boundaryOutputs;
+    // Number of leading tensor input arguments.
+    size_t numTensorInputs = 0;
+    // Split point of the tensor input indices [0, numTensorInputs):
+    // [0, numDeviceResident) is device-resident, the rest is host-staged. A
+    // device-resident input (constant/parameter/KV cache, or a
+    // prelude-allocated scratch buffer) needs no host staging and acts as its
+    // own persistent input slot; everything else is staged from host into a
+    // freshly allocated slot. This partition is the compile-time twin of the
+    // runtime's storage-type test on the trace op's inputs:
+    // insertCaptureOrExecuteTraceOp forwards device-resident inputs on device
+    // and converts the rest to system memory, and the runtime uses the
+    // resulting storage type to decide which inputs to pass to which program.
+    size_t numDeviceResident = 0;
+    // Persistent slot type per tensor input argument: a device-resident
+    // argument is its own slot and keeps its type; a host-staged argument
+    // gets a DRAM slot to be written into.
+    llvm::SmallVector<mlir::Type> inputSlotTypes;
+    // Original arg attrs per tensor input argument, as set on trace-main's
+    // arguments. Never null: missing attrs are normalized to empty dicts.
+    // Slot arguments derived from these follow one rule: a device-resident
+    // slot is the original argument and keeps its attrs; a host-staged slot
+    // is a fresh buffer and gets none.
+    llvm::SmallVector<mlir::DictionaryAttr> inputArgAttrs;
+    // Types of the output slot arguments (also the trace op's result types).
+    llvm::SmallVector<mlir::Type> outputSlotTypes;
+    // Types of the trailing semaphore arguments.
+    llvm::SmallVector<mlir::Type> semaphoreTypes;
+
+    // Contiguous views over the two halves of the tensor-input partition.
+    auto deviceResidentIndices() const {
+      return llvm::seq<size_t>(0, numDeviceResident);
+    }
+    auto hostStagedIndices() const {
+      return llvm::seq(numDeviceResident, numTensorInputs);
+    }
+    llvm::ArrayRef<mlir::Type> deviceResidentSlotTypes() const {
+      return llvm::ArrayRef<mlir::Type>(inputSlotTypes)
+          .take_front(numDeviceResident);
+    }
+    llvm::ArrayRef<mlir::Type> hostStagedSlotTypes() const {
+      return llvm::ArrayRef<mlir::Type>(inputSlotTypes)
+          .drop_front(numDeviceResident);
+    }
+    llvm::ArrayRef<mlir::DictionaryAttr> deviceResidentSlotArgAttrs() const {
+      return llvm::ArrayRef<mlir::DictionaryAttr>(inputArgAttrs)
+          .take_front(numDeviceResident);
+    }
+  };
+
+  // Creates the trace-main function and returns the TraceMainFuncInfo
+  // describing it, from which the slot allocation and capture functions are
+  // derived.
+  //
+  // Results are written into persistent output slots passed in as trailing
+  // arguments rather than returned. Argument order is
+  // [tensor inputs][output slots][semaphores].
+  ::mlir::FailureOr<TraceMainFuncInfo>
   createTraceFunction(func::FuncOp funcOp,
                       llvm::ArrayRef<Operation *> opsToHoist,
                       uint64_t traceFuncIndex) {
@@ -254,25 +335,55 @@ private:
     mlir::IRRewriter rewriter(builder);
 
     llvm::SmallVector<mlir::Value> inputs;
-    llvm::SmallVector<mlir::Type> inputTypes;
     llvm::SmallVector<mlir::Value> outputs;
     llvm::SmallVector<mlir::Type> outputTypes;
 
     collectFunctionBoundary(opsToHoist, inputs, outputs);
 
-    for (mlir::Value input : inputs) {
-      inputTypes.push_back(input.getType());
+    // collectFunctionBoundary sorts tensors before semaphores; split there so
+    // the output slots can be inserted between the two groups.
+    size_t numTensorInputs = 0;
+    while (numTensorInputs < inputs.size() &&
+           !isSemaphoreValue(inputs[numTensorInputs])) {
+      numTensorInputs++;
     }
+
+    // Group device-resident tensor inputs ahead of host-staged ones, so each
+    // partition is a contiguous range and the downstream builders can slice
+    // rather than gather.
+    size_t numDeviceResident =
+        std::stable_partition(
+            inputs.begin(), inputs.begin() + numTensorInputs,
+            [&](mlir::Value input) { return isDeviceResidentValue(input); }) -
+        inputs.begin();
+
     for (mlir::Value output : outputs) {
       outputTypes.push_back(output.getType());
     }
 
     llvm::SmallVector<mlir::DictionaryAttr> inputAttrs =
         getInputAttrs(context, inputs);
+    // Types and attributes for all arguments of the new trace main function,
+    // in signature order: [input tensors][output slots][semaphores].
+    llvm::SmallVector<mlir::Type> argTypes;
+    llvm::SmallVector<mlir::DictionaryAttr> newArgAttrs;
+
+    for (size_t i = 0; i < numTensorInputs; i++) {
+      argTypes.push_back(inputs[i].getType());
+      newArgAttrs.push_back(inputAttrs[i]);
+    }
+    for (mlir::Type outputType : outputTypes) {
+      argTypes.push_back(outputType);
+      newArgAttrs.push_back(mlir::DictionaryAttr::get(context));
+    }
+    for (size_t i = numTensorInputs; i < inputs.size(); i++) {
+      argTypes.push_back(inputs[i].getType());
+      newArgAttrs.push_back(inputAttrs[i]);
+    }
 
     TraceSmallString traceFuncName = getTraceFuncName(funcOp, traceFuncIndex);
 
-    auto traceFuncType = builder.getFunctionType(inputTypes, outputTypes);
+    auto traceFuncType = builder.getFunctionType(argTypes, /*results=*/{});
 
     // Create the function
     builder.setInsertionPoint(funcOp);
@@ -281,7 +392,7 @@ private:
     ttmlir::utils::setFunctionType(traceFuncOp,
                                    ttmlir::utils::FunctionType::TraceMain);
 
-    traceFuncOp.setAllArgAttrs(inputAttrs);
+    traceFuncOp.setAllArgAttrs(newArgAttrs);
     traceFuncOp.setPrivate();
 
     // Build the body of the new function
@@ -291,8 +402,12 @@ private:
     // maps original input values to trace function input
     // arguments/intermediates
     llvm::DenseMap<mlir::Value, mlir::Value> valueMap;
-    for (size_t i = 0; i < inputs.size(); i++) {
+    for (size_t i = 0; i < numTensorInputs; i++) {
       valueMap.insert({inputs[i], traceFuncOp.getArgument(i)});
+    }
+    for (size_t i = numTensorInputs; i < inputs.size(); i++) {
+      valueMap.insert(
+          {inputs[i], traceFuncOp.getArgument(outputTypes.size() + i)});
     }
 
     for (Operation *op : opsToHoist) {
@@ -325,233 +440,239 @@ private:
       }
     }
 
-    // Finally, we need to add a return operation to the trace function
-    llvm::SmallVector<mlir::Value> returnValues;
-    for (mlir::Value output : outputs) {
+    // Store each result into its persistent output slot. These stores are part
+    // of the traced computation, so replaying the trace lands results in the
+    // slots, and the capture function's uncaptured call compiles them.
+    for (auto [i, output] : llvm::enumerate(outputs)) {
       auto it = valueMap.find(output);
-      if (it != valueMap.end()) {
-        returnValues.push_back(it->second);
-      } else {
+      if (it == valueMap.end()) {
         return funcOp.emitError(
             "Could not map output value in hoisted function");
       }
+      builder.create<ttnn::CopyOp>(
+          funcOp.getLoc(), it->second,
+          traceFuncOp.getArgument(numTensorInputs + i));
     }
-    builder.create<func::ReturnOp>(funcOp.getLoc(), returnValues);
+    builder.create<func::ReturnOp>(funcOp.getLoc());
 
-    return mlir::success();
+    TraceMainFuncInfo info;
+    info.traceFunc = traceFuncOp;
+    info.numTensorInputs = numTensorInputs;
+    info.numDeviceResident = numDeviceResident;
+    for (size_t i = 0; i < numTensorInputs; i++) {
+      auto tensorType = mlir::cast<RankedTensorType>(inputs[i].getType());
+      info.inputArgAttrs.push_back(
+          inputAttrs[i] ? inputAttrs[i] : mlir::DictionaryAttr::get(context));
+      if (i < numDeviceResident) {
+        info.inputSlotTypes.push_back(tensorType);
+      } else {
+        info.inputSlotTypes.push_back(utils::RankedTensorTypeFactory::create(
+            tensorType, BufferType::DRAM));
+      }
+    }
+    for (size_t i = numTensorInputs; i < inputs.size(); i++) {
+      info.semaphoreTypes.push_back(inputs[i].getType());
+    }
+    info.outputSlotTypes = std::move(outputTypes);
+    info.boundaryInputs = std::move(inputs);
+    info.boundaryOutputs = std::move(outputs);
+    return info;
   }
 
-  // Creates the run and capture function that wraps the trace function and
-  // manages trace capture.
+  // Creates the slot allocation function.
+  //
+  // This function allocates the persistent device buffers that every capture of
+  // this trace reads from and writes to, and it is the ONLY place they are
+  // allocated. It runs exactly once per trace, on the first capture. Keeping
+  // allocation out of the capture function is what lets a stale trace be
+  // recaptured without allocating anything that outlives its own capture
+  // window, so a recapture cannot perturb the device allocator state that other
+  // cached traces have baked into their command streams.
+  //
+  // Signature: (device-resident tensor args) -> (input slots..., output
+  // slots...) Device-resident arguments are passed through as their own slots;
+  // host-staged inputs and all outputs get freshly allocated DRAM slots.
   mlir::LogicalResult
-  createRunAndCaptureTraceFunction(func::FuncOp funcOp,
-                                   uint64_t traceFuncIndex) {
+  createAllocateSlotsTraceFunction(func::FuncOp funcOp, uint64_t traceFuncIndex,
+                                   const TraceMainFuncInfo &info) {
     mlir::MLIRContext *context = &this->getContext();
     mlir::OpBuilder builder(context);
     mlir::IRRewriter rewriter(builder);
 
-    TraceSmallString traceFuncName = getTraceFuncName(funcOp, traceFuncIndex);
-    ModuleOp moduleOp = funcOp->getParentOfType<ModuleOp>();
-    func::FuncOp traceFunc = moduleOp.lookupSymbol<func::FuncOp>(traceFuncName);
-    if (!traceFunc) {
-      return funcOp.emitError("Could not find trace function with name: " +
-                              traceFuncName);
+    // Results: every input slot, then every output slot.
+    llvm::SmallVector<mlir::Type> outputTypes(info.inputSlotTypes);
+    llvm::append_range(outputTypes, info.outputSlotTypes);
+
+    TraceSmallString allocateSlotsFuncName =
+        getAllocateSlotsTraceFuncName(funcOp, traceFuncIndex);
+
+    builder.setInsertionPoint(funcOp);
+    // Inputs: only the device-resident arguments, which pass through as slots.
+    auto allocateSlotsFunc = builder.create<func::FuncOp>(
+        funcOp.getLoc(), allocateSlotsFuncName,
+        builder.getFunctionType(info.deviceResidentSlotTypes(), outputTypes));
+    ttmlir::utils::setFunctionType(
+        allocateSlotsFunc, ttmlir::utils::FunctionType::TraceAllocateSlots);
+    allocateSlotsFunc.setAllArgAttrs(info.deviceResidentSlotArgAttrs());
+    allocateSlotsFunc.setPrivate();
+
+    auto *entryBlock = allocateSlotsFunc.addEntryBlock();
+    builder.setInsertionPointToStart(entryBlock);
+
+    auto deviceOp = utils::getOrInsertDevice(rewriter, entryBlock);
+
+    llvm::SmallVector<mlir::Value> slots(
+        allocateSlotsFunc.getArguments().begin(),
+        allocateSlotsFunc.getArguments().end());
+    for (mlir::Type slotType : info.hostStagedSlotTypes()) {
+      slots.push_back(createSlot(builder, allocateSlotsFunc.getLoc(), deviceOp,
+                                 mlir::cast<RankedTensorType>(slotType)));
+    }
+    for (mlir::Type outputSlotType : info.outputSlotTypes) {
+      slots.push_back(createSlot(builder, allocateSlotsFunc.getLoc(), deviceOp,
+                                 mlir::cast<RankedTensorType>(outputSlotType)));
     }
 
-    // Build input types for the capture function and corresponding device slot
-    // types. The capture function accepts:
-    // - Regular inputs from host memory that need to be transferred to device
-    // - Constants/parameters that are already on device (persisted)
-    // - KV cache tensors that are device-native and updated in-place
-    // - Global semaphores: pass-through, no slot, no host staging
-    // For each argument, we determine the appropriate input type and slot
-    // allocation strategy.
-    llvm::SmallVector<mlir::Type> inputTypes;
-    llvm::SmallVector<mlir::Type> traceInputSlotTypes;
-    for (size_t i = 0; i < traceFunc.getNumArguments(); i++) {
-      mlir::Value traceFuncArg = traceFunc.getArgument(i);
+    builder.create<func::ReturnOp>(allocateSlotsFunc.getLoc(), slots);
 
-      if (isSemaphoreValue(traceFuncArg)) {
-        inputTypes.push_back(traceFuncArg.getType());
-        continue;
-      }
+    return mlir::success();
+  }
 
-      RankedTensorType originalRankedTensorType =
-          mlir::cast<RankedTensorType>(traceFuncArg.getType());
+  // Allocates one persistent device buffer of the given type.
+  mlir::Value createSlot(mlir::OpBuilder &builder, mlir::Location loc,
+                         mlir::Value deviceOp, RankedTensorType slotType) {
+    mlir::MLIRContext *context = &this->getContext();
+    return builder
+        .create<ttnn::EmptyOp>(
+            loc, slotType, deviceOp,
+            ttnn::ShapeAttr::get(context, slotType.getShape()))
+        .getResult();
+  }
 
-      // Device-resident arguments (constants, parameters, KV cache) bypass host
-      // transfer. These are already on device and will be used directly as
-      // trace input slots.
-      if (shouldKeepArgOnDevice(traceFunc, i)) {
-        if (!utils::isTensorOnDevice(originalRankedTensorType)) {
-          return funcOp.emitError("Device-resident argument ")
-                 << i << " must already be in device memory";
-        }
-        inputTypes.push_back(traceFuncArg.getType());
-        traceInputSlotTypes.push_back(traceFuncArg.getType());
-        continue;
-      }
+  // Creates the capture function.
+  //
+  // Captures the trace against slots that the allocation function already
+  // created and that are passed in as arguments. This is the single capture
+  // path: the runtime invokes it for the initial capture and again, with the
+  // very same slots, to recapture a stale trace. Because it allocates no
+  // persistent buffer of its own, a recapture leaves the allocator untouched.
+  //
+  // Signature:
+  //   (host-staged inputs..., input slots..., output slots..., semaphores...)
+  //     -> trace id
+  mlir::LogicalResult
+  createRunAndCaptureTraceFunction(func::FuncOp funcOp, uint64_t traceFuncIndex,
+                                   const TraceMainFuncInfo &info) {
+    mlir::MLIRContext *context = &this->getContext();
+    mlir::OpBuilder builder(context);
+    mlir::IRRewriter rewriter(builder);
 
-      // Regular input arguments require host-to-device transfer during trace
-      // capture. We create two types for each regular input:
-      // 1. Host-side type (system memory) for the function signature
-      // 2. Device-side slot type (DRAM) for persistent trace storage
-      RankedTensorType inputArgType = utils::RankedTensorTypeFactory::create(
-          originalRankedTensorType, BufferType::SystemMemory);
+    func::FuncOp traceFunc = info.traceFunc;
+    llvm::SmallVector<mlir::Type> argTypes;
+    llvm::SmallVector<mlir::DictionaryAttr> argAttrs;
 
-      inputTypes.push_back(inputArgType);
-
-      // Create the device-side trace input slot type (DRAM) for this argument.
-      // This slot persists on device across trace executions.
-      RankedTensorType dramTraceInputSlotType =
-          utils::RankedTensorTypeFactory::create(originalRankedTensorType,
-                                                 BufferType::DRAM);
-
-      traceInputSlotTypes.push_back(dramTraceInputSlotType);
+    // Host-staged inputs, in system memory, to be written into their slots.
+    for (size_t argIndex : info.hostStagedIndices()) {
+      auto originalType =
+          mlir::cast<RankedTensorType>(info.boundaryInputs[argIndex].getType());
+      argTypes.push_back(utils::RankedTensorTypeFactory::create(
+          originalType, BufferType::SystemMemory));
+      argAttrs.push_back(info.inputArgAttrs[argIndex]);
+    }
+    // Input slots, then output slots, then semaphores. A device-resident slot
+    // is the original argument and keeps its attrs; a host-staged slot is a
+    // fresh buffer and gets none.
+    for (size_t argIndex : info.deviceResidentIndices()) {
+      argTypes.push_back(info.inputSlotTypes[argIndex]);
+      argAttrs.push_back(info.inputArgAttrs[argIndex]);
+    }
+    for (size_t argIndex : info.hostStagedIndices()) {
+      argTypes.push_back(info.inputSlotTypes[argIndex]);
+      argAttrs.push_back(mlir::DictionaryAttr::get(context));
+    }
+    for (mlir::Type outputSlotType : info.outputSlotTypes) {
+      argTypes.push_back(outputSlotType);
+      argAttrs.push_back(mlir::DictionaryAttr::get(context));
+    }
+    for (mlir::Type semaphoreType : info.semaphoreTypes) {
+      argTypes.push_back(semaphoreType);
+      argAttrs.push_back(mlir::DictionaryAttr::get(context));
     }
 
-    // The capture function returns multiple values for trace management:
-    // 1. traceId - Identifier for the captured trace
-    // 2. trace input slots - Persistent device memory for input data
-    // 3. trace output slots - Persistent device memory for output data
-
-    llvm::SmallVector<mlir::Type> outputTypes;
-
-    // Trace ID for the captured trace, used for correlation between capture and
-    // execution.
-    outputTypes.push_back(utils::getTraceIdType(context));
-
-    // Trace input slots for all tensor inputs (including constants/parameters
-    // and KV cache) that are persisted on device.
-    for (mlir::Type traceInputSlotType : traceInputSlotTypes) {
-      outputTypes.push_back(traceInputSlotType);
-    }
-
-    // Trace output slots for all outputs that will be captured on device.
-    // These are also used as the actual outputs for the first invocation.
-    for (mlir::Type outputType : traceFunc.getFunctionType().getResults()) {
-      outputTypes.push_back(outputType);
-    }
-
-    // Create and insert function.
-    auto runAndCaptureTraceFuncType =
-        builder.getFunctionType(inputTypes, outputTypes);
-
-    TraceSmallString runAndCaptureTraceFuncName =
+    TraceSmallString captureFuncName =
         getCaptureTraceFuncName(funcOp, traceFuncIndex);
 
     builder.setInsertionPoint(funcOp);
-    auto runAndCaptureTraceFunc = builder.create<func::FuncOp>(
-        funcOp.getLoc(), runAndCaptureTraceFuncName,
-        runAndCaptureTraceFuncType);
+    auto captureFunc = builder.create<func::FuncOp>(
+        funcOp.getLoc(), captureFuncName,
+        builder.getFunctionType(argTypes, {utils::getTraceIdType(context)}));
     ttmlir::utils::setFunctionType(
-        runAndCaptureTraceFunc,
-        ttmlir::utils::FunctionType::TraceRunAndCapture);
-    if (traceFunc.getAllArgAttrs()) {
-      runAndCaptureTraceFunc.setAllArgAttrs(traceFunc.getAllArgAttrs());
-    }
-    runAndCaptureTraceFunc.setPrivate();
+        captureFunc, ttmlir::utils::FunctionType::TraceRunAndCapture);
+    captureFunc.setAllArgAttrs(argAttrs);
+    captureFunc.setPrivate();
 
-    // Build the body of the function.
-    auto *runAndCaptureTraceFuncEntryBlock =
-        runAndCaptureTraceFunc.addEntryBlock();
-    builder.setInsertionPointToStart(runAndCaptureTraceFuncEntryBlock);
+    auto *entryBlock = captureFunc.addEntryBlock();
+    builder.setInsertionPointToStart(entryBlock);
 
-    auto deviceOp =
-        utils::getOrInsertDevice(rewriter, runAndCaptureTraceFuncEntryBlock);
+    auto deviceOp = utils::getOrInsertDevice(rewriter, entryBlock);
 
-    // Create or reuse trace input slots on device, and build the operand list
-    // for the inner func.call to the trace function.
-    // - Device-resident tensor args (constants/parameters/KV cache): use
-    //   directly as slots.
-    // - Regular tensor inputs: allocate new empty tensors on device for data
-    //   transfer; these become persistent slots.
-    // - Semaphores: pass-through into the inner call only, not slots.
-    llvm::SmallVector<mlir::Value> traceInputSlots;
-    llvm::SmallVector<mlir::Value> traceCallArgs;
-    llvm::SmallVector<std::pair<mlir::Value, mlir::Value>> hostToSlotTransfers;
-    for (size_t i = 0; i < runAndCaptureTraceFunc.getNumArguments(); i++) {
-      mlir::Value funcArg = runAndCaptureTraceFunc.getArgument(i);
+    const size_t inputSlotBase = info.hostStagedIndices().size();
+    const size_t outputSlotBase = inputSlotBase + info.numTensorInputs;
+    const size_t semaphoreBase = outputSlotBase + info.outputSlotTypes.size();
 
-      if (isSemaphoreValue(funcArg)) {
-        traceCallArgs.push_back(funcArg);
-        continue;
-      }
-
-      if (shouldKeepArgOnDevice(traceFunc, i)) {
-        traceInputSlots.push_back(funcArg);
-        traceCallArgs.push_back(funcArg);
-        continue;
-      }
-
-      // Regular inputs need device memory allocation for host-to-device
-      // transfer. Create empty tensors on device that will serve as persistent
-      // slots for trace input data during capture and replay.
-      mlir::Type traceInputSlotType =
-          traceInputSlotTypes[traceInputSlots.size()];
-
-      RankedTensorType deviceTensorType =
-          mlir::cast<RankedTensorType>(traceInputSlotType);
-
-      auto emptyOp = builder.create<ttnn::EmptyOp>(
-          runAndCaptureTraceFunc.getLoc(), deviceTensorType, deviceOp,
-          ttnn::ShapeAttr::get(context, deviceTensorType.getShape()));
-
-      traceInputSlots.push_back(emptyOp.getResult());
-      traceCallArgs.push_back(emptyOp.getResult());
-      hostToSlotTransfers.push_back({funcArg, emptyOp.getResult()});
+    // Each trace function tensor argument's input slot, in argument order.
+    llvm::SmallVector<mlir::Value> inputSlots;
+    for (size_t i = 0; i < info.numTensorInputs; i++) {
+      inputSlots.push_back(captureFunc.getArgument(inputSlotBase + i));
     }
 
-    // Transfer host inputs to their corresponding device slots.
-    for (auto [hostInput, deviceSlot] : hostToSlotTransfers) {
-      builder.create<ttnn::WriteTensorOp>(runAndCaptureTraceFunc.getLoc(),
-                                          hostInput, deviceSlot,
-                                          /*blocking=*/false, /*cq_id=*/0);
+    llvm::SmallVector<mlir::Value> traceOutputSlots;
+    for (size_t i = 0; i < info.outputSlotTypes.size(); i++) {
+      traceOutputSlots.push_back(captureFunc.getArgument(outputSlotBase + i));
+    }
+
+    // Transfer the host-staged inputs into their device slots. This has to
+    // happen before the capture window opens: tt-metal rejects host writes
+    // while a capture is active.
+    for (auto [h, argIndex] : llvm::enumerate(info.hostStagedIndices())) {
+      builder.create<ttnn::WriteTensorOp>(
+          captureFunc.getLoc(), captureFunc.getArgument(h),
+          inputSlots[argIndex], /*blocking=*/false, /*cq_id=*/0);
+    }
+
+    // Rebuild the trace function's call arguments in its own argument order:
+    // [tensor inputs from their slots][output slots][semaphores].
+    llvm::SmallVector<mlir::Value> traceCallArgs(inputSlots);
+    llvm::append_range(traceCallArgs, traceOutputSlots);
+    for (size_t i = 0; i < info.semaphoreTypes.size(); i++) {
+      traceCallArgs.push_back(captureFunc.getArgument(semaphoreBase + i));
     }
 
     // Execute the trace function once without capture to compile programs and
     // populate program cache.
-    builder.create<func::CallOp>(runAndCaptureTraceFunc.getLoc(), traceFunc,
+    builder.create<func::CallOp>(captureFunc.getLoc(), traceFunc,
                                  traceCallArgs);
 
-    // Start capturing the trace.
     auto beginTraceCaptureOp = builder.create<ttnn::BeginTraceCaptureOp>(
-        runAndCaptureTraceFunc.getLoc(), utils::getTraceIdType(context),
-        deviceOp,
+        captureFunc.getLoc(), utils::getTraceIdType(context), deviceOp,
         /*cq_id=*/0);
 
-    // Execute the trace on device and capture it.
-    auto captureTraceCall = builder.create<func::CallOp>(
-        runAndCaptureTraceFunc.getLoc(), traceFunc, traceCallArgs);
+    // Execute the trace function again and capture it.
+    builder.create<func::CallOp>(captureFunc.getLoc(), traceFunc,
+                                 traceCallArgs);
 
-    // Complete the trace capture.
-    builder.create<ttnn::EndTraceCaptureOp>(runAndCaptureTraceFunc.getLoc(),
-                                            deviceOp, beginTraceCaptureOp,
+    builder.create<ttnn::EndTraceCaptureOp>(captureFunc.getLoc(), deviceOp,
+                                            beginTraceCaptureOp,
                                             /*cq_id=*/0);
 
-    // Execute the trace once to fill output slots with real computed values.
-    builder.create<ttnn::ExecuteTraceOp>(runAndCaptureTraceFunc.getLoc(),
-                                         deviceOp, beginTraceCaptureOp,
+    // Replay once so the output slots hold valid results for this invocation.
+    builder.create<ttnn::ExecuteTraceOp>(captureFunc.getLoc(), deviceOp,
+                                         beginTraceCaptureOp,
                                          /*cq_id=*/0, /*blocking=*/false);
 
-    // Assemble return values: trace ID and persistent slots.
-    llvm::SmallVector<mlir::Value> returnValues;
-
-    // Return the trace ID for correlation with execution.
-    returnValues.push_back(beginTraceCaptureOp.getTraceId());
-    // Return the trace input slots for all tensor inputs (including
-    // constants/parameters and KV cache) that are persisted on device.
-    for (mlir::Value inputSlot : traceInputSlots) {
-      returnValues.push_back(inputSlot);
-    }
-    // Return the trace output slots. After the execute_trace above, these
-    // contain valid computed results for the first invocation.
-    for (mlir::Value outputSlot : captureTraceCall.getResults()) {
-      returnValues.push_back(outputSlot);
-    }
-
-    builder.create<func::ReturnOp>(runAndCaptureTraceFunc.getLoc(),
-                                   returnValues);
+    builder.create<func::ReturnOp>(
+        captureFunc.getLoc(),
+        mlir::ValueRange{beginTraceCaptureOp.getTraceId()});
 
     return mlir::success();
   }
@@ -561,14 +682,6 @@ private:
     mlir::MLIRContext *context = &this->getContext();
     mlir::OpBuilder builder(context);
     mlir::IRRewriter rewriter(builder);
-
-    TraceSmallString traceFuncName = getTraceFuncName(funcOp, traceFuncIndex);
-    ModuleOp moduleOp = funcOp->getParentOfType<ModuleOp>();
-    func::FuncOp traceFunc = moduleOp.lookupSymbol<func::FuncOp>(traceFuncName);
-    if (!traceFunc) {
-      return funcOp.emitError("Could not find trace function with name: " +
-                              traceFuncName);
-    }
 
     llvm::SmallVector<mlir::Type> inputTypes;
     inputTypes.push_back(utils::getTraceIdType(context));
@@ -705,10 +818,9 @@ private:
     return mlir::success();
   }
 
-  mlir::LogicalResult
-  insertCaptureOrExecuteTraceOp(func::FuncOp funcOp,
-                                llvm::ArrayRef<Operation *> opsToHoist,
-                                uint64_t traceFuncIndex) {
+  mlir::LogicalResult insertCaptureOrExecuteTraceOp(
+      func::FuncOp funcOp, llvm::ArrayRef<Operation *> opsToHoist,
+      uint64_t traceFuncIndex, const TraceMainFuncInfo &info) {
     mlir::MLIRContext *context = &this->getContext();
     mlir::OpBuilder builder(context);
     mlir::IRRewriter rewriter(builder);
@@ -724,6 +836,16 @@ private:
           captureTraceFuncName);
     }
 
+    TraceSmallString allocateSlotsTraceFuncName =
+        getAllocateSlotsTraceFuncName(funcOp, traceFuncIndex);
+    func::FuncOp allocateSlotsTraceFunc =
+        moduleOp.lookupSymbol<func::FuncOp>(allocateSlotsTraceFuncName);
+    if (!allocateSlotsTraceFunc) {
+      return funcOp.emitError(
+          "Could not find slot allocation trace function with name: " +
+          allocateSlotsTraceFuncName);
+    }
+
     TraceSmallString executeTraceFuncName =
         getExecuteTraceFuncName(funcOp, traceFuncIndex);
     func::FuncOp executeTraceFunc =
@@ -734,18 +856,10 @@ private:
           executeTraceFuncName);
     }
 
-    llvm::SmallVector<mlir::Value> inputs;
-    llvm::SmallVector<mlir::Value> outputs;
-    llvm::SmallVector<mlir::Type> outputTypes;
-
-    collectFunctionBoundary(opsToHoist, inputs, outputs);
-
-    for (mlir::Value output : outputs) {
-      outputTypes.push_back(output.getType());
-    }
-
     auto captureTraceSymbolAttr =
         mlir::SymbolRefAttr::get(context, captureTraceFuncName);
+    auto allocateSlotsTraceSymbolAttr =
+        mlir::SymbolRefAttr::get(context, allocateSlotsTraceFuncName);
     auto executeTraceSymbolAttr =
         mlir::SymbolRefAttr::get(context, executeTraceFuncName);
 
@@ -755,43 +869,32 @@ private:
 
     auto device = utils::getOrInsertDevice(rewriter, firstOp);
 
-    // Split inputs into the two operand groups expected by the op.
-    llvm::SmallVector<mlir::Value> tensorInputs;
-    llvm::SmallVector<mlir::Value> semaphoreInputs;
+    // Split inputs into the two operand groups expected by the op; the
+    // boundary inputs hold the tensors first and the semaphores after them.
+    llvm::SmallVector<mlir::Value> tensorInputs(info.numTensorInputs);
+    llvm::SmallVector<mlir::Value> semaphoreInputs(info.boundaryInputs.begin() +
+                                                       info.numTensorInputs,
+                                                   info.boundaryInputs.end());
 
-    for (size_t i = 0; i < inputs.size(); i++) {
-      mlir::Value input = inputs[i];
-
-      if (isSemaphoreValue(input)) {
-        semaphoreInputs.push_back(input);
-        continue;
-      }
-
-      if (!mlir::isa<RankedTensorType>(input.getType())) {
-        return funcOp.emitError(
-            "Trace input must be a ranked tensor or global semaphore");
-      }
-
-      // Check if this value should remain on device during trace capture.
-      // Handles direct BlockArguments and LoadCachedOp results.
-      bool keepOnDevice = isDeviceResidentValue(input);
-
-      RankedTensorType tensorType =
-          mlir::cast<RankedTensorType>(input.getType());
+    // Device-resident values (constants, parameters, KV cache) can be
+    // captured directly without moving to system memory.
+    for (size_t argIndex : info.deviceResidentIndices()) {
+      mlir::Value input = info.boundaryInputs[argIndex];
+      auto tensorType = mlir::cast<RankedTensorType>(input.getType());
       auto layout = mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
-
-      // Device-resident values (constants, parameters, KV cache) can be
-      // captured directly without moving to system memory.
-      if (keepOnDevice) {
-        if (layout.getBufferType() == ttnn::BufferType::SystemMemory) {
-          return funcOp.emitError(
-              "Device-resident input must be on device, but found on "
-              "system memory");
-        }
-        tensorInputs.push_back(input);
+      if (layout.getBufferType() == ttnn::BufferType::SystemMemory) {
+        return funcOp.emitError(
+            "Device-resident input must be on device, but found on "
+            "system memory");
       }
-      // For inputs, convert them to system memory/row major if needed
-      else if (layout.getBufferType() != ttnn::BufferType::SystemMemory) {
+      tensorInputs[argIndex] = input;
+    }
+    // Host-staged inputs are converted to system memory if needed.
+    for (size_t argIndex : info.hostStagedIndices()) {
+      mlir::Value input = info.boundaryInputs[argIndex];
+      auto tensorType = mlir::cast<RankedTensorType>(input.getType());
+      auto layout = mlir::cast<ttnn::TTNNLayoutAttr>(tensorType.getEncoding());
+      if (layout.getBufferType() != ttnn::BufferType::SystemMemory) {
         // Convert to system memory using ToTensorSpecOp
         RankedTensorType systemMemoryTileType =
             utils::RankedTensorTypeFactory::create(
@@ -799,20 +902,22 @@ private:
 
         auto toTensorSpecOp = builder.create<ttnn::ToTensorSpecOp>(
             funcOp.getLoc(), systemMemoryTileType, input);
-        tensorInputs.push_back(toTensorSpecOp.getResult());
+        tensorInputs[argIndex] = toTensorSpecOp.getResult();
       } else {
         // Already on system memory
-        tensorInputs.push_back(input);
+        tensorInputs[argIndex] = input;
       }
     }
 
     auto traceOp = builder.create<ttnn::CaptureOrExecuteTraceOp>(
-        funcOp.getLoc(), outputTypes, device, captureTraceSymbolAttr,
+        funcOp.getLoc(), info.outputSlotTypes, device,
+        allocateSlotsTraceSymbolAttr, captureTraceSymbolAttr,
         executeTraceSymbolAttr, tensorInputs, semaphoreInputs);
 
     // Replace uses of original outputs with the output of the trace op function
-    for (size_t i = 0; i < outputs.size(); i++) {
-      outputs[i].replaceAllUsesWith(traceOp->getResult(i));
+    for (size_t i = 0; i < info.boundaryOutputs.size(); i++) {
+      mlir::Value output = info.boundaryOutputs[i];
+      output.replaceAllUsesWith(traceOp->getResult(i));
     }
 
     // Remove the original ops in reverse order (to avoid dependency issues)
@@ -827,14 +932,21 @@ private:
   performHoistTransform(func::FuncOp funcOp,
                         llvm::ArrayRef<Operation *> opsToHoist) {
     uint64_t traceFuncIndex = getUniqueTraceFuncIndex();
-    // Create trace function and trace op if there are ops to hoist
-    ::mlir::LogicalResult result =
+    // Create the trace function. Everything the downstream builders need to
+    // know about it is computed here, once.
+    mlir::FailureOr<TraceMainFuncInfo> info =
         createTraceFunction(funcOp, opsToHoist, traceFuncIndex);
+    if (failed(info)) {
+      return mlir::failure();
+    }
+
+    mlir::LogicalResult result =
+        createAllocateSlotsTraceFunction(funcOp, traceFuncIndex, *info);
     if (failed(result)) {
       return result;
     }
 
-    result = createRunAndCaptureTraceFunction(funcOp, traceFuncIndex);
+    result = createRunAndCaptureTraceFunction(funcOp, traceFuncIndex, *info);
     if (failed(result)) {
       return result;
     }
@@ -844,7 +956,8 @@ private:
       return result;
     }
 
-    result = insertCaptureOrExecuteTraceOp(funcOp, opsToHoist, traceFuncIndex);
+    result = insertCaptureOrExecuteTraceOp(funcOp, opsToHoist, traceFuncIndex,
+                                           *info);
     if (failed(result)) {
       return result;
     }

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -3270,6 +3270,16 @@ createOp(FlatbufferObjectCache &cache, WriteTensorOp op) {
                                                  deviceTensor, blocking, cqId);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::CopyOp>
+createOp(FlatbufferObjectCache &cache, CopyOp op) {
+  auto src = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getSrc()));
+  auto dst = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getDst()));
+
+  return ::tt::target::ttnn::CreateCopyOp(*cache.fbb, src, dst);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::BeginTraceCaptureOp>
 createOp(FlatbufferObjectCache &cache, BeginTraceCaptureOp op) {
   ::mlir::Value device = getOperandThroughDPSOps(op.getDevice());
@@ -3342,9 +3352,16 @@ createOp(FlatbufferObjectCache &cache, CaptureOrExecuteTraceOp op,
          "Program name not found in program index map!");
   const uint32_t executeProgramIdx = executeIt->second;
 
+  auto allocateSlotsIt =
+      programIndexMap.find(op.getAllocateSlotsCallee().str());
+  assert(allocateSlotsIt != programIndexMap.end() &&
+         "Program name not found in program index map!");
+  const uint32_t allocateSlotsProgramIdx = allocateSlotsIt->second;
+
   return ::tt::target::ttnn::CreateCaptureOrExecuteTraceOpDirect(
       *cache.fbb, cache.at<::tt::target::DeviceRef>(device), captureProgramIdx,
-      executeProgramIdx, &inputs, &outputs, &semaphoreInputs);
+      executeProgramIdx, allocateSlotsProgramIdx, &inputs, &outputs,
+      &semaphoreInputs);
 }
 
 ::flatbuffers::Offset<::tt::target::ttnn::ConcatenateHeadsOp>
@@ -5041,6 +5058,10 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   }
   if (auto writeTensorOp = dyn_cast<WriteTensorOp>(op); writeTensorOp) {
     return createOperation(cache, createOp(cache, writeTensorOp), debugString,
+                           locInfo);
+  }
+  if (auto copyOp = dyn_cast<CopyOp>(op); copyOp) {
+    return createOperation(cache, createOp(cache, copyOp), debugString,
                            locInfo);
   }
   if (auto beginTraceCaptureOp = dyn_cast<BeginTraceCaptureOp>(op);

--- a/runtime/include/tt/runtime/detail/ttnn/types/trace_cache.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/trace_cache.h
@@ -57,9 +57,14 @@ public:
   void insert(const MainProgramKey &key,
               const CaptureExecuteProgramKey &captureExecuteKey,
               TraceData traceData);
+  /// Removes all entries for the given key, releasing their device-side
+  /// traces.
   void erase(const MainProgramKey &key);
-  void erase(const MainProgramKey &key,
-             const CaptureExecuteProgramKey &captureExecuteKey);
+
+  /// Removes the entry for the given key and returns it, leaving the
+  /// device-side trace untouched. The entry must be present in the cache.
+  TraceData take(const MainProgramKey &key,
+                 const CaptureExecuteProgramKey &captureExecuteKey);
 
   uint64_t getGenerationId() const { return generationId; }
 

--- a/runtime/lib/ttnn/operations/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TTNN_OPS_SRCS
   ${CMAKE_CURRENT_SOURCE_DIR}/global_semaphore/global_semaphore.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/assign.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/concat.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/copy.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/gather.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/pad.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/data_movement/permute.cpp

--- a/runtime/lib/ttnn/operations/data_movement/copy.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/copy.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/data_movement/copy.h"
+#include "tt/runtime/detail/common/logger.h"
+#include "tt/runtime/detail/ttnn/utils.h"
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::CopyOp *op, ProgramContext &context) {
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inDeviceMemory(op->src()),
+             "Source tensor must be in device memory");
+  LOG_ASSERT(::tt::runtime::ttnn::utils::inDeviceMemory(op->dst()),
+             "Destination tensor must be in device memory");
+
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &src = tensorPool.getTTNNTensorAndValidate(op->src());
+  ::ttnn::Tensor &dst = tensorPool.getTTNNTensorAndValidate(op->dst());
+
+  ::ttnn::copy(src, dst);
+}
+} // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/data_movement/copy.h
+++ b/runtime/lib/ttnn/operations/data_movement/copy.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_COPY_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_DATA_MOVEMENT_COPY_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::data_movement {
+void run(const ::tt::target::ttnn::CopyOp *op, ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::data_movement
+
+#endif

--- a/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
+++ b/runtime/lib/ttnn/operations/trace/capture_or_execute_trace.cpp
@@ -41,108 +41,81 @@ static void copyTensorFromDeviceToDevice(const ::ttnn::Tensor &srcTensor,
   ::ttnn::copy_to_device(hostSrcTensor, dstTensor);
 }
 
-static void runTraceProgramAndCaptureTrace(
-    const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
-    ProgramContext &context, ::tt::runtime::ttnn::TraceCache &traceCache) {
-
+// Runs the slot allocation program, which allocates the persistent device
+// buffers this trace will read from and write to. Runs exactly once per trace.
+//
+// Its program inputs are the device-resident subset of the op's inputs (they
+// act as their own slots); it returns the trace input slots followed by the
+// trace output slots.
+static std::vector<::tt::runtime::Tensor>
+allocateTraceSlots(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+                   ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
   ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
 
-  std::vector<::tt::runtime::Tensor> inputTensors;
+  std::vector<::tt::runtime::Tensor> deviceResidentInputs;
   for (const ::tt::target::ttnn::TensorRef *input : *op->inputs()) {
-    ::tt::runtime::Tensor inputTensor =
-        tensorPool.getRuntimeTensorAndValidate(input);
-    inputTensors.push_back(inputTensor);
+    if (::tt::runtime::ttnn::utils::inDeviceMemory(input)) {
+      deviceResidentInputs.push_back(
+          tensorPool.getRuntimeTensorAndValidate(input));
+    }
   }
-
-  std::vector<::tt::runtime::GlobalSemaphore> semaphoreInputs =
-      utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
 
   ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
-                           op->capture_program_id(), inputTensors,
-                           /*constEvalProgram=*/false, semaphoreInputs);
+                           op->allocate_slots_program_id(),
+                           deviceResidentInputs,
+                           /*constEvalProgram=*/false,
+                           /*programSemaphoreInputs=*/{});
   executor.execute();
-  std::vector<::tt::runtime::Tensor> outputTensors =
-      executor.gatherOutputTensors();
+  std::vector<::tt::runtime::Tensor> slots = executor.gatherOutputTensors();
 
-  // Outputs are returned in the order of: traceId, trace input slots, trace
-  // output slots.
-  size_t expectedNumOutputs = 1 + op->inputs()->size() + op->outputs()->size();
-  LOG_ASSERT(outputTensors.size() == expectedNumOutputs,
-             "Mismatched number of output tensors, expected: ",
-             expectedNumOutputs, " got: ", outputTensors.size());
-  size_t currOutputIndex = 0;
+  size_t expectedNumSlots = op->inputs()->size() + op->outputs()->size();
+  LOG_ASSERT(slots.size() == expectedNumSlots,
+             "Mismatched number of trace slots, expected: ", expectedNumSlots,
+             " got: ", slots.size());
 
-  // Handle trace id
-  const ::ttnn::Tensor &traceIdTensor =
-      ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(
-          outputTensors[currOutputIndex++]);
-  LOG_ASSERT(traceIdTensor.dtype() == ::ttnn::DataType::UINT32,
-             "Trace ID must be UINT32");
-
-  uint32_t traceId =
-      ::tt::runtime::ttnn::utils::getScalarFromTensor<uint32_t>(traceIdTensor);
-  ::ttnn::MeshTraceId meshTraceId(traceId);
-
-  // Handle trace input slots
-  std::vector<::tt::runtime::Tensor> inputSlots;
-  for (size_t i = 0; i < op->inputs()->size(); i++) {
-    ::tt::runtime::Tensor &inputSlot = outputTensors[currOutputIndex++];
-    ::tt::runtime::ttnn::TTNNTensorWrapper &inputSlotWrapper =
-        inputSlot.as<::tt::runtime::ttnn::TTNNTensorWrapper>(
-            DeviceRuntime::TTNN);
-
-    // input slots need to be retained
-    inputSlotWrapper.setRetain(true);
-    inputSlots.emplace_back(std::move(inputSlot));
+  // The slots outlive every program that touches them; the trace cache owns
+  // them from here on.
+  for (::tt::runtime::Tensor &slot : slots) {
+    slot.as<::tt::runtime::ttnn::TTNNTensorWrapper>(DeviceRuntime::TTNN)
+        .setRetain(true);
   }
 
-  // Handle trace output slots.
-  std::vector<::tt::runtime::Tensor> outputSlots;
-  for (size_t i = 0; i < op->outputs()->size(); i++) {
-    ::tt::runtime::Tensor &outputSlot = outputTensors[currOutputIndex++];
-    ::tt::runtime::ttnn::TTNNTensorWrapper &outputSlotWrapper =
-        outputSlot.as<::tt::runtime::ttnn::TTNNTensorWrapper>(
-            DeviceRuntime::TTNN);
-
-    // output slots need to be retained
-    outputSlotWrapper.setRetain(true);
-    outputSlots.emplace_back(std::move(outputSlot));
-  }
-
-  // Use output slots as the actual outputs for the first invocation.
-  for (size_t i = 0; i < op->outputs()->size(); i++) {
-    tensorPool.insertRuntimeTensorAndValidate(op->outputs()->Get(i),
-                                              outputSlots[i]);
-  }
-
-  TraceData traceData{.traceId = meshTraceId,
-                      .inputTensors = std::move(inputSlots),
-                      .outputTensors = std::move(outputSlots),
-                      .generationId = traceCache.getGenerationId()};
-  auto [mainProgramKey, captureExecuteKey] = getTraceCacheKeys(op, context);
-  traceCache.insert(mainProgramKey, captureExecuteKey, std::move(traceData));
+  return slots;
 }
 
-static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
-                         ProgramContext &context, TraceData &traceData) {
-  ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
-
-  std::vector<::ttnn::Tensor> inputs;
-  LOG_ASSERT(op->inputs()->size() == traceData.inputTensors.size(),
+// Copies the current values of the op's inputs into the persistent trace input
+// slots.
+//
+// When deviceResidentOnly is set, only tensors that are on the device
+// will be updated. This is used before trace capture, since the capture
+// program will copy the host inputs into the slots itself.
+//
+// TODO(pilkic): we could align `executeTrace` to have the same logic for
+// handling host inputs as `captureTrace`. That would simplify the contract,
+// such that runtime is only responsible for updating device-resident inputs.
+static void
+updateTraceInputSlots(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+                      ProgramContext &context,
+                      std::vector<::tt::runtime::Tensor> &inputSlots,
+                      bool deviceResidentOnly = false) {
+  LOG_ASSERT(op->inputs()->size() == inputSlots.size(),
              "Mismatched number of inputs, expected: ", op->inputs()->size(),
-             " got: ", traceData.inputTensors.size());
-  LOG_ASSERT(op->outputs()->size() == traceData.outputTensors.size(),
-             "Mismatched number of outputs, expected: ", op->outputs()->size(),
-             " got: ", traceData.outputTensors.size());
+             " got: ", inputSlots.size());
 
   for (size_t i = 0; i < op->inputs()->size(); i++) {
     const ::tt::target::ttnn::TensorRef *input = op->inputs()->Get(i);
+    const bool deviceResident =
+        ::tt::runtime::ttnn::utils::inDeviceMemory(input);
+    if (deviceResidentOnly && !deviceResident) {
+      continue;
+    }
+
     const ::tt::runtime::ttnn::TTNNTensorWrapper &inputTensorWrapper =
         context.getTensorPool().getTTNNTensorWrapperAndValidate(input);
 
     ::tt::runtime::ttnn::TTNNTensorWrapper &inputSlotWrapper =
-        traceData.inputTensors[i].as<::tt::runtime::ttnn::TTNNTensorWrapper>(
+        inputSlots[i].as<::tt::runtime::ttnn::TTNNTensorWrapper>(
             DeviceRuntime::TTNN);
 
     // Constants/parameters and KV cache tensors live on device and persist
@@ -153,8 +126,7 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
       continue;
     }
 
-    if (input->desc()->layout()->memory_desc()->storage_type() ==
-        ::tt::target::ttnn::StorageType::Device) {
+    if (deviceResident) {
       // Device-resident tensors (constants/parameters/KV cache) can be
       // legitimately updated by the user (e.g. weight updates during
       // training). This is handled by copying the new device tensor into the
@@ -176,6 +148,100 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
     // Thus we can synchronize their versions
     inputSlotWrapper.syncVersion(inputTensorWrapper);
   }
+}
+
+// Publishes the persistent output slots as the op's outputs.
+static void
+publishTraceOutputs(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+                    ProgramContext &context,
+                    const std::vector<::tt::runtime::Tensor> &outputSlots) {
+  LOG_ASSERT(op->outputs()->size() == outputSlots.size(),
+             "Mismatched number of outputs, expected: ", op->outputs()->size(),
+             " got: ", outputSlots.size());
+  for (size_t i = 0; i < op->outputs()->size(); i++) {
+    const ::tt::target::ttnn::TensorRef *output = op->outputs()->Get(i);
+    context.getTensorPool().insertRuntimeTensorAndValidate(output,
+                                                           outputSlots[i]);
+  }
+}
+
+// Captures the trace against its persistent slots and returns the completed
+// TraceData; the caller inserts it into the cache. The cache therefore only
+// ever holds fully-captured traces.
+//
+// This is the single capture path: it is used both for the initial capture and
+// to recapture a trace that has gone stale, in the latter case with the very
+// same slots. The capture program takes the slots as arguments rather than
+// allocating them, so it allocates nothing that outlives its own trace capture.
+// That is what lets a recaptured trace simply inherit the current cache
+// generation - it cannot have moved any buffer that a sibling cached trace
+// baked into its command stream, so no sibling needs to be invalidated.
+static TraceData captureTrace(
+    const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+    ProgramContext &context, std::vector<::tt::runtime::Tensor> inputSlots,
+    std::vector<::tt::runtime::Tensor> outputSlots, uint64_t generationId) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
+
+  // Program inputs are, in order: the host-staged inputs, the trace input
+  // slots, then the trace output slots - matching the capture function's
+  // signature. ProgramExecutor holds pointers into this vector, so it must
+  // outlive the executor.
+  std::vector<::tt::runtime::Tensor> captureInputs;
+  captureInputs.reserve(op->inputs()->size() + inputSlots.size() +
+                        outputSlots.size());
+  for (const ::tt::target::ttnn::TensorRef *input : *op->inputs()) {
+    if (!::tt::runtime::ttnn::utils::inDeviceMemory(input)) {
+      captureInputs.push_back(tensorPool.getRuntimeTensorAndValidate(input));
+    }
+  }
+  captureInputs.insert(captureInputs.end(), inputSlots.begin(),
+                       inputSlots.end());
+  captureInputs.insert(captureInputs.end(), outputSlots.begin(),
+                       outputSlots.end());
+
+  std::vector<::tt::runtime::GlobalSemaphore> semaphoreInputs =
+      utils::collectSemaphoreInputs(op->semaphore_inputs(), context);
+
+  ProgramExecutor executor(deviceHandle, context.getExecutableHandle(),
+                           op->capture_program_id(), captureInputs,
+                           /*constEvalProgram=*/false, semaphoreInputs);
+  executor.execute();
+  std::vector<::tt::runtime::Tensor> outputTensors =
+      executor.gatherOutputTensors();
+
+  LOG_ASSERT(outputTensors.size() == 1,
+             "Capture program must return exactly the new trace id, got: ",
+             outputTensors.size());
+
+  const ::ttnn::Tensor &traceIdTensor =
+      ::tt::runtime::ttnn::utils::getTTNNTensorFromRuntimeTensor(
+          outputTensors[0]);
+  LOG_ASSERT(traceIdTensor.dtype() == ::ttnn::DataType::UINT32,
+             "Trace ID must be UINT32");
+
+  TraceData traceData{
+      .traceId = ::ttnn::MeshTraceId(
+          ::tt::runtime::ttnn::utils::getScalarFromTensor<uint32_t>(
+              traceIdTensor)),
+      .inputTensors = std::move(inputSlots),
+      .outputTensors = std::move(outputSlots),
+      // Inherit the caller's current generation: the capture allocated no
+      // buffer that outlived it, so it invalidated nothing.
+      .generationId = generationId};
+
+  // The capture program replays the trace once, so the output slots already
+  // hold this invocation's results.
+  publishTraceOutputs(op, context, traceData.outputTensors);
+
+  return traceData;
+}
+
+static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
+                         ProgramContext &context, TraceData &traceData) {
+  ::tt::runtime::Device deviceHandle = context.getDeviceHandle();
+
+  updateTraceInputSlots(op, context, traceData.inputTensors);
 
   ::ttnn::Tensor traceIdTensor =
       ::tt::runtime::ttnn::utils::createTTNNTensor<uint32_t>(
@@ -194,11 +260,7 @@ static void executeTrace(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
                            /*programSemaphoreInputs=*/{});
   executor.execute();
 
-  for (size_t i = 0; i < op->outputs()->size(); i++) {
-    const ::tt::target::ttnn::TensorRef *output = op->outputs()->Get(i);
-    context.getTensorPool().insertRuntimeTensorAndValidate(
-        output, traceData.outputTensors[i]);
-  }
+  publishTraceOutputs(op, context, traceData.outputTensors);
 }
 
 void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
@@ -218,9 +280,30 @@ void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
   auto [mainProgramKey, captureExecuteKey] = getTraceCacheKeys(op, context);
 
   if (!traceCache->contains(mainProgramKey, captureExecuteKey)) {
-    LOG_DEBUG("Trace cache miss, running program and capturing trace");
+    LOG_DEBUG("Trace cache miss, allocating slots and capturing trace");
     traceCache->incrementGeneration();
-    runTraceProgramAndCaptureTrace(op, context, *traceCache);
+
+    // Allocate the persistent slots once, then capture against them.
+    std::vector<::tt::runtime::Tensor> slots = allocateTraceSlots(op, context);
+    size_t numInputSlots = op->inputs()->size();
+    std::vector<::tt::runtime::Tensor> inputSlots(
+        slots.begin(), slots.begin() + numInputSlots);
+    std::vector<::tt::runtime::Tensor> outputSlots(
+        slots.begin() + numInputSlots, slots.end());
+
+    // Fill the input slots before capturing; writes are rejected once the
+    // capture window is open. The capture program does this itself for the
+    // host-staged inputs it receives, so this only has to cover the
+    // device-resident slots, which alias their inputs and are therefore
+    // version-matched no-ops. Keeping the call here means the capture path and
+    // the execute path establish the slots identically.
+    updateTraceInputSlots(op, context, inputSlots,
+                          /*deviceResidentOnly=*/true);
+    TraceData traceData =
+        captureTrace(op, context, std::move(inputSlots), std::move(outputSlots),
+                     traceCache->getGenerationId());
+    traceCache->insert(mainProgramKey, captureExecuteKey, std::move(traceData));
+
     debug::Stats::get().incrementStat("TraceCacheMiss");
     debug::Stats::get().incrementStat("CapturedTrace");
     return;
@@ -239,13 +322,29 @@ void run(const ::tt::target::ttnn::CaptureOrExecuteTraceOp *op,
   if (traceData->generationId < traceCache->getGenerationId()) {
     LOG_DEBUG("Trace is stale (captured at gen ", traceData->generationId,
               ", current gen ", traceCache->getGenerationId(),
-              "), invalidating and recapturing");
+              "), recapturing into the existing slots");
 
-    // Remove the stale trace from the cache and recapture it.
-    traceCache->erase(mainProgramKey, captureExecuteKey);
-    runTraceProgramAndCaptureTrace(op, context, *traceCache);
+    // Recapture through the very same capture program the initial capture used
+    // and against the very same slots: take the entry out of the cache, hand
+    // its slots to the recapture, and reinsert the result. The slots are never
+    // reallocated, so a recapture cannot invalidate any sibling cached trace
+    // and the recaptured trace simply inherits the current generation. Were the
+    // slots reallocated instead, a recapture could shift the allocator state
+    // other cached traces depend on and force them to be recaptured too - a
+    // cycle that recaptures every trace on every iteration.
+    TraceData staleTrace = traceCache->take(mainProgramKey, captureExecuteKey);
 
-    debug::Stats::get().incrementStat("TraceCacheMiss");
+    // Release the old device-side trace before recapturing.
+    ::ttnn::operations::trace::release_trace(&meshDevice, staleTrace.traceId);
+
+    updateTraceInputSlots(op, context, staleTrace.inputTensors,
+                          /*deviceResidentOnly=*/true);
+    TraceData recapturedTrace = captureTrace(
+        op, context, std::move(staleTrace.inputTensors),
+        std::move(staleTrace.outputTensors), traceCache->getGenerationId());
+    traceCache->insert(mainProgramKey, captureExecuteKey,
+                       std::move(recapturedTrace));
+
     debug::Stats::get().incrementStat("TraceStaleRecapture");
     return;
   }

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -47,6 +47,7 @@
 #include "operations/creation/full_with.h"
 #include "operations/data_movement/assign.h"
 #include "operations/data_movement/concat.h"
+#include "operations/data_movement/copy.h"
 #include "operations/data_movement/gather.h"
 #include "operations/data_movement/pad.h"
 #include "operations/data_movement/permute.h"
@@ -440,6 +441,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   case ::tt::target::ttnn::OpType::WriteTensorOp: {
     return operations::data_movement::run(op->type_as_WriteTensorOp(),
                                           getContext());
+  }
+  case ::tt::target::ttnn::OpType::CopyOp: {
+    return operations::data_movement::run(op->type_as_CopyOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::PermuteOp: {
     return operations::data_movement::run(op->type_as_PermuteOp(),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1605,6 +1605,9 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
   case ::tt::target::ttnn::OpType::UpdateCacheOp:
   case ::tt::target::ttnn::OpType::PagedUpdateCacheOp:
   case ::tt::target::ttnn::OpType::WriteTensorOp:
+  // ttnn.copy writes into a caller-provided destination and has no result of
+  // its own, so it contributes no output tensor refs.
+  case ::tt::target::ttnn::OpType::CopyOp:
   case ::tt::target::ttnn::OpType::GetDeviceOp:
   case ::tt::target::ttnn::OpType::DeallocateOp:
   case ::tt::target::ttnn::OpType::EndTraceCaptureOp:
@@ -2220,6 +2223,11 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   case ::tt::target::ttnn::OpType::WriteTensorOp: {
     tensorRefs = {opContext.type_as_WriteTensorOp()->host_tensor(),
                   opContext.type_as_WriteTensorOp()->device_tensor()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::CopyOp: {
+    tensorRefs = {opContext.type_as_CopyOp()->src(),
+                  opContext.type_as_CopyOp()->dst()};
     break;
   }
   case ::tt::target::ttnn::OpType::BeginTraceCaptureOp: {

--- a/runtime/lib/ttnn/types/trace_cache.cpp
+++ b/runtime/lib/ttnn/types/trace_cache.cpp
@@ -55,25 +55,18 @@ void TraceCache::erase(const MainProgramKey &key) {
   cache.erase(outerIt);
 }
 
-void TraceCache::erase(const MainProgramKey &key,
-                       const CaptureExecuteProgramKey &captureExecuteKey) {
+TraceData TraceCache::take(const MainProgramKey &key,
+                           const CaptureExecuteProgramKey &captureExecuteKey) {
   auto outerIt = cache.find(key);
-  if (outerIt == cache.end()) {
-    return;
-  }
+  LOG_ASSERT(outerIt != cache.end(), "Trace entry must be in the cache");
 
   auto innerIt = outerIt->second.find(captureExecuteKey);
-  if (innerIt == outerIt->second.end()) {
-    return;
-  }
+  LOG_ASSERT(innerIt != outerIt->second.end(),
+             "Trace entry must be in the cache");
 
-  std::shared_ptr<::ttnn::MeshDevice> lockedDevice = meshDevice.lock();
-  if (lockedDevice && lockedDevice->is_initialized()) {
-    ::ttnn::operations::trace::release_trace(lockedDevice.get(),
-                                             innerIt->second.traceId);
-  }
-
-  outerIt->second.erase(captureExecuteKey);
+  TraceData traceData = std::move(innerIt->second);
+  outerIt->second.erase(innerIt);
+  return traceData;
 }
 
 } // namespace tt::runtime::ttnn

--- a/runtime/test/ttnn/python/n150/test_trace.py
+++ b/runtime/test/ttnn/python/n150/test_trace.py
@@ -80,8 +80,11 @@ def test_trace_memory_overwrite_multi_graph(helper: Helper, request, trace_regio
 
     We handle this case in runtime by tracking all of the captures - whenever we have a new capture, we bump
     trace cache generation id. Then, when we want to replay a cached trace, we check the generation id of the cached trace
-    against the current generation id of the cache. In case of mismatch, we re-capture & re-cache the trace to ensure that
+    against the current generation id of the cache. In case of mismatch, we re-capture the trace to ensure that
     we won't overlap with any of the new allocations that happened since the last time we captured the trace.
+    The cache entry and its persistent input/output slots stay in place across a re-capture; only the
+    device-side trace is replaced. That is what keeps a re-capture from moving any buffer, and therefore
+    from invalidating the other graph's trace and triggering an endless re-capture cycle.
     """
     binary_path = os.path.join(
         FLATBUFFER_BASE_PATH, "matmul_multiply_consteval.mlir.tmp.ttnn"
@@ -93,7 +96,7 @@ def test_trace_memory_overwrite_multi_graph(helper: Helper, request, trace_regio
     first_bin_config = ProgramTestConfig(
         name="first_graph",
         expected_num_inputs=3,
-        compute_golden=None,
+        compute_golden=lambda inputs: ((inputs[0] @ inputs[1]) * inputs[2]),
         description="Graph whose trace replay can corrupt victim memory",
     )
     first_bin_runner = ProgramTestRunner(first_bin_config, helper.binary, 0)
@@ -118,7 +121,7 @@ def test_trace_memory_overwrite_multi_graph(helper: Helper, request, trace_regio
         # Execute & capture the first graph.
         (
             pressure_inputs,
-            _,
+            pressure_golden,
             _pressure_inputs_torch,
         ) = first_bin_runner.get_inputs_and_golden(device)
         first_bin_runner.run_program(device, pressure_inputs)
@@ -157,12 +160,91 @@ def test_trace_memory_overwrite_multi_graph(helper: Helper, request, trace_regio
                 device, victim_inputs, victim_golden
             )
 
-        # The first graph should have been recaptured once.
+        # The first graph should have been recaptured once, and exactly once: a
+        # recapture reuses its persistent slots, so it cannot invalidate the
+        # victim graph's trace and force it to be recaptured in turn.
         assert debug_stats.get_stat("TraceStaleRecapture") == 1
-        # We have two misses, one for the initial capture of the victim graph and one for the re-capture of the first graph.
-        assert debug_stats.get_stat("TraceCacheMiss") == 2
+        # Only one miss: the initial capture of the victim graph. A stale
+        # recapture is not a cache miss - the entry (and its slots) stay in the
+        # cache and only the device-side trace is replaced.
+        assert debug_stats.get_stat("TraceCacheMiss") == 1
         # We should hit the cache for both graphs each time we run the loop, except for the first recapture.
         assert debug_stats.get_stat("ExecutedTrace") == 2 * loop_count - 1
+
+    ttrt.runtime.DebugStats.get().clear()
+    helper.teardown()
+
+
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_trace_recapture_uses_fresh_inputs(helper: Helper, request, trace_region_size):
+    """
+    Verifies that a re-capture consumes freshly supplied inputs and publishes its
+    output slots. The first graph's trace is made stale by capturing a second
+    graph (which bumps the trace cache generation), then the first graph is run
+    with inputs it has never seen: a re-capture that failed to refresh the input
+    slots, or failed to publish the output slots, would produce a stale result
+    and fail the golden check.
+    """
+    binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "matmul_multiply_consteval.mlir.tmp.ttnn"
+    )
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+    helper.initialize(request.node.name, binary_path)
+    helper.check_constraints()
+
+    first_config = ProgramTestConfig(
+        name="first_graph",
+        expected_num_inputs=3,
+        compute_golden=lambda inputs: ((inputs[0] @ inputs[1]) * inputs[2]),
+        description="Graph whose stale trace gets re-captured",
+    )
+    first_runner = ProgramTestRunner(first_config, helper.binary, 0)
+
+    second_binary = Binary(Logger(), FileManager(Logger()), binary_path)
+    second_config = ProgramTestConfig(
+        name="second_graph",
+        expected_num_inputs=3,
+        compute_golden=lambda inputs: ((inputs[0] @ inputs[1]) * inputs[2]),
+        description="Graph whose capture makes the first graph's trace stale",
+    )
+    second_runner = ProgramTestRunner(second_config, second_binary, 0)
+
+    debug_stats = ttrt.runtime.DebugStats.get()
+
+    with DeviceContext(
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
+    ) as device:
+        # Capture the first graph's trace.
+        inputs, golden, _ = first_runner.get_inputs_and_golden(device)
+        first_runner.run_program_and_compare_golden(device, inputs, golden)
+
+        # Capture the second graph's trace; this bumps the cache generation and
+        # makes the first graph's trace stale.
+        (
+            second_inputs,
+            second_golden,
+            _second_inputs_torch,
+        ) = second_runner.get_inputs_and_golden(device)
+        second_runner.run_program_and_compare_golden(
+            device, second_inputs, second_golden
+        )
+
+        # Run the first graph with brand-new inputs. This takes the re-capture
+        # path, so the golden check fails unless the re-capture refreshed the
+        # input slots and published the output slots.
+        (
+            fresh_inputs,
+            fresh_golden,
+            _fresh_inputs_torch,
+        ) = first_runner.get_inputs_and_golden(device)
+        first_runner.run_program_and_compare_golden(device, fresh_inputs, fresh_golden)
+
+        assert debug_stats.get_stat("TraceStaleRecapture") == 1
+        # Two misses: the initial capture of each graph. The re-capture is not a
+        # miss - the entry and its slots stay in the cache.
+        assert debug_stats.get_stat("TraceCacheMiss") == 2
 
     ttrt.runtime.DebugStats.get().clear()
     helper.teardown()

--- a/runtime/test/ttnn/python/n150/test_trace.py
+++ b/runtime/test/ttnn/python/n150/test_trace.py
@@ -24,6 +24,137 @@ FLATBUFFER_BASE_PATH = (
 )
 
 
+def _read_device_output(runner, device_output):
+    """Read a held device output tensor into a fresh torch container."""
+    output_host = ttrt.runtime.to_host(device_output, untilize=True, blocking=True)[0]
+    output_torch = get_torch_output_container(runner.program)
+    ttrt.runtime.memcpy(output_torch.data_ptr(), output_host)
+    return output_torch
+
+
+@pytest.mark.parametrize("trace_region_size", [0, 80000])
+def test_trace_recapture_slot_reuse_arena(helper: Helper, request, trace_region_size):
+    """
+    Regression test for trace output corruption caused by a stale-trace recapture
+    reallocating its persistent I/O slots.
+
+    Since trace is always writing to same addresses during replay (these addresses
+    are allocated during capture and immediately freed), any persistent allocation
+    that happens after a trace has been captured is not safe since it can be
+    overwritten by the trace's replay (if it is allocated in the same region of
+    memory as the trace's intermediates).
+
+    This test targets a particular wrong-result scenario in which, recaptured trace
+    allocated its output slot in the region of memory used by another trace's
+    intermediates.
+
+    We can define the following terminology:
+    - "safe" hole - is a gap in the memory space that was freed at some point and
+      not used by any of the traces during replay.
+    - "unsafe" hole - is a gap in the memory space that was freed but it IS USED
+      by some trace replay (zone(s) where the trace's intermediates were captured).
+
+    Test is constructed such that we force any re-allocations during trace
+    recapture to be allocated in the "unsafe" hole:
+    1. Allocate a dummy large tensor which will occupy large portion of the
+    bottom space in DRAM.
+    2. Push graph A's params and capture it. All allocations will be above the
+    dummy large tensor allocation.
+    3. Free the large tensor - this will leave a large unallocated gap at the bottom
+    of the DRAM space.
+    4. Capture graph B - the graph is constructed such that it will leave only
+    one "unsafe" hole after the capture.
+    5. Recapture A - anything allocated during recapture will go to the "unsafe"
+    zone. Save the A's output tensor (which will be on device).
+    6. Replay graph B - anything allocated by the graph A's recapture will get
+    overwritten by this replay.
+    7. Read back the saved graph A's output - it should pass the accuracy check.
+
+    """
+    a_binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "matmul_multiply_no_consteval.mlir.tmp.ttnn"
+    )
+    b_binary_path = os.path.join(
+        FLATBUFFER_BASE_PATH, "large_neg_no_consteval.mlir.tmp.ttnn"
+    )
+    for path in (a_binary_path, b_binary_path):
+        assert os.path.exists(path), f"Binary file not found: {path}"
+    helper.initialize(request.node.name, a_binary_path)
+    helper.check_constraints()
+
+    a_config = ProgramTestConfig(
+        name="matmul_multiply",
+        expected_num_inputs=3,
+        compute_golden=lambda inputs: ((inputs[0] @ inputs[1]) * inputs[2]),
+        description="Traced graph whose recapture must reuse its slots",
+    )
+    a_runner = ProgramTestRunner(a_config, helper.binary, 0)
+
+    b_binary = Binary(Logger(), FileManager(Logger()), b_binary_path)
+    b_binary.check_version()
+    b_binary.check_system_desc(helper.query)
+    b_config = ProgramTestConfig(
+        name="large_neg",
+        expected_num_inputs=1,
+        compute_golden=lambda inputs: -inputs[0],
+        description="Traced graph whose replay rewrites the arena",
+    )
+    b_runner = ProgramTestRunner(b_config, b_binary, 0)
+
+    debug_stats = ttrt.runtime.DebugStats.get()
+    debug_stats.clear()
+
+    with DeviceContext(
+        mesh_shape=[1, 1],
+        enable_program_cache=True,
+        trace_region_size=trace_region_size,
+    ) as device:
+        # 1. Large allocation first - it must be the very first device allocation so that
+        # freeing it later opens a region below everything else.
+        large_tensor_shape = [4140, 4096]
+        large_tensor_stride = [4096, 1]
+        large_tensor_layout = ttrt.runtime.test.get_dram_interleaved_row_major_layout(
+            Binary.Program.to_data_type(torch.bfloat16)
+        )
+        large_tensor = ttrt.runtime.create_empty_tensor(
+            device, large_tensor_layout, large_tensor_shape, large_tensor_stride, 2
+        )
+
+        # A's parameters are uploaded to device here - above the large tensor allocation,
+        # like everything else from now on. B's input is host-side only.
+        a_inputs, a_golden, _a_inputs_torch = a_runner.get_inputs_and_golden(device)
+        b_inputs, b_golden, _b_inputs_torch = b_runner.get_inputs_and_golden(device)
+
+        # 2. Capture A above the large tensor.
+        a_output = a_runner.submit_program(device, a_inputs)
+        assert_pcc(_read_device_output(a_runner, a_output), a_golden)
+        assert debug_stats.get_stat("TraceCacheMiss") == 1
+        assert debug_stats.get_stat("CapturedTrace") == 1
+
+        # 3. Free the large tensor - open the arena.
+        ttrt.runtime.deallocate_tensor(large_tensor, force=True)
+
+        # 4. Capture B in the arena. A's trace is now stale.
+        b_runner.run_program_and_compare_golden(device, b_inputs, b_golden)
+        assert debug_stats.get_stat("TraceCacheMiss") == 2
+        assert debug_stats.get_stat("CapturedTrace") == 2
+
+        # 5. Rerun A: stale trace, gets recaptured. Slots must be reused.
+        a_output_recaptured = a_runner.submit_program(device, a_inputs)
+        assert debug_stats.get_stat("TraceStaleRecapture") == 1
+        assert_pcc(_read_device_output(a_runner, a_output_recaptured), a_golden)
+
+        # 6. Replay B (rewrites the arena), then re-read A's output. A
+        # reallocated output slot would live inside the arena and now hold
+        # B's intermediate data.
+        b_runner.run_program_and_compare_golden(device, b_inputs, b_golden)
+        assert debug_stats.get_stat("ExecutedTrace") == 1
+        assert_pcc(_read_device_output(a_runner, a_output_recaptured), a_golden)
+
+    ttrt.runtime.DebugStats.get().clear()
+    helper.teardown()
+
+
 @pytest.mark.parametrize("num_loops", [5])
 @pytest.mark.parametrize("trace_region_size", [0, 80000])
 def test_trace_matmul_multiply_no_consteval(

--- a/test/ttmlir/Conversion/TTNNToEmitC/trace_ops.mlir
+++ b/test/ttmlir/Conversion/TTNNToEmitC/trace_ops.mlir
@@ -28,7 +28,7 @@
 // CHECK-LABEL: func.func private @trace_0_single_add
 // CHECK:       emitc.call_opaque "ttnn::add"
 
-// --- run_and_capture_trace (write_tensor, begin/end trace, execute) ---
+// --- capture_trace (write_tensor, begin/end trace, execute) ---
 // CHECK-LABEL: func.func private @run_and_capture_trace_0_single_add
 // CHECK:       emitc.call_opaque "ttnn::copy_to_device"
 // CHECK:       emitc.call_opaque "ttnn::operations::trace::begin_trace_capture"
@@ -42,8 +42,11 @@
 // --- capture_or_execute wrapper ---
 // CHECK-LABEL: emitc.func @capture_or_execute_trace_0_single_add
 // CHECK:       if
-// CHECK:         call_opaque "run_and_capture_trace_0_single_add"
+// Slot allocation runs first and its tuple is unpacked into the globals; the
+// capture function is then called against those slots and returns the trace id.
+// CHECK:         call_opaque "allocate_slots_trace_0_single_add"
 // CHECK:         call_opaque "::std::get"
+// CHECK:         call_opaque "run_and_capture_trace_0_single_add"
 // CHECK:       } else {
 // CHECK:         call_opaque "execute_trace_0_single_add"
 // CHECK:       call_opaque "::std::make_tuple"
@@ -65,8 +68,11 @@ func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttco
 // --- capture_or_execute wrapper ---
 // CHECK-LABEL: emitc.func @capture_or_execute_trace_1_multi_output
 // CHECK:       if
-// CHECK:         call_opaque "run_and_capture_trace_1_multi_output"
+// Slot allocation runs first and its tuple is unpacked into the globals; the
+// capture function is then called against those slots and returns the trace id.
+// CHECK:         call_opaque "allocate_slots_trace_1_multi_output"
 // CHECK:         call_opaque "::std::get"
+// CHECK:         call_opaque "run_and_capture_trace_1_multi_output"
 // CHECK:       } else {
 // CHECK:         call_opaque "execute_trace_1_multi_output"
 // CHECK:       call_opaque "::std::make_tuple"

--- a/test/ttmlir/Dialect/TTNN/trace/capture_with_semaphores.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/capture_with_semaphores.mlir
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-trace-hoist-transform -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Global semaphores are pass-through handles: they are trace function arguments
+// so device kernels can use them, but they have no persistent device slot. The
+// capture function must therefore take them AFTER all of the slots, because the
+// runtime forwards the slots as the flatbuffer program's tensor inputs and the
+// semaphores separately as program semaphore_inputs.
+//
+// ttnn.create_global_semaphore carries TTCore_CreationOpTrait, so it is not
+// hoisted and the semaphore becomes a trace input. This lets us pin the ordering
+// without needing a CCL op or an OpModel build.
+
+#dram = #ttnn.buffer_type<dram>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // The trace body's arguments are [tensor inputs][output slots][semaphores].
+  // CHECK-LABEL: func.func private @trace_0_main
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>, %arg1: tensor<32x32xbf16, #ttnn_layout>, %arg2: tensor<32x32xbf16, #ttnn_layout>, %arg3: !ttnn.global_semaphore)
+  // CHECK: "ttnn.reset_global_semaphore"
+  // CHECK: "ttnn.copy"
+
+  // A semaphore is not a slot, so the allocation function neither takes nor
+  // returns one.
+  // CHECK-LABEL: func.func private @allocate_slots_trace_0_main
+  // CHECK-SAME: () -> (tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>, tensor<32x32xbf16, #ttnn_layout>)
+  // CHECK-NOT: !ttnn.global_semaphore
+
+  // The capture function's arguments are [host-staged inputs][input slots]
+  // [output slots][semaphores].
+  // CHECK-LABEL: func.func private @run_and_capture_trace_0_main
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout1>, %arg1: tensor<32x32xbf16, #ttnn_layout1>
+  // CHECK-SAME: %arg2: tensor<32x32xbf16, #ttnn_layout>, %arg3: tensor<32x32xbf16, #ttnn_layout>
+  // CHECK-SAME: %arg4: tensor<32x32xbf16, #ttnn_layout>, %arg5: !ttnn.global_semaphore)
+  // CHECK-SAME: -> tensor<ui32, #ttnn.trace_id>
+  // CHECK-NOT: "ttnn.empty"
+  // CHECK-NOT: "ttnn.copy"
+  // CHECK: "ttnn.write_tensor"(%arg0, %arg2)
+  // CHECK: "ttnn.write_tensor"(%arg1, %arg3)
+  // CHECK: call @trace_0_main(%arg2, %arg3, %arg4, %arg5)
+  // CHECK: "ttnn.begin_trace_capture"
+  // CHECK: call @trace_0_main(%arg2, %arg3, %arg4, %arg5)
+  // CHECK: "ttnn.end_trace_capture"
+  // CHECK: "ttnn.execute_trace"
+
+  func.func @main(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> attributes {tt.function_type = "forward_device"} {
+    %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %sem = "ttnn.create_global_semaphore"(%0) <{core_range_set = #ttnn.core_range_set<[#ttnn.core_range<(0,0), (0,0)>]>, initial_value = 0 : ui32}> : (!ttnn.device) -> !ttnn.global_semaphore
+    // The trace op forwards the semaphore in its own operand group (1 device,
+    // 2 tensors, 1 semaphore).
+    // CHECK: "ttnn.capture_or_execute_trace"
+    // CHECK-SAME: allocate_slots_callee = @allocate_slots_trace_0_main
+    // CHECK-SAME: capture_callee = @run_and_capture_trace_0_main
+    // CHECK-SAME: operandSegmentSizes = array<i32: 1, 2, 1>
+    %1 = "ttnn.add"(%arg0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+    "ttnn.reset_global_semaphore"(%sem) <{value = 0 : ui32}> : (!ttnn.global_semaphore) -> ()
+    %2 = "ttnn.multiply"(%1, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+    return %2 : tensor<32x32xbf16, #layout>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/negative_capture_or_execute_trace.mlir
@@ -5,52 +5,159 @@
 // RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
 
 // Negative tests for ttnn.capture_or_execute_trace op verifier.
-// Each test case exercises a single error path in CaptureOrExecuteTraceOp::verify().
+//
+// Capturing is split across two functions: `allocate_slots_callee` allocates the
+// persistent trace input/output slots, and `capture_callee` takes those slots as
+// arguments and captures against them. The trace function itself stores its
+// results into the output slots and returns nothing. Each test below exercises a
+// single error path in CaptureOrExecuteTraceOp::verify().
 
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 1: Capture callee does not reference a function ---
+// --- Test 1: Slot allocation callee does not reference a function ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op 'nonexistent_allocate' does not reference a function
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_allocate_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @nonexistent_allocate, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 2: Slot allocation function returns the wrong number of slots ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Slot allocation function 'allocate_slots_fn' must return 2 slots (1 input slots + 1 output slots), but returns 1
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_allocate_slot_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 3: Slot allocation output slot type does not match the op result ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Slot allocation function output slot 0 type mismatch
+func.func private @trace_fn(%arg0: tensor<32x32xf32, #layout_f32>, %arg1: tensor<32x32xf32, #layout_f32>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xf32, #layout_f32>, tensor<32x32xf32, #layout_f32>) -> tensor<32x32xf32, #layout_f32>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xf32, #layout_f32>, tensor<32x32xf32, #layout_f32>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #layout_f32>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xf32, #layout_f32>
+  return %1, %2 : tensor<32x32xf32, #layout_f32>, tensor<32x32xf32, #layout_f32>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xf32, #layout_f32>, %arg2: tensor<32x32xf32, #layout_f32>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xf32, #layout_f32>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xf32, #layout_f32>, tensor<32x32xf32, #layout_f32>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_allocate_output_slot_type(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 4: Capture callee does not reference a function ---
 // CHECK: error: 'ttnn.capture_or_execute_trace' op 'nonexistent_capture' does not reference a function
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
   return
 }
-func.func @test_capture_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @nonexistent_capture, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  return %1 : tensor<32x32xbf16, #layout>
-}
-
-// -----
-
-#dram = #ttnn.buffer_type<dram>
-#system_memory = #ttnn.buffer_type<system_memory>
-#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
-
-// --- Test 2: Input argument count mismatch with capture function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Number of input arguments (inputs + semaphore_inputs = 2 + 0 = 2) does not match capture function 'capture_fn' input count (1)
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  return %arg0 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
 }
-func.func @test_input_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+func.func @test_capture_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @nonexistent_capture, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -59,31 +166,36 @@ func.func @test_input_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %a
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 #layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 3: Input argument type mismatch with capture function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Input argument 1 type mismatch
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  return %arg0 : tensor<32x32xbf16, #layout>
+// --- Test 5: Capture function takes the wrong number of arguments ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Capture function 'capture_fn' must take 3 arguments (1 host-staged inputs + 2 slots + 0 semaphores), but has 2
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xf32, #layout_f32>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>) {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %arg1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>, tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
 }
-func.func @test_input_type_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+func.func @test_capture_arg_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  // Op passes bf16 but capture_fn expects f32 for arg1.
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -92,22 +204,144 @@ func.func @test_input_type_mismatch(%arg0: tensor<32x32xbf16, #host_layout>, %ar
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 4: No trace function (call op) found in capture function ---
+// --- Test 6: Capture function slot argument type does not match the allocated slot ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Capture function slot argument 0 type mismatch
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xf32, #layout_f32>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xf32, #layout_f32>) -> ()
+  call @trace_fn(%arg2, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_capture_slot_type(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 7: Capture function returns more than a trace id ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Capture function 'capture_fn' must return exactly one trace_id value, but returns 2
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2, %arg2 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_capture_result_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 8: Capture function does not return a trace id tensor ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Capture function 'capture_fn' must return a trace_id tensor (scalar ui32 with TraceIdAttr encoding)
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %arg2 : tensor<32x32xbf16, #layout>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_capture_result_not_trace_id(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 9: No trace function (call op) found in capture function ---
 // CHECK: error: 'ttnn.capture_or_execute_trace' op No trace function found in capture function
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>) {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  "ttnn.end_trace_capture"(%0, %1) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %1, %arg1 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
 }
 func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
   return
 }
-func.func @test_no_trace_function(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+func.func @test_no_trace_func(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0, %arg1) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 2, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -116,158 +350,109 @@ func.func @test_no_trace_function(%arg0: tensor<32x32xbf16, #host_layout>, %arg1
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
-#layout_64x64 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x2x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-
-// --- Test 5: Output result count mismatch with trace function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Number of output results (2) does not match trace function 'trace_fn' output count (1)
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  return %arg0 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
-}
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
-  return
-}
-func.func @test_output_count_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  // trace_fn returns 1 result, but op declares 2 outputs.
-  %1, %2 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> (tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>)
-  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<64x64xbf16, #layout_64x64>
-}
-
-// -----
-
-#dram = #ttnn.buffer_type<dram>
-#system_memory = #ttnn.buffer_type<system_memory>
-#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 #layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
-
-// --- Test 6: Output result type mismatch with trace function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Output result 0 type mismatch
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  return %arg0 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
-}
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
-  return
-}
-func.func @test_output_type_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xf32, #layout_f32> {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  // trace_fn returns bf16 but op declares f32 output.
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xf32, #layout_f32>
-  return %1 : tensor<32x32xf32, #layout_f32>
-}
-
-// -----
-
-#dram = #ttnn.buffer_type<dram>
-#system_memory = #ttnn.buffer_type<system_memory>
-#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 7: Trace function input argument not on device ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op All input arguments of trace function must be on device
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  return %1 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  call @trace_fn(%arg0) : (tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%arg0) : (tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %arg0, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>
-}
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
-  return
-}
-func.func @test_trace_arg_not_on_device(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
-  return %1 : tensor<32x32xbf16, #layout>
-}
-
-// -----
-
-#dram = #ttnn.buffer_type<dram>
-#system_memory = #ttnn.buffer_type<system_memory>
-#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
-
-// --- Test 8: Device config mismatch between trace op and callee get_device ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Device configuration of get_device op in callee must match device configuration of trace op
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
-  // Trace function uses a different mesh shape (1x2 vs 1x1).
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
-  %1 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  return %1 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
-}
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
-  return
-}
-func.func @test_device_config_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
-  return %1 : tensor<32x32xbf16, #layout>
-}
-
-// -----
-
-#dram = #ttnn.buffer_type<dram>
-#system_memory = #ttnn.buffer_type<system_memory>
-#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
-#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
-
-// --- Test 9: Execute callee does not reference a function ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op 'nonexistent_execute' does not reference a function
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+// --- Test 10: Trace function returns results instead of storing into the output slots ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Trace function 'trace_fn' must return no results; it stores its outputs into the output slot arguments
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
   return %0 : tensor<32x32xbf16, #layout>
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  %1 = call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_trace_func_returns_results(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 11: Device config mismatch between trace op and callee get_device ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Device configuration of get_device op in callee must match device configuration of trace op
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %d = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x2>}> : () -> !ttnn.device
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_device_mismatch(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  return %1 : tensor<32x32xbf16, #layout>
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 12: Execute callee does not reference a function ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op 'nonexistent_execute' does not reference a function
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
 }
 func.func @test_execute_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @nonexistent_execute, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @nonexistent_execute, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -276,30 +461,36 @@ func.func @test_execute_callee_missing(%arg0: tensor<32x32xbf16, #host_layout>) 
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 10: Execute function has wrong number of arguments ---
-// CHECK: error: 'ttnn.capture_or_execute_trace' op Execute function 'execute_fn' must take exactly one trace_id argument, but has 2 arguments
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+// --- Test 13: Execute function has the wrong number of arguments ---
+// CHECK: error: 'ttnn.capture_or_execute_trace' op Execute function 'execute_fn' must take exactly one trace_id argument, but has 2
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  return %0 : tensor<32x32xbf16, #layout>
-}
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
-  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
-}
-func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>, %arg1: tensor<32x32xbf16, #layout>) {
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
   return
 }
-func.func @test_execute_wrong_arg_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
+}
+func.func private @execute_fn(%arg0: tensor<ui32, #ttnn.trace_id>, %arg1: tensor<ui32, #ttnn.trace_id>) {
+  return
+}
+func.func @test_execute_arg_count(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }
 
@@ -308,29 +499,35 @@ func.func @test_execute_wrong_arg_count(%arg0: tensor<32x32xbf16, #host_layout>)
 #dram = #ttnn.buffer_type<dram>
 #system_memory = #ttnn.buffer_type<system_memory>
 #layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
 
-// --- Test 11: Execute function argument is not a trace_id tensor ---
+// --- Test 14: Execute function argument is not a trace_id tensor ---
 // CHECK: error: 'ttnn.capture_or_execute_trace' op Execute function 'execute_fn' argument must be a trace_id tensor (scalar ui32 with TraceIdAttr encoding)
-func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout> {
+func.func private @trace_fn(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.add"(%arg0, %arg0) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  return %0 : tensor<32x32xbf16, #layout>
+  "ttnn.copy"(%0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
 }
-func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>) -> (tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
+func.func private @allocate_slots_fn() -> (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
   %1 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
-  "ttnn.write_tensor"(%arg0, %1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
-  call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  %3 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
-  %4 = call @trace_fn(%1) : (tensor<32x32xbf16, #layout>) -> tensor<32x32xbf16, #layout>
-  "ttnn.end_trace_capture"(%0, %3) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
-  return %3, %1, %4 : tensor<ui32, #ttnn.trace_id>, tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+  %2 = "ttnn.empty"(%0) <{layout = #ttnn.layout<tile>, shape = #ttnn.shape<32x32>}> : (!ttnn.device) -> tensor<32x32xbf16, #layout>
+  return %1, %2 : tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>
+}
+func.func private @capture_fn(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>, %arg2: tensor<32x32xbf16, #layout>) -> tensor<ui32, #ttnn.trace_id> {
+  %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+  "ttnn.write_tensor"(%arg0, %arg1) <{blocking = false, cq_id = 0 : ui32}> : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  call @trace_fn(%arg1, %arg2) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #layout>) -> ()
+  %2 = "ttnn.begin_trace_capture"(%0) <{cq_id = 0 : ui32}> : (!ttnn.device) -> tensor<ui32, #ttnn.trace_id>
+  "ttnn.end_trace_capture"(%0, %2) <{cq_id = 0 : ui32}> : (!ttnn.device, tensor<ui32, #ttnn.trace_id>) -> ()
+  return %2 : tensor<ui32, #ttnn.trace_id>
 }
 func.func private @execute_fn(%arg0: tensor<32x32xbf16, #layout>) {
   return
 }
-func.func @test_execute_wrong_arg_type(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
+func.func @test_execute_arg_type(%arg0: tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout> {
   %0 = "ttnn.get_device"() <{mesh_offset = #ttnn<mesh_offset 0x0>, mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
+  %1 = "ttnn.capture_or_execute_trace"(%0, %arg0) <{allocate_slots_callee = @allocate_slots_fn, capture_callee = @capture_fn, execute_callee = @execute_fn, operandSegmentSizes = array<i32: 1, 1, 0>}> : (!ttnn.device, tensor<32x32xbf16, #host_layout>) -> tensor<32x32xbf16, #layout>
   return %1 : tensor<32x32xbf16, #layout>
 }

--- a/test/ttmlir/Dialect/TTNN/trace/negative_copy.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/negative_copy.mlir
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Negative tests for the ttnn.copy op verifier.
+// ttnn.copy exists so a trace can write its results into a caller-provided
+// persistent slot. It deliberately rejects anything tt-metal's copy would refuse
+// at runtime, so a mismatch is a compile error rather than a TT_FATAL raised in
+// the middle of a trace capture window.
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 1: Source tensor on host ---
+// CHECK: error: 'ttnn.copy' op Source tensor must be on device memory
+func.func @test_copy_src_on_host(%arg0: tensor<32x32xbf16, #host_layout>, %arg1: tensor<32x32xbf16, #layout>) {
+  "ttnn.copy"(%arg0, %arg1) : (tensor<32x32xbf16, #host_layout>, tensor<32x32xbf16, #layout>) -> ()
+  return
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#system_memory = #ttnn.buffer_type<system_memory>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#host_layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #system_memory>>
+
+// --- Test 2: Destination tensor on host ---
+// CHECK: error: 'ttnn.copy' op Destination tensor must be on device memory
+func.func @test_copy_dst_on_host(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xbf16, #host_layout>) {
+  "ttnn.copy"(%arg0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xbf16, #host_layout>) -> ()
+  return
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#layout = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_f32 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+// --- Test 3: Mismatched types ---
+// CHECK: error: 'ttnn.copy' op Source and destination tensor types must match
+func.func @test_copy_type_mismatch(%arg0: tensor<32x32xbf16, #layout>, %arg1: tensor<32x32xf32, #layout_f32>) {
+  "ttnn.copy"(%arg0, %arg1) : (tensor<32x32xbf16, #layout>, tensor<32x32xf32, #layout_f32>) -> ()
+  return
+}

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/creation_no_consteval.mlir
@@ -7,7 +7,9 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_creation_ops
   // CHECK: "ttnn.write_tensor"
-  // CHECK: "ttnn.deallocate"
+  // The capture function emits no copies and no deallocations of its own.
+  // CHECK-NOT: "ttnn.copy"
+  // CHECK-NOT: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
   // CHECK: "ttnn.execute_trace"
@@ -24,7 +26,7 @@ module {
     // As ttnn.zeros and ttnn.ones are not const-eval'd, they will be recreated on each iteration of execution, hence they should be treated as regular inputs. We need to move them to host, and create a device trace input slot for them.
     // CHECK: %[[ZEROS_ON_HOST:.+]] = "ttnn.from_device"
     // CHECK: %[[ONES_ON_HOST:.+]] = "ttnn.from_device"
-    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %[[ZEROS_ON_HOST]], %[[ONES_ON_HOST]]) <{capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops, operandSegmentSizes = array<i32: 1, 2, 0>}>
+    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %[[ZEROS_ON_HOST]], %[[ONES_ON_HOST]]) <{allocate_slots_callee = @allocate_slots_trace_0_creation_ops, capture_callee = @run_and_capture_trace_0_creation_ops, execute_callee = @execute_trace_0_creation_ops, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK: return %[[TRACE_RESULT]]
     %0 = "ttir.zeros"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>
     %1 = "ttir.ones"() <{shape = array<i32: 4, 4>}> : () -> tensor<4x4xbf16>

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_consteval.mlir
@@ -9,12 +9,14 @@ module {
   // CHECK: "ttnn.matmul"
 
   // CHECK-LABEL: func.func private @trace_0_matmul_with_multiply
-  // CHECK: %[[TILED_ARG:.*]] = "ttnn.to_layout"(%arg0)
-  // CHECK: "ttnn.multiply"(%arg1, %[[TILED_ARG]])
+  // CHECK: %[[TILED_ARG:.*]] = "ttnn.to_layout"(%arg1)
+  // CHECK: "ttnn.multiply"(%arg0, %[[TILED_ARG]])
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_matmul_with_multiply
   // CHECK: "ttnn.write_tensor"
-  // CHECK: "ttnn.deallocate"
+  // The capture function emits no copies and no deallocations of its own.
+  // CHECK-NOT: "ttnn.copy"
+  // CHECK-NOT: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
   // CHECK: "ttnn.execute_trace"
@@ -26,7 +28,7 @@ module {
   func.func @matmul_with_multiply(%arg0: tensor<64x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg1: tensor<32x64xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}, %arg2: tensor<64x64xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
     // CHECK: %[[LOAD_CACHED_RESULT:.+]] = ttcore.load_cached(@matmul_with_multiply_const_eval_0, [%arg0, %arg1])
-    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg2, %[[LOAD_CACHED_RESULT]]) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 2, 0>}>
+    // CHECK: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %[[LOAD_CACHED_RESULT]], %arg2) <{allocate_slots_callee = @allocate_slots_trace_0_matmul_with_multiply, capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK-NOT: "ttnn.multiply"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/matmul_multiply_no_consteval.mlir
@@ -8,7 +8,9 @@ module {
 
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_matmul_with_multiply
   // CHECK: "ttnn.write_tensor"
-  // CHECK: "ttnn.deallocate"
+  // The capture function emits no copies and no deallocations of its own.
+  // CHECK-NOT: "ttnn.copy"
+  // CHECK-NOT: "ttnn.deallocate"
   // CHECK: "ttnn.begin_trace_capture"
   // CHECK: "ttnn.end_trace_capture"
   // CHECK: "ttnn.execute_trace"
@@ -19,7 +21,7 @@ module {
   // CHECK-LABEL: func.func @matmul_with_multiply(
   func.func @matmul_with_multiply(%arg0: tensor<64x32xbf16>, %arg1: tensor<32x64xbf16>, %arg2: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1, %arg2) <{capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 3, 0>}>
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1, %arg2) <{allocate_slots_callee = @allocate_slots_trace_0_matmul_with_multiply, capture_callee = @run_and_capture_trace_0_matmul_with_multiply, execute_callee = @execute_trace_0_matmul_with_multiply, operandSegmentSizes = array<i32: 1, 3, 0>}>
     // CHECK-NOT: "ttnn.multiply"
     // CHECK-NOT: "ttnn.matmul"
     // CHECK: return %[[TRACE_RESULT]]

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip.mlir
@@ -4,12 +4,17 @@
 // Verify that trace works correctly with presharded args.
 
 module attributes {ttcore.meshes = #ttcore.meshes<[<"mesh" = 1x2>]>} {
-    // Verify that capture trace creates valid local shape tensors.
+    // Verify that the slots are allocated with valid local shape tensors.
+    // CHECK-LABEL: func.func private @allocate_slots_trace_0_main
+    // CHECK: "ttnn.empty"
+    // CHECK-SAME: -> tensor<5x128x512xbf16,
+
+    // The capture function receives the presharded host inputs, then the slots.
     // CHECK-LABEL: func.func private @run_and_capture_trace_0_main
     // CHECK-SAME: %arg0: tensor<5x128x512xbf16,
     // CHECK-SAME: %arg1: tensor<5x128x512xbf16,
-    // CHECK: "ttnn.empty"
-    // CHECK-SAME: -> tensor<5x128x512xbf16,
+    // CHECK-NOT: "ttnn.empty"
+    // CHECK: "ttnn.write_tensor"
 
     // CHECK-LABEL: func.func @main(
     func.func @main(%arg0: tensor<5x128x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<5x128x512xbf16>>} loc("p0.2"), %arg1: tensor<5x128x512xbf16> {ttcore.argument_type = #ttcore.argument_type<input>, ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<5x128x512xbf16>>} loc("p1.3")) -> (tensor<5x128x512xbf16> {ttcore.shard_status = #ttcore.shard_status<presharded>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<5x128x512xbf16>>}) {

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/multichip_kv_cache.mlir
@@ -12,24 +12,32 @@ module {
     // while the regular input should be on system_memory (host).
     // Constants are hoisted as the first arguments.
     //
+    // The slot allocation function takes only the device-resident arguments -
+    // the KV cache and the const-eval'd constant - as pass-through slots.
+    // CHECK-LABEL: func.func private @allocate_slots_trace_0_main
+
+    // CHECK-SAME: %arg0: tensor<1x32x64x512xbf16
+    // CHECK-SAME: buffer_type<dram>
+    // CHECK-SAME: ttcore.kv_cache
+
+    // CHECK-SAME: %arg1:
+    // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<constant>
+
+    // The capture function takes the host-staged inputs first, then every slot.
     // CHECK-LABEL: func.func private @run_and_capture_trace_0_main
 
     // CHECK-SAME: %arg0: tensor<5x128x512xbf16
     // CHECK-SAME: buffer_type<system_memory>
     // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<input>
 
-    // CHECK-SAME: %arg1: tensor<1x32x64x512xbf16
+    // CHECK-SAME: %arg2: tensor<1x32x64x512xbf16
     // CHECK-SAME: buffer_type<dram>
     // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<input>
     // CHECK-SAME: ttcore.kv_cache
 
-    // CHECK-SAME: %arg2:
-    // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<input>
-
     // CHECK-SAME: %arg3:
     // CHECK-SAME: ttcore.argument_type = #ttcore.argument_type<constant>
 
-    // CHECK: "ttnn.deallocate"
     // CHECK: "ttnn.begin_trace_capture"
     // CHECK: "ttnn.end_trace_capture"
     // CHECK: "ttnn.execute_trace"

--- a/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/scenarios/single_add_no_consteval.mlir
@@ -2,17 +2,43 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
+  // The traced computation stores its results into the output slot arguments
+  // and returns nothing.
   // CHECK-LABEL: func.func private @trace_0_single_add
-  // CHECK: "ttnn.add"
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout>
+  // CHECK-SAME: %arg1: tensor<32x32xbf16, #ttnn_layout>
+  // CHECK-SAME: %arg2: tensor<32x32xbf16, #ttnn_layout>)
+  // CHECK-NOT: ->
+  // CHECK: %[[SUM:.+]] = "ttnn.add"(%arg1, %arg0)
+  // CHECK: "ttnn.copy"(%[[SUM]], %arg2)
+  // CHECK: return{{$}}
 
+  // The allocation function is the only place the persistent slots are
+  // allocated; device-resident arguments pass through as their own slots.
+  // CHECK-LABEL: func.func private @allocate_slots_trace_0_single_add
+  // CHECK-NOT: "ttnn.write_tensor"
+  // CHECK-NOT: "ttnn.begin_trace_capture"
+  // CHECK: %[[IN_SLOT:.+]] = "ttnn.empty"
+  // CHECK: %[[OUT_SLOT:.+]] = "ttnn.empty"
+  // CHECK: return %arg0, %[[IN_SLOT]], %[[OUT_SLOT]]
+
+  // The capture function takes every slot as an argument and allocates
+  // nothing itself.
   // CHECK-LABEL: func.func private @run_and_capture_trace_0_single_add
-  // CHECK: "ttnn.write_tensor"
-  // CHECK-NOT: "ttnn.from_device"(%arg0)
-  // CHECK-NOT: "ttnn.from_device"(%arg1)
-  // CHECK: "ttnn.deallocate"
-  // CHECK: "ttnn.begin_trace_capture"
+  // CHECK-SAME: (%arg0: tensor<32x32xbf16, #ttnn_layout1>
+  // CHECK-SAME: %arg1: tensor<32x32xbf16, #ttnn_layout>
+  // CHECK-SAME: %arg2: tensor<32x32xbf16, #ttnn_layout>
+  // CHECK-SAME: %arg3: tensor<32x32xbf16, #ttnn_layout>)
+  // CHECK-SAME: -> tensor<ui32, #ttnn.trace_id>
+  // CHECK-NOT: "ttnn.empty"
+  // CHECK-NOT: "ttnn.copy"
+  // CHECK: "ttnn.write_tensor"(%arg0, %arg2)
+  // CHECK: call @trace_0_single_add(%arg1, %arg2, %arg3)
+  // CHECK: %[[TRACE_ID:.+]] = "ttnn.begin_trace_capture"
+  // CHECK: call @trace_0_single_add(%arg1, %arg2, %arg3)
   // CHECK: "ttnn.end_trace_capture"
   // CHECK: "ttnn.execute_trace"
+  // CHECK: return %[[TRACE_ID]]
 
   // CHECK-LABEL: func.func private @execute_trace_0_single_add
   // CHECK: "ttnn.execute_trace"
@@ -20,7 +46,7 @@ module {
   // CHECK-LABEL: func.func @single_add(
   func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x32xbf16> {
     // CHECK: %[[GET_DEVICE:.+]] = "ttnn.get_device"()
-    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg0, %arg1) <{capture_callee = @run_and_capture_trace_0_single_add, execute_callee = @execute_trace_0_single_add, operandSegmentSizes = array<i32: 1, 2, 0>}>
+    // CHECK-NEXT: %[[TRACE_RESULT:.+]] = "ttnn.capture_or_execute_trace"(%[[GET_DEVICE]], %arg1, %arg0) <{allocate_slots_callee = @allocate_slots_trace_0_single_add, capture_callee = @run_and_capture_trace_0_single_add, execute_callee = @execute_trace_0_single_add, operandSegmentSizes = array<i32: 1, 2, 0>}>
     // CHECK-NOT: "ttnn.add"
     // CHECK: return %[[TRACE_RESULT]]
     %1 = "ttir.add"(%arg0, %arg1) : (tensor<32x32xbf16>, tensor<32x32xbf16>) -> tensor<32x32xbf16>

--- a/test/ttmlir/EmitPy/trace_ops.mlir
+++ b/test/ttmlir/EmitPy/trace_ops.mlir
@@ -41,7 +41,7 @@
 // CHECK-LABEL: func.func private @trace_0_single_add
 // CHECK:       emitpy.call_opaque "ttnn.add"
 
-// --- run_and_capture_trace (write_tensor, begin/end trace, execute) for single_add ---
+// --- capture_trace (write_tensor, begin/end trace, execute) for single_add ---
 // CHECK-LABEL: func.func private @run_and_capture_trace_0_single_add
 // CHECK:       emitpy.call_opaque "ttnn.copy_host_to_device_tensor"
 // CHECK:       emitpy.call_opaque "ttnn.begin_trace_capture"
@@ -66,7 +66,7 @@ func.func @single_add(%arg0: tensor<32x32xbf16>, %arg1: tensor<32x32xbf16> {ttco
 // CHECK:       emitpy.call_opaque "ttnn.add"
 // CHECK:       emitpy.call_opaque "ttnn.multiply"
 
-// --- run_and_capture_trace (write_tensor, begin/end trace, execute) for multi_output ---
+// --- capture_trace (write_tensor, begin/end trace, execute) for multi_output ---
 // CHECK-LABEL: func.func private @run_and_capture_trace_1_multi_output
 // CHECK:       emitpy.call_opaque "ttnn.copy_host_to_device_tensor"
 // CHECK:       emitpy.call_opaque "ttnn.begin_trace_capture"

--- a/test/ttmlir/Runtime/TTNN/n150/trace/large_neg_no_consteval.mlir
+++ b/test/ttmlir/Runtime/TTNN/n150/trace/large_neg_no_consteval.mlir
@@ -1,0 +1,30 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path% enable-const-eval=false enable-trace=true" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+// The runtime test relies on the exact layouts below; if any of these checks
+// break, revisit test_trace_recapture_slot_reuse_arena's sizing assumptions.
+//
+// The persistent input slot must be row-major DRAM (write_tensor copies raw
+// host bytes into it) while compute happens on tiled DRAM - it is this layout
+// pair that forces the on-device tilize inside the traced body:
+// CHECK-DAG: #[[RM_DRAM:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2048x4096xbf16, #dram>, <interleaved>>
+// CHECK-DAG: #[[TILED_DRAM:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x128x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+// The traced body must tilize the row-major input slot into a large
+// capture-time intermediate and free it inside the body - that freed region
+// is the "unsafe" hole the runtime test aims a faulty recapture into:
+// CHECK-LABEL: func.func private @trace_0_large_neg
+// CHECK-SAME: %arg0: tensor<2048x4096xbf16, #[[RM_DRAM]]>
+// CHECK: %[[TILIZED:.*]] = "ttnn.to_layout"(%arg0)
+// CHECK-SAME: -> tensor<2048x4096xbf16, #[[TILED_DRAM]]>
+// CHECK: "ttnn.neg"(%[[TILIZED]])
+// CHECK: "ttnn.deallocate"(%[[TILIZED]])
+
+module {
+  func.func @large_neg(%arg0: tensor<2048x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<2048x4096xbf16> {
+    // CHECK: ttnn.capture_or_execute_trace
+    %0 = "ttir.neg"(%arg0) : (tensor<2048x4096xbf16>) -> tensor<2048x4096xbf16>
+    return %0 : tensor<2048x4096xbf16>
+  }
+}

--- a/tools/chisel/chisel/op_configs.py
+++ b/tools/chisel/chisel/op_configs.py
@@ -63,6 +63,7 @@ def default_configs() -> Dict[Type[OpView], ChiselOpConfig]:
         ttnn.ResetGlobalSemaphoreOp: ChiselOpConfig(no_golden=True),
         # In-place ops with no golden.
         ttnn.WriteTensorOp: ChiselOpConfig(no_golden=True),
+        ttnn.CopyOp: ChiselOpConfig(no_golden=True),
         ttnn.PointToPointOp: ChiselOpConfig(no_golden=True),
         # Quantization ops not currently supported.
         ttnn.QuantizeOp: ChiselOpConfig(no_golden=True),

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -19,6 +19,7 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -17,6 +17,7 @@
 #include "operations/core/core.hpp"
 #include "operations/creation/creation.hpp"
 #include "operations/data_movement/concat/concat.hpp"
+#include "operations/data_movement/copy/copy.hpp"
 #include "operations/data_movement/gather/gather.hpp"
 #include "operations/data_movement/moe_expert_token_remap/moe_expert_token_remap.hpp"
 #include "operations/data_movement/pad/pad.hpp"


### PR DESCRIPTION
The trace recapture mechanism introduced as a defense for situations where multiple traced graphs can overwrite each others' inputs/outputs didn't cover all of the cases. There are situations where the re-allocation of slots (during recapture) can cause slots to be given different addresses - which means that those slots are not safe to use.

In this case, if we would to trigger recaptures (bump the trace generation id) - it can cause an never-ending chain of recaptures.

The solution opted for in this change is to instead move the slot allocations outside of the capture function and do the allocations only once. Then on further re-captures, we would re-use the existing (already allocated) slots - hence we don't have any persistant allocations during the capture, which means we don't have to invalidate the already existing traces.

This has a down-side - for the output tensors we will end up with an extra `ttnn.copy()` from the op result into the allocated output slot. However, from the perf benchmarks I have run - this additional overhead is negligible.

Since `ttnn.copy()` was non-existant, adding it to the TTNN op dialect.

Closes #9191
tenstorrent/tt-xla#5828
