### PR TITLE
Add op model interface for TTML ops

### DIFF
--- a/cmake/modules/TTMLIRInstall.cmake
+++ b/cmake/modules/TTMLIRInstall.cmake
@@ -87,6 +87,16 @@ set(ttmlir_export_targets
   MLIRScheduler
 )
 
+# TTNNOpModelLib links ttml_metal_ops when OpModel is enabled: a few TTNN ops
+# are backed by tt-train's metal ops rather than a ttnn:: symbol (e.g.
+# ttnn.adamw -> ttml::metal::adamw). CMake requires a dependency of an exported
+# target to live in an export set too, and a consumer linking the installed
+# TTNNOpModelLib really does need libttml_metal_ops.a, so append it in the
+# configuration that links it.
+if(TTMLIR_ENABLE_OPMODEL)
+  list(APPEND ttmlir_export_targets ttml_metal_ops)
+endif()
+
 # When TTMLIR_ENABLE_STABLEHLO=ON, certain targets link against third-party
 # StableHLO/Shardy libraries that we don't want to export as part of TTMLIR.
 # Therefore, we only export these targets when StableHLO is disabled (they

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -50,6 +50,11 @@ inline bool requireRowMajor(TTNNLayoutAttr layout) {
   return layout.getLayout() == Layout::RowMajor;
 }
 
+/// Accept only TILE candidates.
+inline bool requireTiled(TTNNLayoutAttr layout) {
+  return layout.getLayout() == Layout::Tile;
+}
+
 /// Reject width-sharded layouts. Returns true if the layout should be kept.
 inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   auto ml = layout.getMemLayout();

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_OPTIMIZERRULES_H
+#define TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_OPTIMIZERRULES_H
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+
+namespace mlir::tt::ttnn {
+
+//===----------------------------------------------------------------------===//
+// Training optimizer step ops: AdamW.
+//
+// AdamW is a zero-result in-place op registered in
+// optimizer_utils::isSinkOp.
+//
+// The ttml device operation validates every operand
+// (adamw_device_operation.cpp:20-90) and TT_FATALs unless each is
+//   - BufferType::DRAM
+//   - TensorMemoryLayout::INTERLEAVED
+//   - Layout::TILE
+//===----------------------------------------------------------------------===//
+
+/// AdamW: every operand must be DRAM-interleaved (see above).
+struct AdamWRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+};
+
+} // namespace mlir::tt::ttnn
+
+#endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_OPTIMIZERRULES_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h
@@ -22,7 +22,7 @@ namespace mlir::tt::ttnn {
 //   - Layout::TILE
 //===----------------------------------------------------------------------===//
 
-/// AdamW: every operand must be DRAM-interleaved (see above).
+/// AdamW: every operand must be tiled and DRAM-interleaved (see above).
 struct AdamWRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -47,15 +47,19 @@ struct SDPARuleBook : OpRuleBook {
 };
 
 /// TTML SDPA forward:
-/// Inherits NULL-only hints and no reshards; requires tiled, interleaved
-/// inputs.
+/// The TTML kernel requires tiled, interleaved inputs; filtering them and
+/// disabling reshards prune unsupported candidates rather than tune
+/// performance. The backend derives both output layouts from the query, so
+/// only the NULL output hint is valid.
 struct TTMLSDPAForwardRuleBook : SDPARuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
 /// TTML SDPA backward:
-/// Tiled inputs, NULL-only hints, and no reshard exploration to bound the
-/// seven-operand search. Sharded inputs remain allowed.
+/// The TTML kernels require tiled inputs but support both interleaved and
+/// sharded memory. Grad-Q/K/V inherit the Q/K/V memory configs, so only the
+/// NULL output hint is valid. Reshard exploration is disabled solely to bound
+/// the seven-operand search, at the cost of not optimizing input sharding.
 struct TTMLSDPABackwardRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
   bool shouldExploreReshards() const override;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -46,6 +46,16 @@ struct SDPARuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// TTML SDPA forward:
+/// Inherits NULL-only hints and no reshards; requires interleaved inputs.
+struct TTMLSDPAForwardRuleBook : SDPARuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+};
+
+/// TTML SDPA backward:
+/// Inherits NULL-only hints and no reshards; all input layouts are allowed.
+struct TTMLSDPABackwardRuleBook : SDPARuleBook {};
+
 /// ScaledDotProductAttentionDecodeOp / PagedScaledDotProductAttentionDecodeOp:
 /// Per-operand input layout filtering.
 /// - Q (operand 0): DRAM (any) or L1-sharded -- L1-interleaved rejected

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -47,14 +47,22 @@ struct SDPARuleBook : OpRuleBook {
 };
 
 /// TTML SDPA forward:
-/// Inherits NULL-only hints and no reshards; requires interleaved inputs.
+/// Inherits NULL-only hints and no reshards; requires tiled, interleaved
+/// inputs.
 struct TTMLSDPAForwardRuleBook : SDPARuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 };
 
 /// TTML SDPA backward:
-/// Inherits NULL-only hints and no reshards; all input layouts are allowed.
-struct TTMLSDPABackwardRuleBook : SDPARuleBook {};
+/// Tiled inputs, NULL-only hints, and no reshard exploration to bound the
+/// seven-operand search. Sharded inputs remain allowed.
+struct TTMLSDPABackwardRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
 
 /// ScaledDotProductAttentionDecodeOp / PagedScaledDotProductAttentionDecodeOp:
 /// Per-operand input layout filtering.

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2726,7 +2726,7 @@ def TTNN_AdamWOp : TTNN_InplaceOp<"adamw"> {
     let hasVerifier = 1;
 }
 
-def TTNN_SDPAForwardOp : TTNN_Op<"sdpa_fw", [OpModelExempt]> {
+def TTNN_SDPAForwardOp : TTNN_Op<"sdpa_fw"> {
     let summary = "Scaled dot-product attention forward (ttml).";
     let description = [{
       Training-oriented fused scaled dot-product attention forward pass, backed
@@ -2760,7 +2760,7 @@ def TTNN_SDPAForwardOp : TTNN_Op<"sdpa_fw", [OpModelExempt]> {
     let hasVerifier = 1;
 }
 
-def TTNN_SDPABackwardOp : TTNN_Op<"sdpa_bw", [OpModelExempt]> {
+def TTNN_SDPABackwardOp : TTNN_Op<"sdpa_bw"> {
     let summary = "Scaled dot-product attention backward (ttml).";
     let description = [{
       Training-oriented fused scaled dot-product attention backward pass, backed

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2683,7 +2683,7 @@ def TTNN_RMSNormOp : TTNN_Op<"rms_norm", [AttrSizedOperandSegments, TTNN_Compute
     let hasVerifier = 1;
 }
 
-def TTNN_AdamWOp : TTNN_InplaceOp<"adamw", [OpModelExempt]> {
+def TTNN_AdamWOp : TTNN_InplaceOp<"adamw"> {
     let summary = "AdamW optimizer step (ttml).";
     let description = [{
       Fused AdamW optimizer step, backed by the ttml metal op

--- a/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h
@@ -33,7 +33,8 @@ inline bool opHasTensorResult(mlir::Operation *op) {
 /// Returns true for in-place ops with no tensor result that still need
 /// input layout validation and upstream reshard propagation in the beam search.
 inline bool isSinkOp(mlir::Operation *op) {
-  return llvm::isa<FillCacheOp, PagedFillCacheOp, PagedUpdateCacheOp>(op);
+  return llvm::isa<FillCacheOp, PagedFillCacheOp, PagedUpdateCacheOp, AdamWOp>(
+      op);
 }
 
 /// Returns true if this op should participate in the greedy beam search —

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -32,6 +32,8 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 }
 } // namespace ttnn::graph::detail
 
+#include "metal/ops/sdpa_bw/sdpa_bw.hpp"
+#include "metal/ops/sdpa_fw/sdpa_fw.hpp"
 #include "metal/optimizers/adamw/adamw.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -32,6 +32,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 }
 } // namespace ttnn::graph::detail
 
+#include "metal/optimizers/adamw/adamw.hpp"
 #include "ttnn/graph/graph_query_op_constraints.hpp"
 #include "ttnn/graph/graph_query_op_runtime.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2309,5 +2309,35 @@ struct OpModel<MeshPartitionOp> {
                TTNNLayoutAttr outputLayout);
 };
 
+//===----------------------------------------------------------------------===//
+// AdamWOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<AdamWOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> paramShape, TTNNLayoutAttr paramLayout,
+      llvm::ArrayRef<int64_t> gradShape, TTNNLayoutAttr gradLayout,
+      llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
+      llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
+      std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
+      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
+      llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
+      llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+      bool stochasticRounding, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> paramShape, TTNNLayoutAttr paramLayout,
+      llvm::ArrayRef<int64_t> gradShape, TTNNLayoutAttr gradLayout,
+      llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
+      llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
+      std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
+      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
+      llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
+      llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+      bool stochasticRounding, TTNNLayoutAttr outputLayout);
+};
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2339,5 +2339,66 @@ struct OpModel<AdamWOp> {
       bool stochasticRounding, TTNNLayoutAttr outputLayout);
 };
 
+//===----------------------------------------------------------------------===//
+// SDPAForwardOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<SDPAForwardOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+      bool returnIntermediates, TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+               llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+               llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+               std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+               std::optional<TTNNLayoutAttr> attentionMaskLayout,
+               ttcore::AttentionMaskType maskType,
+               llvm::APFloat dropoutProbability, bool returnIntermediates,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
+// SDPABackwardOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<SDPABackwardOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> gradOutputShape, TTNNLayoutAttr gradOutputLayout,
+      llvm::ArrayRef<int64_t> attnOutputShape, TTNNLayoutAttr attnOutputLayout,
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> intermediatesShape,
+      TTNNLayoutAttr intermediatesLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t> getOpRuntime(
+      llvm::ArrayRef<int64_t> gradOutputShape, TTNNLayoutAttr gradOutputLayout,
+      llvm::ArrayRef<int64_t> attnOutputShape, TTNNLayoutAttr attnOutputLayout,
+      llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+      llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+      llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+      llvm::ArrayRef<int64_t> intermediatesShape,
+      TTNNLayoutAttr intermediatesLayout,
+      std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+      std::optional<TTNNLayoutAttr> attentionMaskLayout,
+      ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+      TTNNLayoutAttr outputLayout);
+};
+
 } // namespace mlir::tt::ttnn::op_model
 #endif // TTMLIR_OPMODEL_TTNN_TTNNOPMODEL_H

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -511,8 +511,8 @@ typename L1SpillManagementBase<MemoryTracker>::ScheduleData
 L1SpillManagementBase<MemoryTracker>::buildScheduleData() {
   ScheduleData data;
 
-  // Build schedule (ops in IR order = topological order). Include sink ops
-  // (paged_fill_cache / paged_update_cache / fill_cache) even though they
+  // Build schedule (ops in IR order = topological order). Include sink ops (see
+  // optimizer_utils::isSinkOp: the KV-cache writes plus adamw) even though they
   // have no tensor result — their operand uses must be visible to
   // computeLastUsePositions so that values consumed only by a cache write
   // (e.g. per-layer KV typecasts) are kept alive in L1 until the cache
@@ -1460,11 +1460,11 @@ void L1SpillManagementBase<MemoryTracker>::run() {
 
     processDeadTensors(pos, data);
 
-    // Sink ops (paged_fill_cache / paged_update_cache / fill_cache) are in
-    // the schedule only so computeLastUsePositions sees their operand uses
-    // (which keeps their L1-resident input tensors alive in the tracker
-    // until the cache write actually executes). They have no tensor result,
-    // so addResultsToLiveSet / extractOpConfigFromIR / validate do not apply.
+    // Sink ops (see optimizer_utils::isSinkOp) are in the schedule only so
+    // computeLastUsePositions sees their operand uses (which keeps their
+    // L1-resident input tensors alive in the tracker until the cache write
+    // actually executes). They have no tensor result, so addResultsToLiveSet /
+    // extractOpConfigFromIR / validate do not apply.
     if (optimizer_utils::isSinkOp(op)) {
       continue;
     }

--- a/lib/Dialect/TTNN/Analysis/OpRules/CMakeLists.txt
+++ b/lib/Dialect/TTNN/Analysis/OpRules/CMakeLists.txt
@@ -6,6 +6,7 @@ set(OPRULES_SRCS
     MoeRules.cpp
     NormalizationRules.cpp
     OpRuleBook.cpp
+    OptimizerRules.cpp
     ReductionRules.cpp
     TransformerRules.cpp
     TypecastRules.cpp

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -77,6 +77,8 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static RepeatRuleBook repeat;
   static ConcatenateHeadsRuleBook concatHeads;
   static SDPARuleBook sdpa;
+  static TTMLSDPAForwardRuleBook ttmlSdpaForward;
+  static TTMLSDPABackwardRuleBook ttmlSdpaBackward;
   static SDPADecodeRuleBook sdpaDecode;
   static EmbeddingRuleBook embedding;
   static TypecastRuleBook typecast;
@@ -116,6 +118,8 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(ConcatenateHeadsOp::getOperationName(), &concatHeads);
     reg(NLPConcatHeadsDecodeOp::getOperationName(), &sdpa);
     reg(ScaledDotProductAttentionOp::getOperationName(), &sdpa);
+    reg(SDPAForwardOp::getOperationName(), &ttmlSdpaForward);
+    reg(SDPABackwardOp::getOperationName(), &ttmlSdpaBackward);
     reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
     reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(),
         &sdpaDecode);

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -9,6 +9,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/MoeRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/ReductionRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
@@ -88,6 +89,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PagedFillCacheRuleBook pagedFillCache;
   static PagedUpdateCacheRuleBook pagedUpdateCache;
   static ArgMaxRuleBook argMax;
+  static AdamWRuleBook adamW;
 
   static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
   static std::once_flag initFlag;
@@ -131,6 +133,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PagedFillCacheOp::getOperationName(), &pagedFillCache);
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(ArgMaxOp::getOperationName(), &argMax);
+    reg(AdamWOp::getOperationName(), &adamW);
   });
   auto it = registry.find(op->getName());
   return it != registry.end() ? *it->second : defaultRules;

--- a/lib/Dialect/TTNN/Analysis/OpRules/OptimizerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OptimizerRules.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OptimizerRules.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
+
+namespace mlir::tt::ttnn {
+
+// All operands must be DRAM-interleaved, so the filter is operand-independent.
+LayoutFilterFn
+AdamWRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  return layout_filter_utils::requireDRAMInterleaved;
+}
+
+} // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/OptimizerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OptimizerRules.cpp
@@ -7,10 +7,14 @@
 
 namespace mlir::tt::ttnn {
 
-// All operands must be DRAM-interleaved, so the filter is operand-independent.
+// All operands must be tiled and DRAM-interleaved, so the filter is
+// operand-independent.
 LayoutFilterFn
 AdamWRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
-  return layout_filter_utils::requireDRAMInterleaved;
+  return [](TTNNLayoutAttr layout) {
+    return layout_filter_utils::requireTiled(layout) &&
+           layout_filter_utils::requireDRAMInterleaved(layout);
+  };
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -52,7 +52,27 @@ OutputHints SDPARuleBook::getOutputHints(
 
 LayoutFilterFn
 TTMLSDPAForwardRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
-  return layout_filter_utils::rejectAllSharded;
+  return [](TTNNLayoutAttr layout) {
+    return layout_filter_utils::requireTiled(layout) &&
+           layout_filter_utils::rejectAllSharded(layout);
+  };
+}
+
+//===----------------------------------------------------------------------===//
+// TTMLSDPABackwardRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+TTMLSDPABackwardRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  return layout_filter_utils::requireTiled;
+}
+
+bool TTMLSDPABackwardRuleBook::shouldExploreReshards() const { return false; }
+
+OutputHints TTMLSDPABackwardRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> & /*legalConfigs*/) const {
+  // The backend derives grad-Q/K/V layouts from Q/K/V.
+  return layout_filter_utils::nullHintOnly();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -47,6 +47,15 @@ OutputHints SDPARuleBook::getOutputHints(
 }
 
 //===----------------------------------------------------------------------===//
+// TTMLSDPAForwardRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn
+TTMLSDPAForwardRuleBook::getInputLayoutFilter(unsigned /*operandIdx*/) const {
+  return layout_filter_utils::rejectAllSharded;
+}
+
+//===----------------------------------------------------------------------===//
 // SDPADecodeRuleBook
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4545,6 +4545,116 @@ AdamWOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// SDPAForwardOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> SDPAForwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
+         "SDPAForwardOp must have 3 or 4 inputs");
+
+  auto queryShape = getQuery().getType().getShape();
+  auto keyShape = getKey().getType().getShape();
+  auto valueShape = getValue().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape;
+  std::optional<TTNNLayoutAttr> attentionMaskLayout;
+  if (getAttentionMask()) {
+    attentionMaskShape = getAttentionMask().getType().getShape();
+    attentionMaskLayout = inputs[3];
+  }
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, queryShape, inputs[0], keyShape, inputs[1],
+      valueShape, inputs[2], attentionMaskShape, attentionMaskLayout,
+      getMaskType(), getDropoutProbability(), getReturnIntermediates(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+SDPAForwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                            const OpConfig &opConfig) {
+  assert(inputs.size() >= 3 && inputs.size() <= 4 &&
+         "SDPAForwardOp must have 3 or 4 inputs");
+
+  auto queryShape = getQuery().getType().getShape();
+  auto keyShape = getKey().getType().getShape();
+  auto valueShape = getValue().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape;
+  std::optional<TTNNLayoutAttr> attentionMaskLayout;
+  if (getAttentionMask()) {
+    attentionMaskShape = getAttentionMask().getType().getShape();
+    attentionMaskLayout = inputs[3];
+  }
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<SDPAForwardOp>::getOpRuntime, *this, queryShape,
+      inputs[0], keyShape, inputs[1], valueShape, inputs[2], attentionMaskShape,
+      attentionMaskLayout, getMaskType(), getDropoutProbability(),
+      getReturnIntermediates(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
+// SDPABackwardOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> SDPABackwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() >= 6 && inputs.size() <= 7 &&
+         "SDPABackwardOp must have 6 or 7 inputs");
+
+  auto gradOutputShape = getGradOutput().getType().getShape();
+  auto attnOutputShape = getAttnOutput().getType().getShape();
+  auto queryShape = getQuery().getType().getShape();
+  auto keyShape = getKey().getType().getShape();
+  auto valueShape = getValue().getType().getShape();
+  auto intermediatesShape = getIntermediates().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape;
+  std::optional<TTNNLayoutAttr> attentionMaskLayout;
+  if (getAttentionMask()) {
+    attentionMaskShape = getAttentionMask().getType().getShape();
+    attentionMaskLayout = inputs[6];
+  }
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, gradOutputShape, inputs[0], attnOutputShape,
+      inputs[1], queryShape, inputs[2], keyShape, inputs[3], valueShape,
+      inputs[4], intermediatesShape, inputs[5], attentionMaskShape,
+      attentionMaskLayout, getMaskType(), getDropoutProbability(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+SDPABackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                             const OpConfig &opConfig) {
+  assert(inputs.size() >= 6 && inputs.size() <= 7 &&
+         "SDPABackwardOp must have 6 or 7 inputs");
+
+  auto gradOutputShape = getGradOutput().getType().getShape();
+  auto attnOutputShape = getAttnOutput().getType().getShape();
+  auto queryShape = getQuery().getType().getShape();
+  auto keyShape = getKey().getType().getShape();
+  auto valueShape = getValue().getType().getShape();
+  auto intermediatesShape = getIntermediates().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape;
+  std::optional<TTNNLayoutAttr> attentionMaskLayout;
+  if (getAttentionMask()) {
+    attentionMaskShape = getAttentionMask().getType().getShape();
+    attentionMaskLayout = inputs[6];
+  }
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<SDPABackwardOp>::getOpRuntime, *this, gradOutputShape,
+      inputs[0], attnOutputShape, inputs[1], queryShape, inputs[2], keyShape,
+      inputs[3], valueShape, inputs[4], intermediatesShape, inputs[5],
+      attentionMaskShape, attentionMaskLayout, getMaskType(),
+      getDropoutProbability(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4490,6 +4490,61 @@ RMSNormPreAllGatherOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// AdamWOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> AdamWOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() >= 4 && inputs.size() <= 5 &&
+         "AdamWOp must have 4 or 5 inputs");
+
+  auto paramShape = getParam().getType().getShape();
+  auto gradShape = getGrad().getType().getShape();
+  auto expAvgShape = getExpAvg().getType().getShape();
+  auto expAvgSqShape = getExpAvgSq().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape;
+  std::optional<TTNNLayoutAttr> maxExpAvgSqLayout;
+  if (getMaxExpAvgSq()) {
+    maxExpAvgSqShape = getMaxExpAvgSq().getType().getShape();
+    maxExpAvgSqLayout = inputs[4];
+  }
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, paramShape, inputs[0], gradShape, inputs[1],
+      expAvgShape, inputs[2], expAvgSqShape, inputs[3], maxExpAvgSqShape,
+      maxExpAvgSqLayout, getLr(), getBeta1(), getBeta2(), getBeta1Pow(),
+      getBeta2Pow(), getEpsilon(), getWeightDecay(), getStochasticRounding(),
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+AdamWOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                      const OpConfig &opConfig) {
+  assert(inputs.size() >= 4 && inputs.size() <= 5 &&
+         "AdamWOp must have 4 or 5 inputs");
+
+  auto paramShape = getParam().getType().getShape();
+  auto gradShape = getGrad().getType().getShape();
+  auto expAvgShape = getExpAvg().getType().getShape();
+  auto expAvgSqShape = getExpAvgSq().getType().getShape();
+  std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape;
+  std::optional<TTNNLayoutAttr> maxExpAvgSqLayout;
+  if (getMaxExpAvgSq()) {
+    maxExpAvgSqShape = getMaxExpAvgSq().getType().getShape();
+    maxExpAvgSqLayout = inputs[4];
+  }
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<AdamWOp>::getOpRuntime, *this, paramShape, inputs[0],
+      gradShape, inputs[1], expAvgShape, inputs[2], expAvgSqShape, inputs[3],
+      maxExpAvgSqShape, maxExpAvgSqLayout, getLr(), getBeta1(), getBeta2(),
+      getBeta1Pow(), getBeta2Pow(), getEpsilon(), getWeightDecay(),
+      getStochasticRounding(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/GreedyMemoryLayoutPropagation.cpp
@@ -128,10 +128,10 @@ public:
 
       func->walk([&](Operation *op) {
         if (!optimizer_utils::opHasTensorResult(op)) {
-          // Constraint sinks (FillCacheOp, PagedUpdateCacheOp,
-          // PagedFillCacheOp) have no tensor result but still need input layout
-          // validation. Register a null-output OpConfig so processOp can
-          // validate their input combinations and drive upstream reshards.
+          // Constraint sinks (see optimizer_utils::isSinkOp) have no tensor
+          // result but still need input layout validation. Register a
+          // null-output OpConfig so processOp can validate their input
+          // combinations and drive upstream reshards.
           if (mlir::dyn_cast<OpModel>(op) && optimizer_utils::isSinkOp(op)) {
             legalConfigs[op] = {OpConfig{TTNNLayoutAttr()}};
           }

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -587,5 +587,5 @@ const std::set<mlir::StringRef>
         ttnn::SparseMatmulOp::getOperationName(),
         // ArgMax is intentionally absent: at opt-level >= 1 ArgMaxRuleBook's
         // RowMajor input siblings supply its ROW_MAJOR input (tt-metal #46340).
-};
+        ttnn::SDPABackwardOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -587,5 +587,7 @@ const std::set<mlir::StringRef>
         ttnn::SparseMatmulOp::getOperationName(),
         // ArgMax is intentionally absent: at opt-level >= 1 ArgMaxRuleBook's
         // RowMajor input siblings supply its ROW_MAJOR input (tt-metal #46340).
+        // SDPABackwardOp is temporarily enabled to restrict the dtype to bf16:
+        // https://github.com/tenstorrent/tt-mlir/issues/9233
         ttnn::SDPABackwardOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -22,6 +22,19 @@ if (TTMLIR_ENABLE_OPMODEL)
     target_include_directories(${LIB_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTMETAL_INCLUDE_DIRS}>")
     set(TTNN_LIBS TTMETAL_LIBRARY DEVICE_LIBRARY TTNN_LIBRARY TT_STL_LIBRARY TRACY_LIBRARY)
     target_link_libraries(${LIB_NAME} PUBLIC ${TTNN_LIBS} PRIVATE TTMLIRTTNNUtils)
+
+    # A few TTNN ops are backed by tt-train's metal ops rather than a ttnn::
+    # symbol (e.g. ttnn.adamw -> ttml::metal::adamw). Their declarations live
+    # under ${TTML_SOURCE_DIR}, and the public MetalHeaders.h includes them, so
+    # the path must be PUBLIC (as TTMETAL_INCLUDE_DIRS above is) -- anything
+    # reaching MetalHeaders.h via Conversion.h needs it too, e.g. TestConversion.
+    # SYSTEM keeps third-party warnings out of our builds.
+    # No -march=x86-64-v3 here (unlike runtime/lib/ttnn/operations/ttml): the
+    # ttml headers we consume are enums plus out-of-line declarations, so no ttml
+    # inline code is compiled here and there is no ABI surface to match.
+    target_include_directories(${LIB_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTML_SOURCE_DIR}>")
+    target_link_libraries(${LIB_NAME} PRIVATE ttml_metal_ops)
+
     target_compile_definitions(${LIB_NAME} PUBLIC TTMLIR_ENABLE_OPMODEL)
     if (TTMLIR_DISABLE_MOCK_DEVICE)
         target_compile_definitions(${LIB_NAME} PRIVATE TTMLIR_DISABLE_MOCK_DEVICE)
@@ -42,6 +55,10 @@ target_link_libraries(${LIB_NAME} PUBLIC coverage_config)
 
 # Add to export set for build-tree usage (needed by tests)
 install(TARGETS ${LIB_NAME} EXPORT TTNNOpModelLibTargets)
+if (TTMLIR_ENABLE_OPMODEL)
+    # Linked above; must share this export set for the export() below to work.
+    install(TARGETS ttml_metal_ops EXPORT TTNNOpModelLibTargets)
+endif()
 
 # Export for build-tree usage (needed for tests and other targets in this build)
 export(EXPORT TTNNOpModelLibTargets

--- a/lib/OpModel/TTNN/CMakeLists.txt
+++ b/lib/OpModel/TTNN/CMakeLists.txt
@@ -23,15 +23,8 @@ if (TTMLIR_ENABLE_OPMODEL)
     set(TTNN_LIBS TTMETAL_LIBRARY DEVICE_LIBRARY TTNN_LIBRARY TT_STL_LIBRARY TRACY_LIBRARY)
     target_link_libraries(${LIB_NAME} PUBLIC ${TTNN_LIBS} PRIVATE TTMLIRTTNNUtils)
 
-    # A few TTNN ops are backed by tt-train's metal ops rather than a ttnn::
-    # symbol (e.g. ttnn.adamw -> ttml::metal::adamw). Their declarations live
-    # under ${TTML_SOURCE_DIR}, and the public MetalHeaders.h includes them, so
-    # the path must be PUBLIC (as TTMETAL_INCLUDE_DIRS above is) -- anything
-    # reaching MetalHeaders.h via Conversion.h needs it too, e.g. TestConversion.
-    # SYSTEM keeps third-party warnings out of our builds.
-    # No -march=x86-64-v3 here (unlike runtime/lib/ttnn/operations/ttml): the
-    # ttml headers we consume are enums plus out-of-line declarations, so no ttml
-    # inline code is compiled here and there is no ABI surface to match.
+    # TTML-backed ops require TTML headers and metal implementations.
+    # The include path is public because MetalHeaders.h exposes these headers.
     target_include_directories(${LIB_NAME} SYSTEM PUBLIC "$<BUILD_INTERFACE:${TTML_SOURCE_DIR}>")
     target_link_libraries(${LIB_NAME} PRIVATE ttml_metal_ops)
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9309,4 +9309,114 @@ llvm::Expected<size_t> OpModel<MeshPartitionOp>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
+// AdamWOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<AdamWOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> paramShape, TTNNLayoutAttr paramLayout,
+    llvm::ArrayRef<int64_t> gradShape, TTNNLayoutAttr gradLayout,
+    llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
+    llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
+    std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
+    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
+    llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
+    llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+    bool stochasticRounding, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec paramSpec,
+      detail::convertToTensorSpec(device, paramShape, paramLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec gradSpec,
+                   detail::convertToTensorSpec(device, gradShape, gradLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec expAvgSpec,
+      detail::convertToTensorSpec(device, expAvgShape, expAvgLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec expAvgSqSpec,
+      detail::convertToTensorSpec(device, expAvgSqShape, expAvgSqLayout));
+  std::optional<::tt::tt_metal::TensorSpec> maxExpAvgSqSpec =
+      detail::convertToOptionalTensorSpec(device, maxExpAvgSqShape,
+                                          maxExpAvgSqLayout);
+
+  const ::ttml::metal::StochasticRounding stochasticRoundingValue =
+      stochasticRounding ? ::ttml::metal::StochasticRounding::Enabled
+                         : ::ttml::metal::StochasticRounding::Disabled;
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto adamWOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttml::metal::adamw, device, initialStateOpt, paramSpec, gradSpec,
+        expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec, lr.convertToFloat(),
+        beta1.convertToFloat(), beta2.convertToFloat(),
+        beta1Pow.convertToFloat(), beta2Pow.convertToFloat(),
+        epsilon.convertToFloat(), weightDecay.convertToFloat(),
+        stochasticRoundingValue);
+  };
+
+  return operation::getOpConstraintsWithState(paramLayout.getContext(),
+                                              adamWOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> paramShape, TTNNLayoutAttr paramLayout,
+    llvm::ArrayRef<int64_t> gradShape, TTNNLayoutAttr gradLayout,
+    llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
+    llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
+    std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
+    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
+    llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
+    llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+    bool stochasticRounding, TTNNLayoutAttr outputLayout) {
+
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec paramSpec,
+      detail::convertToTensorSpec(device, paramShape, paramLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec gradSpec,
+                   detail::convertToTensorSpec(device, gradShape, gradLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec expAvgSpec,
+      detail::convertToTensorSpec(device, expAvgShape, expAvgLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec expAvgSqSpec,
+      detail::convertToTensorSpec(device, expAvgSqShape, expAvgSqLayout));
+  std::optional<::tt::tt_metal::TensorSpec> maxExpAvgSqSpec =
+      detail::convertToOptionalTensorSpec(device, maxExpAvgSqShape,
+                                          maxExpAvgSqLayout);
+
+  const ::ttml::metal::StochasticRounding stochasticRoundingValue =
+      stochasticRounding ? ::ttml::metal::StochasticRounding::Enabled
+                         : ::ttml::metal::StochasticRounding::Disabled;
+
+  auto adamWOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttml::metal::adamw, device, paramSpec, gradSpec,
+                            expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec,
+                            lr.convertToFloat(), beta1.convertToFloat(),
+                            beta2.convertToFloat(), beta1Pow.convertToFloat(),
+                            beta2Pow.convertToFloat(), epsilon.convertToFloat(),
+                            weightDecay.convertToFloat(),
+                            stochasticRoundingValue);
+  };
+
+  return operation::getOpRuntime(adamWOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
 } // namespace mlir::tt::ttnn::op_model

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9419,4 +9419,205 @@ llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
 #endif // TTMLIR_ENABLE_OPMODEL
 }
 
+//===----------------------------------------------------------------------===//
+// SDPAForwardOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<SDPAForwardOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+    bool returnIntermediates, TTNNLayoutAttr outputLayout,
+    const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  std::optional<::tt::tt_metal::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  const auto maskTypeValue =
+      static_cast<::ttml::metal::AttentionMaskType>(maskType);
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto sdpaForwardOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttml::metal::sdpa_fw, device, initialStateOpt, querySpec, keySpec,
+        valueSpec, maskTypeValue, attentionMaskSpec,
+        dropoutProbability.convertToFloat(), returnIntermediates);
+  };
+
+  return operation::getOpConstraintsWithState(queryLayout.getContext(),
+                                              sdpaForwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<SDPAForwardOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+    bool returnIntermediates, TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  std::optional<::tt::tt_metal::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  const auto maskTypeValue =
+      static_cast<::ttml::metal::AttentionMaskType>(maskType);
+  auto sdpaForwardOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttml::metal::sdpa_fw, device, querySpec, keySpec,
+                            valueSpec, maskTypeValue, attentionMaskSpec,
+                            dropoutProbability.convertToFloat(),
+                            returnIntermediates);
+  };
+
+  return operation::getOpRuntime(sdpaForwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
+// SDPABackwardOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<SDPABackwardOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> gradOutputShape, TTNNLayoutAttr gradOutputLayout,
+    llvm::ArrayRef<int64_t> attnOutputShape, TTNNLayoutAttr attnOutputLayout,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> intermediatesShape,
+    TTNNLayoutAttr intermediatesLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gradOutputSpec,
+      detail::convertToTensorSpec(device, gradOutputShape, gradOutputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec attnOutputSpec,
+      detail::convertToTensorSpec(device, attnOutputShape, attnOutputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec intermediatesSpec,
+                   detail::convertToTensorSpec(device, intermediatesShape,
+                                               intermediatesLayout));
+  std::optional<::tt::tt_metal::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  const auto maskTypeValue =
+      static_cast<::ttml::metal::AttentionMaskType>(maskType);
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto sdpaBackwardOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttml::metal::sdpa_bw, device, initialStateOpt, gradOutputSpec,
+        attnOutputSpec, querySpec, keySpec, valueSpec, intermediatesSpec,
+        maskTypeValue, attentionMaskSpec, dropoutProbability.convertToFloat());
+  };
+
+  return operation::getOpConstraintsWithState(gradOutputLayout.getContext(),
+                                              sdpaBackwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<SDPABackwardOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> gradOutputShape, TTNNLayoutAttr gradOutputLayout,
+    llvm::ArrayRef<int64_t> attnOutputShape, TTNNLayoutAttr attnOutputLayout,
+    llvm::ArrayRef<int64_t> queryShape, TTNNLayoutAttr queryLayout,
+    llvm::ArrayRef<int64_t> keyShape, TTNNLayoutAttr keyLayout,
+    llvm::ArrayRef<int64_t> valueShape, TTNNLayoutAttr valueLayout,
+    llvm::ArrayRef<int64_t> intermediatesShape,
+    TTNNLayoutAttr intermediatesLayout,
+    std::optional<llvm::ArrayRef<int64_t>> attentionMaskShape,
+    std::optional<TTNNLayoutAttr> attentionMaskLayout,
+    ttcore::AttentionMaskType maskType, llvm::APFloat dropoutProbability,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gradOutputSpec,
+      detail::convertToTensorSpec(device, gradOutputShape, gradOutputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec attnOutputSpec,
+      detail::convertToTensorSpec(device, attnOutputShape, attnOutputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec querySpec,
+      detail::convertToTensorSpec(device, queryShape, queryLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec keySpec,
+                   detail::convertToTensorSpec(device, keyShape, keyLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec valueSpec,
+      detail::convertToTensorSpec(device, valueShape, valueLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec intermediatesSpec,
+                   detail::convertToTensorSpec(device, intermediatesShape,
+                                               intermediatesLayout));
+  std::optional<::tt::tt_metal::TensorSpec> attentionMaskSpec =
+      detail::convertToOptionalTensorSpec(device, attentionMaskShape,
+                                          attentionMaskLayout);
+
+  const auto maskTypeValue =
+      static_cast<::ttml::metal::AttentionMaskType>(maskType);
+  auto sdpaBackwardOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttml::metal::sdpa_bw, device, gradOutputSpec,
+                            attnOutputSpec, querySpec, keySpec, valueSpec,
+                            intermediatesSpec, maskTypeValue, attentionMaskSpec,
+                            dropoutProbability.convertToFloat());
+  };
+
+  return operation::getOpRuntime(sdpaBackwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
 } // namespace mlir::tt::ttnn::op_model

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_bw_f32_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/sdpa_bw_f32_workaround.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s --input-file=%t
 
 // RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround="ttnn-optimization-level=1" --canonicalize -o %t1 %s
-// RUN: FileCheck %s --check-prefix=OPT1 --input-file=%t1
+// RUN: FileCheck %s --input-file=%t1
 
 // Test that at opt-level 0 f32 inputs to ttml sdpa_bw are automatically
 // converted to bf16 (and the bf16 grad outputs cast back to f32) by the
@@ -22,12 +22,6 @@ module {
     // CHECK-DAG: "ttnn.to_tensor_spec"(%[[GQ]])
     // CHECK-DAG: "ttnn.to_tensor_spec"(%[[GK]])
     // CHECK-DAG: "ttnn.to_tensor_spec"(%[[GV]])
-
-    // At opt-level 1 the workaround is skipped: no bf16 casts, op stays f32.
-    // OPT1-LABEL: func.func public @sdpa_bw_f32_causal
-    // OPT1-NOT: ttnn.to_tensor_spec
-    // OPT1: "ttnn.sdpa_bw"
-    // OPT1-SAME: -> (tensor<1x8x64x64xf32{{.*}}, tensor<1x8x64x64xf32{{.*}}, tensor<1x8x64x64xf32
     %0, %1, %2 = "ttnn.sdpa_bw"(%grad_output, %attn_output, %query, %key, %value, %intermediates) <{mask_type = #ttcore.attention_mask_type<causal>, dropout_probability = 0.000000e+00 : f32}> : (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x32xf32>) -> (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>)
     return %0, %1, %2 : tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
@@ -23,6 +23,30 @@ module {
     return %0#0 : tensor<1x1x64x64xbf16>
   }
 
+  // AdamW supports f32 state tensors, but the gradient is converted to bf16 by
+  // the input workaround. The optimizer must also select the tiled,
+  // DRAM-interleaved layouts required by the backing kernel.
+  func.func @adamw_optimizer_f32(%param: tensor<1x1x64x64xf32>, %grad: tensor<1x1x64x64xf32>,
+                                 %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>)
+      -> tensor<1x1x64x64xf32> {
+    // CHECK-LABEL: func.func @adamw_optimizer_f32
+    // CHECK: %[[GRAD_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x1x64x64xbf16
+    // CHECK: "ttnn.adamw"(%{{[^,]+}}, %[[GRAD_BF16]], %{{[^,]+}}, %{{[^)]+}})
+    // CHECK-SAME: : (tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xbf16, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>)
+    // CHECK-SAME: -> ()
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
+        lr = 1.000000e-03 : f32,
+        beta1 = 0.899999976 : f32,
+        beta2 = 0.999000012 : f32,
+        beta1_pow = 0.899999976 : f32,
+        beta2_pow = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32,
+        weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+          -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+    return %0#0 : tensor<1x1x64x64xf32>
+  }
+
   // AdamW with AMSGrad (5 operands). The presence of max_exp_avg_sq is what
   // enables amsgrad in ttml, and it exercises the 5-input path through the
   // op model interface.

--- a/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
@@ -1,0 +1,80 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // AdamW without AMSGrad (4 operands).
+  func.func @adamw_optimizer(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
+                             %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>)
+      -> tensor<1x1x64x64xbf16> {
+    // CHECK-LABEL: func.func @adamw_optimizer
+    // CHECK: "ttnn.adamw"
+    // CHECK-SAME: -> ()
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
+        lr = 1.000000e-03 : f32,
+        beta1 = 0.899999976 : f32,
+        beta2 = 0.999000012 : f32,
+        beta1_pow = 0.899999976 : f32,
+        beta2_pow = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32,
+        weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    return %0#0 : tensor<1x1x64x64xbf16>
+  }
+
+  // AdamW with AMSGrad (5 operands). The presence of max_exp_avg_sq is what
+  // enables amsgrad in ttml, and it exercises the 5-input path through the
+  // op model interface.
+  func.func @adamw_amsgrad_optimizer(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
+                                     %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>,
+                                     %max_exp_avg_sq: tensor<1x1x64x64xbf16>)
+      -> tensor<1x1x64x64xbf16> {
+    // CHECK-LABEL: func.func @adamw_amsgrad_optimizer
+    // CHECK: "ttnn.adamw"
+    // CHECK-SAME: -> ()
+    %0:4 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %max_exp_avg_sq) <{
+        lr = 1.000000e-03 : f32,
+        beta1 = 0.899999976 : f32,
+        beta2 = 0.999000012 : f32,
+        beta1_pow = 0.899999976 : f32,
+        beta2_pow = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32,
+        weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    return %0#0 : tensor<1x1x64x64xbf16>
+  }
+
+  // Grad is produced by a compute op the optimizer wants in L1. The multiply is
+  // free to take an L1 sharded layout, but adamw's operands must all be DRAM
+  // interleaved, so a to_memory_config has to be inserted in between rather
+  // than adamw inheriting the L1 layout.
+  //
+  // Grad reaching adamw must be the *reshard* of the multiply rather than the
+  // multiply's own result.
+  func.func @adamw_grad_from_l1_producer(%param: tensor<1x1x256x256xbf16>,
+                                         %g0: tensor<1x1x256x256xbf16>,
+                                         %g1: tensor<1x1x256x256xbf16>,
+                                         %exp_avg: tensor<1x1x256x256xbf16>,
+                                         %exp_avg_sq: tensor<1x1x256x256xbf16>)
+      -> tensor<1x1x256x256xbf16> {
+    // CHECK-LABEL: func.func @adamw_grad_from_l1_producer
+    // CHECK: %[[MUL:[0-9a-z_]+]] = "ttnn.multiply"
+    // CHECK: %[[RESHARD:[0-9a-z_]+]] = "ttnn.to_memory_config"(%[[MUL]])
+    // CHECK: "ttnn.adamw"(%{{[0-9a-z_]+}}, %[[RESHARD]],
+    // CHECK-SAME: -> ()
+    %grad = "ttir.multiply"(%g0, %g1) : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
+        lr = 1.000000e-03 : f32,
+        beta1 = 0.899999976 : f32,
+        beta2 = 0.999000012 : f32,
+        beta1_pow = 0.899999976 : f32,
+        beta2_pow = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32,
+        weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>)
+          -> (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>)
+    return %0#0 : tensor<1x1x256x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
@@ -1,0 +1,67 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // Exercise the optional mask and all forward/backward results through the
+  // optimizer and OpModel validation.
+  func.func @sdpa_forward_backward(
+      %grad_output: tensor<1x8x64x64xbf16>,
+      %query: tensor<1x8x64x64xbf16>,
+      %key: tensor<1x8x64x64xbf16>,
+      %value: tensor<1x8x64x64xbf16>,
+      %mask: tensor<1x1x64x64xbf16>)
+      -> (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+          tensor<1x8x64x64xbf16>) {
+    // CHECK-LABEL: func.func @sdpa_forward_backward
+    // CHECK: %[[OUTPUT:.*]], %[[INTERMEDIATES:.*]] = "ttnn.sdpa_fw"
+    // CHECK: %[[GQ:.*]], %[[GK:.*]], %[[GV:.*]] = "ttnn.sdpa_bw"(%{{.*}}, %[[OUTPUT]], %{{.*}}, %{{.*}}, %{{.*}}, %[[INTERMEDIATES]],
+    // CHECK: return %[[GQ]], %[[GK]], %[[GV]]
+    %output, %intermediates = "ttir.sdpa_fw"(%query, %key, %value, %mask) <{
+        mask_type = #ttcore.attention_mask_type<arbitrary>,
+        dropout_probability = 0.000000e+00 : f32,
+        return_intermediates = true}>
+        : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+           tensor<1x8x64x64xbf16>, tensor<1x1x64x64xbf16>)
+          -> (tensor<1x8x64x64xbf16>, tensor<1x8x64x32xf32>)
+    %grad_query, %grad_key, %grad_value = "ttir.sdpa_bw"(
+        %grad_output, %output, %query, %key, %value, %intermediates, %mask) <{
+        mask_type = #ttcore.attention_mask_type<arbitrary>,
+        dropout_probability = 0.000000e+00 : f32}>
+        : (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+           tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+           tensor<1x8x64x64xbf16>, tensor<1x8x64x32xf32>,
+           tensor<1x1x64x64xbf16>)
+          -> (tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+              tensor<1x8x64x64xbf16>)
+    return %grad_query, %grad_key, %grad_value
+        : tensor<1x8x64x64xbf16>, tensor<1x8x64x64xbf16>,
+          tensor<1x8x64x64xbf16>
+  }
+
+  // SDPA forward requires interleaved inputs. Verify that a compute-produced
+  // query is resharded before reaching the op.
+  func.func @sdpa_fw_query_from_l1_producer(
+      %q0: tensor<1x8x128x64xbf16>,
+      %q1: tensor<1x8x128x64xbf16>,
+      %key: tensor<1x8x128x64xbf16>,
+      %value: tensor<1x8x128x64xbf16>)
+      -> tensor<1x8x128x64xbf16> {
+    // CHECK-LABEL: func.func @sdpa_fw_query_from_l1_producer
+    // CHECK: %[[MUL:.*]] = "ttnn.multiply"
+    // CHECK: %[[INTERLEAVED:.*]] = "ttnn.to_memory_config"(%[[MUL]])
+    // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[INTERLEAVED]])
+    // CHECK: "ttnn.sdpa_fw"(%[[RESHARD]],
+    %query = "ttir.multiply"(%q0, %q1)
+        : (tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>)
+          -> tensor<1x8x128x64xbf16>
+    %output = "ttir.sdpa_fw"(%query, %key, %value) <{
+        mask_type = #ttcore.attention_mask_type<causal>,
+        dropout_probability = 0.000000e+00 : f32,
+        return_intermediates = false}>
+        : (tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>,
+           tensor<1x8x128x64xbf16>)
+          -> tensor<1x8x128x64xbf16>
+    return %output : tensor<1x8x128x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
@@ -92,9 +92,9 @@ module {
     // CHECK-SAME: -> (tensor<1x8x64x64xbf16
     // CHECK-SAME: tensor<1x8x64x64xbf16
     // CHECK-SAME: tensor<1x8x64x64xbf16
-    // CHECK: %[[GQ_F32:.*]] = "ttnn.typecast"(%[[GQ_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
-    // CHECK: %[[GK_F32:.*]] = "ttnn.typecast"(%[[GK_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
-    // CHECK: %[[GV_F32:.*]] = "ttnn.typecast"(%[[GV_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK-DAG: %[[GQ_F32:.*]] = "ttnn.typecast"(%[[GQ_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK-DAG: %[[GK_F32:.*]] = "ttnn.typecast"(%[[GK_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK-DAG: %[[GV_F32:.*]] = "ttnn.typecast"(%[[GV_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
     // CHECK: return %[[GQ_F32]], %[[GK_F32]], %[[GV_F32]]
     %grad_query, %grad_key, %grad_value = "ttir.sdpa_bw"(
         %grad_output, %output, %query, %key, %value, %intermediates, %mask) <{

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
@@ -39,6 +39,78 @@ module {
           tensor<1x8x64x64xbf16>
   }
 
+  // The backing kernel requires bf16 inputs and output. Verify that f32 values
+  // are cast to bf16 for the kernel and that its output is cast back to f32.
+  // The optional intermediates must remain f32.
+  func.func @sdpa_forward_f32(
+      %query: tensor<1x8x64x64xf32>,
+      %key: tensor<1x8x64x64xf32>,
+      %value: tensor<1x8x64x64xf32>,
+      %mask: tensor<1x1x64x64xf32>)
+      -> tensor<1x8x64x64xf32> {
+    // CHECK-LABEL: func.func @sdpa_forward_f32
+    // CHECK: %[[QUERY_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[KEY_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[VALUE_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[MASK_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x1x64x64xbf16
+    // CHECK: %[[OUTPUT_BF16:.*]], %[[INTERMEDIATES_F32:.*]] = "ttnn.sdpa_fw"(%[[QUERY_BF16]], %[[KEY_BF16]], %[[VALUE_BF16]], %[[MASK_BF16]])
+    // CHECK-SAME: -> (tensor<1x8x64x64xbf16
+    // CHECK-SAME: tensor<1x8x64x32xf32
+    // CHECK: %[[OUTPUT_F32:.*]] = "ttnn.typecast"(%[[OUTPUT_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK: return %[[OUTPUT_F32]]
+    %output, %intermediates = "ttir.sdpa_fw"(%query, %key, %value, %mask) <{
+        mask_type = #ttcore.attention_mask_type<arbitrary>,
+        dropout_probability = 0.000000e+00 : f32,
+        return_intermediates = true}>
+        : (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+           tensor<1x8x64x64xf32>, tensor<1x1x64x64xf32>)
+          -> (tensor<1x8x64x64xf32>, tensor<1x8x64x32xf32>)
+    return %output : tensor<1x8x64x64xf32>
+  }
+
+  // The backward kernel requires bf16 data tensors and gradient outputs, while
+  // the log-sum-exp intermediates must remain f32. Verify that the f32 function
+  // boundary is preserved with casts around the kernel.
+  func.func @sdpa_backward_f32(
+      %grad_output: tensor<1x8x64x64xf32>,
+      %output: tensor<1x8x64x64xf32>,
+      %query: tensor<1x8x64x64xf32>,
+      %key: tensor<1x8x64x64xf32>,
+      %value: tensor<1x8x64x64xf32>,
+      %intermediates: tensor<1x8x64x32xf32>,
+      %mask: tensor<1x1x64x64xf32>)
+      -> (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+          tensor<1x8x64x64xf32>) {
+    // CHECK-LABEL: func.func @sdpa_backward_f32
+    // CHECK: %[[GRAD_OUTPUT_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[OUTPUT_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[QUERY_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[KEY_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[VALUE_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x8x64x64xbf16
+    // CHECK: %[[MASK_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x1x64x64xbf16
+    // CHECK: %[[GQ_BF16:.*]], %[[GK_BF16:.*]], %[[GV_BF16:.*]] = "ttnn.sdpa_bw"(%[[GRAD_OUTPUT_BF16]], %[[OUTPUT_BF16]], %[[QUERY_BF16]], %[[KEY_BF16]], %[[VALUE_BF16]], %{{.*}}, %[[MASK_BF16]])
+    // CHECK-SAME: -> (tensor<1x8x64x64xbf16
+    // CHECK-SAME: tensor<1x8x64x64xbf16
+    // CHECK-SAME: tensor<1x8x64x64xbf16
+    // CHECK: %[[GQ_F32:.*]] = "ttnn.typecast"(%[[GQ_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK: %[[GK_F32:.*]] = "ttnn.typecast"(%[[GK_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK: %[[GV_F32:.*]] = "ttnn.typecast"(%[[GV_BF16]]) : {{.*}} -> tensor<1x8x64x64xf32
+    // CHECK: return %[[GQ_F32]], %[[GK_F32]], %[[GV_F32]]
+    %grad_query, %grad_key, %grad_value = "ttir.sdpa_bw"(
+        %grad_output, %output, %query, %key, %value, %intermediates, %mask) <{
+        mask_type = #ttcore.attention_mask_type<arbitrary>,
+        dropout_probability = 0.000000e+00 : f32}>
+        : (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+           tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+           tensor<1x8x64x64xf32>, tensor<1x8x64x32xf32>,
+           tensor<1x1x64x64xf32>)
+          -> (tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+              tensor<1x8x64x64xf32>)
+    return %grad_query, %grad_key, %grad_value
+        : tensor<1x8x64x64xf32>, tensor<1x8x64x64xf32>,
+          tensor<1x8x64x64xf32>
+  }
+
   // SDPA forward requires interleaved inputs. Verify that a compute-produced
   // query is resharded before reaching the op.
   func.func @sdpa_fw_query_from_l1_producer(

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5769,26 +5769,6 @@ TEST_F(OpModelAdamWTest, AdamWOpFloat32) {
   }
 }
 
-TEST_F(OpModelAdamWTest, AdamWOpBFloat16) {
-  const llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
-
-  // With a BFLOAT16 param every operand is BFLOAT16, and stochastic rounding is
-  // only legal in this configuration.
-  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
-      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-
-  auto constraintsExp = queryConstraints(shape, bf16Layout, bf16Layout,
-                                         bf16Layout, /*amsgrad=*/false,
-                                         /*stochasticRounding=*/true);
-  EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  if (constraintsExp) {
-    OpConstraints &opCstr = constraintsExp.get();
-    EXPECT_GT(opCstr.cbL1PeakSize, 0);
-    EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
-    EXPECT_EQ(opCstr.outputL1BufferSize, 0);
-  }
-}
-
 TEST_F(OpModelAdamWTest, AdamWOpRejectsL1Param) {
   // The ttml device operation TT_FATALs unless every operand is in DRAM. The
   // query must surface that as an error rather than a bogus cost, otherwise the

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5691,13 +5691,6 @@ TEST_F(OpModelTest, PagedFillCacheOp) {
 // AdamWOp Tests
 //===----------------------------------------------------------------------===//
 
-// AdamWOp is backed by the ttml metal op `ttml::metal::adamw` rather than a
-// `ttnn::` symbol. Its device operation validates every operand as
-// DRAM / INTERLEAVED / TILE, with `grad` always BFLOAT16 and the moments
-// matching `param`'s dtype, so all layouts below are built explicitly.
-//
-// The whole cost of the op is circular buffers: the output aliases `param` and
-// lives in DRAM, so tensorL1PeakSize and outputL1BufferSize are both 0.
 class OpModelAdamWTest : public OpModelTest {
 protected:
   static constexpr float kLr = 1e-3f;
@@ -5796,26 +5789,6 @@ TEST_F(OpModelAdamWTest, AdamWOpBFloat16) {
   }
 }
 
-TEST_F(OpModelAdamWTest, AdamWOpLargeShape) {
-  // A larger tensor to confirm the reported numbers really come from the
-  // per-core block split rather than being shape-independent constants.
-  const llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
-
-  const TTNNLayoutAttr f32Layout = CreateTiledLayout(
-      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
-      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
-      builder.getF32Type());
-  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
-      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
-
-  auto constraintsExp = queryConstraints(shape, f32Layout, bf16Layout,
-                                         f32Layout, /*amsgrad=*/false);
-  EXPECT_TRUE(static_cast<bool>(constraintsExp));
-  if (constraintsExp) {
-    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
-  }
-}
-
 TEST_F(OpModelAdamWTest, AdamWOpRejectsL1Param) {
   // The ttml device operation TT_FATALs unless every operand is in DRAM. The
   // query must surface that as an error rather than a bogus cost, otherwise the
@@ -5839,6 +5812,73 @@ TEST_F(OpModelAdamWTest, AdamWOpRejectsL1Param) {
   if (!constraintsExp) {
     llvm::consumeError(constraintsExp.takeError());
   }
+}
+
+//===----------------------------------------------------------------------===//
+// SDPAForwardOp Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpModelTest, SDPAForwardOp) {
+  const llvm::SmallVector<int64_t> shape = {1, 2, 64, 64};
+  const llvm::SmallVector<int64_t> maskShape = {1, 1, 64, 64};
+  const TTNNLayoutAttr layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr maskLayout = CreateTiledLayout(
+      maskShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<SDPAForwardOp>::getOpConstraints(
+      shape, layout, shape, layout, shape, layout, maskShape, maskLayout,
+      ttcore::AttentionMaskType::Arbitrary, llvm::APFloat(0.0f),
+      /*returnIntermediates=*/true, /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().tensorL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputL1BufferSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputLayouts.size(), 2u);
+
+  auto runtimeExp = OpModel<SDPAForwardOp>::getOpRuntime(
+      shape, layout, shape, layout, shape, layout, maskShape, maskLayout,
+      ttcore::AttentionMaskType::Arbitrary, llvm::APFloat(0.0f),
+      /*returnIntermediates=*/true, /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_GT(runtimeExp.get(), 0);
+}
+
+//===----------------------------------------------------------------------===//
+// SDPABackwardOp Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpModelTest, SDPABackwardOp) {
+  const llvm::SmallVector<int64_t> shape = {1, 2, 64, 64};
+  const llvm::SmallVector<int64_t> intermediatesShape = {1, 2, 64, 32};
+  const llvm::SmallVector<int64_t> maskShape = {1, 1, 64, 64};
+  const TTNNLayoutAttr layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr intermediatesLayout = CreateTiledLayout(
+      intermediatesShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  const TTNNLayoutAttr maskLayout = CreateTiledLayout(
+      maskShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<SDPABackwardOp>::getOpConstraints(
+      shape, layout, shape, layout, shape, layout, shape, layout, shape, layout,
+      intermediatesShape, intermediatesLayout, maskShape, maskLayout,
+      ttcore::AttentionMaskType::Arbitrary, llvm::APFloat(0.0f),
+      /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().tensorL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputL1BufferSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputLayouts.size(), 3u);
+
+  auto runtimeExp = OpModel<SDPABackwardOp>::getOpRuntime(
+      shape, layout, shape, layout, shape, layout, shape, layout, shape, layout,
+      intermediatesShape, intermediatesLayout, maskShape, maskLayout,
+      ttcore::AttentionMaskType::Arbitrary, llvm::APFloat(0.0f),
+      /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_GT(runtimeExp.get(), 0);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5688,6 +5688,160 @@ TEST_F(OpModelTest, PagedFillCacheOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// AdamWOp Tests
+//===----------------------------------------------------------------------===//
+
+// AdamWOp is backed by the ttml metal op `ttml::metal::adamw` rather than a
+// `ttnn::` symbol. Its device operation validates every operand as
+// DRAM / INTERLEAVED / TILE, with `grad` always BFLOAT16 and the moments
+// matching `param`'s dtype, so all layouts below are built explicitly.
+//
+// The whole cost of the op is circular buffers: the output aliases `param` and
+// lives in DRAM, so tensorL1PeakSize and outputL1BufferSize are both 0.
+class OpModelAdamWTest : public OpModelTest {
+protected:
+  static constexpr float kLr = 1e-3f;
+  static constexpr float kBeta1 = 0.9f;
+  static constexpr float kBeta2 = 0.999f;
+  static constexpr float kEpsilon = 1e-8f;
+  static constexpr float kWeightDecay = 0.01f;
+
+  llvm::Expected<OpConstraints>
+  queryConstraints(llvm::ArrayRef<int64_t> shape, TTNNLayoutAttr paramLayout,
+                   TTNNLayoutAttr gradLayout, TTNNLayoutAttr momentLayout,
+                   bool amsgrad, bool stochasticRounding = false) {
+    std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape;
+    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout;
+    if (amsgrad) {
+      maxExpAvgSqShape = shape;
+      maxExpAvgSqLayout = momentLayout;
+    }
+    return OpModel<AdamWOp>::getOpConstraints(
+        shape, paramLayout, shape, gradLayout, shape, momentLayout, shape,
+        momentLayout, maxExpAvgSqShape, maxExpAvgSqLayout, llvm::APFloat(kLr),
+        llvm::APFloat(kBeta1), llvm::APFloat(kBeta2), llvm::APFloat(kBeta1),
+        llvm::APFloat(kBeta2), llvm::APFloat(kEpsilon),
+        llvm::APFloat(kWeightDecay), stochasticRounding,
+        /*outputLayout=*/paramLayout);
+  }
+};
+
+TEST_F(OpModelAdamWTest, AdamWOpFloat32) {
+  const llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  const TTNNLayoutAttr f32Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = queryConstraints(shape, f32Layout, bf16Layout,
+                                         f32Layout, /*amsgrad=*/false);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+
+  size_t cbSizeWithoutAmsgrad = 0;
+  if (constraintsExp) {
+    OpConstraints &opCstr = constraintsExp.get();
+    EXPECT_GT(opCstr.cbL1PeakSize, 0);
+    // Every operand is required to be in DRAM, so nothing lands in L1.
+    EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+    EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+    // Captures the updated parameter, even though it is an in-place update.
+    EXPECT_EQ(opCstr.outputLayouts.size(), 1);
+    cbSizeWithoutAmsgrad = opCstr.cbL1PeakSize;
+  }
+
+  // AMSGrad is implied by the presence of max_exp_avg_sq (ttml forwards
+  // `max_exp_avg_sq.has_value()` as the amsgrad flag), and it allocates an
+  // extra set of circular buffers. This is what proves the optional operand is
+  // actually threaded through to the kernel rather than dropped.
+  auto amsgradConstraintsExp =
+      queryConstraints(shape, f32Layout, bf16Layout, f32Layout,
+                       /*amsgrad=*/true);
+  EXPECT_TRUE(static_cast<bool>(amsgradConstraintsExp));
+  if (amsgradConstraintsExp && cbSizeWithoutAmsgrad > 0) {
+    EXPECT_GT(amsgradConstraintsExp.get().cbL1PeakSize, cbSizeWithoutAmsgrad);
+  }
+
+  auto runtimeExp = OpModel<AdamWOp>::getOpRuntime(
+      shape, f32Layout, shape, bf16Layout, shape, f32Layout, shape, f32Layout,
+      /*maxExpAvgSqShape=*/std::nullopt, /*maxExpAvgSqLayout=*/std::nullopt,
+      llvm::APFloat(kLr), llvm::APFloat(kBeta1), llvm::APFloat(kBeta2),
+      llvm::APFloat(kBeta1), llvm::APFloat(kBeta2), llvm::APFloat(kEpsilon),
+      llvm::APFloat(kWeightDecay), /*stochasticRounding=*/false, f32Layout);
+  EXPECT_TRUE(static_cast<bool>(runtimeExp));
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  }
+}
+
+TEST_F(OpModelAdamWTest, AdamWOpBFloat16) {
+  const llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  // With a BFLOAT16 param every operand is BFLOAT16, and stochastic rounding is
+  // only legal in this configuration.
+  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = queryConstraints(shape, bf16Layout, bf16Layout,
+                                         bf16Layout, /*amsgrad=*/false,
+                                         /*stochasticRounding=*/true);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  if (constraintsExp) {
+    OpConstraints &opCstr = constraintsExp.get();
+    EXPECT_GT(opCstr.cbL1PeakSize, 0);
+    EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+    EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+  }
+}
+
+TEST_F(OpModelAdamWTest, AdamWOpLargeShape) {
+  // A larger tensor to confirm the reported numbers really come from the
+  // per-core block split rather than being shape-independent constants.
+  const llvm::SmallVector<int64_t> shape = {1, 1, 1024, 1024};
+
+  const TTNNLayoutAttr f32Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = queryConstraints(shape, f32Layout, bf16Layout,
+                                         f32Layout, /*amsgrad=*/false);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  if (constraintsExp) {
+    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  }
+}
+
+TEST_F(OpModelAdamWTest, AdamWOpRejectsL1Param) {
+  // The ttml device operation TT_FATALs unless every operand is in DRAM. The
+  // query must surface that as an error rather than a bogus cost, otherwise the
+  // optimizer could pick an L1 layout that fails at runtime.
+  const llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  const TTNNLayoutAttr f32LayoutL1 =
+      CreateTiledLayout(shape, BufferType::L1, TensorMemoryLayout::Interleaved,
+                        /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+                        builder.getF32Type());
+  const TTNNLayoutAttr f32Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = queryConstraints(shape, f32LayoutL1, bf16Layout,
+                                         f32Layout, /*amsgrad=*/false);
+  EXPECT_FALSE(static_cast<bool>(constraintsExp));
+  if (!constraintsExp) {
+    llvm::consumeError(constraintsExp.takeError());
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // QuantizeOp Tests
 //===----------------------------------------------------------------------===//
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6214,6 +6214,108 @@ TEST_F(OpModelBase, PagedFillCacheOpInterface) {
   }
 }
 
+// AdamWOp mutates its operands in place and has no results, so the generic
+// getOpConstraints(Operation*) helper cannot be used (it reads getResult(0)).
+// The ttml kernel also requires every operand in DRAM / INTERLEAVED / TILE with
+// `grad` always BFLOAT16, whereas getInputLayouts() would default unencoded
+// operands to L1 -- hence the explicit layouts on each tensor.
+TEST_F(OpModelBase, AdamWOpInterface) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  auto f32Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  auto bf16Layout = CreateTiledLayout(shape, BufferType::DRAM,
+                                      TensorMemoryLayout::Interleaved);
+
+  auto param = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  auto grad = createEmptyTensor(shape, builder.getBF16Type(), bf16Layout);
+  auto expAvg = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  auto expAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+
+  auto adamW = builder.create<AdamWOp>(
+      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq,
+      /*lr=*/llvm::APFloat(1e-3f), /*beta1=*/llvm::APFloat(0.9f),
+      /*beta2=*/llvm::APFloat(0.999f), /*beta1_pow=*/llvm::APFloat(0.9f),
+      /*beta2_pow=*/llvm::APFloat(0.999f), /*epsilon=*/llvm::APFloat(1e-8f),
+      /*weight_decay=*/llvm::APFloat(0.01f));
+
+  auto backend = dyn_cast<OpModel>(adamW.getOperation());
+  ASSERT_TRUE(backend);
+
+  auto inputLayouts = getInputLayouts(adamW.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 4u);
+
+  // OpConfig() carries a null output layout, which is what the optimizer passes
+  // for an op with no results.
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  if (constraintsExp) {
+    auto constraints = constraintsExp.get();
+    const auto [cbSize, l1PeakSize, totalPeakSize, outputSize, outputLayouts,
+                outputAllocations] = constraints;
+    EXPECT_GT(cbSize, 0);
+    // All operands are DRAM-resident, so the op holds nothing in L1.
+    EXPECT_EQ(l1PeakSize, 0);
+    EXPECT_EQ(outputSize, 0);
+  } else {
+    FAIL() << "Missing constraints for AdamWOp; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+
+  auto runtimeExp = backend.getOpRuntime(inputLayouts, OpConfig());
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << "Error getting runtime for AdamWOp: "
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+// Same op with the optional max_exp_avg_sq operand present, which is what
+// enables AMSGrad in ttml. Exercises the 5-input path through the interface.
+TEST_F(OpModelBase, AdamWOpInterfaceAmsgrad) {
+  llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  auto f32Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  auto bf16Layout = CreateTiledLayout(shape, BufferType::DRAM,
+                                      TensorMemoryLayout::Interleaved);
+
+  auto param = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  auto grad = createEmptyTensor(shape, builder.getBF16Type(), bf16Layout);
+  auto expAvg = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  auto expAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  auto maxExpAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+
+  auto adamW = builder.create<AdamWOp>(
+      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq, maxExpAvgSq,
+      /*lr=*/builder.getF32FloatAttr(1e-3f),
+      /*beta1=*/builder.getF32FloatAttr(0.9f),
+      /*beta2=*/builder.getF32FloatAttr(0.999f),
+      /*beta1_pow=*/builder.getF32FloatAttr(0.9f),
+      /*beta2_pow=*/builder.getF32FloatAttr(0.999f),
+      /*epsilon=*/builder.getF32FloatAttr(1e-8f),
+      /*weight_decay=*/builder.getF32FloatAttr(0.01f),
+      /*stochastic_rounding=*/builder.getBoolAttr(false));
+
+  auto backend = dyn_cast<OpModel>(adamW.getOperation());
+  ASSERT_TRUE(backend);
+
+  auto inputLayouts = getInputLayouts(adamW.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 5u);
+
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  if (constraintsExp) {
+    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  } else {
+    FAIL() << "Missing constraints for AdamWOp with amsgrad; Error="
+           << llvm::toString(constraintsExp.takeError()) << std::endl;
+  }
+}
+
 TEST_F(OpModelBase, QuantizeOpInterface) {
   llvm::SmallVector<int64_t> inputShape = {32, 64};
   llvm::SmallVector<int64_t> scaleShape = {64};

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6316,6 +6316,97 @@ TEST_F(OpModelBase, AdamWOpInterfaceAmsgrad) {
   }
 }
 
+TEST_F(OpModelBase, SDPAForwardOpInterface) {
+  llvm::SmallVector<int64_t> shape = {1, 2, 64, 64};
+  auto layout = CreateTiledLayout(shape, BufferType::DRAM,
+                                  TensorMemoryLayout::Interleaved);
+  auto tensorType =
+      createRankedTensorType(shape, builder.getBF16Type(), layout);
+  auto query = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto key = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto value = createEmptyTensor(shape, builder.getBF16Type(), layout);
+
+  auto sdpaForward = builder.create<SDPAForwardOp>(
+      builder.getUnknownLoc(), TypeRange{tensorType}, query, key, value,
+      /*attention_mask=*/Value(),
+      ttcore::AttentionMaskTypeAttr::get(&context,
+                                         ttcore::AttentionMaskType::Causal),
+      builder.getF32FloatAttr(0.0f), builder.getBoolAttr(false));
+
+  auto backend = dyn_cast<OpModel>(sdpaForward.getOperation());
+  ASSERT_TRUE(backend);
+  auto inputLayouts = getInputLayouts(sdpaForward.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 3u);
+
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  if (constraintsExp) {
+    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+    ASSERT_EQ(constraintsExp.get().outputLayouts.size(), 1u);
+  } else {
+    FAIL() << "Missing constraints for SDPAForwardOp; Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = backend.getOpRuntime(inputLayouts, OpConfig());
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << "Error getting runtime for SDPAForwardOp: "
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
+TEST_F(OpModelBase, SDPABackwardOpInterface) {
+  llvm::SmallVector<int64_t> shape = {1, 2, 64, 64};
+  llvm::SmallVector<int64_t> intermediatesShape = {1, 2, 64, 32};
+  auto layout = CreateTiledLayout(shape, BufferType::DRAM,
+                                  TensorMemoryLayout::Interleaved);
+  auto intermediatesLayout = CreateTiledLayout(
+      intermediatesShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  auto tensorType =
+      createRankedTensorType(shape, builder.getBF16Type(), layout);
+
+  auto gradOutput = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto attnOutput = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto query = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto key = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto value = createEmptyTensor(shape, builder.getBF16Type(), layout);
+  auto intermediates = createEmptyTensor(
+      intermediatesShape, builder.getF32Type(), intermediatesLayout);
+
+  auto sdpaBackward = builder.create<SDPABackwardOp>(
+      builder.getUnknownLoc(), TypeRange{tensorType, tensorType, tensorType},
+      gradOutput, attnOutput, query, key, value, intermediates,
+      /*attention_mask=*/Value(),
+      ttcore::AttentionMaskTypeAttr::get(&context,
+                                         ttcore::AttentionMaskType::Causal),
+      builder.getF32FloatAttr(0.0f));
+
+  auto backend = dyn_cast<OpModel>(sdpaBackward.getOperation());
+  ASSERT_TRUE(backend);
+  auto inputLayouts = getInputLayouts(sdpaBackward.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 6u);
+
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  if (constraintsExp) {
+    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+    ASSERT_EQ(constraintsExp.get().outputLayouts.size(), 3u);
+  } else {
+    FAIL() << "Missing constraints for SDPABackwardOp; Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = backend.getOpRuntime(inputLayouts, OpConfig());
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << "Error getting runtime for SDPABackwardOp: "
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, QuantizeOpInterface) {
   llvm::SmallVector<int64_t> inputShape = {32, 64};
   llvm::SmallVector<int64_t> scaleShape = {64};

--- a/third_party/ttml/CMakeLists.txt
+++ b/third_party/ttml/CMakeLists.txt
@@ -3,7 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-if (NOT (TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN))
+# Built for the TTNN runtime (which dispatches these ops on device) and for
+# OpModel (which queries their constraints/runtime through ttnn::graph). Either
+# consumer alone is enough; both gate on tt-metal, which third_party/CMakeLists
+# builds under the same `RUNTIME OR OPMODEL` condition.
+if (NOT ((TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN) OR TTMLIR_ENABLE_OPMODEL))
   add_library(ttml_metal_ops INTERFACE)
   return()
 endif()


### PR DESCRIPTION
### Ticket
Related #9097 

### Problem description
TTML ops are missing op model interface.

### What's changed
Link TTML when op model is enabled.
Implement op model interface for `adamw`, `sdpa_fw`, `sdpa_bw`.

### Checklist
- [x] New/Existing tests provide coverage for changes
