### PR TITLE
docs: add googletest and python@3.12 to macOS build dependencies

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -46,7 +46,7 @@ Full developer dependencies as packaged in our docker image:
 On MacOS we need to install the latest version of [cmake](https://cmake.org/), and [ninja](https://ninja-build.org/) which can be done using Homebrew with (Docs for installing Homebrew: https://brew.sh).
 
 ```bash
-brew install cmake ninja
+brew install cmake ninja googletest python@3.12
 ```
 
 ### Clone the tt-mlir Repo


### PR DESCRIPTION
## Problem
The macOS section of the getting-started guide lists only `cmake` and `ninja`
in its Homebrew install command, but a clean macOS build also requires
`googletest` (CMake fails at `find_package(GTest)` without it) and Python 3.12
(`python@3.12`). New macOS contributors hit these as build errors before they
can get started.

## Fix
Add `googletest` and `python@3.12` to the macOS `brew install` command so the
documented setup produces a working build.
