### PR TITLE
[op-by-op] Report ops that cannot be wrapped in a module, and bound error text

### DIFF
--- a/test/python/op_by_op/test_unbuildable_op_reporting.py
+++ b/test/python/op_by_op/test_unbuildable_op_reporting.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Ops that cannot be wrapped in a module must still be reported.
+
+Regression tests: `execute_extracted_ops` used to `continue` past such an op, so
+it appeared in no result -- neither passed nor failed. The op vanished from the
+totals and the failure survived only as a line in a job log, which meant the
+op-by-op data could not be used to count how many ops were actually attempted.
+"""
+
+import pytest
+
+from op_by_op_infra.execution_result import (
+    MAX_ERROR_MESSAGE_CHARS,
+    _truncate_error_message,
+)
+from op_by_op_infra.workflow_internal import build_unbuildable_op_model
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _bootstrap_system_desc():
+    """Override the package-wide fixture: these tests never touch a device.
+
+    The conftest fixture generates a system descriptor, which needs hardware.
+    Everything here is pure record construction, so requiring a device would only
+    make the tests unrunnable on a dev box and on any CPU-only CI runner.
+    """
+    yield
+
+
+class _FakeOp:
+    """Duck-typed stand-in for OpWrapper.
+
+    Only `op_name` and `origin_model` are read when building the record, and a
+    real OpWrapper cannot be constructed without a live MLIR context, so the two
+    attributes are supplied directly. `origin_model` is a list on OpWrapper.
+    """
+
+    def __init__(self, op_name, origin_model):
+        self.op_name = op_name
+        self.origin_model = origin_model
+
+    def as_module_str(self):
+        # Present so this fake stands in for a real OpWrapper on both the old and
+        # the new failure path; the old one printed the whole module here.
+        return "module { }"
+
+
+def test_unbuildable_op_is_reported_as_a_failure():
+    model = build_unbuildable_op_model(
+        _FakeOp("stablehlo.custom_call", ["pytorch_SomeModel"]),
+        RuntimeError("operand #0 has no defining op"),
+    )
+
+    # The point of the fix: the op is present, and present as a failure.
+    assert model.success is False
+    assert model.op_name == "stablehlo.custom_call"
+    assert model.model_name == "pytorch_SomeModel"
+    assert "Failed to create module from op" in model.error_message
+    assert "operand #0 has no defining op" in model.error_message
+
+    # No compiled module exists for these ops, so there are no tensor descriptions
+    # to report. Empty rather than absent, so the record still validates.
+    assert model.inputs == []
+    assert model.outputs == []
+    assert model.test_start_ts is not None and model.test_end_ts is not None
+
+
+def test_multi_model_origin_is_joined_like_the_executed_path():
+    """Deduplicated ops carry several origin models; both paths must agree.
+
+    `ModuleWrapper` joins with ", " (utils.py), so an unbuildable op has to use
+    the same separator or the two paths would write different shapes of value for
+    the same column.
+    """
+    model = build_unbuildable_op_model(
+        _FakeOp("stablehlo.dot_general", ["model_a", "model_b"]),
+        ValueError("nope"),
+    )
+    assert model.model_name == "model_a, model_b"
+
+
+def test_empty_origin_model_becomes_none_not_empty_string():
+    model = build_unbuildable_op_model(_FakeOp("stablehlo.add", [""]), ValueError("x"))
+    assert model.model_name is None
+
+
+def test_op_name_is_coerced_to_str():
+    """`op_name` can be an MLIR StringAttr rather than a plain str."""
+
+    class _AttrLike:
+        def __str__(self):
+            return "stablehlo.reshape"
+
+    model = build_unbuildable_op_model(_FakeOp(_AttrLike(), ["m"]), ValueError("boom"))
+    assert model.op_name == "stablehlo.reshape"
+    assert isinstance(model.op_name, str)
+
+
+def test_execute_extracted_ops_reports_rather_than_drops(monkeypatch):
+    """The actual regression: the op must appear in the returned list.
+
+    Stubs the device path so this stays a test of the loop's bookkeeping -- the
+    executor and system descriptor are irrelevant to whether an op that failed
+    `as_module()` survives into the results.
+    """
+    from op_by_op_infra import workflow
+
+    good = _FakeOp("stablehlo.add", ["model_a"])
+    bad = _FakeOp("stablehlo.custom_call", ["model_b"])
+    good.as_module = lambda: "module-for-good"
+
+    def _raise():
+        raise RuntimeError("cannot build module")
+
+    bad.as_module = _raise
+
+    monkeypatch.setattr(workflow, "_ensure_system_desc", lambda: None)
+
+    class _StubExecutor:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def execute(self, module):
+            return module
+
+    monkeypatch.setattr(workflow.workflow_internal, "MLIRModuleExecutor", _StubExecutor)
+    monkeypatch.setattr(
+        workflow.workflow_internal,
+        "convert_results_to_pydantic_models",
+        lambda results, frontend=None: [
+            build_unbuildable_op_model(good, RuntimeError("executed-placeholder"))
+            for _ in results
+        ],
+    )
+
+    models = workflow.execute_extracted_ops([good, bad], frontend="tt-xla")
+
+    # One record for the executed op, one for the op that could not be built.
+    # Before the fix the second was dropped and this returned a single record.
+    assert len(models) == 2
+
+    unbuildable = [m for m in models if m.op_name == "stablehlo.custom_call"]
+    assert len(unbuildable) == 1, "the unbuildable op must be reported, not dropped"
+    assert unbuildable[0].success is False
+    assert "cannot build module" in unbuildable[0].error_message
+    # Frontend still gets stamped on the synthesized record.
+    assert unbuildable[0].frontend == "tt-xla"
+
+
+def test_short_error_messages_are_left_alone():
+    message = "operand #0 has no defining op"
+    assert _truncate_error_message(message) == message
+
+
+def test_long_error_messages_are_truncated_and_say_so():
+    """Compiler errors can embed a whole module; one real one was 57k characters."""
+    message = "x" * (MAX_ERROR_MESSAGE_CHARS + 5000)
+
+    truncated = _truncate_error_message(message)
+
+    assert len(truncated) < len(message)
+    assert truncated.startswith("x" * 100)
+    # The amount dropped is stated, so a truncated message is never mistaken for
+    # the whole error.
+    assert "truncated 5000 of" in truncated
+
+
+def test_unbuildable_op_error_message_is_bounded():
+    model = build_unbuildable_op_model(
+        _FakeOp("stablehlo.add", ["m"]), RuntimeError("y" * 50_000)
+    )
+    assert len(model.error_message) < 50_000
+    assert "truncated" in model.error_message

--- a/tools/op-by-op-infra/op_by_op_infra/execution_result.py
+++ b/tools/op-by-op-infra/op_by_op_infra/execution_result.py
@@ -12,6 +12,22 @@ from typing import Optional
 from .pydantic_models import OpTest, TensorDesc
 from .utils import ModuleWrapper
 
+# Longest error text kept on a reported op. Compiler and splitter errors can embed
+# a whole module -- one such message ran to 57k characters in a real nightly run --
+# and every op carrying that verbatim is what makes a job log unreadable.
+MAX_ERROR_MESSAGE_CHARS = 2000
+
+
+def _truncate_error_message(message: str) -> str:
+    """Bounds an error string, noting how much was cut so nothing looks complete."""
+    if len(message) <= MAX_ERROR_MESSAGE_CHARS:
+        return message
+    dropped = len(message) - MAX_ERROR_MESSAGE_CHARS
+    return (
+        message[:MAX_ERROR_MESSAGE_CHARS]
+        + f"... [truncated {dropped} of {len(message)} characters]"
+    )
+
 
 class ExecutionPhase(Enum):
     """Progress marks in execution pipeline."""
@@ -116,7 +132,10 @@ def convert_to_pydantic_model(result: ExecutionResult) -> OpTest:
     if result.device_run_passed:
         error_msg = None
     elif result.error_message:
-        error_msg = result.error_message
+        # Bounded: compiler and splitter errors can embed a whole module, and one
+        # such message ran to 57k characters in a real nightly run. Every op
+        # carrying that verbatim is what makes the job log unreadable.
+        error_msg = _truncate_error_message(result.error_message)
     else:
         error_msg = f"Last step successfully finished: {result.execution_phase.name}."
 

--- a/tools/op-by-op-infra/op_by_op_infra/workflow.py
+++ b/tools/op-by-op-infra/op_by_op_infra/workflow.py
@@ -233,15 +233,22 @@ def execute_extracted_ops(
         compile_only, debug_print=debug_print
     )
     execution_results = []
+    # Ops that never reached the executor because a module could not be built for
+    # them. They still have to be reported: silently dropping them removes them
+    # from the totals entirely, so an op that cannot even be wrapped in a module
+    # looks identical to an op that was never seen.
+    unbuildable_op_models = []
 
     for op in workflow_internal.progress_bar(ops, desc="Executing submodules..."):
         try:
             sub_module = op.as_module()
         except Exception as e:
-            print(f"ERROR: Failed to create module from op")
+            print(f"ERROR: Failed to create module from op '{op.op_name}'")
             print(f"Origin model: {op.origin_model}")
-            print(f"Module string:\n{op.as_module_str()}")
             print(f"Exception: {e}")
+            unbuildable_op_models.append(
+                workflow_internal.build_unbuildable_op_model(op, e)
+            )
             continue
 
         execution_result = executor.execute(sub_module)
@@ -250,6 +257,18 @@ def execute_extracted_ops(
     if failed_ops_folder is not None:
         _save_failed_ops(execution_results, failed_ops_folder)
 
-    return workflow_internal.convert_results_to_pydantic_models(
+    models = workflow_internal.convert_results_to_pydantic_models(
         execution_results, frontend=frontend
     )
+
+    if unbuildable_op_models:
+        print(
+            f"WARNING: {len(unbuildable_op_models)} op(s) could not be wrapped in a "
+            f"module and are reported as failures."
+        )
+        if frontend is not None:
+            for model in unbuildable_op_models:
+                workflow_internal.add_missing_attributes(model, frontend=frontend)
+        models.extend(unbuildable_op_models)
+
+    return models

--- a/tools/op-by-op-infra/op_by_op_infra/workflow_internal.py
+++ b/tools/op-by-op-infra/op_by_op_infra/workflow_internal.py
@@ -3,12 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from datetime import datetime
 from typing import List, Optional
 
 from tqdm import tqdm
 from ttmlir.ir import Module
 
-from .execution_result import convert_to_pydantic_model
+from .execution_result import _truncate_error_message, convert_to_pydantic_model
 from .mlir_module_executor import ExecutionResult, MLIRModuleExecutor
 from .mlir_module_splitter import MLIRModuleSplitter
 from .pydantic_models import OpTest
@@ -44,6 +45,38 @@ def progress_msg(*args, **kwargs) -> None:
     """
     if show_workflow_progress():
         tqdm.write(*args, **kwargs)
+
+
+def build_unbuildable_op_model(op, error: Exception) -> OpTest:
+    """
+    Builds an `OpTest` for an op that could not be wrapped in a module.
+
+    These ops never reach the executor, so there is no `ExecutionResult` and no
+    compiled module to read tensor descriptions from -- `inputs` and `outputs` are
+    therefore empty. Reporting the op with what is known still matters: it keeps
+    the op in the totals and names it in the data, instead of the op vanishing and
+    the failure existing only as a line in a job log.
+
+    `model_name` is joined with ", " to match what `ModuleWrapper` produces for
+    executed ops (utils.py), so both paths write the same shape of value.
+    """
+    now = datetime.now()
+    origin_model = op.origin_model
+    if isinstance(origin_model, (list, tuple)):
+        origin_model = ", ".join(m for m in origin_model if m)
+
+    return OpTest(
+        test_start_ts=now,
+        test_end_ts=now,
+        success=False,
+        error_message=_truncate_error_message(
+            f"Failed to create module from op: {error}"
+        ),
+        op_name=str(op.op_name),
+        model_name=origin_model or None,
+        inputs=[],
+        outputs=[],
+    )
 
 
 def convert_results_to_pydantic_models(


### PR DESCRIPTION
Two data-quality fixes in the op-by-op reporting path, both found while auditing why the op-by-op dataset can't be trusted for counting.

### 1. Ops that fail module creation were silently dropped

`execute_extracted_ops` caught the exception from `op.as_module()`, printed it, and `continue`d without appending anything:

```python
except Exception as e:
    print(f"ERROR: Failed to create module from op")
    print(f"Origin model: {op.origin_model}")
    print(f"Module string:\n{op.as_module_str()}")
    print(f"Exception: {e}")
    continue          # <- no result recorded
```

The op then appeared in **no result — neither passed nor failed**. It vanished from the totals, and the failure survived only as a line in a job log. An op that cannot be wrapped in a module was indistinguishable from an op that was never attempted, so the recorded counts could not be read as "what we tried".

These ops are now reported as failures. There is no `ExecutionResult` and no compiled module for them, so `inputs`/`outputs` are empty and the message names the cause, while `op_name` and `model_name` are preserved so the row stays attributable. `model_name` is joined with `", "` to match what `ModuleWrapper` produces for executed ops, so both paths write the same shape of value.

The handler also no longer prints the full module: `op.as_module_str()` inside the `except` both dumped a whole module into the log and could itself raise, masking the original error.

### 2. Error text is now bounded

Compiler and splitter errors can embed an entire module. In the 2026-08-09 nightly dump, **44 such warnings produced a 34MB log, with one line of 57,231 characters**. Messages are truncated to 2000 characters with the dropped count stated, so a truncated message is never mistaken for a complete one.

### Tests

`test/python/op_by_op/test_unbuildable_op_reporting.py`, 8 cases: the unbuildable op is reported as a failure carrying its name, model and cause; multi-model origins join identically to the executed path; an empty origin becomes `None` rather than `""`; `op_name` is coerced from a StringAttr; long messages are truncated and say so.

The regression test was checked against the old loop and fails there **on the count itself** — `assert 1 == 2` — rather than incidentally. On the first attempt it failed with an `AttributeError` because the fake op lacked `as_module_str`, which the old path calls; the fake now implements it so the old path runs to completion and the comparison is honest.

These tests need no device — they override the package-wide system-descriptor fixture, since they only construct records. Locally the other 19 op-by-op tests error in this environment on system-descriptor generation, identically on unmodified `main`.

`black` clean on every file touched. (`mlir_module_splitter.py` is flagged by black on `main` already and is untouched here.)

### Not included: actual correctness checking

While tracing this I confirmed something worth stating separately: **op-by-op does not verify that ops produce correct results.** `success` comes from whether compile+run completed (`workflow.py`), `OpTest` has no accuracy field, and in `_flatbuffer_worker.py` the outputs are brought to host and deallocated **without ever being read**. Inputs are `torch.randn`/`torch.zeros` generated inside the worker. So an op that runs and returns garbage is recorded as passing, and the dashboard's pass rate means "executes", not "is correct".

The pieces to fix that already exist here — `tools/golden` has `get_atol_rtol_pcc` and a `GOLDEN_MAPPINGS` op→torch reference table, and chisel already replays flatbuffers against goldens. The blocker is structural: inputs are generated inside the subprocess and outputs are discarded, so there is nothing to compare and no shared input to compare against. A workable design is to seed input generation and pass the seed across the subprocess boundary, so the parent can regenerate identical inputs and compute a torch golden, returning outputs for comparison — plus a schema field, which needs ingestion-side agreement.

That is a larger change than this PR and I did not want to half-ship it. Happy to take it as a follow-up if the shape above looks right.

Refs tenstorrent/tt-xla#5867