### PR TITLE
Add REQUIRES: stablehlo to complex gather tests 

### DIFF
--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_gather.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_gather.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 

--- a/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_gather_with_reshape.mlir
+++ b/test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/complex_gather_with_reshape.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: stablehlo
 // RUN: ttmlir-opt --stablehlo-complex-math-expander --stablehlo-complex-data-type-conversion -o %t %s
 // RUN: FileCheck %s --input-file=%t
 


### PR DESCRIPTION
## Problem
Two tests under `test/ttmlir/Dialect/StableHLO/ComplexDataTypeConversion/`
fail when tt-mlir is built without StableHLO enabled (the default, e.g. a
standard macOS build):

- `complex_gather.mlir`
- `complex_gather_with_reshape.mlir`

They invoke `--stablehlo-complex-data-type-conversion` and
`--stablehlo-complex-math-expander`, which are only registered under
`#if TTMLIR_ENABLE_STABLEHLO` (see `lib/RegisterAll.cpp`). With StableHLO
disabled, `ttmlir-opt` reports "unknown command line argument" and the tests
fail instead of being skipped.

## Root cause
Every other StableHLO test carries a `// REQUIRES: stablehlo` marker so lit
skips it when the `stablehlo` feature is unavailable (`test/lit.cfg.py`).
These two tests were missing that marker.

## Fix
Add `// REQUIRES: stablehlo` to both test files, matching the convention used
by the rest of the StableHLO test suite.

## Testing
Verified locally on macOS with `check-ttmlir`:
- Before: `Failed: 2`
- After: `Failed: 0` (both tests now Unsupported/skipped).
StableHLO-enabled builds (CI) still run them as before.