### PR TITLE
Uplift third_party/tt-metal to d7f3415767d65cb98a0f23ae6a450191a7aff606 2026-08-17

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=8a934ae01866a8e76ed58695ddbd34f596d45889
+ARG TT_METAL_DEPENDENCIES_COMMIT=d7f3415767d65cb98a0f23ae6a450191a7aff606
 
 # Install dependencies
 RUN <<EOT

--- a/env/pip-constraints.txt
+++ b/env/pip-constraints.txt
@@ -1,1 +1,1 @@
-nanobind==2.12.0
+nanobind==2.14.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.14.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -777,7 +777,7 @@ void ProgramExecutor::syncAfterOpIfNeeded() {
   static const bool enabled =
       std::getenv("TT_RUNTIME_SYNC_AFTER_OP") != nullptr;
   if (enabled) {
-    ::tt::tt_metal::distributed::Synchronize(&context->getMeshDevice(),
+    ::tt::tt_metal::distributed::Synchronize(context->getMeshDevice(),
                                              std::nullopt);
   }
 }

--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -10,6 +10,12 @@ list(APPEND CMAKE_PREFIX_PATH "${Python3_SITEARCH}" "${Python3_SITELIB}")
 if (NOT TARGET Python::Module AND TARGET Python3::Module)
   add_library(Python::Module ALIAS Python3::Module)
 endif()
+# nanobind 2.14 nanobind-config.cmake requires both Python::Interpreter
+# and Python::Module. find_package(Python3) only creates Python3::*
+# targets, so alias Interpreter like the existing Module alias.
+if (NOT TARGET Python::Interpreter AND TARGET Python3::Interpreter)
+  add_executable(Python::Interpreter ALIAS Python3::Interpreter)
+endif()
 if (NOT DEFINED Python_EXECUTABLE AND DEFINED Python3_EXECUTABLE)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}" CACHE FILEPATH "" FORCE)
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "8a934ae01866a8e76ed58695ddbd34f596d45889")
+set(TT_METAL_VERSION "d7f3415767d65cb98a0f23ae6a450191a7aff606")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/tools/pykernel/pyproject.toml
+++ b/tools/pykernel/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.14.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -2,4 +2,4 @@
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl; sys_platform == "linux" and platform_machine == "x86_64"
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl; sys_platform == "linux" and platform_machine == "aarch64"
 torch==2.9.1; sys_platform == "darwin"
-nanobind==2.12.0
+nanobind==2.14.0


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d7f3415767d65cb98a0f23ae6a450191a7aff606

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):https://github.com/tenstorrent/tt-forge-onnx/actions/runs/32072304835
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):https://github.com/tenstorrent/tt-xla/actions/runs/32072297842
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):