### PR TITLE
StableHLO: fix inferred output sharding preservation

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/WrapUnderManualComputation.cpp
+++ b/lib/Dialect/StableHLO/Transforms/WrapUnderManualComputation.cpp
@@ -5,6 +5,7 @@
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
 #include "ttmlir/Dialect/StableHLO/Utils/GSPMDUtils.h"
 #include "ttmlir/Dialect/StableHLO/Utils/ShardyUtils.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIR.h"
 
 namespace mlir::tt::stablehlo {
@@ -26,6 +27,23 @@ static mlir::LogicalResult wrapFunctionBodyInManualComputationOp(
       mlir::sdy::TensorShardingPerValueAttr::get(
           context,
           shardy_utils::getOutShardingAttrs(context, funcOp, globalMeshOp));
+
+  // Shardy may infer a non-replicated output sharding even when the frontend
+  // did not annotate the public function result. Preserve that inferred
+  // sharding before local-shape annotation decides the result shard status.
+  for (auto [index, outSharding] :
+       llvm::enumerate(outShardings.getShardings())) {
+    if (shardy_utils::isFullyReplicatedTensor(outSharding, globalMeshOp)) {
+      continue;
+    }
+
+    funcOp.setResultAttr(index, mlir::sdy::TensorShardingAttr::name,
+                         outSharding);
+    funcOp.setResultAttr(
+        index, mlir::tt::ttcore::ShardStatusAttr::name,
+        mlir::tt::ttcore::ShardStatusAttr::get(
+            context, mlir::tt::ttcore::ShardStatus::Presharded));
+  }
 
   // Create sdy.manual_computation op
   mlir::FunctionType funcType = funcOp.getFunctionType();

--- a/test/python/golden/test_shardy_ops_n300.py
+++ b/test/python/golden/test_shardy_ops_n300.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 from builder.base.builder_utils import Operand, Shape, TypeInfo
 from builder.stablehlo.stablehlo_builder import StableHLOBuilder
 from builder.base.builder_apis import compile_and_execute_shlo
+from golden import apply_sharding
 from test_utils import Marks, shape_str
 
 pytestmark = [pytest.mark.frontend("shlo"), pytest.mark.n300]
@@ -50,7 +51,16 @@ def test_sharding_constraint(
             )
 
             builder.sharding_constraint(in0, tensor_sharding_attr=tensor_sharding_attr)
-            return builder.add(in0, in1)
+            add0 = builder.add(in0, in1)
+            builder.set_goldens_from_builder_tensor(
+                {},
+                {
+                    add0: apply_sharding(
+                        builder._get_golden_tensor(add0), mesh_shape, (0, 1)
+                    )
+                },
+            )
+            return add0
 
     compile_and_execute_shlo(
         module,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/ccl/ccl_ops_shardy.mlir
@@ -333,13 +333,12 @@ module @jit_reshape attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 
 // CHECK: builtin.module @jit_reshape
 // arg0 sharded on dim 0 by mesh axis "batch"=8 -> tensor<128x2x32x32xf32>.
+// result sharding is inferred through the reshape -> tensor<256x1024xf32>.
 // CHECK: func.func public @main
 // CHECK-SAME: %arg0: tensor<128x2x32x32xf32>
-// CHECK: "ttir.mesh_shard"
-// CHECK-SAME: shard_dims = array<i64: -1, 0>
-// CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
-// CHECK-SAME: shard_shape = array<i64: 8, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
+// CHECK-SAME: -> (tensor<256x1024xf32>
+// CHECK: [[RESHAPE:%[0-9]+]] = "ttir.reshape"(%arg0) <{shape = [256 : i32, 1024 : i32]}>
+// CHECK-NEXT: return [[RESHAPE]] : tensor<256x1024xf32>
 
 // -----
 
@@ -350,6 +349,9 @@ module @jit_reshape attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas
 // CHECK-SAME: %arg0: tensor<1024x1024xf32>
 // CHECK-SAME: %arg1: tensor<1024xf32>
 // CHECK-SAME: %arg2: tensor<128x1024xf32>
+// CHECK-SAME: -> (tensor<1024x1024xf32>
+// CHECK-SAME: tensor<1024xf32>
+// CHECK-SAME: tensor<128x1024xf32>
 module @jit__unnamed_wrapped_function_ attributes {mhlo.num_partitions = 8 : i32, mhlo.num_replicas = 1 : i32} {
   sdy.mesh @mesh = <["x"=1, "batch"=8]>
   func.func public @main(%arg0: tensor<1024x1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, %arg1: tensor<1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}]>}, %arg2: tensor<1024x1024xf32> {sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) -> (tensor<1024x1024xf32> {jax.result_info = "[0]['_module.linear.weight']", sdy.sharding = #sdy.sharding<@mesh, [{}, {}]>}, tensor<1024xf32> {jax.result_info = "[0]['_module.linear.bias']", sdy.sharding = #sdy.sharding<@mesh, [{}]>}, tensor<1024x1024xf32> {jax.result_info = "[1]", sdy.sharding = #sdy.sharding<@mesh, [{"batch"}, {}]>}) {
@@ -367,6 +369,7 @@ module @jit__unnamed_wrapped_function_ attributes {mhlo.num_partitions = 8 : i32
   }
 }
 
+// CHECK: [[DP_RESULT:%[0-9]+]] = "ttir.add"
 // CHECK: "ttir.mesh_shard"
 // CHECK-SAME: shard_dims = array<i64: -1>
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
@@ -377,11 +380,7 @@ module @jit__unnamed_wrapped_function_ attributes {mhlo.num_partitions = 8 : i32
 // CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
 // CHECK-SAME: shard_shape = array<i64: 1>
 // CHECK-SAME: shard_type = #ttcore.shard_type<replicate>
-// CHECK: "ttir.mesh_shard"
-// CHECK-SAME: shard_dims = array<i64: -1, 0>
-// CHECK-SAME: shard_direction = #ttcore.shard_direction<shard_to_full>
-// CHECK-SAME: shard_shape = array<i64: 8, 1>
-// CHECK-SAME: shard_type = #ttcore.shard_type<devices>
+// CHECK: return {{%[0-9]+}}, {{%[0-9]+}}, [[DP_RESULT]] : tensor<1024x1024xf32>, tensor<1024xf32>, tensor<128x1024xf32>
 
 // -----
 

--- a/test/ttmlir/Dialect/StableHLO/argument_shard_status/arg_shard_status.mlir
+++ b/test/ttmlir/Dialect/StableHLO/argument_shard_status/arg_shard_status.mlir
@@ -14,4 +14,4 @@ module {
 }
 
 // CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<128x2x32x32xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>
-// CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<2048x1024xf32>>, ttcore.shard_status = #ttcore.shard_status<unsharded>
+// CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<256x1024xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>

--- a/test/ttmlir/Dialect/StableHLO/argument_shard_status/result_shard_status.mlir
+++ b/test/ttmlir/Dialect/StableHLO/argument_shard_status/result_shard_status.mlir
@@ -13,5 +13,5 @@ module {
   }
 }
 
-// CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<2048x1024xf32>>, ttcore.shard_status = #ttcore.shard_status<unsharded>
+// CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<256x1024xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>
 // CHECK: ttcore.local_shape = #ttcore<local_shape local_shape = tensor<256x1024xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>


### PR DESCRIPTION
## Summary
- Bugfix: preserve non-replicated Shardy-inferred `out_shardings` on public function results before local-shape annotation.
- Mark those inferred results `presharded`.
- Update shard-status tests to expect local result shapes for inferred sharded outputs.

Without this, an inferred sharded result can be treated as unsharded/full-shape during lowering, introducing an unnecessary full aggregation.

## Testing
- `cmake --build build-pr --target ttmlir-opt -j $(nproc)`
- `llvm-lit -q test/ttmlir/Dialect/StableHLO/argument_shard_status/arg_shard_status.mlir test/ttmlir/Dialect/StableHLO/argument_shard_status/result_shard_status.mlir`