### PR TITLE
Uplift third_party/tt-metal to 8a934ae01866a8e76ed58695ddbd34f596d45889 2026-08-13

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=771807262cf3051238364bb5afe3f4bcbde01fde
+ARG TT_METAL_DEPENDENCIES_COMMIT=8a934ae01866a8e76ed58695ddbd34f596d45889
 
 # Install dependencies
 RUN <<EOT

--- a/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpConstraints.h
@@ -31,9 +31,14 @@ struct OpModelAllocationRecord {
  */
 
 struct OpConstraints {
-  size_t cbL1PeakSize;       // CB L1 peak allocation in bytes
-  size_t tensorL1PeakSize;   // Tensor L1 peak allocation in bytes
-  size_t peakL1MemorySize;   // Peak memory (CB+L1) allocation in bytes
+  // Program-scope temporary L1 peak in bytes.
+  // TODO(#9216): metal reports CB / dataflow-buffer / scratchpad separately
+  // after Metal 2.0; TTNNOpModel folds those three into this field so existing
+  // consumers keep seeing "scratch L1" under the old CB-era name.
+  size_t cbL1PeakSize;
+  size_t tensorL1PeakSize; // Tensor L1 peak allocation in bytes
+  size_t
+      peakL1MemorySize; // Peak memory (scratch+tensor L1) allocation in bytes
   size_t outputL1BufferSize; // Output L1 buffer allocation in bytes
   llvm::SmallVector<tt::ttnn::TTNNLayoutAttr>
       outputLayouts; // Layouts of all output tensors (one layout per output

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -4178,7 +4178,8 @@ public:
 
     // Args must match tt-metal invoke parameter order:
     // input, dtype, residual_input, compute_kernel_config,
-    // program_config, memory_config, use_2d_core_grid
+    // program_config, memory_config, use_2d_core_grid,
+    // fast_and_approximate_mode
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getDtypeAttr()),
@@ -4187,6 +4188,7 @@ public:
         emitter.emit(srcOp.getProgramConfig()),
         emitter.emit(srcOp.getMemoryConfig()),
         emitter.emit(srcOp.getUse_2dCoreGrid()),
+        /*fast_and_approximate_mode=*/emitter.emit(false),
     };
 
     emitter.replaceOp(*this, args);
@@ -4317,7 +4319,8 @@ public:
 
     // Args must match tt-metal invoke parameter order:
     // input, dtype, residual_input, compute_kernel_config,
-    // program_config, memory_config, recip_tensor
+    // program_config, memory_config, recip_tensor,
+    // fast_and_approximate_mode
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getInput()),
         emitter.emit(srcOp.getDtypeAttr()),
@@ -4326,6 +4329,7 @@ public:
         emitter.emit(srcOp.getProgramConfig()),
         emitter.emit(srcOp.getMemoryConfig()),
         emitter.emit(srcOp.getRecip()),
+        /*fast_and_approximate_mode=*/emitter.emit(false),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -4087,6 +4087,7 @@ public:
         emitter.emit(srcOp.getProgramConfig(), "program_config"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
         emitter.emit(srcOp.getUse_2dCoreGrid(), "use_2d_core_grid"),
+        emitter.emit(false, "fast_and_approximate_mode"),
     };
 
     emitter.replaceOp(*this, args);
@@ -4209,6 +4210,7 @@ public:
         emitter.emit(srcOp.getProgramConfig(), "program_config"),
         emitter.emit(srcOp.getMemoryConfig(), "memory_config"),
         emitter.emit(srcOp.getRecip(), "recip_tensor"),
+        emitter.emit(false, "fast_and_approximate_mode"),
     };
 
     emitter.replaceOp(*this, args);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -7503,7 +7503,8 @@ llvm::Expected<OpConstraints> OpModel<RMSNormPreAllGatherOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt,
         /*program_config=*/std::nullopt,
         detail::getNullableMemoryConfig(outputLayout),
-        /*use_2d_core_grid=*/use2DCoreGrid);
+        /*use_2d_core_grid=*/use2DCoreGrid,
+        /*fast_and_approximate_mode=*/false);
   };
 
   return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
@@ -7537,14 +7538,14 @@ llvm::Expected<size_t> OpModel<RMSNormPreAllGatherOp>::getOpRuntime(
   }
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::rms_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*use_2d_core_grid=*/use2DCoreGrid);
+    return QUERY_OP_RUNTIME(::ttnn::rms_norm_pre_all_gather, device, inputSpec,
+                            /*dtype=*/metalDtype,
+                            /*residual_input_tensor=*/residualInputSpec,
+                            /*compute_kernel_config=*/std::nullopt,
+                            /*program_config=*/std::nullopt,
+                            detail::getNullableMemoryConfig(outputLayout),
+                            /*use_2d_core_grid=*/use2DCoreGrid,
+                            /*fast_and_approximate_mode=*/false);
   };
   return operation::getOpRuntime(query);
 #else
@@ -7680,7 +7681,8 @@ OpModel<LayerNormPreAllGatherOp>::getOpConstraints(
         /*compute_kernel_config=*/std::nullopt,
         /*program_config=*/std::nullopt,
         detail::getNullableMemoryConfig(outputLayout),
-        /*recip_tensor=*/recipSpec);
+        /*recip_tensor=*/recipSpec,
+        /*fast_and_approximate_mode=*/false);
   };
 
   return operation::getOpConstraintsWithState(inputLayout.getContext(), query);
@@ -7716,14 +7718,15 @@ llvm::Expected<size_t> OpModel<LayerNormPreAllGatherOp>::getOpRuntime(
   }
 
   auto query = [=]() {
-    return ::ttnn::graph::query_op_runtime(
-        ::ttnn::layer_norm_pre_all_gather, device, inputSpec,
-        /*dtype=*/metalDtype,
-        /*residual_input_tensor=*/residualInputSpec,
-        /*compute_kernel_config=*/std::nullopt,
-        /*program_config=*/std::nullopt,
-        detail::getNullableMemoryConfig(outputLayout),
-        /*recip_tensor=*/recipSpec);
+    return QUERY_OP_RUNTIME(::ttnn::layer_norm_pre_all_gather, device,
+                            inputSpec,
+                            /*dtype=*/metalDtype,
+                            /*residual_input_tensor=*/residualInputSpec,
+                            /*compute_kernel_config=*/std::nullopt,
+                            /*program_config=*/std::nullopt,
+                            detail::getNullableMemoryConfig(outputLayout),
+                            /*recip_tensor=*/recipSpec,
+                            /*fast_and_approximate_mode=*/false);
   };
 
   return operation::getOpRuntime(query);

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -147,6 +147,16 @@ executeConstraintQuery(Callable &callable) {
  * @param callable A callable object that performs the query.
  * @return A tuple containing query results or a string error.
  */
+// TODO(#9216): Metal 2.0 splits program scratch into CB / DFB / scratchpad.
+// Fold them into the legacy cbL1PeakSize slot until OpConstraints exposes
+// separate fields.
+inline size_t
+programScratchL1PeakSize(const ::ttnn::graph::ResourceUsage &usage) {
+  return usage.cb_peak_size_per_core +
+         usage.dataflow_buffer_peak_size_per_core +
+         usage.scratchpad_peak_size_per_core;
+}
+
 template <class Callable>
 llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
                                                Callable &callable) {
@@ -173,7 +183,7 @@ llvm::Expected<OpConstraints> getOpConstraints(MLIRContext *context,
         context, outputTensorSpec, deviceGrid));
   }
 
-  return OpConstraints(response.resource_usage.cb_peak_size_per_core,
+  return OpConstraints(programScratchL1PeakSize(response.resource_usage),
                        response.resource_usage.l1_buffers_peak_per_core,
                        response.resource_usage.peak_memory_usage_per_core,
                        response.resource_usage.l1_output_buffer_per_core,
@@ -291,7 +301,7 @@ llvm::Expected<OpConstraints> getOpConstraintsWithState(MLIRContext *context,
                                 static_cast<uint64_t>(record.size_per_bank)});
   }
 
-  return OpConstraints(out.response.resource_usage.cb_peak_size_per_core,
+  return OpConstraints(programScratchL1PeakSize(out.response.resource_usage),
                        out.response.resource_usage.l1_buffers_peak_per_core,
                        out.response.resource_usage.peak_memory_usage_per_core,
                        out.response.resource_usage.l1_output_buffer_per_core,

--- a/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
+++ b/runtime/include/tt/runtime/detail/ttnn/debug_apis.h
@@ -47,6 +47,8 @@ inline std::string toString(const ::ttnn::DataType &dtype) {
     return "INT32";
   case ::ttnn::DataType::FP8_E4M3:
     return "FP8_E4M3";
+  case ::ttnn::DataType::INT8:
+    return "INT8";
   case ::ttnn::DataType::INVALID:
     return "INVALID";
   }

--- a/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/layer_norm_pre_all_gather.cpp
@@ -48,7 +48,7 @@ void run(const ::tt::target::ttnn::LayerNormPreAllGatherOp *op,
 
   ::ttnn::Tensor output = ::ttnn::layer_norm_pre_all_gather(
       input, dtype, residualInput, computeConfig, programConfig, memoryConfig,
-      recip);
+      recip, /*fast_and_approximate_mode=*/false);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }

--- a/runtime/lib/ttnn/operations/normalization/rms_norm_pre_all_gather.cpp
+++ b/runtime/lib/ttnn/operations/normalization/rms_norm_pre_all_gather.cpp
@@ -46,7 +46,7 @@ void run(const ::tt::target::ttnn::RMSNormPreAllGatherOp *op,
   // Call TTNN RMS Norm Pre all-gather Op
   ::ttnn::Tensor output = ::ttnn::rms_norm_pre_all_gather(
       input, dtype, residual, computeConfig, programConfig, memoryConfig,
-      use2DCoreGrid);
+      use2DCoreGrid, /*fast_and_approximate_mode=*/false);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), output);
 }

--- a/test/python/golden/ttir_ops/normalization/test_normalization.py
+++ b/test/python/golden/ttir_ops/normalization/test_normalization.py
@@ -475,6 +475,15 @@ def test_distributed_rms_norm(
 
             return gathered
 
+    # Without weight, DistributedRMSNorm decomposes to RMSNormPreAllGather.
+    # Metal #52081 sizes intermediate DFBs as FP32 when fp32_dest_acc_en=true;
+    # with default pipeline fp32_dest_acc_en=true, local Wt=128 (global W=8192
+    # on mesh 1x2) overflows L1. This golden checks the distributed op pattern,
+    # not intermediate dtype, so disable fp32 dest acc for that case only.
+    pipeline_options = None
+    if shape == (1, 1, 32, 8192) and not has_weight:
+        pipeline_options = ["compute-cfg-fp32-dest-acc-en=false"]
+
     compile_and_execute_ttir(
         module,
         mesh_name="mesh",
@@ -482,6 +491,7 @@ def test_distributed_rms_norm(
         **get_request_kwargs(request),
         device=device,
         target=target,
+        pipeline_options=pipeline_options,
     )
 
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "5beed318d0f0d1c6212e605947fb0be80c9e0a1d")
+set(TT_METAL_VERSION "8a934ae01866a8e76ed58695ddbd34f596d45889")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 8a934ae01866a8e76ed58695ddbd34f596d45889

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):