### PR TITLE
[d2m-jit] Add multi-chip testing to CI

### DIFF
--- a/.github/settings/tests.json
+++ b/.github/settings/tests.json
@@ -40,7 +40,7 @@
     { "runs-on": "n150",   "image": "tracy",  "script": "pykernel.sh" },
     { "runs-on": "n150",   "image": "tracy",  "script": "ttnn_jit.sh", "args": "nightly", "if": "ttnn-jit-nightly" },
     { "runs-on": ["n150","llmbox","p150"],   "image": "tracy",  "script": "ttnn_jit.sh" },
-    { "runs-on": ["n150","p150"],   "image": "tracy",  "script": "d2m_jit.sh" },
+    { "runs-on": ["n150","p150","n300","llmbox"],   "image": "tracy",  "script": "d2m_jit.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "alchemist.sh" },
     { "runs-on": "n150",   "image": "speedy",  "script": "emitc.sh"}
   ]

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -36,6 +36,9 @@ pytest -v "$WORK_DIR"/test/d2m-jit --junit-xml="$TEST_REPORT_PATH"
 # reference the device run uses -- no hand-copied sim suite, and no separate
 # device-vs-sim comparison needed. Tests marked `device_only` skip themselves
 # here (see conftest.py).
+#
+# TODO(https://github.com/tenstorrent/tt-mlir/issues/9202): the sim backend
+# currently does not support multi-chip topologies
 if [[ "$RUNS_ON" != "n300" && "$RUNS_ON" != "llmbox" ]]; then
     echo "Re-running d2m-jit tests on the simulator backend..."
     D2M_JIT_BACKEND=sim pytest -v "$WORK_DIR"/test/d2m-jit \

--- a/.github/test_scripts/d2m_jit.sh
+++ b/.github/test_scripts/d2m_jit.sh
@@ -21,7 +21,14 @@ echo "Running d2m-jit tests (RUNS_ON=$RUNS_ON)..."
 # Full suite: FileCheck lit tests + every pytest module. Runs on every PR.
 # Pass the directory, not a test_*.py glob: the glob only matches the top level
 # and would silently skip subdirectories such as test/d2m-jit/sim/.
-llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
+#
+# On the multi-chip machines (n300/llmbox) only the device pytest pass runs:
+# the `machines` marker (see conftest.py) skips every test that did not opt
+# into that machine type, and the lit + simulator passes are hardware
+# independent -- the n150/p150 lanes already cover them.
+if [[ "$RUNS_ON" != "n300" && "$RUNS_ON" != "llmbox" ]]; then
+    llvm-lit -v --xunit-xml-output "$LIT_REPORT_PATH" "$BUILD_DIR/test/d2m-jit/lit"
+fi
 pytest -v "$WORK_DIR"/test/d2m-jit --junit-xml="$TEST_REPORT_PATH"
 
 # Re-run the same kernels on the pure-Python/torch simulator backend. Every test
@@ -29,9 +36,11 @@ pytest -v "$WORK_DIR"/test/d2m-jit --junit-xml="$TEST_REPORT_PATH"
 # reference the device run uses -- no hand-copied sim suite, and no separate
 # device-vs-sim comparison needed. Tests marked `device_only` skip themselves
 # here (see conftest.py).
-echo "Re-running d2m-jit tests on the simulator backend..."
-D2M_JIT_BACKEND=sim pytest -v "$WORK_DIR"/test/d2m-jit \
-    --junit-xml="$SIM_REPORT_PATH"
+if [[ "$RUNS_ON" != "n300" && "$RUNS_ON" != "llmbox" ]]; then
+    echo "Re-running d2m-jit tests on the simulator backend..."
+    D2M_JIT_BACKEND=sim pytest -v "$WORK_DIR"/test/d2m-jit \
+        --junit-xml="$SIM_REPORT_PATH"
+fi
 
 # cleanup
 rm -rf $WORK_DIR/third_party/tt-metal

--- a/test/d2m-jit/conftest.py
+++ b/test/d2m-jit/conftest.py
@@ -98,9 +98,16 @@ def pytest_collection_modifyitems(config, items):
                 )
                 item.add_marker(pytest.mark.skip(reason=f"device_only: {reason}"))
         marker = item.get_closest_marker("machines")
+        if marker is not None and not marker.args:
+            raise pytest.UsageError(
+                "machines marker requires at least one machine name, e.g. "
+                "@pytest.mark.machines(\"n300\")"
+            )
         allowed = frozenset(marker.args) if marker else _DEFAULT_MACHINES
-        required = min(_MACHINE_NUM_DEVICES.get(m, 1) for m in allowed)
-        if runs_on:
+        unknown = sorted(m for m in allowed if m not in _MACHINE_NUM_DEVICES)
+        if unknown:
+            raise pytest.UsageError(f"Unknown machines marker values: {unknown}")
+        required = min(_MACHINE_NUM_DEVICES[m] for m in allowed)
             if runs_on not in allowed:
                 item.add_marker(
                     pytest.mark.skip(

--- a/test/d2m-jit/conftest.py
+++ b/test/d2m-jit/conftest.py
@@ -101,13 +101,14 @@ def pytest_collection_modifyitems(config, items):
         if marker is not None and not marker.args:
             raise pytest.UsageError(
                 "machines marker requires at least one machine name, e.g. "
-                "@pytest.mark.machines(\"n300\")"
+                '@pytest.mark.machines("n300")'
             )
         allowed = frozenset(marker.args) if marker else _DEFAULT_MACHINES
         unknown = sorted(m for m in allowed if m not in _MACHINE_NUM_DEVICES)
         if unknown:
             raise pytest.UsageError(f"Unknown machines marker values: {unknown}")
         required = min(_MACHINE_NUM_DEVICES[m] for m in allowed)
+        if runs_on:
             if runs_on not in allowed:
                 item.add_marker(
                     pytest.mark.skip(

--- a/test/d2m-jit/conftest.py
+++ b/test/d2m-jit/conftest.py
@@ -24,17 +24,19 @@ _MACHINE_NUM_DEVICES = {"n150": 1, "p150": 1, "n300": 2, "llmbox": 8}
 
 @functools.lru_cache(maxsize=1)
 def _num_devices():
-    """Chip count read from SYSTEM_DESC_PATH, without opening a runtime device.
+    """Chip count read from the builder's resolved system descriptor
+    (SYSTEM_DESC_PATH if set, otherwise queried from the runtime).
 
     Unknown (no system desc, no runtime bindings) counts as a single-chip box:
     single-device tests still run and multi-chip tests skip."""
-    system_desc = os.environ.get("SYSTEM_DESC_PATH")
-    if not system_desc:
-        return 1
     try:
         # Imported lazily: the simulator suite runs with no MLIR bindings.
         from _ttmlir_runtime import binary
+        from d2m_jit._src.builder import _get_system_desc_path
 
+        system_desc = _get_system_desc_path()
+        if not system_desc:
+            return 1
         desc = binary.load_system_desc_from_path(system_desc).as_json()
         desc = re.sub(r"\bnan\b", "NaN", desc)
         desc = re.sub(r"\binf\b", "Infinity", desc)

--- a/test/d2m-jit/conftest.py
+++ b/test/d2m-jit/conftest.py
@@ -2,10 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import functools
+import json
 import os
+import re
 
 import pytest
 import torch
+
+
+# CI machine types (the RUNS_ON env var) a test runs on when it carries no
+# `machines` marker: the single-chip lanes. Tests that need other hardware opt
+# in with e.g. @pytest.mark.machines("n300", "llmbox").
+_DEFAULT_MACHINES = frozenset({"n150", "p150"})
+
+# Devices each CI machine type provides. A test's device requirement is the
+# smallest count among the machines it opted into; local runs (RUNS_ON unset)
+# use it to skip tests this system doesn't have enough chips for.
+_MACHINE_NUM_DEVICES = {"n150": 1, "p150": 1, "n300": 2, "llmbox": 8}
+
+
+@functools.lru_cache(maxsize=1)
+def _num_devices():
+    """Chip count read from SYSTEM_DESC_PATH, without opening a runtime device.
+
+    Unknown (no system desc, no runtime bindings) counts as a single-chip box:
+    single-device tests still run and multi-chip tests skip."""
+    system_desc = os.environ.get("SYSTEM_DESC_PATH")
+    if not system_desc:
+        return 1
+    try:
+        # Imported lazily: the simulator suite runs with no MLIR bindings.
+        from _ttmlir_runtime import binary
+
+        desc = binary.load_system_desc_from_path(system_desc).as_json()
+        desc = re.sub(r"\bnan\b", "NaN", desc)
+        desc = re.sub(r"\binf\b", "Infinity", desc)
+        return len(json.loads(desc)["system_desc"]["chip_desc_indices"])
+    except Exception:
+        return 1
 
 
 def pytest_configure(config):
@@ -18,6 +53,14 @@ def pytest_configure(config):
         "`reason=`: it is what shows up in the skip report, and it should name "
         "the root cause, not the symptom.",
     )
+    config.addinivalue_line(
+        "markers",
+        "machines(*names): CI machine types (RUNS_ON values) this test runs "
+        "on. Unmarked tests default to the single-chip lanes (n150/p150); "
+        "multi-chip tests opt into n300/llmbox. In CI (RUNS_ON set) a test "
+        "runs only on its listed machines; locally it runs whenever this "
+        "system has at least as many devices as the smallest machine listed.",
+    )
 
 
 def _sim_backend_requested():
@@ -25,23 +68,50 @@ def _sim_backend_requested():
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip `device_only` tests when the whole suite is re-run on the simulator.
+    """Skip tests that don't apply to this backend or CI machine.
 
-    CI runs this directory twice: once on the device, once with
-    D2M_JIT_BACKEND=sim (see .github/test_scripts/d2m_jit.sh). Skipping by
-    marker rather than by deselecting paths keeps the exclusions visible in the
-    junit report instead of silently narrowing what the sim lane covers.
+    Two filters, both skip-by-marker rather than deselect-by-path so the
+    exclusions stay visible in the junit report instead of silently narrowing
+    what a lane covers:
+
+    - `device_only` tests are skipped when the whole suite is re-run with
+      D2M_JIT_BACKEND=sim (see .github/test_scripts/d2m_jit.sh).
+    - When RUNS_ON is set (CI), each test runs only on its `machines` marker's
+      machine types, defaulting to the single-chip lanes (_DEFAULT_MACHINES).
+      This is what keeps the n300/llmbox lanes down to the multi-chip tests.
+    - Locally (RUNS_ON unset), a test is skipped when this system has fewer
+      devices than the least-demanding machine the test opted into, so a
+      single-chip box runs everything except the multi-chip tests.
     """
-    if not _sim_backend_requested():
-        return
+    sim = _sim_backend_requested()
+    runs_on = os.environ.get("RUNS_ON")
     for item in items:
-        marker = item.get_closest_marker("device_only")
-        if marker is None:
-            continue
-        reason = marker.kwargs.get("reason") or (
-            marker.args[0] if marker.args else "NO REASON GIVEN -- please add one"
-        )
-        item.add_marker(pytest.mark.skip(reason=f"device_only: {reason}"))
+        if sim:
+            marker = item.get_closest_marker("device_only")
+            if marker is not None:
+                reason = marker.kwargs.get("reason") or (
+                    marker.args[0]
+                    if marker.args
+                    else "NO REASON GIVEN -- please add one"
+                )
+                item.add_marker(pytest.mark.skip(reason=f"device_only: {reason}"))
+        marker = item.get_closest_marker("machines")
+        allowed = frozenset(marker.args) if marker else _DEFAULT_MACHINES
+        required = min(_MACHINE_NUM_DEVICES.get(m, 1) for m in allowed)
+        if runs_on:
+            if runs_on not in allowed:
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"machines: runs on {sorted(allowed)}, not {runs_on}"
+                    )
+                )
+        elif _num_devices() < required:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=f"machines: needs >= {required} devices, "
+                    f"this system has {_num_devices()}"
+                )
+            )
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/test/d2m-jit/test_mesh.py
+++ b/test/d2m-jit/test_mesh.py
@@ -2,43 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import functools
-import json
-import os
-import re
-
 import pytest
 import torch
 
 import d2m_jit as d2m
 from d2m_jit._src.builder import _Builder
 
-try:
-    from _ttmlir_runtime import binary, runtime
-except (ImportError, ModuleNotFoundError):
-    binary = None
-    runtime = None
 
-
-@functools.lru_cache(maxsize=1)
-def _num_devices():
-    """Read the chip count without opening a runtime device."""
-    system_desc = os.environ.get("SYSTEM_DESC_PATH")
-    if binary is None or not system_desc:
-        return 0
-    try:
-        desc = binary.load_system_desc_from_path(system_desc).as_json()
-        desc = re.sub(r"\bnan\b", "NaN", desc)
-        desc = re.sub(r"\binf\b", "Infinity", desc)
-        return len(json.loads(desc)["system_desc"]["chip_desc_indices"])
-    except Exception:
-        return 0
-
-
-requires_mesh = pytest.mark.skipif(
-    runtime is None or _num_devices() < 2,
-    reason="requires SYSTEM_DESC_PATH for a system with at least two devices",
-)
+pytestmark = pytest.mark.machines("n300")
 
 
 def test_mesh_configuration():
@@ -68,7 +39,6 @@ def test_mesh_gather_derives_full_shape():
     assert gathered.mesh.full_shape == [64, 128]
 
 
-@requires_mesh
 def test_mesh_shard_round_trip_1x2():
     d2m.mesh((1, 2), topology=("linear", "ring"))
     layout = d2m.Layout(
@@ -91,7 +61,6 @@ def test_mesh_shard_round_trip_1x2():
     assert torch.allclose(result, full, atol=1e-2)
 
 
-@requires_mesh
 def test_mesh_compute_round_trip_1x2():
     @d2m.kernel
     def sigmoid_kernel(input_, output, m_blocks, n_blocks):


### PR DESCRIPTION
Closes #9200

## Changes

- **`.github/settings/tests.json`** — the `d2m_jit.sh` entry now also runs on n300 and llmbox.
- **`test/d2m-jit/conftest.py`** — new `machines(*names)` pytest marker: each test declares which CI machine types (`RUNS_ON` values) it runs on, defaulting to the single-chip lanes (n150/p150). Enforced in `pytest_collection_modifyitems` by skip-marking (not deselecting) mismatches, matching the existing `device_only` convention so exclusions stay visible in the junit report. Locally (`RUNS_ON` unset), a test is instead skipped when the system has fewer devices than the least-demanding machine it opted into — chip count is read from `SYSTEM_DESC_PATH` without opening a device, and defaults to a single-chip assumption when unknown.
- **`test/d2m-jit/test_mesh.py`** — the whole file is routed to the n300 lane via a module-level `pytestmark`; the previous per-test `requires_mesh` skipif (and its system-desc helper, now in the conftest) is removed.
- **`.github/test_scripts/d2m_jit.sh`** — multi-chip lanes (n300/llmbox) run only the device pytest pass; the lit and simulator passes are hardware-independent and already covered by the n150/p150 lanes.

## Testing

Verified locally by running the suite under each condition:
- `RUNS_ON=n300`: only `test_mesh.py` tests are selected; everything else skips with a `machines: runs on ['n150', 'p150'], not n300` reason.
- `RUNS_ON=n150`: `test_mesh.py` skips with the machines reason; the rest of the suite is unaffected.
- `RUNS_ON` unset (local): multi-chip tests skip with `machines: needs >= 2 devices, this system has 1`; single-device tests run as before.

## Follow-ups (tracked in #9200)

- llmbox-specific mesh shapes (current mesh tests hardcode 1x2, so the llmbox lane currently has no opted-in tests).
- Mesh-parametrize the broader kernel suite so existing tests double as multidevice coverage.
- Simulator-backend mesh semantics for multidevice logic coverage without multi-chip hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)