### PR TITLE
[TTIR] Match gathered freqs column in interleaved-pair RoPE

### DIFF
--- a/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/RoPEFusingPattern.cpp
@@ -728,6 +728,49 @@ static SliceStaticOp findSliceThroughTMs(Value v) {
   return nullptr;
 }
 
+// Matches the flat-gather form of `freqs_cis[..., c]`: freqs_cis linearised,
+// one element looked up per output position. Returns the freqs_cis the gather
+// reads, or nullptr. Guard 3 in the caller rejects a gather over anything other
+// than the cache the sibling branch slices.
+//
+// Which column is selected is not recoverable, the index tensor being opaque
+// here. Callers must only use this for the column complementary to a branch
+// whose column a slice proved.
+static Value matchFlatGatherFreqs(Value v) {
+  auto embedding = dyn_cast_or_null<EmbeddingOp>(skipTMs(v).getDefiningOp());
+  if (!embedding) {
+    return nullptr;
+  }
+
+  // The lookup table must be a linearised copy of freqs_cis.
+  Value freqs = skipTMs(embedding.getWeight());
+  auto freqsType = mlir::dyn_cast<RankedTensorType>(freqs.getType());
+  auto indicesType =
+      mlir::dyn_cast<RankedTensorType>(embedding.getInput().getType());
+  if (!freqsType || !indicesType || !freqsType.hasStaticShape() ||
+      !indicesType.hasStaticShape()) {
+    return nullptr;
+  }
+
+  // One column is half of the trailing 2x2.
+  if (freqsType.getNumElements() != 2 * indicesType.getNumElements()) {
+    return nullptr;
+  }
+
+  return freqs;
+}
+
+// True when both values are the same tensor up to reshapes.
+static bool sameFreqsModuloReshape(Value a, Value b) {
+  auto root = [](Value v) {
+    while (auto reshape = dyn_cast_or_null<ReshapeOp>(v.getDefiningOp())) {
+      v = reshape.getInput();
+    }
+    return v;
+  };
+  return root(a) == root(b);
+}
+
 // For a slice on a 6D reshape of x at pair dim, returns the pair index
 // (0 or 1) if the slice has the form [..., 0:1, 0:1] or [..., 0:1, 1:2]
 // on the last two dims of a (..., 1, 2) shape. Returns nullopt otherwise.
@@ -814,45 +857,54 @@ static std::optional<int64_t> getColumnIndex(SliceStaticOp slice) {
 struct InterleavedBranch {
   MultiplyOp mulOp;
   SliceStaticOp xSlice;     // slice on the 6D reshape of x; pair index encoded
-  SliceStaticOp freqsSlice; // slice on freqs_cis; column index encoded
-  int64_t pairIdx;          // 0 or 1
-  int64_t colIdx;           // 0 or 1
+  SliceStaticOp freqsSlice; // slice on freqs_cis; unset when freqsIsGather
+  int64_t pairIdx = -1;     // 0 or 1
+  int64_t colIdx = -1;      // 0 or 1
   Value xReshape6D;         // the 6D reshape of x (slice's input)
-  Value freqsSrc;           // freqs_cis source tensor
+  Value freqsSrc;           // freqs_cis; linearised view when freqsIsGather
+  bool freqsIsGather = false;
 };
 
 // Try to interpret a MultiplyOp as one branch of the interleaved RoPE pattern.
-// Returns the populated branch if both operands trace back to a pair-slice on
-// x's 6D reshape and a column-slice on freqs_cis; nullopt otherwise.
+// Returns the populated branch if the x operand traces back to a pair-slice on
+// x's 6D reshape and the freqs operand to either a column-slice on freqs_cis or
+// its flat-gather form; nullopt otherwise.
 static std::optional<InterleavedBranch> matchBranch(MultiplyOp mulOp) {
   for (int swap = 0; swap < 2; ++swap) {
     Value xSide = mulOp.getOperand(swap);
     Value freqsSide = mulOp.getOperand(1 - swap);
 
     SliceStaticOp xSlice = findSliceThroughTMs(xSide);
-    SliceStaticOp freqsSlice = findSliceThroughTMs(freqsSide);
-    if (!xSlice || !freqsSlice) {
+    if (!xSlice) {
       continue;
     }
-
     auto pairIdx = getPairIndex(xSlice);
     if (!pairIdx) {
-      continue;
-    }
-    auto colIdx = getColumnIndex(freqsSlice);
-    if (!colIdx) {
       continue;
     }
 
     InterleavedBranch br;
     br.mulOp = mulOp;
     br.xSlice = xSlice;
-    br.freqsSlice = freqsSlice;
     br.pairIdx = *pairIdx;
-    br.colIdx = *colIdx;
     br.xReshape6D = xSlice.getOperand();
-    br.freqsSrc = freqsSlice.getOperand();
-    return br;
+
+    if (SliceStaticOp freqsSlice = findSliceThroughTMs(freqsSide)) {
+      if (auto colIdx = getColumnIndex(freqsSlice)) {
+        br.freqsSlice = freqsSlice;
+        br.colIdx = *colIdx;
+        br.freqsSrc = freqsSlice.getOperand();
+        br.freqsIsGather = false;
+        return br;
+      }
+    }
+
+    // colIdx stays unset; the caller derives it from the sibling branch.
+    if (Value gatheredFreqs = matchFlatGatherFreqs(freqsSide)) {
+      br.freqsSrc = gatheredFreqs;
+      br.freqsIsGather = true;
+      return br;
+    }
   }
   return std::nullopt;
 }
@@ -875,9 +927,22 @@ mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
     return failure();
   }
 
-  // 3. Both branches must share the same x 6D reshape and same freqs_cis.
-  if (br0->xReshape6D != br1->xReshape6D || br0->freqsSrc != br1->freqsSrc) {
+  // 3. Both branches must share the same x 6D reshape and the same freqs_cis,
+  //    modulo reshape since the gather form reads a linearised view.
+  if (br0->xReshape6D != br1->xReshape6D ||
+      !sameFreqsModuloReshape(br0->freqsSrc, br1->freqsSrc)) {
     return failure();
+  }
+
+  // 3b. Only one branch may be gathered; its column is the sibling's
+  //     complement.
+  if (br0->freqsIsGather && br1->freqsIsGather) {
+    return failure();
+  }
+  if (br0->freqsIsGather) {
+    br0->colIdx = 1 - br1->colIdx;
+  } else if (br1->freqsIsGather) {
+    br1->colIdx = 1 - br0->colIdx;
   }
 
   // 4. The two branches must select pair indices {0, 1} and columns {0, 1}.
@@ -889,6 +954,12 @@ mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
   if (br0->pairIdx != br0->colIdx || br1->pairIdx != br1->colIdx) {
     return failure();
   }
+
+  // 4b. Only the slice branch carries the (..., D/2, 2, 2) shape cos and sin
+  // are
+  //     sliced from below.
+  const InterleavedBranch &freqsBranch = br0->freqsIsGather ? *br1 : *br0;
+  Value freqsSrc = freqsBranch.freqsSrc;
 
   // 5. The x 6D reshape must come from a ReshapeOp that produced shape
   //    (..., D/2, 1, 2) from (..., D).
@@ -917,7 +988,7 @@ mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
   }
 
   // 6. freqs_cis must be 6D shape (..., D/2, 2, 2).
-  auto freqsType = mlir::cast<RankedTensorType>(br0->freqsSrc.getType());
+  auto freqsType = mlir::cast<RankedTensorType>(freqsSrc.getType());
   ArrayRef<int64_t> freqsShape = freqsType.getShape();
   int64_t fRank = freqsShape.size();
   if (fRank != 6 || freqsShape[fRank - 3] != halfD ||
@@ -953,12 +1024,12 @@ mlir::LogicalResult RoPEInterleavedPairFusingPattern::matchAndRewrite(
   //    sin = freqs_cis[..., 1, 0]  (row 1, col 0)
   // First slice on the row dim (rank-2), then on the col dim (rank-1).
   SliceStaticOp cosRowSlice =
-      buildSliceOnDim(rewriter, loc, br0->freqsSrc, fRank - 2, 0, 1);
+      buildSliceOnDim(rewriter, loc, freqsSrc, fRank - 2, 0, 1);
   SliceStaticOp cosColSlice =
       buildSliceOnDim(rewriter, loc, cosRowSlice.getResult(), fRank - 1, 0, 1);
 
   SliceStaticOp sinRowSlice =
-      buildSliceOnDim(rewriter, loc, br0->freqsSrc, fRank - 2, 1, 2);
+      buildSliceOnDim(rewriter, loc, freqsSrc, fRank - 2, 1, 2);
   SliceStaticOp sinColSlice =
       buildSliceOnDim(rewriter, loc, sinRowSlice.getResult(), fRank - 1, 0, 1);
 

--- a/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_rope_fusing.py
@@ -615,3 +615,156 @@ def test_rope_interleaved_pair(
     )
 
     assert check_op(output, "rotary_embedding")
+
+
+def build_rope_interleaved_pair_gathered_column(
+    input: Operand,
+    freqs_input: Operand,
+    builder: TTIRBuilder,
+):
+    """Pattern 3 with the freqs column 1 read as a flat gather.
+
+    Frontends that lower `freqs[..., 1]` as advanced indexing emit a gather over
+    a linearised freqs_cis rather than a slice. Column 0 stays a slice, so the
+    two branches reach the multiplies in different forms.
+    """
+    input_shape = list(input.type.shape)
+    freqs_shape = list(freqs_input.type.shape)
+    B, H, S, D = input_shape
+    half_dim = D // 2
+
+    x_6d = builder.reshape(input, shape=[B, H, S, half_dim, 1, 2])
+    x_p0 = builder.slice(
+        x_6d,
+        begins=[0, 0, 0, 0, 0, 0],
+        ends=[B, H, S, half_dim, 1, 1],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    x_p1 = builder.slice(
+        x_6d,
+        begins=[0, 0, 0, 0, 0, 1],
+        ends=[B, H, S, half_dim, 1, 2],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    x_real_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(x_p0, shape=[B, H, S, half_dim]),
+            shape=[B, H, S, half_dim, 1],
+        ),
+        broadcast_dimensions=[1, 1, 1, 1, 2],
+    )
+    x_imag_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(x_p1, shape=[B, H, S, half_dim]),
+            shape=[B, H, S, half_dim, 1],
+        ),
+        broadcast_dimensions=[1, 1, 1, 1, 2],
+    )
+
+    # Column 0: sliced.
+    freqs_c0 = builder.slice(
+        freqs_input,
+        begins=[0, 0, 0, 0, 0, 0],
+        ends=[freqs_shape[0], freqs_shape[1], freqs_shape[2], half_dim, 2, 1],
+        step=[1, 1, 1, 1, 1, 1],
+    )
+    cos_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(
+                freqs_c0, shape=[freqs_shape[0], freqs_shape[2], half_dim, 2]
+            ),
+            shape=[freqs_shape[0], 1, freqs_shape[2], half_dim, 2],
+        ),
+        broadcast_dimensions=[1, H, 1, 1, 1],
+    )
+
+    # Column 1: gathered. Its elements sit at the odd linear offsets of the
+    # flattened cache, the trailing dim being the 2-wide column axis.
+    numel = 1
+    for d in freqs_shape:
+        numel *= d
+    col_numel = numel // 2
+
+    table = builder.reshape(
+        builder.reshape(freqs_input, shape=[numel]), shape=[numel, 1]
+    )
+    idx = builder.constant(torch.arange(col_numel, dtype=torch.int64) * 2 + 1)
+    zeros = builder.constant(torch.zeros(col_numel, dtype=torch.int64))
+    size = builder.constant(torch.full((col_numel,), numel, dtype=torch.int64))
+    normalized = builder.where(builder.ge(idx, zeros), idx, builder.add(idx, size))
+
+    gathered = builder.embedding(
+        builder.reshape(normalized, shape=[1, col_numel]), table
+    )
+    sin_bc = builder.broadcast(
+        builder.reshape(
+            builder.reshape(
+                builder.reshape(gathered, shape=[col_numel]),
+                shape=[freqs_shape[0], freqs_shape[2], half_dim, 2],
+            ),
+            shape=[freqs_shape[0], 1, freqs_shape[2], half_dim, 2],
+        ),
+        broadcast_dimensions=[1, H, 1, 1, 1],
+    )
+
+    sum_5d = builder.add(
+        builder.multiply(cos_bc, x_real_bc),
+        builder.multiply(sin_bc, x_imag_bc),
+    )
+    return builder.reshape(sum_5d, shape=input_shape)
+
+
+@pytest.mark.parametrize("input_shape, freqs_shape", INTERLEAVED_PAIR_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("target", ["ttnn"])
+def test_rope_interleaved_pair_gathered_column(
+    input_shape, freqs_shape, dtype, target, request, device
+):
+    """
+    Pattern 3 where freqs column 1 arrives as a flat gather instead of a slice,
+    as HiDream-I1 does through tt-xla. The gathered column is inferred as the
+    complement of the sliced one, so the chain still fuses.
+    """
+    shapes = [input_shape, freqs_shape]
+    dtypes = [dtype] * 2
+
+    def module(builder: TTIRBuilder):
+        @builder.func(shapes, dtypes)
+        def rotary_embedding(
+            input: Operand,
+            freqs_input: Operand,
+            builder: TTIRBuilder,
+        ):
+            input_data = torch.randn(input_shape, dtype=dtype)
+
+            angles = torch.randn(freqs_shape[:-2], dtype=torch.float32)
+            c, s = torch.cos(angles), torch.sin(angles)
+            freqs_data = (
+                torch.stack([c, -s, s, c], dim=-1).reshape(freqs_shape).to(dtype)
+            )
+
+            golden = torch_rope_interleaved_pair(input_data, freqs_data)
+
+            result = build_rope_interleaved_pair_gathered_column(
+                input, freqs_input, builder
+            )
+
+            builder.set_goldens(
+                {input: input_data, freqs_input: freqs_data},
+                {result: golden},
+            )
+            return result
+
+    output = compile_and_execute_ttir(
+        module,
+        target=target,
+        **get_request_kwargs(request),
+        device=device,
+        pipeline_options=[
+            "enable-ttnn-decomposition-pass=false",
+            "composite-resolution=force-promote",
+        ],
+        save_artifacts=True,
+    )
+
+    assert check_op(output, "rotary_embedding")

--- a/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/rotary_embedding/rope.mlir
@@ -238,3 +238,115 @@ module {
     return %result : tensor<1x4x2x8xf32>
   }
 }
+
+// Column 1 read as a flat gather over a linearised freqs_cis instead of a
+// slice. The gathered column is inferred as the complement of the sliced one.
+// CHECK-LABEL: @rope_interleaved_pair_gathered_column
+// CHECK: "ttcore.composite"
+// CHECK-SAME: composite_name = "rotary_embedding"
+module {
+  func.func @rope_interleaved_pair_gathered_column(
+      %x: tensor<1x4x2x8xf32>,
+      %freqs: tensor<1x4x1x4x2x2xf32>,
+      %idx: tensor<1x4x1x4x2xi64>,
+      %zero: tensor<32xi64>,
+      %size: tensor<32xi64>) -> tensor<1x4x2x8xf32> {
+
+    // ---- col 0, sliced ----
+    %f0_slice = "ttir.slice_static"(%freqs) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x1x4x2x2xf32>) -> tensor<1x4x1x4x2x1xf32>
+    %f0_r1 = "ttir.reshape"(%f0_slice) <{shape = [1:i32, 4:i32, 4:i32, 2:i32]}> : (tensor<1x4x1x4x2x1xf32>) -> tensor<1x4x4x2xf32>
+    %f0_r2 = "ttir.reshape"(%f0_r1) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x4x4x2xf32>) -> tensor<1x4x1x4x2xf32>
+    %f0_bc = "ttir.broadcast"(%f0_r2) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    // ---- col 1, gathered ----
+    %flat = "ttir.reshape"(%freqs) <{shape = [64:i32]}> : (tensor<1x4x1x4x2x2xf32>) -> tensor<64xf32>
+    %table = "ttir.reshape"(%flat) <{shape = [64:i32, 1:i32]}> : (tensor<64xf32>) -> tensor<64x1xf32>
+    %idx_flat = "ttir.reshape"(%idx) <{shape = [32:i32]}> : (tensor<1x4x1x4x2xi64>) -> tensor<32xi64>
+    %ge = "ttir.ge"(%idx_flat, %zero) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+    %off = "ttir.add"(%idx_flat, %size) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %sel = "ttir.where"(%ge, %idx_flat, %off) : (tensor<32xi1>, tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %idx_u = "ttir.typecast"(%sel) : (tensor<32xi64>) -> tensor<32xui32>
+    %idx_2d = "ttir.reshape"(%idx_u) <{shape = [1:i32, 32:i32]}> : (tensor<32xui32>) -> tensor<1x32xui32>
+    %emb = "ttir.embedding"(%idx_2d, %table) : (tensor<1x32xui32>, tensor<64x1xf32>) -> tensor<1x32x1xf32>
+    %e_flat = "ttir.reshape"(%emb) <{shape = [32:i32]}> : (tensor<1x32x1xf32>) -> tensor<32xf32>
+    %f1_r1 = "ttir.reshape"(%e_flat) <{shape = [1:i32, 4:i32, 4:i32, 2:i32]}> : (tensor<32xf32>) -> tensor<1x4x4x2xf32>
+    %f1_r2 = "ttir.reshape"(%f1_r1) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x4x4x2xf32>) -> tensor<1x4x1x4x2xf32>
+    %f1_bc = "ttir.broadcast"(%f1_r2) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %x_6d = "ttir.reshape"(%x) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32]}> : (tensor<1x4x2x8xf32>) -> tensor<1x4x2x4x1x2xf32>
+
+    %x0_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x0_r1 = "ttir.reshape"(%x0_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x0_r2 = "ttir.reshape"(%x0_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x0_bc = "ttir.broadcast"(%x0_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %x1_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 1:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x1_r1 = "ttir.reshape"(%x1_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x1_r2 = "ttir.reshape"(%x1_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x1_bc = "ttir.broadcast"(%x1_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %cos_branch = "ttir.multiply"(%f0_bc, %x0_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sin_branch = "ttir.multiply"(%f1_bc, %x1_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sum = "ttir.add"(%cos_branch, %sin_branch) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %result = "ttir.reshape"(%sum) <{shape = [1:i32, 4:i32, 2:i32, 8:i32]}> : (tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x8xf32>
+    return %result : tensor<1x4x2x8xf32>
+  }
+}
+
+// Both columns gathered — neither column is proven, so nothing to infer from.
+// CHECK-LABEL: @rope_interleaved_pair_both_gathered_no_fuse
+// CHECK-NOT: "ttcore.composite"
+// CHECK: "ttir.add"
+module {
+  func.func @rope_interleaved_pair_both_gathered_no_fuse(
+      %x: tensor<1x4x2x8xf32>,
+      %freqs: tensor<1x4x1x4x2x2xf32>,
+      %idx0: tensor<1x4x1x4x2xi64>,
+      %idx1: tensor<1x4x1x4x2xi64>,
+      %zero: tensor<32xi64>,
+      %size: tensor<32xi64>) -> tensor<1x4x2x8xf32> {
+
+    %flat = "ttir.reshape"(%freqs) <{shape = [64:i32]}> : (tensor<1x4x1x4x2x2xf32>) -> tensor<64xf32>
+    %table = "ttir.reshape"(%flat) <{shape = [64:i32, 1:i32]}> : (tensor<64xf32>) -> tensor<64x1xf32>
+
+    %i0_flat = "ttir.reshape"(%idx0) <{shape = [32:i32]}> : (tensor<1x4x1x4x2xi64>) -> tensor<32xi64>
+    %ge0 = "ttir.ge"(%i0_flat, %zero) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+    %off0 = "ttir.add"(%i0_flat, %size) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %sel0 = "ttir.where"(%ge0, %i0_flat, %off0) : (tensor<32xi1>, tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %u0 = "ttir.typecast"(%sel0) : (tensor<32xi64>) -> tensor<32xui32>
+    %u0_2d = "ttir.reshape"(%u0) <{shape = [1:i32, 32:i32]}> : (tensor<32xui32>) -> tensor<1x32xui32>
+    %emb0 = "ttir.embedding"(%u0_2d, %table) : (tensor<1x32xui32>, tensor<64x1xf32>) -> tensor<1x32x1xf32>
+    %e0_r1 = "ttir.reshape"(%emb0) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x32x1xf32>) -> tensor<1x4x1x4x2xf32>
+    %f0_bc = "ttir.broadcast"(%e0_r1) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %i1_flat = "ttir.reshape"(%idx1) <{shape = [32:i32]}> : (tensor<1x4x1x4x2xi64>) -> tensor<32xi64>
+    %ge1 = "ttir.ge"(%i1_flat, %zero) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi1>
+    %off1 = "ttir.add"(%i1_flat, %size) : (tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %sel1 = "ttir.where"(%ge1, %i1_flat, %off1) : (tensor<32xi1>, tensor<32xi64>, tensor<32xi64>) -> tensor<32xi64>
+    %u1 = "ttir.typecast"(%sel1) : (tensor<32xi64>) -> tensor<32xui32>
+    %u1_2d = "ttir.reshape"(%u1) <{shape = [1:i32, 32:i32]}> : (tensor<32xui32>) -> tensor<1x32xui32>
+    %emb1 = "ttir.embedding"(%u1_2d, %table) : (tensor<1x32xui32>, tensor<64x1xf32>) -> tensor<1x32x1xf32>
+    %e1_r1 = "ttir.reshape"(%emb1) <{shape = [1:i32, 4:i32, 1:i32, 4:i32, 2:i32]}> : (tensor<1x32x1xf32>) -> tensor<1x4x1x4x2xf32>
+    %f1_bc = "ttir.broadcast"(%e1_r1) <{broadcast_dimensions = array<i64: 1, 1, 2, 1, 1>}> : (tensor<1x4x1x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %x_6d = "ttir.reshape"(%x) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32]}> : (tensor<1x4x2x8xf32>) -> tensor<1x4x2x4x1x2xf32>
+
+    %x0_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 0:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 1:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x0_r1 = "ttir.reshape"(%x0_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x0_r2 = "ttir.reshape"(%x0_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x0_bc = "ttir.broadcast"(%x0_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %x1_slice = "ttir.slice_static"(%x_6d) <{begins = [0:i32, 0:i32, 0:i32, 0:i32, 0:i32, 1:i32], ends = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32, 2:i32], step = [1:i32, 1:i32, 1:i32, 1:i32, 1:i32, 1:i32]}> : (tensor<1x4x2x4x1x2xf32>) -> tensor<1x4x2x4x1x1xf32>
+    %x1_r1 = "ttir.reshape"(%x1_slice) <{shape = [1:i32, 4:i32, 2:i32, 4:i32]}> : (tensor<1x4x2x4x1x1xf32>) -> tensor<1x4x2x4xf32>
+    %x1_r2 = "ttir.reshape"(%x1_r1) <{shape = [1:i32, 4:i32, 2:i32, 4:i32, 1:i32]}> : (tensor<1x4x2x4xf32>) -> tensor<1x4x2x4x1xf32>
+    %x1_bc = "ttir.broadcast"(%x1_r2) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 2>}> : (tensor<1x4x2x4x1xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %cos_branch = "ttir.multiply"(%f0_bc, %x0_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sin_branch = "ttir.multiply"(%f1_bc, %x1_bc) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+    %sum = "ttir.add"(%cos_branch, %sin_branch) : (tensor<1x4x2x4x2xf32>, tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x4x2xf32>
+
+    %result = "ttir.reshape"(%sum) <{shape = [1:i32, 4:i32, 2:i32, 8:i32]}> : (tensor<1x4x2x4x2xf32>) -> tensor<1x4x2x8xf32>
+    return %result : tensor<1x4x2x8xf32>
+  }
+}


### PR DESCRIPTION
### Ticket

- fixes https://github.com/tenstorrent/tt-xla/issues/5965

### Problem description

`RoPEInterleavedPairFusingPattern` introduced in [#8725](https://github.com/tenstorrent/tt-mlir/pull/8725) misses on HiDream-I1, leaving the `(..., D/2, 1, 2)` reshape in the graph. Its trailing `1` and `2` each pad to a 32x32 tile, so the tensor inflates 512x — 22.9 MB of real data becomes an 11.74 GB allocation that OOMs on a 4-chip run.

The matcher walks back from each multiply expecting a slice on `freqs_cis` to tell it which column that branch uses. Only column 0 obliges; column 1 arrives as a flat gather over a linearised copy of the cache, so `findSliceThroughTMs` finds nothing, `matchBranch` returns `nullopt`, and the whole chain stays unfused. The gather is already present in the earliest dumped module — still VHLO, before any TTIR conversion — so the matcher has to be adjusted to cope with it.

For the complete root cause analysis, see https://github.com/tenstorrent/tt-xla/issues/5965#issuecomment-5341903572

### What's changed

Recognition only — the rewrite is untouched. It already rebuilds cos and sin from `freqs_cis` itself (`[..., 0, 0]` and `[..., 1, 0]`) and never used the second branch's value, so that branch only needs to be *identified*, not consumed.

- `matchFlatGatherFreqs` matches the flat-gather form and returns the `freqs_cis` the gather reads: an `EmbeddingOp` whose table is a linearised view of a tensor holding exactly `2 x` the index count.
- `matchBranch` tries the slice form first and falls back to the gather form, leaving `colIdx` unset there.
- Guard 3 compares the two branches' `freqs_cis` modulo reshape, since the gather reads a linearised view of what the other branch slices. This is also what rejects a gather over an unrelated table, e.g. a token lookup.
- Guard 3b rejects two gathered branches and infers the gathered column as the complement of the sibling, whose column a real slice proved.
- Guard 4b takes `freqsSrc` from the slice branch — only that one carries the `(..., D/2, 2, 2)` shape guard 6 and the rewrite need. Without it the match fails whenever `mul0` happens to be the gathered branch.

**Impact** : The 512x padding overhead is gone in both the sanity test and the model: the `(..., D/2, 1, 2)` tensor and its 11.74 GB allocation no longer appear in either TTNN module. The full pipeline reaches the VAE for the first time with transformer `0.999791` for `num_inference_steps=1`.

### Checklist

- [x] Verify the changes through local testing in QB2

### Logs

- [aug17_hidream_e2e_pcc_test_before_fix.log.zip](https://github.com/user-attachments/files/31229444/aug17_hidream_e2e_pcc_test_rope_OOM.log.zip)
- [aug19_hidream_rope_sanity_before_fix.log](https://github.com/user-attachments/files/31229448/aug19_hidream_rope.log)
- [aug19_hidream_rope_sanity_after_fix.log](https://github.com/user-attachments/files/31232158/aug19_z_hidream_rope_after_fix.log)
- [aug19_hidream_e2e_pcc_test_after_fix.log.zip](https://github.com/user-attachments/files/31233846/aug19_z_hidream_e2e_pcc_test_after_fix_f.log.zip)

