### PR TITLE
Conv decomposition

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPEDCONVCHANNELSPLITREWRITEPATTERN_H
+#define TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPEDCONVCHANNELSPLITREWRITEPATTERN_H
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#include <cstdint>
+
+namespace mlir::tt::ttnn::decomposition {
+
+// Channel budget for a single grouped convolution. A grouped conv wider than
+// this is split into chunks that each stay within it. This is because tt-metal
+// crashes if the channel count is too large.
+// tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/49793
+constexpr int64_t kMaxGroupedConvChannels = 4096;
+
+// Splits a wide grouped convolution into a sequence of narrower ones.
+//
+// A grouped conv partitions channels: group i reads input channels
+// [i*Cin/G, (i+1)*Cin/G) and writes output channels [i*Cout/G, (i+1)*Cout/G)
+// using weight rows over that same output range. No output element depends on a
+// channel outside its own group, so any partition of the groups splits the conv
+// exactly.
+//
+template <typename ConvOp>
+class GroupedConvChannelSplitRewritePattern
+    : public mlir::OpRewritePattern<ConvOp> {
+public:
+  using mlir::OpRewritePattern<ConvOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ConvOp srcOp, mlir::PatternRewriter &rewriter) const override;
+};
+
+} // namespace mlir::tt::ttnn::decomposition
+
+#endif // TTMLIR_DIALECT_TTNN_TRANSFORMS_DECOMPOSITION_GROUPEDCONVCHANNELSPLITREWRITEPATTERN_H

--- a/lib/Dialect/TTNN/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Transforms/CMakeLists.txt
@@ -64,6 +64,7 @@ add_mlir_dialect_library(MLIRTTNNTransforms
         Decomposition/DistributedRMSNormDecompositionRewritePattern.cpp
         Decomposition/DistributedLayerNormDecompositionRewritePattern.cpp
         Decomposition/GroupNormDecompositionRewritePattern.cpp
+        Decomposition/GroupedConvChannelSplitRewritePattern.cpp
         Decomposition/SDPADecodeDecompositionPattern.cpp
         Decomposition/SDPADecompositionPattern.cpp
         Decomposition/TopKDecompositionRewritePattern.cpp

--- a/lib/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.h"
+
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/Types/Types.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Utils.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/PatternMatch.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <algorithm>
+#include <string>
+
+namespace mlir::tt::ttnn::decomposition {
+
+namespace {
+
+// Extract [begin, end) along `dim`, keeping every other dimension whole.
+mlir::Value sliceAlongDim(mlir::PatternRewriter &rewriter, mlir::Location loc,
+                          mlir::Value value, int64_t dim, int64_t begin,
+                          int64_t end) {
+  auto valueType = mlir::cast<mlir::RankedTensorType>(value.getType());
+  llvm::ArrayRef<int64_t> shape = valueType.getShape();
+
+  llvm::SmallVector<mlir::Attribute> begins, ends, steps;
+  for (int64_t i = 0; i < valueType.getRank(); ++i) {
+    begins.push_back(
+        rewriter.getI32IntegerAttr(i == dim ? static_cast<int32_t>(begin) : 0));
+    ends.push_back(rewriter.getI32IntegerAttr(
+        static_cast<int32_t>(i == dim ? end : shape[i])));
+    steps.push_back(rewriter.getI32IntegerAttr(1));
+  }
+
+  llvm::SmallVector<int64_t> slicedShape(shape);
+  slicedShape[dim] = end - begin;
+
+  return rewriter.create<ttnn::SliceStaticOp>(
+      loc, utils::RankedTensorTypeFactory::create(valueType, slicedShape),
+      value, rewriter.getArrayAttr(begins), rewriter.getArrayAttr(ends),
+      rewriter.getArrayAttr(steps));
+}
+
+// Pick how many whole groups belong in each chunk.
+//
+// Only divisors of `groups` are considered, so every chunk comes out the same
+// shape and the resulting convs share a single program cache entry. Among
+// those, tile-aligned channel counts are preferred over a merely larger chunk,
+// since a chunk boundary off a tile edge makes the slices and the final concat
+// pay for unaligned copies. Returns 0 when even one group exceeds the budget.
+int64_t chooseGroupsPerChunk(int64_t groups, int64_t inChannelsPerGroup,
+                             int64_t outChannelsPerGroup,
+                             int64_t maxChannelsPerChunk) {
+  constexpr int64_t tileWidth = static_cast<int64_t>(ttnn::TILE_WIDTH);
+
+  int64_t widestPerGroup = std::max(inChannelsPerGroup, outChannelsPerGroup);
+  int64_t upperBound = std::min(maxChannelsPerChunk / widestPerGroup, groups);
+
+  int64_t largestDivisor = 0;
+  for (int64_t candidate = upperBound; candidate >= 1; --candidate) {
+    if (groups % candidate != 0) {
+      continue;
+    }
+    if (largestDivisor == 0) {
+      largestDivisor = candidate;
+    }
+    if ((candidate * inChannelsPerGroup) % tileWidth == 0 &&
+        (candidate * outChannelsPerGroup) % tileWidth == 0) {
+      return candidate;
+    }
+  }
+  return largestDivisor;
+}
+
+} // namespace
+
+template <typename ConvOp>
+mlir::LogicalResult
+GroupedConvChannelSplitRewritePattern<ConvOp>::matchAndRewrite(
+    ConvOp srcOp, mlir::PatternRewriter &rewriter) const {
+  int64_t groups = srcOp.getGroups();
+  int64_t inChannels = srcOp.getInChannels();
+  int64_t outChannels = srcOp.getOutChannels();
+
+  // With groups == 1 every output channel reads every input channel, so there
+  // is no channel partition to cut along.
+  if (groups <= 1) {
+    return mlir::failure();
+  }
+
+  if (std::max(inChannels, outChannels) <= kMaxGroupedConvChannels) {
+    return mlir::failure();
+  }
+
+  if (inChannels % groups != 0 || outChannels % groups != 0) {
+    return mlir::failure();
+  }
+
+  // The weight and bias offsets below assume the unprepared conv weight layout
+  // (O, C/G, ...). PrepareConv2dWeights rewrites it to (1, 1, K*K*C/G, O),
+  // where output channels are no longer dimension 0.
+  auto weightType =
+      mlir::cast<mlir::RankedTensorType>(srcOp.getWeight().getType());
+  if (weightType.getDimSize(0) != outChannels) {
+    return mlir::failure();
+  }
+
+  int64_t inChannelsPerGroup = inChannels / groups;
+  int64_t outChannelsPerGroup = outChannels / groups;
+  int64_t groupsPerChunk = chooseGroupsPerChunk(
+      groups, inChannelsPerGroup, outChannelsPerGroup, kMaxGroupedConvChannels);
+  if (groupsPerChunk == 0 || groupsPerChunk == groups) {
+    return mlir::failure();
+  }
+
+  mlir::RankedTensorType resultType = srcOp.getResult().getType();
+  int64_t inputChannelDim =
+      mlir::cast<mlir::RankedTensorType>(srcOp.getInput().getType()).getRank() -
+      1;
+  int64_t resultChannelDim = resultType.getRank() - 1;
+
+  int64_t numChunks = groups / groupsPerChunk;
+  int64_t inChannelsPerChunk = groupsPerChunk * inChannelsPerGroup;
+  int64_t outChannelsPerChunk = groupsPerChunk * outChannelsPerGroup;
+
+  llvm::SmallVector<int64_t> chunkResultShape(resultType.getShape());
+  chunkResultShape[resultChannelDim] = outChannelsPerChunk;
+  mlir::RankedTensorType chunkResultType =
+      utils::RankedTensorTypeFactory::create(resultType, chunkResultShape);
+
+  llvm::SmallVector<mlir::Value> chunkResults;
+  chunkResults.reserve(numChunks);
+
+  for (int64_t chunk = 0; chunk < numChunks; ++chunk) {
+    mlir::Location chunkLoc = ttmlir::utils::appendLocationSuffix(
+        srcOp.getLoc(), "_group_chunk_" + std::to_string(chunk));
+
+    mlir::Value inputSlice = sliceAlongDim(
+        rewriter, chunkLoc, srcOp.getInput(), inputChannelDim,
+        chunk * inChannelsPerChunk, (chunk + 1) * inChannelsPerChunk);
+    mlir::Value weightSlice = sliceAlongDim(
+        rewriter, chunkLoc, srcOp.getWeight(), /*dim=*/0,
+        chunk * outChannelsPerChunk, (chunk + 1) * outChannelsPerChunk);
+
+    // Bias is (1, 1, 1, O), so it covers the same output channel range as the
+    // weight rows. Sliced before cloning the conv so that every operand
+    // dominates its use.
+    mlir::Value biasSlice;
+    if (srcOp.getBias()) {
+      int64_t biasChannelDim =
+          mlir::cast<mlir::RankedTensorType>(srcOp.getBias().getType())
+              .getRank() -
+          1;
+      biasSlice = sliceAlongDim(rewriter, chunkLoc, srcOp.getBias(),
+                                biasChannelDim, chunk * outChannelsPerChunk,
+                                (chunk + 1) * outChannelsPerChunk);
+    }
+
+    auto chunkConv = mlir::cast<ConvOp>(rewriter.clone(*srcOp.getOperation()));
+    chunkConv->setLoc(chunkLoc);
+    chunkConv.getInputMutable().assign(inputSlice);
+    chunkConv.getWeightMutable().assign(weightSlice);
+    if (biasSlice) {
+      chunkConv.getBiasMutable().assign(biasSlice);
+    }
+    chunkConv.setInChannelsAttr(
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(inChannelsPerChunk)));
+    chunkConv.setOutChannelsAttr(
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(outChannelsPerChunk)));
+    chunkConv.setGroupsAttr(
+        rewriter.getI32IntegerAttr(static_cast<int32_t>(groupsPerChunk)));
+    chunkConv.getResult().setType(chunkResultType);
+
+    chunkResults.push_back(chunkConv.getResult());
+  }
+
+  rewriter.replaceOpWithNewOp<ttnn::ConcatOp>(
+      srcOp, resultType, chunkResults, static_cast<int32_t>(resultChannelDim));
+
+  return mlir::success();
+}
+
+template class GroupedConvChannelSplitRewritePattern<ttnn::Conv1dOp>;
+template class GroupedConvChannelSplitRewritePattern<ttnn::Conv2dOp>;
+
+} // namespace mlir::tt::ttnn::decomposition

--- a/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
+++ b/lib/Dialect/TTNN/Transforms/Decomposition/TTNNDecompositionPass.cpp
@@ -6,6 +6,7 @@
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedLayerNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/DistributedRMSNormDecompositionRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupNormDecompositionRewritePattern.h"
+#include "ttmlir/Dialect/TTNN/Transforms/Decomposition/GroupedConvChannelSplitRewritePattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecodeDecompositionPattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/SDPADecompositionPattern.h"
 #include "ttmlir/Dialect/TTNN/Transforms/Decomposition/TopKDecompositionRewritePattern.h"
@@ -31,6 +32,12 @@ public:
     patterns
         .add<decomposition::DistributedLayerNormDecompositionRewritePattern>(
             &getContext());
+    patterns.add<
+        decomposition::GroupedConvChannelSplitRewritePattern<ttnn::Conv1dOp>>(
+        &getContext());
+    patterns.add<
+        decomposition::GroupedConvChannelSplitRewritePattern<ttnn::Conv2dOp>>(
+        &getContext());
 
     if (enableOpConstraints) {
       OpValidationConfig validationConfig;

--- a/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/grouped_conv_channel_split.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Decomposition/grouped_conv_channel_split.mlir
@@ -1,0 +1,155 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-decomposition -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module attributes {} {
+  // A depthwise conv2d (groups == in_channels == out_channels) too wide to fit
+  // L1 is split into two 4096-channel convs concatenated on the channel dim.
+  func.func @depthwise_conv2d_8192_channels(%arg0: tensor<1x1x64x8192xbf16>, %arg1: tensor<8192x1x3x3xbf16>) -> tensor<1x1x64x8192xbf16> {
+    // CHECK-LABEL: func.func @depthwise_conv2d_8192_channels
+    // Input is cut on the channel dim (last), weight on the output-channel dim (first).
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [1 : i32, 1 : i32, 64 : i32, 4096 : i32]
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [4096 : i32, 1 : i32, 3 : i32, 3 : i32]
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: groups = 4096 : i32
+    // CHECK-SAME: in_channels = 4096 : i32
+    // CHECK-SAME: out_channels = 4096 : i32
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: groups = 4096 : i32
+    // CHECK-NOT: "ttnn.conv2d"
+    // CHECK: "ttnn.concat"
+    // CHECK-SAME: dim = 3 : si32
+
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 8192 : i32,
+            in_channels = 8192 : i32,
+            input_height = 8 : i32,
+            input_width = 8 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 8192 : i32,
+            padding = array<i32: 1, 1>,
+            stride = array<i32: 1, 1>
+          }> : (tensor<1x1x64x8192xbf16>, tensor<8192x1x3x3xbf16>, !ttnn.device) -> tensor<1x1x64x8192xbf16>
+    return %1 : tensor<1x1x64x8192xbf16>
+  }
+
+  // A grouped (non-depthwise) conv2d splits on group boundaries too: 64 groups
+  // of 128 channels become two convs of 32 groups each.
+  func.func @grouped_conv2d_with_bias(%arg0: tensor<1x1x64x8192xbf16>, %arg1: tensor<8192x128x3x3xbf16>, %arg2: tensor<1x1x1x8192xbf16>) -> tensor<1x1x64x8192xbf16> {
+    // CHECK-LABEL: func.func @grouped_conv2d_with_bias
+    // Input, weight and bias are each cut over the same group range; the bias is
+    // (1, 1, 1, O), so it follows the weight's output-channel range.
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [1 : i32, 1 : i32, 64 : i32, 4096 : i32]
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [4096 : i32, 128 : i32, 3 : i32, 3 : i32]
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [1 : i32, 1 : i32, 1 : i32, 4096 : i32]
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: groups = 32 : i32
+    // CHECK-SAME: in_channels = 4096 : i32
+    // CHECK-SAME: out_channels = 4096 : i32
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: groups = 32 : i32
+    // CHECK-NOT: "ttnn.conv2d"
+    // CHECK: "ttnn.concat"
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %arg2, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 64 : i32,
+            in_channels = 8192 : i32,
+            input_height = 8 : i32,
+            input_width = 8 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 8192 : i32,
+            padding = array<i32: 1, 1>,
+            stride = array<i32: 1, 1>
+          }> : (tensor<1x1x64x8192xbf16>, tensor<8192x128x3x3xbf16>, tensor<1x1x1x8192xbf16>, !ttnn.device) -> tensor<1x1x64x8192xbf16>
+    return %1 : tensor<1x1x64x8192xbf16>
+  }
+
+  // Depthwise conv1d takes the same path; channels are the last dim of its
+  // (N, L, C) input and of its flattened (1, 1, N * L_out, O) result.
+  func.func @depthwise_conv1d_8192_channels(%arg0: tensor<1x512x8192xbf16>, %arg1: tensor<8192x1x3xbf16>) -> tensor<1x1x512x8192xbf16> {
+    // CHECK-LABEL: func.func @depthwise_conv1d_8192_channels
+    // CHECK: "ttnn.slice_static"
+    // CHECK-SAME: ends = [1 : i32, 512 : i32, 4096 : i32]
+    // CHECK: "ttnn.conv1d"
+    // CHECK-SAME: groups = 4096 : i32
+    // CHECK-SAME: in_channels = 4096 : i32
+    // CHECK: "ttnn.conv1d"
+    // CHECK-SAME: groups = 4096 : i32
+    // CHECK-NOT: "ttnn.conv1d"
+    // CHECK: "ttnn.concat"
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.conv1d"(%arg0, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = 1 : i32,
+            groups = 8192 : i32,
+            in_channels = 8192 : i32,
+            input_length = 512 : i32,
+            kernel_size = 3 : i32,
+            out_channels = 8192 : i32,
+            padding = array<i32: 1, 1>,
+            stride = 1 : i32
+          }> : (tensor<1x512x8192xbf16>, tensor<8192x1x3xbf16>, !ttnn.device) -> tensor<1x1x512x8192xbf16>
+    return %1 : tensor<1x1x512x8192xbf16>
+  }
+
+  // groups == 1 is left alone: every output channel reads every input channel,
+  // so there is no channel partition to cut along.
+  func.func @dense_conv2d_is_not_split(%arg0: tensor<1x1x64x8192xbf16>, %arg1: tensor<8192x8192x1x1xbf16>) -> tensor<1x1x64x8192xbf16> {
+    // CHECK-LABEL: func.func @dense_conv2d_is_not_split
+    // CHECK-NOT: "ttnn.slice_static"
+    // CHECK-NOT: "ttnn.concat"
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: in_channels = 8192 : i32
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 1 : i32,
+            in_channels = 8192 : i32,
+            input_height = 8 : i32,
+            input_width = 8 : i32,
+            kernel_size = array<i32: 1, 1>,
+            out_channels = 8192 : i32,
+            padding = array<i32: 0, 0>,
+            stride = array<i32: 1, 1>
+          }> : (tensor<1x1x64x8192xbf16>, tensor<8192x8192x1x1xbf16>, !ttnn.device) -> tensor<1x1x64x8192xbf16>
+    return %1 : tensor<1x1x64x8192xbf16>
+  }
+
+  // A grouped conv already inside the channel budget is left alone.
+  func.func @narrow_depthwise_conv2d_is_not_split(%arg0: tensor<1x1x64x512xbf16>, %arg1: tensor<512x1x3x3xbf16>) -> tensor<1x1x64x512xbf16> {
+    // CHECK-LABEL: func.func @narrow_depthwise_conv2d_is_not_split
+    // CHECK-NOT: "ttnn.slice_static"
+    // CHECK-NOT: "ttnn.concat"
+    // CHECK: "ttnn.conv2d"
+    // CHECK-SAME: in_channels = 512 : i32
+    %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
+    %1 = "ttnn.conv2d"(%arg0, %arg1, %0)
+          <{
+            batch_size = 1 : i32,
+            dilation = array<i32: 1, 1>,
+            groups = 512 : i32,
+            in_channels = 512 : i32,
+            input_height = 8 : i32,
+            input_width = 8 : i32,
+            kernel_size = array<i32: 3, 3>,
+            out_channels = 512 : i32,
+            padding = array<i32: 1, 1>,
+            stride = array<i32: 1, 1>
+          }> : (tensor<1x1x64x512xbf16>, tensor<512x1x3x3xbf16>, !ttnn.device) -> tensor<1x1x64x512xbf16>
+    return %1 : tensor<1x1x64x512xbf16>
+  }
+}


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-mlir/issues/9188

### Problem description
Convolutions with too many channels cannot fit in L1.

### What's changed
Added a decomposition for grouped convolutions with large amounts of channels that slices them into smaller convolutions and concatenates results.

### Checklist
- [x] New/Existing tests provide coverage for changes
