### PR TITLE
[Shardy] Account for pre-existing sharding on `sdy.all_slice` lowering

### DIFF
--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -1498,8 +1498,68 @@ public:
 
     mlir::Value currInput = adaptor.getOperands().front();
     auto meshShape = shardyMeshSharding->getMeshShape();
+
+    // Shardy emits all_slice as a DELTA, not as an absolute sharding: the
+    // operand may already carry some of out_sharding's axes. A dim0 sharded
+    // {_axis_0, _axis_1} on a mesh [2, 4] is commonly fed by a reduce_scatter
+    // that already scattered _axis_0, so only _axis_1 is left to apply.
+    // Applying every axis in out_sharding would divide that dim twice (128 ->
+    // 64 -> 16 instead of 128 -> 32) and produce a value whose type no longer
+    // matches the composite's declared result, which then fails to legalize as
+    // a live unresolved materialization.
+    //
+    // The declared result type is authoritative, so use it to work out how much
+    // of out_sharding is still outstanding, consuming axes minor-most first
+    // (Shardy lists them major -> minor, and the major ones are the
+    // already-applied ones).
+    auto operandType =
+        mlir::cast<RankedTensorType>(adaptor.getOperands().front().getType());
+    auto declaredResultType =
+        mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
+    if (declaredResultType.getRank() != operandType.getRank()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "sdy.all_slice operand and result ranks differ.");
+    }
+    llvm::SmallVector<int64_t> pendingDivisor(operandType.getRank(), 1);
+    for (int32_t dim : tensorDims) {
+      if (dim < 0 || dim >= operandType.getRank()) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "Invalid mesh partition dimension index.");
+      }
+      int64_t inDim = operandType.getShape()[dim];
+      int64_t outDim = declaredResultType.getShape()[dim];
+      if (ShapedType::isDynamic(inDim) || ShapedType::isDynamic(outDim) ||
+          outDim <= 0 || inDim % outDim != 0) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "sdy.all_slice result shape is not an integral shard of its "
+                   "operand shape.");
+      }
+      pendingDivisor[dim] = inDim / outDim;
+    }
+    llvm::SmallVector<bool> applyAxis(tensorDims.size(), false);
+    for (int i = static_cast<int>(tensorDims.size()) - 1; i >= 0; --i) {
+      if (static_cast<size_t>(clusterAxes[i]) >= meshShape.size()) {
+        return rewriter.notifyMatchFailure(srcOp, "Invalid mesh axis index.");
+      }
+      int64_t axisSize = meshShape[clusterAxes[i]];
+      int64_t &pending = pendingDivisor[tensorDims[i]];
+      if (pending > 1 && axisSize > 1 && pending % axisSize == 0) {
+        applyAxis[i] = true;
+        pending /= axisSize;
+      }
+    }
+    if (llvm::any_of(pendingDivisor, [](int64_t d) { return d != 1; })) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "Could not reconcile sdy.all_slice out_sharding with its "
+                 "declared result shape.");
+    }
+
     // Replace the composite op with 1 or more ttir.mesh_partition ops.
     for (size_t i = 0; i < tensorDims.size(); ++i) {
+      if (!applyAxis[i]) {
+        // Already reflected in the operand's sharding.
+        continue;
+      }
       auto currInputType = mlir::cast<RankedTensorType>(currInput.getType());
       llvm::SmallVector<int64_t> newShape(currInputType.getShape().begin(),
                                           currInputType.getShape().end());

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -1441,6 +1441,8 @@ public:
   }
 };
 
+// Legalize the stablehlo.composite Shardy emits for sdy.all_slice into a chain
+// of ttir.mesh_partition ops, one per mesh axis that still has to be applied.
 class ShardyAllSliceToTTIRMeshPartitionConversionPattern
     : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
 public:
@@ -1455,139 +1457,133 @@ public:
       return failure();
     }
 
-    if (srcOp->getNumOperands() != 1) {
+    if (srcOp->getNumOperands() != 1 || srcOp->getNumResults() != 1) {
       return rewriter.notifyMatchFailure(
-          srcOp,
-          "sdy.all_slice composite op must have exactly one input operand");
+          srcOp, "sdy.all_slice composite op must have exactly one input "
+                 "operand and one result.");
     }
 
     DictionaryAttr compositeAttrs = srcOp.getCompositeAttributes();
-    auto maybeOutShardingAttr = compositeAttrs.get("out_sharding");
-    if (!maybeOutShardingAttr) {
-      return rewriter.notifyMatchFailure(srcOp,
-                                         "out_sharding attribute is required");
-    }
-    // Extract the out_sharding attribute
-    mlir::ModuleOp moduleOp = srcOp->getParentOfType<mlir::ModuleOp>();
-    mlir::sdy::MeshOp globalMeshOp = shardy_utils::getMeshOps(moduleOp)[0];
-    mlir::sdy::TensorShardingAttr outShardingAttr =
-        mlir::cast<mlir::sdy::TensorShardingAttr>(maybeOutShardingAttr);
-
-    // Calculate the attributes for the ttir.mesh_shard op.
-    llvm::Expected<mlir::tt::shardy_utils::ShardyMeshSharding>
-        shardyMeshSharding =
-            mlir::tt::shardy_utils::ShardyMeshSharding::generate(
-                globalMeshOp.getMeshAttr(), outShardingAttr,
-                mlir::tt::ttcore::ShardStatus::Unsharded,
-                ttcore::MeshShardDirection::FullToShard);
-    if (auto err = shardyMeshSharding.takeError()) {
+    auto outShardingAttr =
+        mlir::dyn_cast_if_present<mlir::sdy::TensorShardingAttr>(
+            compositeAttrs ? compositeAttrs.get("out_sharding")
+                           : mlir::Attribute());
+    if (!outShardingAttr) {
       return rewriter.notifyMatchFailure(
-          srcOp, "Error trying to parse shardy annotation when legalizing "
-                 "sdy.all_slice composite op.");
+          srcOp, "out_sharding attribute is required and must be a shardy "
+                 "tensor sharding.");
     }
-    auto shardDims = shardyMeshSharding->getShardDims();
-    llvm::SmallVector<int32_t> tensorDims;
-    llvm::SmallVector<uint32_t> clusterAxes;
-    for (auto [dimIdx, dim] : llvm::enumerate(shardDims)) {
-      if (dim >= 0) {
-        tensorDims.push_back(static_cast<int32_t>(dim));
-        clusterAxes.push_back(static_cast<uint32_t>(dimIdx));
-      }
+    if (!outShardingAttr.isFullyClosed()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "sdy.all_slice with an open out_sharding dimension is "
+                 "currently not supported.");
     }
-    rewriter.setInsertionPoint(srcOp);
+    // Resolve the mesh the sharding itself names rather than assuming the
+    // module's first one.
+    mlir::sdy::MeshAttr meshAttr = outShardingAttr.getMesh(srcOp);
+    if (!meshAttr) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "Could not resolve the mesh referenced by out_sharding.");
+    }
+    llvm::ArrayRef<mlir::sdy::MeshAxisAttr> meshAxes = meshAttr.getAxes();
+    llvm::SmallDenseMap<llvm::StringRef, uint32_t> clusterAxisByName;
+    for (auto [idx, meshAxis] : llvm::enumerate(meshAxes)) {
+      clusterAxisByName[meshAxis.getName()] = static_cast<uint32_t>(idx);
+    }
 
-    mlir::Value currInput = adaptor.getOperands().front();
-    auto meshShape = shardyMeshSharding->getMeshShape();
-
-    // Shardy emits all_slice as a DELTA, not as an absolute sharding: the
-    // operand may already carry some of out_sharding's axes. A dim0 sharded
-    // {_axis_0, _axis_1} on a mesh [2, 4] is commonly fed by a reduce_scatter
-    // that already scattered _axis_0, so only _axis_1 is left to apply.
-    // Applying every axis in out_sharding would divide that dim twice (128 ->
-    // 64 -> 16 instead of 128 -> 32) and produce a value whose type no longer
-    // matches the composite's declared result, which then fails to legalize as
-    // a live unresolved materialization.
-    //
-    // The declared result type is authoritative, so use it to work out how much
-    // of out_sharding is still outstanding, consuming axes minor-most first
-    // (Shardy lists them major -> minor, and the major ones are the
-    // already-applied ones).
     auto operandType =
         mlir::cast<RankedTensorType>(adaptor.getOperands().front().getType());
-    auto declaredResultType =
+    auto resultType =
         mlir::cast<RankedTensorType>(srcOp.getResult(0).getType());
-    if (declaredResultType.getRank() != operandType.getRank()) {
+    int64_t rank = operandType.getRank();
+    if (resultType.getRank() != rank || outShardingAttr.getRank() != rank) {
       return rewriter.notifyMatchFailure(
-          srcOp, "sdy.all_slice operand and result ranks differ.");
+          srcOp, "sdy.all_slice operand, result and out_sharding ranks must "
+                 "all match.");
     }
-    llvm::SmallVector<int64_t> pendingDivisor(operandType.getRank(), 1);
-    for (int32_t dim : tensorDims) {
-      if (dim < 0 || dim >= operandType.getRank()) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "Invalid mesh partition dimension index.");
-      }
-      int64_t inDim = operandType.getShape()[dim];
-      int64_t outDim = declaredResultType.getShape()[dim];
-      if (ShapedType::isDynamic(inDim) || ShapedType::isDynamic(outDim) ||
-          outDim <= 0 || inDim % outDim != 0) {
+    if (operandType.getElementType() != resultType.getElementType()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "sdy.all_slice must not change the element type.");
+    }
+
+    // Mesh axes to slice along, as {tensor dim, cluster axis} pairs in the
+    // order they have to be applied.
+    llvm::SmallVector<std::pair<int32_t, uint32_t>> outstandingAxes;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+      int64_t inDimSize = operandType.getDimSize(dim);
+      int64_t outDimSize = resultType.getDimSize(dim);
+      if (ShapedType::isDynamic(inDimSize) ||
+          ShapedType::isDynamic(outDimSize) || outDimSize <= 0 ||
+          inDimSize % outDimSize != 0) {
         return rewriter.notifyMatchFailure(
             srcOp, "sdy.all_slice result shape is not an integral shard of its "
                    "operand shape.");
       }
-      pendingDivisor[dim] = inDim / outDim;
-    }
-    llvm::SmallVector<bool> applyAxis(tensorDims.size(), false);
-    for (int i = static_cast<int>(tensorDims.size()) - 1; i >= 0; --i) {
-      if (static_cast<size_t>(clusterAxes[i]) >= meshShape.size()) {
-        return rewriter.notifyMatchFailure(srcOp, "Invalid mesh axis index.");
+      // How much of this dim's sharding out_sharding still has to apply.
+      int64_t pendingDivisor = inDimSize / outDimSize;
+
+      // The mesh axes out_sharding shards this dim over, major -> minor.
+      // Unit-sized axes divide nothing, so drop them.
+      llvm::SmallVector<uint32_t> clusterAxes;
+      for (mlir::sdy::AxisRefAttr axisRef :
+           outShardingAttr.getDimSharding(dim).getAxes()) {
+        if (axisRef.getSubAxisInfo()) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "sdy.all_slice with sub-axis partitioning is currently "
+                     "not supported.");
+        }
+        auto clusterAxis = clusterAxisByName.find(axisRef.getName());
+        if (clusterAxis == clusterAxisByName.end()) {
+          return rewriter.notifyMatchFailure(
+              srcOp, "out_sharding references an axis that the mesh does not "
+                     "have.");
+        }
+        if (meshAxes[clusterAxis->second].getSize() > 1) {
+          clusterAxes.push_back(clusterAxis->second);
+        }
       }
-      int64_t axisSize = meshShape[clusterAxes[i]];
-      int64_t &pending = pendingDivisor[tensorDims[i]];
-      if (pending > 1 && axisSize > 1 && pending % axisSize == 0) {
-        applyAxis[i] = true;
-        pending /= axisSize;
+
+      // Consume axes minor-most first until the outstanding divisor is used up;
+      // whatever is left is the major prefix the operand already carries.
+      size_t firstOutstanding = clusterAxes.size();
+      while (pendingDivisor > 1 && firstOutstanding > 0) {
+        int64_t axisSize =
+            meshAxes[clusterAxes[firstOutstanding - 1]].getSize();
+        if (pendingDivisor % axisSize != 0) {
+          break;
+        }
+        pendingDivisor /= axisSize;
+        --firstOutstanding;
       }
-    }
-    if (llvm::any_of(pendingDivisor, [](int64_t d) { return d != 1; })) {
-      return rewriter.notifyMatchFailure(
-          srcOp, "Could not reconcile sdy.all_slice out_sharding with its "
-                 "declared result shape.");
+      if (pendingDivisor != 1) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "Could not reconcile sdy.all_slice out_sharding with its "
+                   "declared result shape.");
+      }
+      for (uint32_t clusterAxis :
+           llvm::ArrayRef(clusterAxes).drop_front(firstOutstanding)) {
+        outstandingAxes.emplace_back(static_cast<int32_t>(dim), clusterAxis);
+      }
     }
 
-    // Replace the composite op with 1 or more ttir.mesh_partition ops.
-    for (size_t i = 0; i < tensorDims.size(); ++i) {
-      if (!applyAxis[i]) {
-        // Already reflected in the operand's sharding.
-        continue;
-      }
-      auto currInputType = mlir::cast<RankedTensorType>(currInput.getType());
-      llvm::SmallVector<int64_t> newShape(currInputType.getShape().begin(),
-                                          currInputType.getShape().end());
-      if (static_cast<size_t>(tensorDims[i]) >= newShape.size()) {
-        return rewriter.notifyMatchFailure(
-            srcOp, "Invalid mesh partition dimension index.");
-      }
-      if (static_cast<size_t>(clusterAxes[i]) >= meshShape.size()) {
-        return rewriter.notifyMatchFailure(srcOp, "Invalid mesh axis index.");
-      }
-      // Compute new shape for the result tensor, with original dimension
-      // divided by mesh axis size
-      int64_t meshAxisSize = meshShape[clusterAxes[i]];
-      if (newShape[tensorDims[i]] == ShapedType::kDynamic ||
-          newShape[tensorDims[i]] % meshAxisSize != 0) {
-        return rewriter.notifyMatchFailure(
-            srcOp,
-            "Dimension size must be static and divisible by mesh axis size.");
-      }
-      newShape[tensorDims[i]] = newShape[tensorDims[i]] / meshAxisSize;
-      auto resultType =
-          mlir::RankedTensorType::get(newShape, currInputType.getElementType(),
-                                      currInputType.getEncoding());
+    // Replace the composite op with 0 or more ttir.mesh_partition ops. The
+    // reconciliation above guarantees the last one has the declared result
+    // shape, so no unresolved materialization is left behind.
+    rewriter.setInsertionPoint(srcOp);
+    llvm::SmallVector<int64_t> currShape(operandType.getShape());
+    mlir::Value currInput = adaptor.getOperands().front();
+    for (auto [dim, clusterAxis] : outstandingAxes) {
+      currShape[dim] /= meshAxes[clusterAxis].getSize();
+      auto currType = mlir::RankedTensorType::get(
+          currShape, operandType.getElementType(), operandType.getEncoding());
       currInput = rewriter.create<ttir::MeshPartitionOp>(
-          srcOp->getLoc(), resultType, currInput,
-          rewriter.getSI32IntegerAttr(tensorDims[i]),
-          rewriter.getUI32IntegerAttr(clusterAxes[i]));
+          srcOp->getLoc(), currType, currInput,
+          rewriter.getSI32IntegerAttr(dim),
+          rewriter.getUI32IntegerAttr(clusterAxis));
     }
+    assert(llvm::ArrayRef(currShape) == resultType.getShape() &&
+           "sdy.all_slice legalization must preserve the declared result "
+           "shape.");
     rewriter.replaceOp(srcOp, currInput);
     return success();
   }

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_composite.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_composite.mlir
@@ -24,9 +24,11 @@ module {
   }
 }
 
+// One ttir.mesh_partition per outstanding mesh axis, emitted tensor dim by
+// tensor dim.
 // CHECK-LABEL: func.func @test_sdy_all_slice_composite
 // CHECK: "ttir.mesh_partition"
-// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 1 : si32}> : (tensor<4x32xbf16>) -> tensor<4x16xbf16>
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<4x32xbf16>) -> tensor<1x32xbf16>
 // CHECK: "ttir.mesh_partition"
-// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<4x16xbf16>) -> tensor<1x16xbf16>
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 1 : si32}> : (tensor<1x32xbf16>) -> tensor<1x16xbf16>
 // CHECK-NOT: func.func private @sdy.all_slice1

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_partial_sharding.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_partial_sharding.mlir
@@ -1,0 +1,414 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt -split-input-file --legalize-stablehlo-composite-to-ttir -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Shardy emits stablehlo.composite "sdy.all_slice" as a DELTA from the
+// operand's existing sharding: out_sharding is the sharding of the result, so
+// the axes the operand already carries (a major prefix of each dim's axis list)
+// must not be applied again. The composite's declared result type is what says
+// how much is still outstanding.
+//
+// These tests exercise the pattern in isolation. Because this pass leaves
+// StableHLO neither legal nor illegal, a composite the pattern cannot handle is
+// left untouched for later passes to inline, so the negative cases check that
+// the composite survives instead of being rewritten to a wrong type.
+
+// Nothing of out_sharding has been applied yet: the single axis is outstanding.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @replicated_operand_single_axis(%arg0: tensor<64x32xbf16>) -> tensor<16x32xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x32xbf16>) -> tensor<16x32xbf16>
+    return %0 : tensor<16x32xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x32xbf16>) -> tensor<16x32xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<16x32xbf16>
+    return %0 : tensor<16x32xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @replicated_operand_single_axis
+// CHECK: "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<64x32xbf16>) -> tensor<16x32xbf16>
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// dim0 is sharded over both axes but the operand already carries "_axis_0"
+// (e.g. it comes out of a reduce_scatter over "_axis_0"), so only "_axis_1"
+// is outstanding: 128 / 4 = 32, not 128 / 2 / 4 = 16.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @partly_sharded_operand(%arg0: tensor<128x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<128x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @partly_sharded_operand
+// CHECK: "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// Same out_sharding, but this time the operand is fully replicated, so both
+// axes are outstanding and are applied major -> minor.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @replicated_operand_multi_axis(%arg0: tensor<256x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<256x2112xbf16>) -> tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<256x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @replicated_operand_multi_axis
+// CHECK: %[[MAJOR:[0-9]+]] = "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 0 : si32}> : (tensor<256x2112xbf16>) -> tensor<128x2112xbf16>
+// CHECK: "ttir.mesh_partition"(%[[MAJOR]])
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// The operand already carries all of out_sharding, so the all_slice is a no-op
+// and is folded away entirely.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @fully_sharded_operand(%arg0: tensor<32x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<32x2112xbf16>) -> tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<32x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @fully_sharded_operand(
+// CHECK-SAME: %[[ARG:[a-z0-9]+]]: tensor<32x2112xbf16>
+// CHECK-NEXT: return %[[ARG]]
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// Two dims sharded over one axis each, neither applied yet.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @two_dims_outstanding(%arg0: tensor<4x32xbf16>) -> tensor<1x16xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_1"}, {"_axis_0"}]>}, decomposition = @sdy.all_slice1} : (tensor<4x32xbf16>) -> tensor<1x16xbf16>
+    return %0 : tensor<1x16xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<4x32xbf16>) -> tensor<1x16xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<1x16xbf16>
+    return %0 : tensor<1x16xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @two_dims_outstanding
+// CHECK: %[[DIM0:[0-9]+]] = "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<4x32xbf16>) -> tensor<1x32xbf16>
+// CHECK: "ttir.mesh_partition"(%[[DIM0]])
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 1 : si32}> : (tensor<1x32xbf16>) -> tensor<1x16xbf16>
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// Same sharding as above, but dim0 is already sliced: only dim1 is left. A
+// per-tensor-dim delta is needed here, not a single global one.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @one_of_two_dims_outstanding(%arg0: tensor<1x32xbf16>) -> tensor<1x16xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_1"}, {"_axis_0"}]>}, decomposition = @sdy.all_slice1} : (tensor<1x32xbf16>) -> tensor<1x16xbf16>
+    return %0 : tensor<1x16xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<1x32xbf16>) -> tensor<1x16xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<1x16xbf16>
+    return %0 : tensor<1x16xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @one_of_two_dims_outstanding
+// CHECK: "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 1 : si32}> : (tensor<1x32xbf16>) -> tensor<1x16xbf16>
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// A dim's axes are listed major -> minor, which is not necessarily mesh order.
+// "_axis_1" is the major axis here, so it has to be sliced first, otherwise
+// each device ends up with a different shard than out_sharding asks for.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @axes_in_reverse_mesh_order(%arg0: tensor<256x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_1", "_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<256x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<256x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @axes_in_reverse_mesh_order
+// CHECK: %[[MAJOR:[0-9]+]] = "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<256x8xbf16>) -> tensor<64x8xbf16>
+// CHECK: "ttir.mesh_partition"(%[[MAJOR]])
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 0 : si32}> : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// The same dim is sharded over a unit-sized axis too; slicing by 1 is a no-op
+// so no mesh_partition is emitted for it.
+module {
+  sdy.mesh @mesh = <["x"=1, "y"=2]>
+  func.func @unit_sized_axis(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"x", "y"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @unit_sized_axis
+// CHECK: "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// Back-to-back all_slices: the second one sees the type the first one produced,
+// so its own delta is just the axis it adds.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @chained_all_slice(%arg0: tensor<256x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<256x2112xbf16>) -> tensor<128x2112xbf16>
+    %1 = stablehlo.composite "sdy.all_slice" %0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice2} : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+    return %1 : tensor<32x2112xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<256x2112xbf16>) -> tensor<128x2112xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<128x2112xbf16>
+    return %0 : tensor<128x2112xbf16>
+  }
+  func.func private @sdy.all_slice2(%arg0: tensor<128x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x2112xbf16>
+    return %0 : tensor<32x2112xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @chained_all_slice
+// CHECK: %[[FIRST:[0-9]+]] = "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 0 : ui32, dim = 0 : si32}> : (tensor<256x2112xbf16>) -> tensor<128x2112xbf16>
+// CHECK: "ttir.mesh_partition"(%[[FIRST]])
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+// CHECK-NOT: stablehlo.composite
+
+// -----
+
+// The result is not an integral shard of the operand, so there is no chain of
+// mesh_partitions that lands on the declared result type.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @non_integral_shard(%arg0: tensor<100x8xbf16>) -> tensor<33x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<100x8xbf16>) -> tensor<33x8xbf16>
+    return %0 : tensor<33x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<100x8xbf16>) -> tensor<33x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<33x8xbf16>
+    return %0 : tensor<33x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @non_integral_shard
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// out_sharding cannot explain the operand -> result divisor: dim0 shrinks by 2,
+// but the only outstanding-axis suffixes of {"_axis_0", "_axis_1"} divide it by
+// 1, 4 or 8. Bail out instead of guessing a subset of the axes, which would
+// give a right-shaped result holding the wrong shard.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @irreconcilable_divisor(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @irreconcilable_divisor
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// A dim shrinks without out_sharding naming any axis for it.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @unsharded_dim_shrinks(%arg0: tensor<64x8xbf16>) -> tensor<32x4xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x4xbf16>
+    return %0 : tensor<32x4xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x4xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x4xbf16>
+    return %0 : tensor<32x4xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @unsharded_dim_shrinks
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// Ranks have to line up before any of the per-dim reasoning is meaningful.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @rank_mismatch(%arg0: tensor<64x8xbf16>) -> tensor<32xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32xbf16>
+    return %0 : tensor<32xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32xbf16>
+    return %0 : tensor<32xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @rank_mismatch
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// out_sharding's rank has to match the tensor's.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @sharding_rank_mismatch(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0"}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @sharding_rank_mismatch
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// An open dim sharding may still be sharded further by Shardy, so the axis list
+// is not the whole story yet.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @open_dim_sharding(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", ?}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @open_dim_sharding
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// Sub-axis partitioning has no single cluster axis to slice along.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @sub_axis_sharding(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_1":(1)2}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @sub_axis_sharding
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// The mesh the sharding names is not in the module.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @unknown_mesh(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = #sdy.sharding<@other_mesh, [{"_axis_0"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @unknown_mesh
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// out_sharding is missing altogether.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @missing_out_sharding(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @missing_out_sharding
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"
+
+// -----
+
+// out_sharding is present but is not a shardy tensor sharding.
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @out_sharding_wrong_type(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.composite "sdy.all_slice" %arg0 {composite_attributes = {out_sharding = 1 : i64}, decomposition = @sdy.all_slice1} : (tensor<64x8xbf16>) -> tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<64x8xbf16>) -> tensor<32x8xbf16> {
+    %0 = stablehlo.constant dense<0.000000e+00> : tensor<32x8xbf16>
+    return %0 : tensor<32x8xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @out_sharding_wrong_type
+// CHECK: stablehlo.composite "sdy.all_slice"
+// CHECK-NOT: "ttir.mesh_partition"

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_reduce_scatter.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_sdy_all_slice_reduce_scatter.mlir
@@ -1,0 +1,44 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-to-ttir-pipeline -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Shardy emits stablehlo.composite "sdy.all_slice" as a DELTA from the
+// operand's existing sharding. Here dim0 is sharded over both mesh axes, but a
+// reduce_scatter has already scattered "_axis_0" (256 -> 128), so only
+// "_axis_1" is still outstanding (128 -> 32). Legalizing every axis named in
+// out_sharding would divide dim0 twice (128 -> 64 -> 16) and leave a value
+// whose type no longer matches the composite's declared 32x2112 result, which
+// used to fail the whole pipeline with:
+//   error: failed to legalize unresolved materialization from
+//     ('tensor<16x2112xbf16>') to ('tensor<32x2112xbf16>')
+
+module {
+  sdy.mesh @mesh = <["_axis_0"=2, "_axis_1"=4]>
+  func.func @all_slice_after_reduce_scatter(%arg0: tensor<256x2112xbf16>) -> tensor<256x2112xbf16> {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {}]>] out_shardings=[<@mesh, [{"_axis_0", "_axis_1"}, {}]>] manual_axes={"_axis_0", "_axis_1"} (%arg1: tensor<256x2112xbf16>) {
+      %1 = "stablehlo.reduce_scatter"(%arg1) <{channel_handle = #stablehlo.channel_handle<handle = 1, type = 1>, replica_groups = dense<[[0, 4], [1, 5], [2, 6], [3, 7]]> : tensor<4x2xi64>, scatter_dimension = 0 : i64, use_global_device_ids}> ({
+      ^bb0(%arg2: tensor<bf16>, %arg3: tensor<bf16>):
+        %3 = stablehlo.add %arg2, %arg3 : tensor<bf16>
+        stablehlo.return %3 : tensor<bf16>
+      }) : (tensor<256x2112xbf16>) -> tensor<128x2112xbf16>
+      %2 = stablehlo.composite "sdy.all_slice" %1 {composite_attributes = {out_sharding = #sdy.sharding<@mesh, [{"_axis_0", "_axis_1"}, {}]>}, decomposition = @sdy.all_slice1} : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+      sdy.return %2 : tensor<32x2112xbf16>
+    } : (tensor<256x2112xbf16>) -> tensor<256x2112xbf16>
+    return %0 : tensor<256x2112xbf16>
+  }
+  func.func private @sdy.all_slice1(%arg0: tensor<128x2112xbf16>) -> tensor<32x2112xbf16> {
+    %0 = stablehlo.reshape %arg0 : (tensor<128x2112xbf16>) -> tensor<4x32x2112xbf16>
+    %1 = stablehlo.slice %0 [0:1, 0:32, 0:2112] : (tensor<4x32x2112xbf16>) -> tensor<1x32x2112xbf16>
+    %2 = stablehlo.reshape %1 : (tensor<1x32x2112xbf16>) -> tensor<32x2112xbf16>
+    return %2 : tensor<32x2112xbf16>
+  }
+}
+
+// CHECK-LABEL: func.func @all_slice_after_reduce_scatter
+// CHECK: "ttir.reduce_scatter"
+// CHECK-SAME: -> tensor<128x2112xbf16>
+// Only "_axis_1" (cluster_axis 1) is left to apply.
+// CHECK: "ttir.mesh_partition"
+// CHECK-SAME: <{cluster_axis = 1 : ui32, dim = 0 : si32}> : (tensor<128x2112xbf16>) -> tensor<32x2112xbf16>
+// CHECK-NOT: "ttir.mesh_partition"
+// CHECK-NOT: func.func private @sdy.all_slice1


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Shardy emits `stablehlo.composite "sdy.all_slice"` as a delta from the operand's existing sharding: `out_sharding` describes the sharding of the result, not axes still to be applied. ShardyAllSliceToTTIRMeshPartitionConversionPattern ignored this and rebuilt the sharding from `out_sharding` as if the operand were fully replicated, emitting one `ttir.mesh_partition` per axis named there.

### What's changed
Account for the actual pre-existing sharding (if any) on a tensor instead of just assuming it is replicated:
- Compute the outstanding divisor per tensor dim as `operandDim / resultDim`.
- Consume that dim's mesh axes minor-most first (Shardy lists them major → minor, so the already-applied ones are the major prefix), and skip the rest.
- Resolve the mesh named by `out_sharding` itself rather than assuming the module's first mesh op.
- Fail the match (leaving the composite for later inlining) instead of emitting a wrong type when ranks/dtypes mismatch, the result isn't an integral shard of the operand, sub-axis partitioning is used, or the mesh/axis can't be resolved.

Updated the existing composite test for the new per-dim emission order and added targeted unit tests (test_sdy_all_slice_partial_sharding.mlir) plus an end-to-end pipeline test (test_sdy_all_slice_reduce_scatter.mlir) covering the reduce_scatter case that motivated the fix.

### Checklist
- [x] New/Existing tests provide coverage for changes
