### PR TITLE
[dtype] perform bfp8 typecast on device

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNWeightDtypeConversion.cpp
@@ -99,17 +99,15 @@ public:
     auto newWeightType =
         ttnn::utils::RankedTensorTypeFactory::create(weightType, dtype);
 
-    // Blockfloat targets (BFP_BFloat4, BFP_BFloat8) go through a host-side
-    // typecast via: from_device → typecast (host) → to_device.
-    // The host typecast dispatches to tt-metal's host packer for BFP
-    // formats. Const-eval results are cached at compile time, so the
-    // host roundtrip is paid once per cached weight per program.
+    // BFP_BFloat4 weights go through a host-side typecast via:
+    // from_device → typecast (host) → to_device.
     //
-    // Other targets (e.g. BFloat16 per-tensor override) keep the existing
-    // single-`typecast` device codepath.
+    // The host typecast dispatches to tt-metal's host packer for BFP
+    // formats, which provides better accuracy.
+    //
+    // Other targets keep the existing single-`typecast` device codepath.
     mlir::Value newWeight;
-    if (dtype == ttcore::DataType::BFP_BFloat4 ||
-        dtype == ttcore::DataType::BFP_BFloat8) {
+    if (dtype == ttcore::DataType::BFP_BFloat4) {
       auto hostInputType = ttnn::utils::RankedTensorTypeFactory::create(
           mlir::cast<RankedTensorType>(weight.getType()),
           ttnn::BufferType::SystemMemory);
@@ -126,7 +124,6 @@ public:
           op.getLoc(), newWeightType, typecastOp.getResult(), device);
       newWeight = toDevOp.getResult();
     } else {
-      // Single device typecast for non-blockfloat targets.
       auto typecastOp =
           rewriter.create<TypecastOp>(op.getLoc(), newWeightType, weight);
       newWeight = typecastOp.getResult();

--- a/test/python/golden/test_ttnn_model_snippets.py
+++ b/test/python/golden/test_ttnn_model_snippets.py
@@ -128,10 +128,16 @@ def test_ttnn_model_snippet_compile_execute(
         print(f"Skipping execution (--skip-exec): {snippet_id}")
         return
 
+    # PCC for llama is adjusted because the device typecast for `bfp8` causes
+    # small degradation of PCC with these particular random inputs/weights.
+    # Real llama model does not exibit this behaviour, and all accuracy checks are passing.
+    pcc = 0.985 if snippet_id == "llama_3_2_1b_decode_layer" else 0.99
+
     execute_fb(
         compiled_bin,
         input_output_goldens=input_output_goldens,
         intermediate_goldens=intermediate_goldens,
+        pcc=pcc,
         device=device,
         bypass_ops=builder._bypass_ops,
     )

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp8_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/linear_bfp8_weights.mlir
@@ -1,8 +1,7 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test that the BFP8 weight conversion pass correctly:
-// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
-//    the linear for blockfloat targets.
+// 1. Inserts a single on-device typecast before the linear for bfp8 targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf8
 // 3. Updates the linear to use the resulting on-device tensor
 // 4. Keeps the output of linear as bf16 (unchanged)
@@ -15,15 +14,14 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_linear_bfp8_weights
 
-    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
     %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
+    // CHECK-NOT: "ttnn.from_device"
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
     // CHECK-SAME: -> tensor<1024x2048x!ttcore.tile<32x32, bfp_bf8>,
-    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
+    // CHECK-NOT: "ttnn.to_device"
 
-    // CHECK: "ttnn.linear"(%arg2, %[[TO_DEV]], %arg3)
+    // CHECK: "ttnn.linear"(%arg2, %[[TYPECAST]], %arg3)
     // CHECK-SAME: -> tensor<2048x1024xbf16,
     %0 = "ttnn.linear"(%arg2, %arg1, %arg3) <{transpose_a = false, transpose_b = true}> : (tensor<2048x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1024x2048xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<32x64x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<2048x1024xbf16, #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<64x32x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp8_weights.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_bfp8_weights.mlir
@@ -1,8 +1,7 @@
 // RUN: ttmlir-opt --ttnn-weight-dtype-conversion="target-dtype=bfp_bf8" %s | FileCheck %s
 
 // Test that the BFP8 weight conversion pass correctly:
-// 1. Inserts a host-side chain (from_device -> typecast -> to_device) before
-//    the matmul for blockfloat targets.
+// 1. Inserts a single on-device typecast before the matmul for bfp8 targets.
 // 2. Converts the weight tensor (B operand) to bfp_bf8
 // 3. Updates the matmul to use the resulting on-device tensor
 // 4. Keeps the output of matmul as bf16 (unchanged)
@@ -15,15 +14,14 @@ module attributes {} {
 
     // CHECK-LABEL: func.func @test_matmul_bfp8_weights
 
-    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
     %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
+    // CHECK-NOT: "ttnn.from_device"
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>,
-    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
+    // CHECK-NOT: "ttnn.to_device"
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_mixed_per_arg_and_global.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_mixed_per_arg_and_global.mlir
@@ -2,8 +2,8 @@
 
 // Test mixed per-op and global weight dtype. Two matmuls:
 // - First matmul: op has per-op annotation "bfp_bf4" -> host-side chain to bfp4
-// - Second matmul: op has no annotation -> falls back to global bfp8
-// Both blockfloat targets emit the from_device -> typecast -> to_device chain.
+// - Second matmul: op has no annotation -> falls back to global bfp8; bfp8 emits a
+// single on-device typecast.
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -28,12 +28,12 @@ module attributes {} {
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bfp_bf4"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     // Second matmul: no per-op annotation, falls back to global bfp8.
-    // CHECK: %[[FROM_DEV2:.*]] = "ttnn.from_device"(%arg2)
-    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%[[FROM_DEV2]])
+    // CHECK-NOT: "ttnn.from_device"
+    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%arg2)
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>
-    // CHECK: %[[TO_DEV2:.*]] = "ttnn.to_device"(%[[TYPECAST2]], %[[DEV]])
+    // CHECK-NOT: "ttnn.to_device"
 
-    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TO_DEV2]])
+    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TYPECAST2]])
     %1 = "ttnn.matmul"(%arg0, %arg2) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     return %0, %1 : tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bfloat16_override.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_bfloat16_override.mlir
@@ -14,7 +14,6 @@ module attributes {} {
     %arg2: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}
   ) -> (tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) {
 
-    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
     %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
     // First matmul: per-op "bf16" annotation, no conversion should be inserted.
@@ -22,14 +21,14 @@ module attributes {} {
     // CHECK: %[[MM1:.*]] = "ttnn.matmul"(%arg0, %arg1)
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bf16"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
-    // Second matmul: no per-op annotation, falls back to global bfp8 via the
-    // host-side chain.
-    // CHECK: %[[FROM_DEV2:.*]] = "ttnn.from_device"(%arg2)
-    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%[[FROM_DEV2]])
+    // Second matmul: no per-op annotation, falls back to global bfp8 via a
+    // single on-device typecast.
+    // CHECK-NOT: "ttnn.from_device"
+    // CHECK: %[[TYPECAST2:.*]] = "ttnn.typecast"(%arg2)
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>
-    // CHECK: %[[TO_DEV2:.*]] = "ttnn.to_device"(%[[TYPECAST2]], %[[DEV]])
+    // CHECK-NOT: "ttnn.to_device"
 
-    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TO_DEV2]])
+    // CHECK: %[[MM2:.*]] = "ttnn.matmul"(%arg0, %[[TYPECAST2]])
     %1 = "ttnn.matmul"(%arg0, %arg2) : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 
     return %0, %1 : tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>

--- a/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_weight_dtype.mlir
+++ b/test/ttmlir/Dialect/TTNN/weight_conversion/matmul_per_arg_weight_dtype.mlir
@@ -2,8 +2,7 @@
 
 // Test per-op weight dtype override without a global target-dtype.
 // The "ttcore.weight_dtype" discardable attribute on the matmul op should drive
-// the conversion. For blockfloat targets the conversion is the host-side
-// chain (from_device -> typecast -> to_device).
+// the conversion.
 
 #dram = #ttnn.buffer_type<dram>
 
@@ -11,15 +10,14 @@ module attributes {} {
   // CHECK-LABEL: func.func @test_per_arg_bfp8
   func.func @test_per_arg_bfp8(%arg0: tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, %arg1: tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>> {
 
-    // CHECK: %[[DEV:.*]] = "ttnn.get_device"
     %dev = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
 
-    // CHECK: %[[FROM_DEV:.*]] = "ttnn.from_device"(%arg1)
-    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%[[FROM_DEV]])
+    // CHECK-NOT: "ttnn.from_device"
+    // CHECK: %[[TYPECAST:.*]] = "ttnn.typecast"(%arg1)
     // CHECK-SAME: -> tensor<1x128x256x!ttcore.tile<32x32, bfp_bf8>,
-    // CHECK: %[[TO_DEV:.*]] = "ttnn.to_device"(%[[TYPECAST]], %[[DEV]])
+    // CHECK-NOT: "ttnn.to_device"
 
-    // CHECK: "ttnn.matmul"(%arg0, %[[TO_DEV]])
+    // CHECK: "ttnn.matmul"(%arg0, %[[TYPECAST]])
     // CHECK-SAME: -> tensor<1x32x256xbf16,
     %0 = "ttnn.matmul"(%arg0, %arg1) {ttcore.weight_dtype = "bfp_bf8"} : (tensor<1x32x128xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x4x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>, tensor<1x128x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>) -> tensor<1x32x256xbf16, #ttnn.ttnn_layout<(d0, d1, d2) -> (d0, d1, d2), <1x1>, memref<1x1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>>
 


### PR DESCRIPTION
The logic introduced in #8140 for performing typecast to `bfp4` and `bfp8` on host was based on observed accuracy loss for the `bfp4`.

Since we haven't observed any accuracy issues (on real models) when typecasting `bfp8` on the device and typecasting it on host is significantly slowing down first runs of large models - this change excludes `bfp8` from this logic and will perform host typecast only for `bfp4`.

`llama_3_2_1b_decode_layer` test hit a small PCC regression from this change (from ~0.9945 to ~0.9893). This was found to be insignificant when running the actual model. Test's PCC target is reduced accordingly.

Original issue related to GPT-OSS accuracy issues (`bfp4`): #8138