### PR TITLE
[Shardy] Rescale group_norm num_groups when the channel dim is sharded

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
+++ b/include/ttmlir/Dialect/StableHLO/Utils/StableHLOUtils.h
@@ -23,6 +23,12 @@ inline constexpr llvm::StringLiteral
     kReoutlineArgOperandIndicesAttr("reoutline.arg_operand_indices");
 inline constexpr llvm::StringLiteral
     kReoutlineResultPosAttr("reoutline.result_pos");
+// Size of the channel dimension of a group_norm composite's activation operand
+// before sharding. Stamped on the seed op alongside kReoutlineCompAttrsAttr so
+// that re-outlining can rescale the (global) `num_groups` attribute to the
+// local shape. See rescaleGroupNormNumGroups() in ReoutlineComposite.cpp.
+inline constexpr llvm::StringLiteral
+    kReoutlineGlobalChannelsAttr("reoutline.global_channels");
 
 // Composite op related string definitions.
 inline constexpr llvm::StringLiteral kCompDecompositionKey("decomposition");
@@ -66,6 +72,13 @@ inline constexpr llvm::StringLiteral
 // Composite name emitted by the frontend for scaled_dot_product_attention.
 inline constexpr llvm::StringLiteral
     kTTSDPACompositeName("tenstorrent.scaled_dot_product_attention");
+
+// Composite name emitted by the frontend for group_norm.
+inline constexpr llvm::StringLiteral
+    kTTGroupNormCompositeName("tenstorrent.group_norm");
+// Keys of the group_norm composite attributes that describe the channel layout.
+inline constexpr llvm::StringLiteral kGroupNormNumGroupsKey("num_groups");
+inline constexpr llvm::StringLiteral kGroupNormChannelDimKey("channel_dim");
 
 // Composite names that have custom sharding rules. These composites are
 // converted to stablehlo.custom_call ops so that Shardy can propagate shardings

--- a/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
+++ b/lib/Dialect/StableHLO/Transforms/FlattenOrConvertComposites.cpp
@@ -14,6 +14,40 @@ namespace mlir::tt::stablehlo {
 #define GEN_PASS_DEF_FLATTENORCONVERTCOMPOSITESPASS
 #include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
 
+// Returns the size of the channel dimension of a group_norm composite's
+// activation operand (operand 0), or std::nullopt for any other composite or if
+// the shape/attributes are not in the expected form.
+//
+// `num_groups` in the composite attributes describes the *global* channel
+// layout. Sharding the channel dimension shrinks the activation without
+// touching that attribute, so ReoutlineCompositePass needs the pre-sharding
+// size to rescale it. See rescaleGroupNormNumGroups() in
+// ReoutlineComposite.cpp.
+static std::optional<int64_t>
+getGroupNormGlobalChannels(mlir::stablehlo::CompositeOp comp,
+                           mlir::DictionaryAttr compAttrs) {
+  if (comp.getName() != utils::kTTGroupNormCompositeName ||
+      comp.getNumOperands() == 0) {
+    return std::nullopt;
+  }
+  auto channelDim = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+      compAttrs.get(utils::kGroupNormChannelDimKey));
+  auto actType =
+      llvm::dyn_cast<mlir::RankedTensorType>(comp.getOperand(0).getType());
+  if (!channelDim || !actType) {
+    return std::nullopt;
+  }
+  // channel_dim may be given as a negative (from-the-end) index.
+  int64_t dim = channelDim.getInt();
+  if (dim < 0) {
+    dim += actType.getRank();
+  }
+  if (dim < 0 || dim >= actType.getRank() || actType.isDynamicDim(dim)) {
+    return std::nullopt;
+  }
+  return actType.getDimSize(dim);
+}
+
 // Inline a single stablehlo.composite op. Returns success if it was flattened.
 static mlir::LogicalResult
 flattenOneComposite(mlir::stablehlo::CompositeOp comp,
@@ -111,6 +145,12 @@ flattenOneComposite(mlir::stablehlo::CompositeOp comp,
       cloned->setAttr(utils::kReoutlineOrigNameAttr, origName);
       // { approximate = "tanh" }
       cloned->setAttr(utils::kReoutlineCompAttrsAttr, origCompAttrs);
+      // 512, when the group_norm activation is <1x512x1x40x64> pre-sharding.
+      if (std::optional<int64_t> globalChannels =
+              getGroupNormGlobalChannels(comp, origCompAttrs)) {
+        cloned->setAttr(utils::kReoutlineGlobalChannelsAttr,
+                        builder.getI64IntegerAttr(*globalChannels));
+      }
       seeded = true;
     }
     clonedOps.push_back(cloned);

--- a/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
+++ b/lib/Dialect/StableHLO/Transforms/ReoutlineComposite.cpp
@@ -213,6 +213,88 @@ computeSafeInsertAfter(llvm::ArrayRef<mlir::Value> captures,
   return latestDef;
 }
 
+// Find the local (post-sharding) size of dimension `channelDim` of the
+// composite's operand 0, using the operand mapping recorded on the flattened
+// ops by FlattenOrConvertCompositesPass. Returns nullopt if operand 0 is not
+// reachable from any op in the group with a static shape.
+static std::optional<int64_t>
+getLocalChannels(llvm::ArrayRef<mlir::Operation *> ops, int64_t channelDim) {
+  for (mlir::Operation *op : ops) {
+    auto argIndices = op->getAttrOfType<mlir::DenseI64ArrayAttr>(
+        utils::kReoutlineArgOperandIndicesAttr);
+    if (!argIndices) {
+      continue;
+    }
+    for (auto [pos, compOperandIdx] :
+         llvm::enumerate(argIndices.asArrayRef())) {
+      if (compOperandIdx != 0 || pos >= op->getNumOperands()) {
+        continue;
+      }
+      auto type =
+          llvm::dyn_cast<mlir::RankedTensorType>(op->getOperand(pos).getType());
+      if (!type) {
+        continue;
+      }
+      // channel_dim may be given as a negative (from-the-end) index.
+      int64_t dim = channelDim < 0 ? channelDim + type.getRank() : channelDim;
+      if (dim < 0 || dim >= type.getRank() || type.isDynamicDim(dim)) {
+        continue;
+      }
+      return type.getDimSize(dim);
+    }
+  }
+  return std::nullopt;
+}
+
+// `num_groups` on a group_norm composite counts groups over the *global*
+// channel dimension. Sharding that dimension shrinks the activation but leaves
+// the attribute untouched, and StableHLOLegalizeCompositePass builds
+// ttir.group_norm from the attribute rather than from the (correctly sharded)
+// decomposition body, so without this each device would normalize over the
+// wrong channel partition. 512 channels / 32 groups sharded 4 ways is 128
+// channels / 8 groups per device, not 128 channels / 32 groups.
+static mlir::DictionaryAttr
+rescaleGroupNormNumGroups(mlir::DictionaryAttr compAttrs,
+                          int64_t globalChannels,
+                          llvm::ArrayRef<mlir::Operation *> ops,
+                          mlir::Operation *seedOp, mlir::OpBuilder &builder) {
+  auto numGroupsAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+      compAttrs.get(utils::kGroupNormNumGroupsKey));
+  auto channelDimAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(
+      compAttrs.get(utils::kGroupNormChannelDimKey));
+  if (!numGroupsAttr || !channelDimAttr || globalChannels <= 0) {
+    return compAttrs;
+  }
+
+  std::optional<int64_t> localChannels =
+      getLocalChannels(ops, channelDimAttr.getInt());
+  // Channel dimension was left replicated: attributes are already correct.
+  if (!localChannels || *localChannels == globalChannels) {
+    return compAttrs;
+  }
+
+  int64_t numGroups = numGroupsAttr.getInt();
+  if (*localChannels <= 0 || globalChannels % *localChannels != 0 ||
+      numGroups % (globalChannels / *localChannels) != 0) {
+    // A group would straddle devices, which a local group_norm cannot express.
+    seedOp->emitWarning()
+        << "group_norm channel dimension sharded " << globalChannels << " -> "
+        << *localChannels << " does not split its " << numGroups
+        << " groups evenly; num_groups left unscaled and results will be "
+           "numerically wrong. Replicate the channel dimension instead.";
+    return compAttrs;
+  }
+
+  int64_t shards = globalChannels / *localChannels;
+  llvm::SmallVector<mlir::NamedAttribute> updated(compAttrs.getValue());
+  for (mlir::NamedAttribute &attr : updated) {
+    if (attr.getName() == utils::kGroupNormNumGroupsKey) {
+      attr.setValue(builder.getI64IntegerAttr(numGroups / shards));
+    }
+  }
+  return builder.getDictionaryAttr(updated);
+}
+
 // Replace the original ops range with a stablehlo.composite, wiring
 // captures/results. Erase the old ops.
 void replaceWithComposite(mlir::func::FuncOp parentFunc,
@@ -254,8 +336,11 @@ void replaceWithComposite(mlir::func::FuncOp parentFunc,
       mlir::SymbolRefAttr::get(ctx, callee.getSymName());
   mlir::DictionaryAttr compAttrs = mlir::DictionaryAttr::get(ctx);
   mlir::StringAttr targetName = builder.getStringAttr(callee.getSymName());
+  mlir::Operation *seedOp = nullptr;
+  std::optional<int64_t> globalChannels;
   for (mlir::Operation *op : opsToErase) {
     if (op->hasAttr(utils::kReoutlineSeedAttr)) {
+      seedOp = op;
       if (auto origName = op->getAttrOfType<mlir::StringAttr>(
               utils::kReoutlineOrigNameAttr)) {
         targetName = origName;
@@ -264,7 +349,19 @@ void replaceWithComposite(mlir::func::FuncOp parentFunc,
               utils::kReoutlineCompAttrsAttr)) {
         compAttrs = compAttr;
       }
+      if (auto channels = op->getAttrOfType<mlir::IntegerAttr>(
+              utils::kReoutlineGlobalChannelsAttr)) {
+        globalChannels = channels.getInt();
+      }
     }
+  }
+
+  // The restored attributes describe the pre-sharding shape; group_norm's
+  // num_groups has to follow the channel dimension down to the local shape.
+  if (globalChannels &&
+      targetName.getValue() == utils::kTTGroupNormCompositeName) {
+    compAttrs = rescaleGroupNormNumGroups(compAttrs, *globalChannels,
+                                          opsToErase, seedOp, builder);
   }
 
   mlir::OperationState state(loc,

--- a/lib/Dialect/StableHLO/Utils/StableHLOUtils.cpp
+++ b/lib/Dialect/StableHLO/Utils/StableHLOUtils.cpp
@@ -69,6 +69,9 @@ mlir::func::FuncOp createPrivateFunction(
     if (cloned->hasAttr(utils::kReoutlineResultPosAttr)) {
       cloned->removeAttr(utils::kReoutlineResultPosAttr);
     }
+    if (cloned->hasAttr(utils::kReoutlineGlobalChannelsAttr)) {
+      cloned->removeAttr(utils::kReoutlineGlobalChannelsAttr);
+    }
   }
 
   // Emit return with remapped escape values.

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups.mlir
@@ -1,0 +1,47 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt -split-input-file --reoutline-composite -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// `num_groups` on a group_norm composite counts groups over the global channel
+// dimension. When Shardy shards that dimension the flattened body is rewritten
+// to local shapes, so re-outlining has to rescale the attribute it restores --
+// StableHLOLegalizeCompositePass builds ttir.group_norm from the attribute, not
+// from the decomposition body.
+//
+// Here 512 channels / 32 groups sharded 4 ways gives 128 channels per device,
+// which must be 8 groups of 16, not 32 groups of 4.
+
+// CHECK-LABEL: func.func @main
+// CHECK: stablehlo.composite "tenstorrent.group_norm"
+// CHECK-SAME: num_groups = 8 : i64
+module @ReoutlineGroupNormShardedChannels attributes {} {
+  func.func @main(%arg0: tensor<1x128x1x40x64xf32>, %arg1: tensor<128xf32>, %arg2: tensor<128xf32>) -> tensor<1x128x1x40x64xf32> {
+    %0 = stablehlo.reshape %arg0 {reoutline.arg_operand_indices = array<i64: 0>, reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}, reoutline.global_channels = 512 : i64, reoutline.group = "composite_tenstorrent.group_norm.impl", reoutline.orig_name = "tenstorrent.group_norm", reoutline.seed} : (tensor<1x128x1x40x64xf32>) -> tensor<1x8x40960xf32>
+    %1 = stablehlo.reshape %0 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<1x8x40960xf32>) -> tensor<1x128x1x40x64xf32>
+    %2 = stablehlo.broadcast_in_dim %arg1, dims = [1] {reoutline.arg_operand_indices = array<i64: 1>, reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<128xf32>) -> tensor<1x128x1x40x64xf32>
+    %3 = stablehlo.multiply %1, %2 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x128x1x40x64xf32>
+    %4 = stablehlo.broadcast_in_dim %arg2, dims = [1] {reoutline.arg_operand_indices = array<i64: 2>, reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<128xf32>) -> tensor<1x128x1x40x64xf32>
+    %5 = stablehlo.add %3, %4 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x128x1x40x64xf32>
+    return %5 : tensor<1x128x1x40x64xf32>
+  }
+}
+
+// -----
+
+// When the channel dimension is left replicated the local shape matches the
+// recorded global one, so the attributes must be restored untouched.
+
+// CHECK-LABEL: func.func @main
+// CHECK: stablehlo.composite "tenstorrent.group_norm"
+// CHECK-SAME: num_groups = 32 : i64
+module @ReoutlineGroupNormReplicatedChannels attributes {} {
+  func.func @main(%arg0: tensor<1x512x1x40x64xf32>, %arg1: tensor<512xf32>, %arg2: tensor<512xf32>) -> tensor<1x512x1x40x64xf32> {
+    %0 = stablehlo.reshape %arg0 {reoutline.arg_operand_indices = array<i64: 0>, reoutline.comp_attrs = {channel_dim = 1 : i64, epsilon = 9.99999997E-7 : f32, num_groups = 32 : i64}, reoutline.global_channels = 512 : i64, reoutline.group = "composite_tenstorrent.group_norm.impl", reoutline.orig_name = "tenstorrent.group_norm", reoutline.seed} : (tensor<1x512x1x40x64xf32>) -> tensor<1x32x40960xf32>
+    %1 = stablehlo.reshape %0 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<1x32x40960xf32>) -> tensor<1x512x1x40x64xf32>
+    %2 = stablehlo.broadcast_in_dim %arg1, dims = [1] {reoutline.arg_operand_indices = array<i64: 1>, reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<512xf32>) -> tensor<1x512x1x40x64xf32>
+    %3 = stablehlo.multiply %1, %2 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x512x1x40x64xf32>
+    %4 = stablehlo.broadcast_in_dim %arg2, dims = [1] {reoutline.arg_operand_indices = array<i64: 2>, reoutline.group = "composite_tenstorrent.group_norm.impl"} : (tensor<512xf32>) -> tensor<1x512x1x40x64xf32>
+    %5 = stablehlo.add %3, %4 {reoutline.group = "composite_tenstorrent.group_norm.impl"} : tensor<1x512x1x40x64xf32>
+    return %5 : tensor<1x512x1x40x64xf32>
+  }
+}


### PR DESCRIPTION
### Ticket

[#4792](https://github.com/tenstorrent/tt-xla/issues/4792)

### Problem description
HunyuanVideo VAE decoder test fails with

```
AssertionError: Evaluation result 0 failed: PCC comparison failed.
Calculated: pcc=0.8330624955527607. Required: pcc=0.99.
```
tenstorrent.group_norm is not in kCompositesWithCustomSharding, which is the KEEP list (composites converted to custom_call so a Shardy sharding rule can apply). Everything off that list is flattened by FlattenOrConvertCompositesPass into its constituent stablehlo ops, sharded, localized, then rebuilt by ReoutlineCompositePass from attributes stashed verbatim on the seed op in reoutline.comp_attrs.

Shardy shards the flattened body correctly — for a 512-channel / 32-group norm split 4 ways the partitioned decomposition reshapes 1x128x1x40x64 -> 1x8x40960 and reduces with a 1/40960 normalizer, i.e. 8 local groups of 16 channels. The loss happens on the way back out: the stashed num_groups = 32 was captured pre-propagation against the global channel count, and TenstorrentGroupNormConversionPattern builds ttir.group_norm from that attribute rather than from the decomposition body, discarding the correctly sharded body. Each device then normalized its 128 local channels into 32 groups of 4 instead of 8 groups of 16 — the wrong channel partition, silently. Every resnet norm2 is fed by a column-parallel conv and so always sees a channel-sharded activation.

### What's changed

- In FlattenOrConvertComposites.cpp, the global channel count of a tenstorrent.group_norm is now stashed on the seed op alongside reoutline.comp_attrs via a new getGroupNormGlobalChannels and constant kReoutlineGlobalChannelsAttr. This is required because by reoutline time only local shapes remain, so the shard factor is otherwise unrecoverable. The channel dimension is read from channel_dim, normalized for negative (from-the-end) indices.

- In ReoutlineComposite.cpp, replaceWithComposite now rescales num_groups through rescaleGroupNormNumGroups before baking the stashed attributes back into the composite, using the shard-invariant group size. The local channel count is recovered by getLocalChannels, which finds the op whose reoutline.arg_operand_indices maps to composite operand 0 and reads its (now local) activation type — reusing the operand mapping the flatten pass already records rather than relying on capture ordering.

- This holds because Shardy shards a dim into contiguous blocks and GroupNorm's groups are contiguous channel ranges, so every device holds a whole number of whole groups. When the channel dim is left replicated the global and local counts match and num_groups is untouched. When a group does not divide evenly into the local shard the pass emits a warning on the seed op naming the global -> local sizes and the group count, and leaves the attribute unscaled.

- createPrivateFunction in StableHLOUtils.cpp strips the new attribute from callee clones along with the other reoutline.* markers. A lit test at test/ttmlir/Conversion/StableHLOToTTIR/composite/test_reoutline_group_norm_num_groups.mlir covers both paths — sharded expects num_groups = 8, replicated expects it to stay 32.

- The rescale gates only tenstorrent.group_norm reconstruction; all other composites restore their attributes exactly as before. The grouping, outlining, and capture/escape wiring are unchanged. Post this fix, the sharded decoder emits num_groups = 8 on the 28 sharded norms (18 at 128 local channels, 4 at 64, 6 at 32) and leaves the 2 replicated 1x256x1x160x256 norms at num_groups = 32, and test_vae_decoder_sharded passes in 61.96s.

### Checklist

- [x] Verify the changes through local testing in N150

### Logs
[hunyuan_vae_decoder_before_fix_aug13.log](https://github.com/user-attachments/files/31013333/hunyuan_vae_decoder_before_fix_aug13.log)
[hunyuan_vae_decoder_after_fix_aug13.log](https://github.com/user-attachments/files/31013332/hunyuan_vae_decoder_after_fix_aug13.log)


