### PR TITLE
[EmitC] Format float literals via APFloat::toString instead of std::to_string

### DIFF
--- a/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
+++ b/include/ttmlir/Conversion/TTNNToEmitC/EmitCConversion.h
@@ -16,13 +16,14 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/STLForwardCompat.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <array>
-#include <cmath>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -482,32 +483,53 @@ struct EmitCTypeConverter<T,
     return convert(attr.getValue());
   }
 
+  // Formats a finite value as a C++ floating point literal.
+  //
+  // Not `std::to_string`: that formats with `%f`, i.e. six digits after the
+  // decimal point, so anything smaller than 5e-7 comes out as `0.000000` - an
+  // `epsilon` of `1e-8` being the usual casualty. `APFloat::toString` instead
+  // prints enough significant digits to recover the value, switching to
+  // scientific notation when that is shorter.
   static std::string convert(mlir::APFloat value) {
-    return convert(value.convertToDouble());
+    // Round to the target type first, so the digits printed are the ones that
+    // survive the literal's own type rather than the source attribute's.
+    llvm::APFloat rounded = value;
+    bool losesInfo = false;
+    rounded.convert(std::is_same_v<T, float> ? llvm::APFloat::IEEEsingle()
+                                             : llvm::APFloat::IEEEdouble(),
+                    llvm::APFloat::rmNearestTiesToEven, &losesInfo);
+
+    // Check the non-finite classes on the *rounded* value: a finite f64 above
+    // FLT_MAX overflows to infinity when rounded to float, and letting it
+    // reach `toString` would emit `+Inf.0f`, which is not a C++ literal.
+    if (rounded.isInfinity()) {
+      std::string result = rounded.isNegative() ? "-" : "";
+      result.append("::std::numeric_limits<" + TypeNameV<T> + ">::infinity()");
+      return result;
+    }
+
+    if (rounded.isNaN()) {
+      return "::std::numeric_limits<" + TypeNameV<T> + ">::quiet_NaN()";
+    }
+
+    llvm::SmallString<32> literal;
+    rounded.toString(literal);
+    // A whole number prints without a decimal point or exponent, and `1f` is
+    // not a floating point literal in C++ (nor is a bare `1` a double one).
+    if (literal.find('.') == llvm::StringRef::npos &&
+        literal.find('E') == llvm::StringRef::npos) {
+      literal.append(".0");
+    }
+    if constexpr (std::is_same_v<T, float>) {
+      literal.push_back('f');
+    }
+    return literal.str().str();
   }
 
   template <typename U>
   static std::enable_if_t<std::is_floating_point_v<U>, std::string>
   convert(U value) {
-    if (std::isfinite(value)) {
-      std::string result = std::to_string(static_cast<T>(value));
-      if constexpr (std::is_same_v<T, float>) {
-        result.append("f");
-      }
-      return result;
-    }
-
-    if (std::isinf(value)) {
-      std::string result = value > 0 ? "" : "-";
-      result.append("::std::numeric_limits<" + TypeNameV<T> + ">::infinity()");
-      return result;
-    }
-
-    if (std::isnan(value)) {
-      return "::std::numeric_limits<" + TypeNameV<T> + ">::quiet_NaN()";
-    }
-
-    llvm_unreachable("Unknown class of floating point value");
+    return convert(llvm::APFloat(static_cast<double>(value)));
   }
 };
 

--- a/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
+++ b/test/unittests/TTNNToEmitC/TestEmitCConversion.cpp
@@ -127,44 +127,77 @@ TEST_F(EmitCConversionTest, IntegralExpectedFailure) {
 TEST_F(EmitCConversionTest, ConvertF32FloatAttr) {
   mlir::FloatAttr floatAttr = builder.getF32FloatAttr(42.0);
   std::string converted = EmitCTypeConverter<float>::convert(floatAttr);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 
   mlir::Attribute floatAsAttribute = floatAttr;
   std::optional<std::string> maybeConverted =
       EmitCTypeConverter<float>::convert(floatAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted, "42.000000f");
+  EXPECT_EQ(*maybeConverted, "42.0f");
 }
 
 TEST_F(EmitCConversionTest, ConvertF64FloatAttr) {
   mlir::FloatAttr floatAttr = builder.getF64FloatAttr(42.0);
   std::string converted = EmitCTypeConverter<double>::convert(floatAttr);
-  EXPECT_EQ(converted, "42.000000");
+  EXPECT_EQ(converted, "42.0");
 
   mlir::Attribute floatAsAttribute = floatAttr;
   std::optional<std::string> maybeConverted =
       EmitCTypeConverter<double>::convert(floatAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted, "42.000000");
+  EXPECT_EQ(*maybeConverted, "42.0");
 }
 
 TEST_F(EmitCConversionTest, ConvertAPFloat) {
   mlir::APFloat apFloat32(42.0);
   std::string converted = EmitCTypeConverter<float>::convert(apFloat32);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 
   mlir::APFloat apFloat64(42.0);
   converted = EmitCTypeConverter<double>::convert(apFloat64);
-  EXPECT_EQ(converted, "42.000000");
+  EXPECT_EQ(converted, "42.0");
+}
+
+// Regression test for #9198: small magnitudes used to be formatted with `%f`,
+// six digits after the decimal point, so anything under 5e-7 was emitted as
+// `0.000000f` - an AdamW `epsilon` of 1e-8 silently became zero.
+TEST_F(EmitCConversionTest, ConvertSmallMagnitudeFloatAttr) {
+  mlir::FloatAttr epsilon = builder.getF32FloatAttr(1e-8);
+  EXPECT_EQ(EmitCTypeConverter<float>::convert(epsilon), "9.99999993E-9f");
+
+  mlir::FloatAttr tiny = builder.getF64FloatAttr(1e-300);
+  EXPECT_EQ(EmitCTypeConverter<double>::convert(tiny), "1.0E-300");
+}
+
+// Values that need every digit they can get to survive a round trip, and one
+// whose f32 form is exact so it prints short.
+TEST_F(EmitCConversionTest, ConvertFloatAttrPrecision) {
+  mlir::FloatAttr beta1 = builder.getF32FloatAttr(0.9);
+  EXPECT_EQ(EmitCTypeConverter<float>::convert(beta1), "0.899999976f");
+
+  mlir::FloatAttr half = builder.getF32FloatAttr(0.5);
+  EXPECT_EQ(EmitCTypeConverter<float>::convert(half), "0.5f");
+}
+
+// A finite f64 value that overflows float when rounded to the literal's own
+// type must still come out as an infinity() expression, not `+Inf.0f`.
+TEST_F(EmitCConversionTest, ConvertOverflowingF64ToFloatLiteral) {
+  mlir::FloatAttr huge = builder.getF64FloatAttr(1e300);
+  EXPECT_EQ(EmitCTypeConverter<float>::convert(huge),
+            "::std::numeric_limits<float>::infinity()");
+
+  mlir::FloatAttr negHuge = builder.getF64FloatAttr(-1e300);
+  EXPECT_EQ(EmitCTypeConverter<float>::convert(negHuge),
+            "-::std::numeric_limits<float>::infinity()");
 }
 
 TEST_F(EmitCConversionTest, ConvertCFPType) {
   float f32Val = 42.0;
   std::string converted = EmitCTypeConverter<float>::convert(f32Val);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 
   converted = EmitCTypeConverter<double>::convert(f32Val);
-  EXPECT_EQ(converted, "42.000000");
+  EXPECT_EQ(converted, "42.0");
 }
 
 TEST_F(EmitCConversionTest, ConvertCFPTypeNonFiniteValues) {
@@ -240,14 +273,13 @@ TEST_F(EmitCConversionTest, ConvertDenseF32ArrayAttrToStdVector) {
       builder.getDenseF32ArrayAttr({1.0, 2.0, 3.0});
   std::string converted =
       EmitCTypeConverter<std::vector<float>>::convert(denseArrayAttr);
-  EXPECT_EQ(converted, "::std::vector<float>{1.000000f, 2.000000f, 3.000000f}");
+  EXPECT_EQ(converted, "::std::vector<float>{1.0f, 2.0f, 3.0f}");
 
   mlir::Attribute denseArrayAsAttribute = denseArrayAttr;
   std::optional<std::string> maybeConverted =
       EmitCTypeConverter<std::vector<float>>::convert(denseArrayAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted,
-            "::std::vector<float>{1.000000f, 2.000000f, 3.000000f}");
+  EXPECT_EQ(*maybeConverted, "::std::vector<float>{1.0f, 2.0f, 3.0f}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseIntElementsAttrToStdVector) {
@@ -304,8 +336,7 @@ TEST_F(EmitCConversionTest, ConvertDenseF32ArrayAttrToTtnnSmallVector) {
       builder.getDenseF32ArrayAttr({1.0, 2.0, 3.0});
   std::string converted =
       EmitCTypeConverter<::ttsl::SmallVector<float>>::convert(denseArrayAttr);
-  EXPECT_EQ(converted,
-            "::ttsl::SmallVector<float>{1.000000f, 2.000000f, 3.000000f}");
+  EXPECT_EQ(converted, "::ttsl::SmallVector<float>{1.0f, 2.0f, 3.0f}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseIntElementsAttrToTtnnSmallVector) {
@@ -373,15 +404,13 @@ TEST_F(EmitCConversionTest, ConvertDenseF32ArrayAttrToStdArray) {
   std::optional<std::string> converted =
       EmitCTypeConverter<std::array<float, 3>>::convert(denseArrayAttr);
   ASSERT_TRUE(converted);
-  EXPECT_EQ(*converted,
-            "::std::array<float, 3>{1.000000f, 2.000000f, 3.000000f}");
+  EXPECT_EQ(*converted, "::std::array<float, 3>{1.0f, 2.0f, 3.0f}");
 
   mlir::Attribute denseArrayAsAttribute = denseArrayAttr;
   std::optional<std::string> maybeConverted =
       EmitCTypeConverter<std::array<float, 3>>::convert(denseArrayAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted,
-            "::std::array<float, 3>{1.000000f, 2.000000f, 3.000000f}");
+  EXPECT_EQ(*maybeConverted, "::std::array<float, 3>{1.0f, 2.0f, 3.0f}");
 }
 
 TEST_F(EmitCConversionTest, ConvertDenseIntElementsAttrToStdArray) {
@@ -410,7 +439,7 @@ TEST_F(EmitCConversionTest, ConvertStdVariantPrimitiveTypes) {
 
   mlir::FloatAttr floatAttr = builder.getF32FloatAttr(42.0);
   converted = EmitCTypeConverter<TargetTy>::convert(floatAttr);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 
   mlir::Attribute int32AsAttribute = int32Attr;
   std::optional<std::string> maybeConverted =
@@ -421,7 +450,7 @@ TEST_F(EmitCConversionTest, ConvertStdVariantPrimitiveTypes) {
   mlir::Attribute floatAsAttribute = floatAttr;
   maybeConverted = EmitCTypeConverter<TargetTy>::convert(floatAsAttribute);
   ASSERT_TRUE(maybeConverted);
-  EXPECT_EQ(*maybeConverted, "42.000000f");
+  EXPECT_EQ(*maybeConverted, "42.0f");
 }
 
 TEST_F(EmitCConversionTest, ConvertStdVariantCompoundTypes) {
@@ -437,7 +466,7 @@ TEST_F(EmitCConversionTest, ConvertStdVariantCompoundTypes) {
 
   mlir::FloatAttr floatAttr = builder.getF32FloatAttr(42.0);
   converted = EmitCTypeConverter<TargetTy>::convert(floatAttr);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 }
 
 TEST_F(EmitCConversionTest, ConvertStdVariantMultiLevelCompoundTypes) {
@@ -462,7 +491,7 @@ TEST_F(EmitCConversionTest, ConvertStdVariantMultiLevelCompoundTypes) {
 
   mlir::FloatAttr floatAttr = builder.getF32FloatAttr(42.0);
   converted = EmitCTypeConverter<TargetTy>::convert(floatAttr);
-  EXPECT_EQ(converted, "42.000000f");
+  EXPECT_EQ(converted, "42.0f");
 
   mlir::IntegerAttr int32Attr = builder.getI32IntegerAttr(42);
   converted = EmitCTypeConverter<TargetTy>::convert(int32Attr);


### PR DESCRIPTION
### Ticket

Fixes #9198.

### Problem description

`EmitCTypeConverter<float/double>::convert` formatted float attributes with `std::to_string`, which uses `%f` — six fixed digits after the decimal point. Two consequences in the generated C++:

- Anything below 5e-7 was emitted as `0.000000f`. An `epsilon` of `1e-8` silently became zero, so e.g. `rsqrt(var + 0.0f)` produces `inf` on zero-variance rows. Eight TTNN ops emit an epsilon through this path, and every `F32Attr`/`F64Attr` (31 across the dialect) plus every float inside dense-array args goes through it.
- Ordinary values were truncated: `0.899999976f` (the f32-exact 0.9) came out as `0.900000`, re-parsing to a different float than the attribute held — bit-wise divergence between the EmitC path and the flatbuffer path for the same graph.

Only generated C++ (ttnn-standalone, tt-alchemist output) was affected; the flatbuffer/runtime path serializes floats in binary.

### What's changed

- Format finite values with `APFloat::toString`, which prints enough significant digits to round-trip the value and switches to scientific notation when shorter. Append `.0` when the result has no decimal point or exponent, so the literal stays a floating-point literal.
- Round to the literal's own type (`float` or `double`) before classification and printing, so a finite f64 above `FLT_MAX` is emitted as `::std::numeric_limits<float>::infinity()` rather than the invalid `+Inf.0f`, and the digits printed are the ones that survive the literal's type.
- Unit tests: small magnitudes (`1e-8` → `9.99999993E-9f`, `1e-300`), round-trip precision (`0.9` → `0.899999976f`, `0.5` → `0.5f`), f64→float overflow to ±infinity, and updated expectations for the new short forms (`42.0f` instead of `42.000000f`).

Split out of #9203, where the truncated `epsilon = 1e-8` surfaced the bug.

### Checklist

- [x] New/Existing tests provide coverage for changes: `TTNNToEmitCTests` (40 tests) pass, including 3 new regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)