### PR TITLE
Uplift third_party/tt-metal to 632d7a0 2026-08-07

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=771807262cf3051238364bb5afe3f4bcbde01fde
+ARG TT_METAL_DEPENDENCIES_COMMIT=632d7a0
 
 # Install dependencies
 RUN <<EOT

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "5beed318d0f0d1c6212e605947fb0be80c9e0a1d")
+set(TT_METAL_VERSION "632d7a0")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 632d7a0

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):