### PR TITLE
[optimizer] cache opmodel failures

### DIFF
--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -64,10 +64,9 @@ public:
 
   // Statistics about cache performance.
   struct CacheStats {
-    size_t hits = 0;             // Number of cache hits
-    size_t misses = 0;           // Number of cache misses
-    size_t entries = 0;          // Total number of entries in the cache
-    size_t rejectionEntries = 0; // Subset of entries that are rejections
+    size_t hits = 0;    // Number of cache hits
+    size_t misses = 0;  // Number of cache misses
+    size_t entries = 0; // Total number of entries in the cache
   };
 
   // Get current cache statistics.
@@ -96,15 +95,13 @@ public:
     const double missRatio =
         (static_cast<double>(stats.misses) / total) * 100.0;
 
-    std::string statsStr =
-        "  Cache Statistics (" + std::to_string(total) + " total accesses):\n" +
-        "    Hits: " + std::to_string(stats.hits) + " (" +
-        std::to_string(hitRatio) + "%)\n" +
-        "    Misses: " + std::to_string(stats.misses) + " (" +
-        std::to_string(missRatio) + "%)\n" +
-        "    Size: " + std::to_string(size()) + "\n" +
-        "    Rejection entries: " + std::to_string(stats.rejectionEntries) +
-        "\n";
+    std::string statsStr = "  Cache Statistics (" + std::to_string(total) +
+                           " total accesses):\n" +
+                           "    Hits: " + std::to_string(stats.hits) + " (" +
+                           std::to_string(hitRatio) + "%)\n" +
+                           "    Misses: " + std::to_string(stats.misses) +
+                           " (" + std::to_string(missRatio) + "%)\n" +
+                           "    Size: " + std::to_string(size()) + "\n";
     return statsStr;
   }
 
@@ -159,7 +156,7 @@ public:
     llvm::Error error = result.takeError();
     // We don't cache OpNotSupportedError - the caller depends on the exact
     // type.
-    if (!cacheFailures || error.isA<detail::OpNotSupportedError>()) {
+    if (error.isA<detail::OpNotSupportedError>()) {
       return std::move(error);
     }
     // takeError() consumed the error, so hand back an equivalent one.
@@ -172,8 +169,7 @@ public:
 
 private:
   // Private constructor - only accessible by friend functions.
-  explicit TTNNOpModelCache(bool cacheFailures)
-      : cacheFailures(cacheFailures) {}
+  TTNNOpModelCache() = default;
 
   ~TTNNOpModelCache() = default;
 
@@ -219,7 +215,6 @@ private:
     mlir::TypeID opTypeID = op->getName().getTypeID();
     if (failures[opTypeID].try_emplace(hash, std::move(message)).second) {
       stats.entries++;
-      stats.rejectionEntries++;
     }
   }
 
@@ -232,15 +227,13 @@ private:
   // efficient to use it as a key in the cache.
   //
   // Kept separate from SuccessCache: llvm::Error/Expected is not suitable for
-  // storing in cache, so a rejection is a plain string, turned into a fresh
+  // storing in cache, so a failure is a plain string, turned into a fresh
   // Error on each hit.
   using SuccessCache = llvm::DenseMap<llvm::hash_code, ValueT>;
   using SuccessCacheMap = llvm::DenseMap<mlir::TypeID, SuccessCache>;
   using FailureCache = llvm::DenseMap<llvm::hash_code, std::string>;
   using FailureCacheMap = llvm::DenseMap<mlir::TypeID, FailureCache>;
 
-  // Should rejections be cached?
-  const bool cacheFailures;
   SuccessCacheMap values;
   FailureCacheMap failures;
   CacheStats stats;
@@ -256,13 +249,12 @@ inline TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache() {
   //  §6.7 [stmt.dcl] p4 If control enters the declaration concurrently while
   //  the variable is being initialized, the concurrent execution shall wait for
   //  completion of the initialization.
-  static TTNNOpModelCache<op_model::OpConstraints> instance(
-      /*cacheFailures=*/true);
+  static TTNNOpModelCache<op_model::OpConstraints> instance;
   return instance;
 }
 
 inline TTNNOpModelCache<size_t> &opRuntimeCache() {
-  static TTNNOpModelCache<size_t> instance(/*cacheFailures=*/false);
+  static TTNNOpModelCache<size_t> instance;
   return instance;
 }
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpsModelCache.h
@@ -5,19 +5,24 @@
 #ifndef TTMLIR_OPMODEL_TTNN_TTNNOPSMODELCACHE_H
 #define TTMLIR_OPMODEL_TTNN_TTNNOPSMODELCACHE_H
 
+#include "ttmlir/Dialect/TTNN/Interfaces/OpModelError.h"
 #include "ttmlir/OpModel/TTNN/TTNNOpConstraints.h"
 // Self-guards on TTMLIR_ENABLE_OPMODEL (expands to nothing when OpModel is
 // disabled); the device-generation lookup below is guarded separately.
 #include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+#include "ttmlir/Utils.h"
 
 #include "mlir/IR/Operation.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <optional>
+#include <string>
 #include <type_traits>
+#include <utility>
 
 namespace mlir::tt::ttnn {
 
@@ -29,9 +34,23 @@ class TTNNOpModelCache;
 TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache();
 TTNNOpModelCache<size_t> &opRuntimeCache();
 
+// Trimming down large error messages.
+inline std::string trimFailureMessage(std::string message) {
+  constexpr int keptLines = 8;
+  constexpr size_t keptBytes = 4096;
+  std::string bounded =
+      ttmlir::utils::firstNLines(std::move(message), keptLines);
+  if (bounded.size() > keptBytes) {
+    bounded.resize(keptBytes);
+  }
+  return bounded;
+}
+
 // A cache for TTNN operation model results. This cache stores the results of
 // getOpConstraints and getOpRuntime calls to avoid redundant computations.
 // Using this cache results in a 20-30% average compile time reduction.
+//
+// Failures are memoized too, not just accepted results.
 template <typename ValueT>
 class TTNNOpModelCache {
   // It is important to define the singleton accessor functions to prevent
@@ -45,9 +64,10 @@ public:
 
   // Statistics about cache performance.
   struct CacheStats {
-    size_t hits = 0;    // Number of cache hits
-    size_t misses = 0;  // Number of cache misses
-    size_t entries = 0; // Total number of entries in the cache
+    size_t hits = 0;             // Number of cache hits
+    size_t misses = 0;           // Number of cache misses
+    size_t entries = 0;          // Total number of entries in the cache
+    size_t rejectionEntries = 0; // Subset of entries that are rejections
   };
 
   // Get current cache statistics.
@@ -55,11 +75,12 @@ public:
 
   // Clear the cache and reset statistics.
   void clear() {
-    cache.clear();
+    values.clear();
+    failures.clear();
     stats = CacheStats{};
   }
 
-  // Get the total number of cached items.
+  // Get the total number of cached items, accepted and rejected.
   size_t size() const { return stats.entries; }
 
   bool empty() const { return size() == 0; }
@@ -75,13 +96,15 @@ public:
     const double missRatio =
         (static_cast<double>(stats.misses) / total) * 100.0;
 
-    std::string statsStr = "  Cache Statistics (" + std::to_string(total) +
-                           " total accesses):\n" +
-                           "    Hits: " + std::to_string(stats.hits) + " (" +
-                           std::to_string(hitRatio) + "%)\n" +
-                           "    Misses: " + std::to_string(stats.misses) +
-                           " (" + std::to_string(missRatio) + "%)\n" +
-                           "    Size: " + std::to_string(size()) + "\n";
+    std::string statsStr =
+        "  Cache Statistics (" + std::to_string(total) + " total accesses):\n" +
+        "    Hits: " + std::to_string(stats.hits) + " (" +
+        std::to_string(hitRatio) + "%)\n" +
+        "    Misses: " + std::to_string(stats.misses) + " (" +
+        std::to_string(missRatio) + "%)\n" +
+        "    Size: " + std::to_string(size()) + "\n" +
+        "    Rejection entries: " + std::to_string(stats.rejectionEntries) +
+        "\n";
     return statsStr;
   }
 
@@ -119,50 +142,85 @@ public:
     // overload (via ADL) for the type (provided at the end of this file).
     llvm::hash_code hashValue = llvm::hash_combine(std::forward<Args>(args)...);
 
-    // Try to read from cache first.
-    if (auto cached = tryGetFromCache(op, hashValue)) {
-      return *cached;
+    if (std::optional<llvm::Expected<ValueT>> cached =
+            tryGetFromCache(op, hashValue)) {
+      return std::move(*cached);
     }
 
     // Not in cache, compute the value.
     llvm::Expected<ValueT> result =
         std::forward<Callable>(computeFunc)(std::forward<Args>(args)...);
 
-    // If computation was successful, store the result.
     if (result) {
       storeInCache(op, hashValue, *result);
+      return result;
     }
 
-    return result;
+    llvm::Error error = result.takeError();
+    // We don't cache OpNotSupportedError - the caller depends on the exact
+    // type.
+    if (!cacheFailures || error.isA<detail::OpNotSupportedError>()) {
+      return std::move(error);
+    }
+    // takeError() consumed the error, so hand back an equivalent one.
+    std::string message = trimFailureMessage(llvm::toString(std::move(error)));
+    llvm::Error rejection =
+        llvm::createStringError(llvm::inconvertibleErrorCode(), message);
+    storeInCache(op, hashValue, std::move(message));
+    return rejection;
   }
 
 private:
   // Private constructor - only accessible by friend functions.
-  TTNNOpModelCache() = default;
+  explicit TTNNOpModelCache(bool cacheFailures)
+      : cacheFailures(cacheFailures) {}
 
-  std::optional<ValueT> tryGetFromCache(Operation *op, llvm::hash_code hash) {
+  ~TTNNOpModelCache() = default;
+
+  // Returns std::nullopt on a miss.
+  std::optional<llvm::Expected<ValueT>> tryGetFromCache(Operation *op,
+                                                        llvm::hash_code hash) {
     mlir::TypeID opTypeID = op->getName().getTypeID();
-    typename Cache::iterator cacheIt = cache.find(opTypeID);
-    if (cacheIt == cache.end()) {
-      stats.misses++;
-      return std::nullopt;
+    typename SuccessCacheMap::const_iterator valueOpIt = values.find(opTypeID);
+    if (valueOpIt != values.end()) {
+      typename SuccessCache::const_iterator it = valueOpIt->second.find(hash);
+      if (it != valueOpIt->second.end()) {
+        stats.hits++;
+        return llvm::Expected<ValueT>(it->second);
+      }
     }
-
-    OpCache &opCache = cacheIt->second;
-    typename OpCache::iterator opCacheIt = opCache.find(hash);
-    if (opCacheIt == opCache.end()) {
-      stats.misses++;
-      return std::nullopt;
+    if (!failures.empty()) {
+      typename FailureCacheMap::const_iterator rejectionOpIt =
+          failures.find(opTypeID);
+      if (rejectionOpIt != failures.end()) {
+        typename FailureCache::const_iterator it =
+            rejectionOpIt->second.find(hash);
+        if (it != rejectionOpIt->second.end()) {
+          stats.hits++;
+          return llvm::Expected<ValueT>(llvm::createStringError(
+              llvm::inconvertibleErrorCode(), it->second));
+        }
+      }
     }
-
-    stats.hits++;
-    return opCacheIt->second;
+    stats.misses++;
+    return std::nullopt;
   }
 
+  // try_emplace rather than operator[]: a re-store of a key already present
+  // must not double-count `entries`, which is what size()/empty() report.
   void storeInCache(Operation *op, llvm::hash_code hash, const ValueT &value) {
     mlir::TypeID opTypeID = op->getName().getTypeID();
-    cache[opTypeID][hash] = value;
-    stats.entries++;
+    if (values[opTypeID].try_emplace(hash, value).second) {
+      stats.entries++;
+    }
+  }
+
+  void storeInCache(Operation *op, llvm::hash_code hash, std::string message) {
+    mlir::TypeID opTypeID = op->getName().getTypeID();
+    if (failures[opTypeID].try_emplace(hash, std::move(message)).second) {
+      stats.entries++;
+      stats.rejectionEntries++;
+    }
   }
 
   // This class uses indirect hashing to enable caching for each op type
@@ -172,10 +230,19 @@ private:
   // According to llvm docs, mlir::TypeID is unique for each Operation*
   // (https://mlir.llvm.org/doxygen/classmlir_1_1TypeID.html), so it is safe and
   // efficient to use it as a key in the cache.
-  using OpCache = llvm::DenseMap<llvm::hash_code, ValueT>;
-  using Cache = llvm::DenseMap<mlir::TypeID, OpCache>;
+  //
+  // Kept separate from SuccessCache: llvm::Error/Expected is not suitable for
+  // storing in cache, so a rejection is a plain string, turned into a fresh
+  // Error on each hit.
+  using SuccessCache = llvm::DenseMap<llvm::hash_code, ValueT>;
+  using SuccessCacheMap = llvm::DenseMap<mlir::TypeID, SuccessCache>;
+  using FailureCache = llvm::DenseMap<llvm::hash_code, std::string>;
+  using FailureCacheMap = llvm::DenseMap<mlir::TypeID, FailureCache>;
 
-  Cache cache;
+  // Should rejections be cached?
+  const bool cacheFailures;
+  SuccessCacheMap values;
+  FailureCacheMap failures;
   CacheStats stats;
   // MLIR context that owns any attributes/types stored in cached values.
   MLIRContext *context = nullptr;
@@ -189,12 +256,13 @@ inline TTNNOpModelCache<op_model::OpConstraints> &opConstraintsCache() {
   //  §6.7 [stmt.dcl] p4 If control enters the declaration concurrently while
   //  the variable is being initialized, the concurrent execution shall wait for
   //  completion of the initialization.
-  static TTNNOpModelCache<op_model::OpConstraints> instance;
+  static TTNNOpModelCache<op_model::OpConstraints> instance(
+      /*cacheFailures=*/true);
   return instance;
 }
 
 inline TTNNOpModelCache<size_t> &opRuntimeCache() {
-  static TTNNOpModelCache<size_t> instance;
+  static TTNNOpModelCache<size_t> instance(/*cacheFailures=*/false);
   return instance;
 }
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -4509,6 +4509,140 @@ TEST_F(OpModelBase, CacheOpConstraintsMissesTest) {
   EXPECT_EQ(stats2.misses, 2);
 }
 
+TEST_F(OpModelBase, CacheFailureIsCachedTest) {
+  opConstraintsCache().clear();
+  opRuntimeCache().clear();
+
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+  auto sub = builder.create<SubtractOp>(builder.getUnknownLoc(), outputType,
+                                        mlir::ValueRange{input1, input2});
+
+  // test the constraints cache:
+  auto failingConstraintsCompute =
+      [](int marker) -> llvm::Expected<op_model::OpConstraints> {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "synthetic failure");
+  };
+
+  auto firstConstraintsExp = opConstraintsCache().getOrCompute(
+      failingConstraintsCompute, sub.getOperation(), 42);
+  ASSERT_FALSE(static_cast<bool>(firstConstraintsExp));
+  std::string firstConstraintsMessage =
+      llvm::toString(firstConstraintsExp.takeError());
+
+  auto constraintsStats = opConstraintsCache().getStats();
+  EXPECT_EQ(constraintsStats.hits, 0);
+  EXPECT_EQ(constraintsStats.misses, 1);
+  EXPECT_EQ(opConstraintsCache().size(), 1u);
+
+  // Repeating the same query must hit the failure cache, returning the same
+  // error message.
+  auto secondConstraintsExp = opConstraintsCache().getOrCompute(
+      failingConstraintsCompute, sub.getOperation(), 42);
+  ASSERT_FALSE(static_cast<bool>(secondConstraintsExp));
+  EXPECT_EQ(llvm::toString(secondConstraintsExp.takeError()),
+            firstConstraintsMessage);
+
+  constraintsStats = opConstraintsCache().getStats();
+  EXPECT_EQ(constraintsStats.hits, 1);
+  EXPECT_EQ(constraintsStats.misses, 1);
+  EXPECT_EQ(opConstraintsCache().size(), 1u);
+
+  // test the runtime cache:
+  auto failingRuntimeCompute = [](int marker) -> llvm::Expected<size_t> {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "synthetic failure");
+  };
+
+  auto firstRuntimeExp = opRuntimeCache().getOrCompute(failingRuntimeCompute,
+                                                       sub.getOperation(), 42);
+  ASSERT_FALSE(static_cast<bool>(firstRuntimeExp));
+  std::string firstRuntimeMessage = llvm::toString(firstRuntimeExp.takeError());
+
+  auto runtimeStats = opRuntimeCache().getStats();
+  EXPECT_EQ(runtimeStats.hits, 0);
+  EXPECT_EQ(runtimeStats.misses, 1);
+  EXPECT_EQ(opRuntimeCache().size(), 1u);
+
+  // Repeating the same query must hit the failure cache, returning the same
+  // error message.
+  auto secondRuntimeExp = opRuntimeCache().getOrCompute(failingRuntimeCompute,
+                                                        sub.getOperation(), 42);
+  ASSERT_FALSE(static_cast<bool>(secondRuntimeExp));
+  EXPECT_EQ(llvm::toString(secondRuntimeExp.takeError()), firstRuntimeMessage);
+
+  runtimeStats = opRuntimeCache().getStats();
+  EXPECT_EQ(runtimeStats.hits, 1);
+  EXPECT_EQ(runtimeStats.misses, 1);
+  EXPECT_EQ(opRuntimeCache().size(), 1u);
+}
+
+TEST_F(OpModelBase, CacheOpNotSupportedErrorIsNotCachedTest) {
+  opConstraintsCache().clear();
+  opRuntimeCache().clear();
+
+  llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
+  auto input1 = createEmptyTensor(tensorShape);
+  auto input2 = createEmptyTensor(tensorShape);
+  auto outputType = createRankedTensorType(tensorShape);
+  auto sub = builder.create<SubtractOp>(builder.getUnknownLoc(), outputType,
+                                        mlir::ValueRange{input1, input2});
+
+  // test the constraints cache:
+  auto unsupportedConstraintsCompute =
+      [](int marker) -> llvm::Expected<op_model::OpConstraints> {
+    return llvm::make_error<detail::OpNotSupportedError>(
+        "SyntheticOp", detail::ReasonForLackOfSupport::NeedsMemoryIO,
+        "getOpConstraints");
+  };
+
+  auto firstConstraintsExp = opConstraintsCache().getOrCompute(
+      unsupportedConstraintsCompute, sub.getOperation(), 7);
+  ASSERT_FALSE(static_cast<bool>(firstConstraintsExp));
+  EXPECT_TRUE(firstConstraintsExp.errorIsA<detail::OpNotSupportedError>());
+  llvm::consumeError(firstConstraintsExp.takeError());
+
+  // OpNotSupportedError is not memoized.
+  auto secondConstraintsExp = opConstraintsCache().getOrCompute(
+      unsupportedConstraintsCompute, sub.getOperation(), 7);
+  ASSERT_FALSE(static_cast<bool>(secondConstraintsExp));
+  EXPECT_TRUE(secondConstraintsExp.errorIsA<detail::OpNotSupportedError>());
+  llvm::consumeError(secondConstraintsExp.takeError());
+
+  auto constraintsStats = opConstraintsCache().getStats();
+  EXPECT_EQ(constraintsStats.hits, 0);
+  EXPECT_EQ(constraintsStats.misses, 2);
+  EXPECT_EQ(opConstraintsCache().size(), 0u);
+
+  // test the runtime cache:
+  auto unsupportedRuntimeCompute = [](int marker) -> llvm::Expected<size_t> {
+    return llvm::make_error<detail::OpNotSupportedError>(
+        "SyntheticOp", detail::ReasonForLackOfSupport::NeedsMemoryIO,
+        "getOpRuntime");
+  };
+
+  auto firstRuntimeExp = opRuntimeCache().getOrCompute(
+      unsupportedRuntimeCompute, sub.getOperation(), 7);
+  ASSERT_FALSE(static_cast<bool>(firstRuntimeExp));
+  EXPECT_TRUE(firstRuntimeExp.errorIsA<detail::OpNotSupportedError>());
+  llvm::consumeError(firstRuntimeExp.takeError());
+
+  // OpNotSupportedError is not memoized.
+  auto secondRuntimeExp = opRuntimeCache().getOrCompute(
+      unsupportedRuntimeCompute, sub.getOperation(), 7);
+  ASSERT_FALSE(static_cast<bool>(secondRuntimeExp));
+  EXPECT_TRUE(secondRuntimeExp.errorIsA<detail::OpNotSupportedError>());
+  llvm::consumeError(secondRuntimeExp.takeError());
+
+  auto runtimeStats = opRuntimeCache().getStats();
+  EXPECT_EQ(runtimeStats.hits, 0);
+  EXPECT_EQ(runtimeStats.misses, 2);
+  EXPECT_EQ(opRuntimeCache().size(), 0u);
+}
+
 TEST_F(OpModelBase, WhereOpInterface) {
   llvm::SmallVector<int64_t> tensorShape = {workerCoresN300, 1024};
   auto input1 = createEmptyTensor(tensorShape);


### PR DESCRIPTION
The TTNN Op model cache is only caching successes, leaving the failure cases to be re-evaluated each time.

Adding a failure cache map which holds the error message for the given op and hash.

This improves the opt-level 2 compile times significantly. E.g. `resnet` benchmark on `tt-xla`, total time went from 16min to 5min.