### PR TITLE
[TTNN] Avoid degenerate tile padding in reshape -> to_tensor_spec

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -1142,6 +1142,107 @@ public:
   }
 };
 
+// This pattern pulls the row-major conversion above an op whose only consumer
+// is a to_tensor_spec that converts that op's result to row-major.
+//
+// An op that produces a non tile-aligned result in TILE layout pads its
+// degenerate height to a full tile, inflating the DRAM footprint. When the next
+// op immediately converts that result to row-major, the padded TILE buffer is
+// pure transient waste.
+//
+// The rewrite converts the input to row-major first and re-emits the op
+// directly in row-major, avoiding materialization of the padded TILE buffer.
+//
+// Example, for OpTy = ttnn::ReshapeOp:
+//   reshape [108365, 64] TILE -> [6935360] TILE
+//   to_tensor_spec [6935360] TILE -> [6935360] ROW_MAJOR
+//
+// becomes:
+//
+//   to_tensor_spec [108365, 64] TILE -> [108365, 64] ROW_MAJOR
+//   reshape [108365, 64] ROW_MAJOR -> [6935360] ROW_MAJOR
+template <typename OpTy>
+class ToTensorSpecRowMajorAdjusting : public OpRewritePattern<OpTy> {
+public:
+  using OpRewritePattern<OpTy>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(OpTy op,
+                                PatternRewriter &rewriter) const override {
+    if (!op->hasOneUse()) {
+      return failure();
+    }
+
+    auto toTensorSpecUser =
+        mlir::dyn_cast<ttnn::ToTensorSpecOp>(*op->user_begin());
+    if (!toTensorSpecUser) {
+      return failure();
+    }
+
+    auto opResultType =
+        mlir::cast<RankedTensorType>(op->getResult(0).getType());
+    auto opResultLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(opResultType.getEncoding());
+    if (!opResultLayout || !opResultLayout.isTiled()) {
+      return failure();
+    }
+
+    auto toTensorSpecResultType =
+        mlir::cast<RankedTensorType>(toTensorSpecUser.getResult().getType());
+    auto toTensorSpecResultLayout = mlir::dyn_cast<ttnn::TTNNLayoutAttr>(
+        toTensorSpecResultType.getEncoding());
+    if (!toTensorSpecResultLayout || toTensorSpecResultLayout.isTiled()) {
+      return failure();
+    }
+
+    // The op inherits the consumer's encoding, but cannot change dtype.
+    if (toTensorSpecResultLayout.getDataType() !=
+        opResultLayout.getDataType()) {
+      return failure();
+    }
+
+    auto rowMajorOpLayout = TTNNLayoutAttr::Builder(opResultType)
+                                .setLayout(ttnn::Layout::RowMajor)
+                                .build();
+
+    // Skip unless tiling actually inflates the memory footprint.
+    if (opResultLayout.getShardSizeInBytes() <=
+        rowMajorOpLayout.getShardSizeInBytes()) {
+      return failure();
+    }
+
+    // Gate on the layout, not the producing op: a to_tensor_spec producer can
+    // still yield TILE.
+    Value opInput = op->getOperand(0);
+    auto inputType = mlir::cast<RankedTensorType>(opInput.getType());
+    auto inputLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+    if (!inputLayout) {
+      return failure();
+    }
+
+    if (inputLayout.isTiled()) {
+      auto rowMajorInput = utils::createToTensorSpecOp(
+          op, mlir::cast<mlir::TypedValue<RankedTensorType>>(opInput), rewriter,
+          Layout::RowMajor, inputLayout.getBufferType(),
+          inputLayout.getMemLayout(), inputLayout.getDataType(),
+          "_input_row_major");
+      opInput = rowMajorInput.getResult();
+    }
+
+    // Clone rather than construct: the logical shape is unchanged, so every
+    // op-specific attribute stays valid and only the operand and the result
+    // encoding need overriding.
+    Operation *newOp = rewriter.clone(*op);
+    newOp->setOperand(0, opInput);
+    newOp->getResult(0).setType(toTensorSpecResultType);
+
+    rewriter.replaceOp(toTensorSpecUser, newOp->getResult(0));
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
 class TTNNMemoryManagement
     : public impl::TTNNMemoryManagementBase<TTNNMemoryManagement> {
 public:
@@ -1159,7 +1260,8 @@ public:
                    ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
                    ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
                    ReshapeElementwiseAdjusting<ttnn::DivideOp>,
-                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(
+                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting,
+                   ToTensorSpecRowMajorAdjusting<ttnn::ReshapeOp>>(
           &getContext());
     }
     patterns.add<PropagateSliceThroughPermute, PropagateSliceThroughReshape,

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -2,6 +2,7 @@
 // RUN: FileCheck %s --input-file=%t
 
 #dram = #ttnn.buffer_type<dram>
+#l1 = #ttnn.buffer_type<l1>
 #layout_128x128 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_64x64 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_32x128 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x4x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
@@ -27,6 +28,15 @@
 #layout_8192x16384_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_1x1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 * 8192 + d2, d3), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_8192x8192x1x1_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 + d2, d3), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_E_F = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<3387x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_1d_t = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x216730x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_1d_rm = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x6935360xf32, #dram>, <interleaved>>
+#layout_64x64_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64xf32, #dram>, <interleaved>>
+#layout_1d_rm_l1 = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x6935360xf32, #l1>, <interleaved>>
+#layout_E_F_rm = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<108365x64xf32, #dram>, <interleaved>>
+#layout_100x50 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_5000_t = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x157x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_5000_rm = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x5000xf32, #dram>, <interleaved>>
 
 module {
   // sliceReshape
@@ -163,5 +173,77 @@ module {
     %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>
     %1 = "ttnn.permute"(%0) <{permutation = array<i64: 2, 3, 0, 1>}> : (tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
     return %1 : tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
+  }
+
+  // a 1-D reshape whose only consumer is a to_tensor_spec(row_major) must emit its result directly in row-major
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_row_major
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // CHECK: "ttnn.reshape"(%[[RM_IN]])
+  // CHECK-SAME: shape = [6935360 : i32]
+  // CHECK-SAME: -> tensor<6935360xf32
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  // CHECK: return
+  func.func @reshape_to_tensor_spec_row_major(%arg0: tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_rm> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [6935360 : i32]}> : (tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_t>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<6935360xf32, #layout_1d_t>) -> tensor<6935360xf32, #layout_1d_rm>
+    return %1 : tensor<6935360xf32, #layout_1d_rm>
+  }
+
+  // a tile-aligned reshape result has equal tiled and row-major footprints, so the guard skips the rewrite
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_tile_aligned
+  // CHECK: %[[R:.*]] = "ttnn.reshape"
+  // CHECK: "ttnn.to_tensor_spec"(%[[R]])
+  // CHECK: return
+  func.func @reshape_to_tensor_spec_tile_aligned(%arg0: tensor<128x32xf32, #layout_128x32>) -> tensor<64x64xf32, #layout_64x64_rm> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [64 : i32, 64 : i32]}> : (tensor<128x32xf32, #layout_128x32>) -> tensor<64x64xf32, #layout_64x64>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<64x64xf32, #layout_64x64>) -> tensor<64x64xf32, #layout_64x64_rm>
+    return %1 : tensor<64x64xf32, #layout_64x64_rm>
+  }
+
+  // a consumer targeting row-major L1 rather than DRAM is resolved by the same single op
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_l1_consumer
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // CHECK: "ttnn.reshape"(%[[RM_IN]])
+  // CHECK-SAME: -> tensor<6935360xf32
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  // CHECK: return
+  func.func @reshape_to_tensor_spec_l1_consumer(%arg0: tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_rm_l1> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [6935360 : i32]}> : (tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_t>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<6935360xf32, #layout_1d_t>) -> tensor<6935360xf32, #layout_1d_rm_l1>
+    return %1 : tensor<6935360xf32, #layout_1d_rm_l1>
+  }
+
+  // a second consumer needs the tiled result, so hasOneUse() blocks the rewrite
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_multi_use
+  // CHECK: %[[R:.*]] = "ttnn.reshape"(%arg0)
+  // CHECK: "ttnn.to_tensor_spec"(%[[R]])
+  func.func @reshape_to_tensor_spec_multi_use(%arg0: tensor<108365x64xf32, #layout_E_F>) -> (tensor<6935360xf32, #layout_1d_rm>, tensor<6935360xf32, #layout_1d_t>) {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [6935360 : i32]}> : (tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_t>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<6935360xf32, #layout_1d_t>) -> tensor<6935360xf32, #layout_1d_rm>
+    return %1, %0 : tensor<6935360xf32, #layout_1d_rm>, tensor<6935360xf32, #layout_1d_t>
+  }
+
+  // a to_tensor_spec producer can still yield TILE, so the input is gated on its layout; the inserted conversion then folds against it
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_tiled_input
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  // CHECK: "ttnn.reshape"(%arg0)
+  // CHECK-SAME: -> tensor<6935360xf32
+  func.func @reshape_to_tensor_spec_tiled_input(%arg0: tensor<108365x64xf32, #layout_E_F_rm>) -> tensor<6935360xf32, #layout_1d_rm> {
+    %0 = "ttnn.to_tensor_spec"(%arg0) : (tensor<108365x64xf32, #layout_E_F_rm>) -> tensor<108365x64xf32, #layout_E_F>
+    %1 = "ttnn.reshape"(%0) <{shape = [6935360 : i32]}> : (tensor<108365x64xf32, #layout_E_F>) -> tensor<6935360xf32, #layout_1d_t>
+    %2 = "ttnn.to_tensor_spec"(%1) : (tensor<6935360xf32, #layout_1d_t>) -> tensor<6935360xf32, #layout_1d_rm>
+    return %2 : tensor<6935360xf32, #layout_1d_rm>
+  }
+
+  // the rewrite applies the same way when the flattened length is not a multiple of the tile height
+  // CHECK-LABEL: func.func @reshape_to_tensor_spec_unaligned_flatten
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // CHECK: "ttnn.reshape"(%[[RM_IN]])
+  // CHECK-SAME: -> tensor<5000xf32
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  func.func @reshape_to_tensor_spec_unaligned_flatten(%arg0: tensor<100x50xf32, #layout_100x50>) -> tensor<5000xf32, #layout_5000_rm> {
+    %0 = "ttnn.reshape"(%arg0) <{shape = [5000 : i32]}> : (tensor<100x50xf32, #layout_100x50>) -> tensor<5000xf32, #layout_5000_t>
+    %1 = "ttnn.to_tensor_spec"(%0) : (tensor<5000xf32, #layout_5000_t>) -> tensor<5000xf32, #layout_5000_rm>
+    return %1 : tensor<5000xf32, #layout_5000_rm>
   }
 }


### PR DESCRIPTION
### Ticket

Closes #8887

### Problem description

In the scatter lowering the `[E, F]` operand is flattened to 1-D `[E*F]`, and `ttnn.reshape` produces that result in `TILE` layout. A 1-D shape is laid out as `[1, E*F]`, so with 32x32 tiles the degenerate height of 1 is padded out to 32 rows. The very next op converts the buffer back to row-major - that is what `ttnn.scatter` actually consumes - so the tiled buffer is pure transient waste.

For the GATv2 / full-PubMed training case in the issue that is 887,726,080 B (216,730 tiles x 4,096 B) where 27,741,440 B (6,935,360 elements x 4 B) is needed: exactly 32.00x, and enough to push an N300 into DRAM OOM. (The comment on the issue quoted these in mixed units; the byte counts here are the exact ones.)

There is merged downstream waiting on this: tt-blacksmith [#611](https://github.com/tenstorrent/tt-blacksmith/pull/611) routed around the bug via SpMM and explicitly left the stock `use_spmm: false` path in the tree pending a fix for #8887.

### What's changed

New pattern `ToTensorSpecRowMajorAdjusting<OpTy>` in `TTNNMemoryManagement.cpp`, instantiated for `ttnn::ReshapeOp`. It matches `op -> to_tensor_spec(row_major)` where `op` has a single use, converts the input to row-major up front, and rrebuilds `op` by cloning it with the consumer's encoding, so the tiled 1-D result is never materialized and no trailing conversion is needed.

As suggested by @djstefanovicTT in the issue, the pattern is templated on `OpTy` and instantiated only for `ReshapeOp` for now, so the scope stays narrow. Rebuilding through `rewriter.clone` rather than `create<ttnn::ReshapeOp>` is what keeps it op-agnostic, since `getShapeAttr()` is `ReshapeOp`-specific.

The rewrite fires only when `getShardSizeInBytes()` for the tiled layout exceeds the row-major one. There is deliberately no size threshold, unlike the neighbouring `PermuteRowMajorAdjusting` / `ReshapeRowMajorAdjusting`: those *add* a layout conversion and so have to amortize its cost, whereas here the conversion already exists in the incoming IR and is only moved earlier in the chain - there is nothing to amortize.

Whether the input needs converting is decided from `inputLayout.isTiled()` rather than from the kind of op that produced it, since a `to_tensor_spec` producer can hand back `TILE`.

#### Changes in tests

Six functions in `test/ttmlir/Transforms/memory_management.mlir`:

- `reshape_to_tensor_spec_row_major` - the rewrite itself.
- `reshape_to_tensor_spec_tile_aligned` - negative. Differs from the positive case *only* in tile alignment, so the pattern not firing is attributable to the footprint guard and nothing else.
- `reshape_to_tensor_spec_l1_consumer` - consumer in L1 rather than DRAM, covered by the same single conversion.
- `reshape_to_tensor_spec_multi_use` - negative, locking the `hasOneUse` boundary.
- `reshape_to_tensor_spec_tiled_input` - input produced by a `to_tensor_spec` that yields `TILE`, covering the layout-based gate.
- `reshape_to_tensor_spec_unaligned_flatten` - flattened length not a multiple of 32.

Not verified on device: I don't have TT hardware. `check-ttmlir` is green locally and `git clang-format` is clean; the two `StableHLO/ComplexDataTypeConversion` failures reproduce on an unmodified `origin/main` and are unrelated to this diff. Silicon coverage would have to come from CI.

### Checklist

- [x] New/Existing tests provide coverage for changes
