### PR TITLE
Uplift third_party/tt-metal to d5f9bc4a43b1287523458f1af6a470c6b2adc180 2026-08-20

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=8a934ae01866a8e76ed58695ddbd34f596d45889
+ARG TT_METAL_DEPENDENCIES_COMMIT=d5f9bc4a43b1287523458f1af6a470c6b2adc180
 
 # Install dependencies
 RUN <<EOT

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -55,6 +55,10 @@ namespace mlir::tt::ttnn::op_model {
 
 using MockAllocatorState = ::tt::tt_metal::experimental::MockAllocatorState;
 
+// Returns true when op-model queries are using the internally managed mock
+// device. Returns false when op-model support is disabled.
+bool isMockDevice();
+
 // Build a MockAllocatorState representing the given live allocations, for the
 // stateful (build-from-records) constraint query. Confines all tt-metalium
 // interaction (extract + with_allocations + record conversion) to the op-model

--- a/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
+++ b/lib/Dialect/TTNN/Validation/OpConstraintValidation.cpp
@@ -153,8 +153,25 @@ checkConstraintsResult(Operation *contextOp,
           // (https://github.com/tenstorrent/tt-mlir/issues/9045). A genuine
           // backend constraint (unsupported config, etc.) carries neither
           // marker and still routes to metalBackendError.
-          if (errorMsg.find("Out of Memory") != std::string::npos ||
-              errorMsg.find("clash with L1 buffers") != std::string::npos) {
+          // Metal 2.0 program validation currently looks up a WORKER dispatch
+          // grid for mock devices even when placement used the mock device's
+          // ETH dispatch grid. Treat only that precise mock-only validation
+          // failure as unsupported until the grids use the same dispatch
+          // configuration. See
+          // https://github.com/tenstorrent/tt-mlir/issues/9235.
+          const bool mockProgramSpecGridMismatch =
+              op_model::isMockDevice() &&
+              errorMsg.find("WorkUnitSpec '") != std::string::npos &&
+              errorMsg.find("targets node (") != std::string::npos &&
+              errorMsg.find("which is out of bounds") != std::string::npos &&
+              errorMsg.find("The compute worker grid on this device is ") !=
+                  std::string::npos;
+          if (mockProgramSpecGridMismatch) {
+            result = ValidationResult::notImplemented(
+                ttmlir::utils::firstNLines(errorMsg, 8));
+          } else if (errorMsg.find("Out of Memory") != std::string::npos ||
+                     errorMsg.find("clash with L1 buffers") !=
+                         std::string::npos) {
             result = ValidationResult::outOfMemoryError(
                 ttmlir::utils::firstNLines(errorMsg, 8));
           } else {

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -38,6 +38,14 @@
 
 namespace mlir::tt::ttnn::op_model {
 
+bool isMockDevice() {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  return SingletonDeviceContext::getInstance().isMockDevice();
+#else
+  return false;
+#endif
+}
+
 #ifdef TTMLIR_ENABLE_OPMODEL
 
 // Macros to wrap overloaded functions for use with

--- a/test/python/golden/d2m/test_tms.py
+++ b/test/python/golden/d2m/test_tms.py
@@ -52,9 +52,6 @@ NOC_ISSUE_SKIP = pytest.mark.skip(
         pytest.param(
             (32, 128 * 500),
             [1, 0],
-            marks=pytest.mark.xfail_config(
-                ["n150", "sim"], reason="ttsim WH grid is 9×8", strict=True
-            ),
         ),
         pytest.param(
             (32, 128 * 501),

--- a/test/unittests/Validation/TestOpConstraintValidation.cpp
+++ b/test/unittests/Validation/TestOpConstraintValidation.cpp
@@ -506,6 +506,34 @@ TEST_F(OpConstraintValidationTest, GenericBackendErrorStaysBackendError) {
   EXPECT_TRUE(result.isError());
 }
 
+// Regression test for https://github.com/tenstorrent/tt-mlir/issues/9235:
+// Metal 2.0 validates mock ProgramSpec nodes against a WORKER dispatch grid
+// even when the program factory placed them using the mock device's ETH grid.
+// Until tt-metal uses a consistent grid, this mock-only infrastructure failure
+// must not reject otherwise valid operation configurations.
+TEST_F(OpConstraintValidationTest,
+       MockProgramSpecGridMismatchClassifiedAsNotImplemented) {
+  auto addOp = createMockAddOp();
+
+  llvm::Expected<op_model::OpConstraints> gridMismatchError =
+      llvm::make_error<llvm::StringError>(
+          "Op constraint query failed with error: TT_FATAL @ "
+          "program_spec.cpp:665: node.x < compute_grid.x && "
+          "node.y < compute_grid.y\n"
+          "info:\n"
+          "WorkUnitSpec 'typecast_group_1' targets node (0,7), which is out "
+          "of bounds. The compute worker grid on this device is 8x7.",
+          llvm::inconvertibleErrorCode());
+
+  auto result = op_constraint_validation::checkConstraintsResult(
+      addOp.getOperation(), std::move(gridMismatchError));
+
+  EXPECT_EQ(result.status,
+            op_constraint_validation::ValidationStatus::NotImplemented);
+  EXPECT_TRUE(result.isNotImplemented());
+  EXPECT_TRUE(result.isError());
+}
+
 // Test ValidationStatus::UnmatchedReferenceConfig
 // Use validateWithMultipleAttributes with non-matching reference configs
 TEST_F(OpConstraintValidationTest, ValidationStatusUnmatchedReferenceConfig) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "5804b6a00497d2a6043bb8925408ed97c851f755")
+set(TT_METAL_VERSION "d5f9bc4a43b1287523458f1af6a470c6b2adc180")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/tools/builder/base/builder_apis.py
+++ b/tools/builder/base/builder_apis.py
@@ -1272,8 +1272,21 @@ def compile_ttir_module_to_flatbuffer(
         If an unsupported target is specified
     """
 
-    if pipeline_options is None:
-        pipeline_options = []
+    pipeline_options = list(pipeline_options or [])
+    if (
+        target == "ttmetal"
+        and os.environ.get("TT_METAL_SIMULATOR")
+        and os.environ.get("ARCH_NAME") == "wormhole_b0"
+        and custom_pipeline is None
+        and not any(
+            option.startswith("override-device-shape=") for option in pipeline_options
+        )
+    ):
+        # Wormhole TTSim currently reports a 10x8 grid. Keep D2M compilation on
+        # the usable 9x8 grid until the simulator system descriptor reports it
+        # correctly.
+        # tracking issue: https://github.com/tenstorrent/tt-mlir/issues/9241
+        pipeline_options.append("override-device-shape=9,8")
 
     if type(custom_pipeline) is str:
         custom_pipeline = create_custom_ttir_pipeline_fn(


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d5f9bc4a43b1287523458f1af6a470c6b2adc180

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/32392219483
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/32392219035
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): https://github.com/tenstorrent/tt-mlir/issues/9241
  - [x] **Frontend fix PRs** ready (if needed by this uplift): 
 `FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape1--1-True]`
`FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape3--1-False]`
`FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape13-dim13-False]`
`FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape33-dim33-False]`
`FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape69-dim69-False]`
`FAILED forge/test/mlir/operators/reduce/test_reduce.py::test_reduce_max[input_shape70-dim70-True]`
On forge onnx those tests were marked with xfail, but now pass.