### PR TITLE
Return embedding backward output with the declared shape

### DIFF
--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -31,12 +31,12 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
   }
-  ::ttnn::Tensor preallocatedOutput =
-      ::tt::runtime::ttnn::operations::utils::allocateTensorOnDevice(
-          op->out(), context.getMeshDevice());
+  ::ttnn::Tensor out =
+      ::ttnn::embedding_bw(input, weight, inGrad, dtype, memoryConfig);
 
-  ::ttnn::Tensor out = ::ttnn::embedding_bw(input, weight, inGrad, dtype,
-                                            memoryConfig, preallocatedOutput);
+  const auto *fbShape = op->out()->desc()->shape();
+  std::vector<int32_t> declaredShape(fbShape->begin(), fbShape->end());
+  out = ::ttnn::reshape(out, declaredShape, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
+++ b/runtime/lib/ttnn/operations/embedding/embedding_backward.cpp
@@ -31,8 +31,12 @@ void run(const ::tt::target::ttnn::EmbeddingBackwardOp *op,
   if (op->dtype()) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
   }
-  ::ttnn::Tensor out =
-      ::ttnn::embedding_bw(input, weight, inGrad, dtype, memoryConfig);
+  ::ttnn::Tensor preallocatedOutput =
+      ::tt::runtime::ttnn::operations::utils::allocateTensorOnDevice(
+          op->out(), context.getMeshDevice());
+
+  ::ttnn::Tensor out = ::ttnn::embedding_bw(input, weight, inGrad, dtype,
+                                            memoryConfig, preallocatedOutput);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/test/ttnn/python/n150/test_embedding_backward.py
+++ b/runtime/test/ttnn/python/n150/test_embedding_backward.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import torch
+import ttrt
+import ttrt.runtime
+from ttrt.common.util import *
+from ..utils import (
+    TT_MLIR_HOME,
+    Helper,
+    DeviceContext,
+    assert_pcc,
+    get_runtime_tensor_from_torch,
+    get_to_layout_inputs,
+    get_torch_output_container,
+)
+
+FLATBUFFER_BASE_PATH = (
+    f"{TT_MLIR_HOME}/build/test/ttmlir/Runtime/TTNN/n150/embedding_backward/Output"
+)
+
+VOCAB_SIZE = 512
+EMBEDDING_DIM = 128
+SEQ_LEN = 32
+
+
+def test_embedding_backward_output_matches_declared_shape(helper: Helper, request):
+    binary_path = os.path.join(FLATBUFFER_BASE_PATH, "embedding_backward.mlir.tmp.ttnn")
+    assert os.path.exists(binary_path), f"Binary file not found: {binary_path}"
+    helper.initialize(request.node.name, binary_path)
+    helper.check_constraints()
+
+    program: Binary.Program = helper.binary.get_program(0)
+    assert program.num_inputs() == 3 and program.num_outputs() == 1
+
+    torch.manual_seed(0)
+    indices = torch.randint(0, VOCAB_SIZE, (1, SEQ_LEN), dtype=torch.int32)
+    weight = torch.zeros((VOCAB_SIZE, EMBEDDING_DIM), dtype=torch.float32)
+    in_gradient = torch.randn((1, SEQ_LEN, EMBEDDING_DIM), dtype=torch.float32)
+    inputs_torch = [indices, weight, in_gradient]
+
+    golden = torch.zeros((VOCAB_SIZE, EMBEDDING_DIM), dtype=torch.float32)
+    golden.index_add_(
+        0, indices.flatten().long(), in_gradient.reshape(-1, EMBEDDING_DIM)
+    )
+
+    declared_shape = program.outputs[0]["desc"]["shape"]
+    assert declared_shape == [VOCAB_SIZE, EMBEDDING_DIM]
+
+    torch_result = get_torch_output_container(program)
+
+    with DeviceContext(mesh_shape=[1, 1]) as device:
+        inputs_runtime = [
+            get_runtime_tensor_from_torch(input) for input in inputs_torch
+        ]
+        inputs = get_to_layout_inputs(device, inputs_runtime, helper.binary, 0)
+        outputs = ttrt.runtime.submit(device, helper.binary.fbb, 0, inputs)
+        assert outputs[0].get_shape() == declared_shape
+        host_output = ttrt.runtime.to_host(outputs[0], untilize=True)[0]
+        ttrt.runtime.memcpy(torch_result.data_ptr(), host_output)
+        ttrt.runtime.deallocate_tensor(outputs[0], force=True)
+        ttrt.runtime.deallocate_tensor(host_output, force=True)
+
+    assert_pcc(golden, torch_result, threshold=0.99)
+    helper.teardown()

--- a/test/ttmlir/Runtime/TTNN/n150/embedding_backward/embedding_backward.mlir
+++ b/test/ttmlir/Runtime/TTNN/n150/embedding_backward/embedding_backward.mlir
@@ -1,0 +1,11 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+// RUN: ttmlir-translate --ttnn-to-flatbuffer -o %t.ttnn %t.mlir
+
+module attributes {} {
+  func.func @embedding_backward(%arg0: tensor<1x32xi32>, %arg1: tensor<512x128xf32>, %arg2: tensor<1x32x128xf32>) -> tensor<512x128xf32> {
+    // CHECK: "ttnn.embedding_bw"
+    %0 = "ttir.embedding_backward"(%arg0, %arg1, %arg2) : (tensor<1x32xi32>, tensor<512x128xf32>, tensor<1x32x128xf32>) -> tensor<512x128xf32>
+    return %0 : tensor<512x128xf32>
+  }
+}


### PR DESCRIPTION
### Problem

`ttnn::embedding_bw` always builds its output as `(1, 1, num_embeddings, embedding_dim)`, while both dialects type the result as `(num_embeddings, embedding_dim)` and the flatbuffer declares that shape. Consumers inside the same program tolerate the leading unit dimensions, so the disagreement is invisible until the tensor is bound as an input to another program, where it is checked against the declared shape and rejected. Runtime validation only covers layout, dtype and storage, so nothing flags it either.

### Fix

The runtime now allocates the output tensor from the declared `TensorRef` and passes it to `ttnn::embedding_bw` as the optional output tensor, which tt-metal returns unchanged. No dialect, verifier or API change; the returned shape simply matches what the program advertises.

### Tests

- `test/ttmlir/Runtime/TTNN/n150/embedding_backward/embedding_backward.mlir` compiles the op and emits a flatbuffer.
- `runtime/test/ttnn/python/n150/test_embedding_backward.py` submits it and asserts the output shape equals the declared shape, plus PCC against a torch reference. Without the fix it fails with `assert [1, 1, 512, 128] == [512, 128]`.
