### PR TITLE
Uplift third_party/tt-metal to 5804b6a00497d2a6043bb8925408ed97c851f755 2026-08-18

### DIFF
--- a/env/pip-constraints.txt
+++ b/env/pip-constraints.txt
@@ -1,1 +1,1 @@
-nanobind==2.12.0
+nanobind==2.14.0

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.14.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/runtime/lib/ttnn/operations/reduction/reduction.cpp
+++ b/runtime/lib/ttnn/operations/reduction/reduction.cpp
@@ -10,15 +10,8 @@
 #include "tt/runtime/detail/ttnn/utils.h"
 
 namespace tt::runtime::ttnn::operations::reduction {
-static void runReductionOp(
-    const ::tt::target::ttnn::ReductionOp *op, ProgramTensorPool &tensorPool,
-    const std::function<::ttnn::Tensor(
-        const ::ttnn::Tensor &,
-        const std::optional<
-            std::variant<int, int64_t, ::ttsl::SmallVector<int>>> &,
-        const bool, const std::optional<::ttnn::MemoryConfig> &,
-        const std::optional<::ttnn::DeviceComputeKernelConfig> &, float, bool,
-        const std::optional<::ttnn::CoreRangeSet> &)> &ttnnOp) {
+void run(const ::tt::target::ttnn::ReductionOp *op, ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
 
   std::optional<::ttnn::MemoryConfig> outputMemoryConfig =
       ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
@@ -41,61 +34,30 @@ static void runReductionOp(
         utils::createDeviceComputeKernelConfig(op->compute_config());
   }
 
-  ::ttnn::Tensor out = ttnnOp(
-      in, dimArg, op->keep_dim(), outputMemoryConfig /* memory_config_arg */,
-      computeConfig /* compute_kernel_config */, 1.0f /* scalar */,
-      true /* correction */, std::nullopt /* sub_core_grids */);
-
-  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
-}
-
-void run(const ::tt::target::ttnn::ReductionOp *op, ProgramContext &context) {
-  ProgramTensorPool &tensorPool = context.getTensorPool();
+  ::ttnn::Tensor out;
   switch (op->type()) {
   case ::tt::target::ttnn::ReductionOpType::Sum: {
-    // ttnn::sum gained an extra output_layout arg; wrap so the extra
-    // parameter is not part of the std::function conversion.
-    runReductionOp(
-        op, tensorPool,
-        [](const ::ttnn::Tensor &input,
-           const std::optional<
-               std::variant<int, int64_t, ::ttsl::SmallVector<int>>> &dimArg,
-           const bool keepDim,
-           const std::optional<::ttnn::MemoryConfig> &memoryConfig,
-           const std::optional<::ttnn::DeviceComputeKernelConfig>
-               &computeConfig,
-           float scalar, bool correction,
-           const std::optional<::ttnn::CoreRangeSet> &subCoreGrids) {
-          return ::ttnn::sum(input, dimArg, keepDim, memoryConfig,
-                             computeConfig, scalar, correction, subCoreGrids);
-        });
+    out = ::ttnn::sum(in, dimArg, op->keep_dim(), outputMemoryConfig,
+                      computeConfig);
     break;
   }
   case ::tt::target::ttnn::ReductionOpType::Mean: {
-    runReductionOp(
-        op, tensorPool,
-        [](const ::ttnn::Tensor &input,
-           const std::optional<
-               std::variant<int, int64_t, ::ttsl::SmallVector<int>>> &dimArg,
-           const bool keepDim,
-           const std::optional<::ttnn::MemoryConfig> &memoryConfig,
-           const std::optional<::ttnn::DeviceComputeKernelConfig>
-               &computeConfig,
-           float scalar, bool correction,
-           const std::optional<::ttnn::CoreRangeSet> &subCoreGrids) {
-          return ::ttnn::mean(input, dimArg, keepDim, memoryConfig,
-                              computeConfig, scalar, correction, subCoreGrids);
-        });
+    out = ::ttnn::mean(in, dimArg, op->keep_dim(), outputMemoryConfig,
+                       computeConfig);
     break;
   }
   case ::tt::target::ttnn::ReductionOpType::Max: {
-    runReductionOp(op, tensorPool, ::ttnn::max);
+    out = ::ttnn::max(in, dimArg, op->keep_dim(), outputMemoryConfig,
+                      computeConfig);
     break;
   }
   case ::tt::target::ttnn::ReductionOpType::Min: {
-    runReductionOp(op, tensorPool, ::ttnn::min);
+    out = ::ttnn::min(in, dimArg, op->keep_dim(), outputMemoryConfig,
+                      computeConfig);
     break;
   }
   }
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::reduction

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -777,7 +777,7 @@ void ProgramExecutor::syncAfterOpIfNeeded() {
   static const bool enabled =
       std::getenv("TT_RUNTIME_SYNC_AFTER_OP") != nullptr;
   if (enabled) {
-    ::tt::tt_metal::distributed::Synchronize(&context->getMeshDevice(),
+    ::tt::tt_metal::distributed::Synchronize(context->getMeshDevice(),
                                              std::nullopt);
   }
 }

--- a/runtime/python/CMakeLists.txt
+++ b/runtime/python/CMakeLists.txt
@@ -10,6 +10,12 @@ list(APPEND CMAKE_PREFIX_PATH "${Python3_SITEARCH}" "${Python3_SITELIB}")
 if (NOT TARGET Python::Module AND TARGET Python3::Module)
   add_library(Python::Module ALIAS Python3::Module)
 endif()
+# nanobind 2.14 nanobind-config.cmake requires both Python::Interpreter
+# and Python::Module. find_package(Python3) only creates Python3::*
+# targets, so alias Interpreter like the existing Module alias.
+if (NOT TARGET Python::Interpreter AND TARGET Python3::Interpreter)
+  add_executable(Python::Interpreter ALIAS Python3::Interpreter)
+endif()
 if (NOT DEFINED Python_EXECUTABLE AND DEFINED Python3_EXECUTABLE)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}" CACHE FILEPATH "" FORCE)
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "8a934ae01866a8e76ed58695ddbd34f596d45889")
+set(TT_METAL_VERSION "5804b6a00497d2a6043bb8925408ed97c851f755")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/tools/pykernel/pyproject.toml
+++ b/tools/pykernel/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.12.0", "wheel", "pip", "ninja"]
+requires = ["setuptools>=61.0", "cmake", "pybind11", "nanobind==2.14.0", "wheel", "pip", "ninja"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tools/ttrt/requirements.txt
+++ b/tools/ttrt/requirements.txt
@@ -2,4 +2,4 @@
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl; sys_platform == "linux" and platform_machine == "x86_64"
 torch@https://download.pytorch.org/whl/cpu/torch-2.9.1%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl; sys_platform == "linux" and platform_machine == "aarch64"
 torch==2.9.1; sys_platform == "darwin"
-nanobind==2.12.0
+nanobind==2.14.0


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 5804b6a00497d2a6043bb8925408ed97c851f755



### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml):https://github.com/tenstorrent/tt-forge-onnx/actions/runs/32193302706
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml):https://github.com/tenstorrent/tt-xla/actions/runs/32193319510
- **Follow-up Actions**
  - [ ] **Issues filed** to follow up on incomplete changes (if any):
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):