### PR TITLE
Fix macOS build: match integer types in std::max in ConstEvalHoist

### DIFF
--- a/lib/Transforms/ConstEvalHoist.cpp
+++ b/lib/Transforms/ConstEvalHoist.cpp
@@ -470,7 +470,7 @@ public:
         if (it == maxSubgraphIndexMap.end()) {
           maxSubgraphIndexMap[orgFuncOp] = subgraphIdx;
         } else {
-          it->second = std::max(it->second, subgraphIdx);
+          it->second = std::max(it->second, static_cast<size_t>(subgraphIdx));
         }
       }
       return WalkResult::advance();


### PR DESCRIPTION
## Problem
Building tt-mlir on macOS (Apple Silicon) fails to compile
`lib/Transforms/ConstEvalHoist.cpp`:

    error: no matching function for call to 'max'
      it->second = std::max(it->second, subgraphIdx);

`it->second` is `size_t` (the value type of `maxSubgraphIndexMap`), while
`subgraphIdx` is `uint64_t`. On Linux these resolve to the same underlying
type, so the build passes and CI doesn't catch it. On macOS/arm64, `size_t`
is `unsigned long` and `uint64_t` is `unsigned long long` — two distinct
types — so `std::max` template argument deduction fails.

## Fix
Cast `subgraphIdx` to `size_t` so both arguments to `std::max` share a type:

    it->second = std::max(it->second, static_cast<size_t>(subgraphIdx));

## Testing
With this change, the file compiles and the full tt-mlir build completes
successfully on macOS (Apple Silicon).
