### PR TITLE
[ttnn-pipeline] fix option value resolving

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -553,8 +553,7 @@ struct TTIRToTTNNCommonPipelineOptions
                                   "enable-create-d2m-subgraphs to be enabled.");
     }
 
-    if (enableCreateD2MSubgraphs &&
-        enableD2MElementwiseFusion.getNumOccurrences() == 0) {
+    if (enableCreateD2MSubgraphs && !enableD2MElementwiseFusion.hasValue()) {
       enableD2MElementwiseFusion = true;
     }
   }
@@ -568,23 +567,21 @@ struct TTIRToTTNNCommonPipelineOptions
           ". Must be 0, 1, or 2.");
     }
 
-    // Only apply optimization_level if user didn't explicitly set the option.
-    // Use getNumOccurrences() to detect explicit user settings.
-    if (optimizerPassEnabled.getNumOccurrences() == 0) {
+    // Only apply optimization_level to options not explicitly set (via CLI or
+    // direct assignment).
+    if (!optimizerPassEnabled.hasValue()) {
       optimizerPassEnabled = (optimizationLevel >= 1);
     }
-    if (enableFusingConv2dWithMultiplyPattern.getNumOccurrences() == 0) {
+    if (!enableFusingConv2dWithMultiplyPattern.hasValue()) {
       enableFusingConv2dWithMultiplyPattern = (optimizationLevel >= 1);
     }
-    if (memoryLayoutAnalysisEnabled.getNumOccurrences() == 0) {
+    if (!memoryLayoutAnalysisEnabled.hasValue()) {
       memoryLayoutAnalysisEnabled = (optimizationLevel >= 2);
     }
-    if (computeCfgMathFidelity.getNumOccurrences() == 0 &&
-        optimizationLevel > 0) {
+    if (!computeCfgMathFidelity.hasValue() && optimizationLevel > 0) {
       computeCfgMathFidelity = OptionalMathFidelity::Undefined;
     }
-    if (computeCfgFp32DestAccEn.getNumOccurrences() == 0 &&
-        optimizationLevel > 0) {
+    if (!computeCfgFp32DestAccEn.hasValue() && optimizationLevel > 0) {
       computeCfgFp32DestAccEn = std::optional<bool>(std::nullopt);
     }
   }

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_unittest(OptimizerTests
     TestLegalTensorLayoutAnalysis.cpp
     TestConv2dConfigGenerator.cpp
     TestConv3dConfigHeuristic.cpp
+    TestPipelineOptionResolution.cpp
     PARTIAL_SOURCES_INTENDED
 )
 
@@ -13,6 +14,7 @@ target_link_libraries(OptimizerTests
     MLIRTTTransforms
     MLIRTTNNAnalysis
     MLIRTTNNValidation
+    MLIRTTNNPipelines
 )
 
 if (TTMLIR_ENABLE_OPMODEL)

--- a/test/unittests/Optimizer/TestPipelineOptionResolution.cpp
+++ b/test/unittests/Optimizer/TestPipelineOptionResolution.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
+
+#include "gtest/gtest.h"
+
+#include <optional>
+
+using namespace mlir::tt::ttnn;
+
+// Options explicitly set by the user must be preserved.
+TEST(TTNNPipelineOptionResolution, OptionAlreadySetNoOverrideDirectAssignment) {
+  TTIRToTTNNCommonPipelineOptions options;
+
+  options.optimizationLevel = 2;
+  options.optimizerPassEnabled = false;
+  options.enableFusingConv2dWithMultiplyPattern = false;
+  options.memoryLayoutAnalysisEnabled = false;
+  options.computeCfgMathFidelity = OptionalMathFidelity::HiFi2;
+  options.computeCfgFp32DestAccEn = std::optional<bool>(false);
+  options.enableCreateD2MSubgraphs = true;
+  options.enableD2MElementwiseFusion = false;
+
+  options.resolveOptimizationLevelOptions();
+  options.resolveCreateD2MSubgraphsOptions();
+
+  EXPECT_FALSE(options.optimizerPassEnabled);
+  EXPECT_FALSE(options.enableFusingConv2dWithMultiplyPattern);
+  EXPECT_FALSE(options.memoryLayoutAnalysisEnabled);
+  EXPECT_EQ(options.computeCfgMathFidelity.getValue(),
+            OptionalMathFidelity::HiFi2);
+  EXPECT_EQ(options.computeCfgFp32DestAccEn.getValue(),
+            std::optional<bool>(false));
+  EXPECT_FALSE(options.enableD2MElementwiseFusion);
+}
+
+// Options explicitly set by the user must be preserved.
+TEST(TTNNPipelineOptionResolution, OptionAlreadySetNoOverrideCliParse) {
+  TTIRToTTNNCommonPipelineOptions options;
+
+  ASSERT_TRUE(mlir::succeeded(options.parseFromString(
+      "optimization-level=2 enable-optimizer=false "
+      "enable-fusing-conv2d-with-multiply-pattern=false "
+      "memory-layout-analysis-enabled=false "
+      "compute-cfg-math-fidelity=hifi2 compute-cfg-fp32-dest-acc-en=false "
+      "enable-create-d2m-subgraphs=true "
+      "enable-d2m-elementwise-fusion=false")));
+
+  options.resolveOptimizationLevelOptions();
+  options.resolveCreateD2MSubgraphsOptions();
+
+  EXPECT_FALSE(options.optimizerPassEnabled);
+  EXPECT_FALSE(options.enableFusingConv2dWithMultiplyPattern);
+  EXPECT_FALSE(options.memoryLayoutAnalysisEnabled);
+  EXPECT_EQ(options.computeCfgMathFidelity.getValue(),
+            OptionalMathFidelity::HiFi2);
+  EXPECT_EQ(options.computeCfgFp32DestAccEn.getValue(),
+            std::optional<bool>(false));
+  EXPECT_FALSE(options.enableD2MElementwiseFusion);
+}


### PR DESCRIPTION
This fixes methods which derive and set options which were not set by the user.

Previously, we used `getNumOccurrences()` to figure out whether the user had set an option or not. This is wrong, because it only takes care of the options which were set via string parsing, i.e. CLI argument parsing.

Use `hasValue()` instead which works whether the user used strings or assigned the individual fields directly.