### PR TITLE
Uplift third_party/tt-metal to 58342a6f63d822599484977d61dcd8f3993350f0 2026-08-26

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=d5f9bc4a43b1287523458f1af6a470c6b2adc180
+ARG TT_METAL_DEPENDENCIES_COMMIT=b64aae9d5259238afb6072df3f80ee0fd53be70e
 
 # Install dependencies
 RUN <<EOT

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=b64aae9d5259238afb6072df3f80ee0fd53be70e
+ARG TT_METAL_DEPENDENCIES_COMMIT=58342a6f63d822599484977d61dcd8f3993350f0
 
 # Install dependencies
 RUN <<EOT

--- a/.github/workflows/call-test-ttsim.yml
+++ b/.github/workflows/call-test-ttsim.yml
@@ -16,7 +16,7 @@ on:
         description: "TTSim release tag"
         required: false
         type: string
-        default: "v1.9.6"
+        default: "v1.10.2"
       timeout:
         description: "Timeout in minutes for the TTSim test job"
         required: false

--- a/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
+++ b/lib/Conversion/D2MToTTKernel/D2MToTTKernel.cpp
@@ -1520,9 +1520,7 @@ public:
           auto scalarParam = scalarToI32Bits(rewriter, loc, adaptor.getRhs());
           rewriter.create<ttkernel::DivUnaryTileOp>(loc, dstIdx, scalarParam);
         } else if constexpr (std::is_same_v<ConcreteOp, d2m::TilePowOp>) {
-          // For power, convert float value to integer (not bitcast)
-          auto scalarParam = rewriter.create<arith::FPToSIOp>(
-              loc, rewriter.getI32Type(), adaptor.getRhs());
+          auto scalarParam = scalarToI32Bits(rewriter, loc, adaptor.getRhs());
           rewriter.create<ttkernel::PowUnaryTileOp>(loc, dstIdx, scalarParam);
         }
         // Scalar ops operate in-place on DST slot - replace with the same

--- a/runtime/lib/ttmetal/executor.cpp
+++ b/runtime/lib/ttmetal/executor.cpp
@@ -325,7 +325,7 @@ void MCQExecutor::execute(
              "Global semaphore with id ", command->ref()->global_id(),
              " already exists.");
   auto global_semaphore = tt::tt_metal::experimental::CreateGlobalSemaphore(
-      meshDevice, common::toCoreRangeSet(command->core_range_set()),
+      *meshDevice, common::toCoreRangeSet(command->core_range_set()),
       command->initial_value(), tt_metal::BufferType::L1,
       deviceAddressValidator(command->ref()->address(),
                              target::BufferType::L1));

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -24,7 +24,7 @@ from lit.llvm.subst import FindTool
 # name: The name of this test suite.
 config.name = "TTMLIR"
 
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest()
 
 # Stablehlo tests can be optionally enabled.
 if config.enable_stablehlo:

--- a/test/ttmlir/Dialect/TTNN/Transforms/ttnn_adjust_deallocs.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/ttnn_adjust_deallocs.mlir
@@ -1,7 +1,7 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" -o %t %s
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="system-desc-path=%system_desc_path%" --ttnn-adjust-deallocs -o %t2 %s
-// RUN: [ "$(cat %t | grep -c ttnn.deallocate)" -eq 5 ]
-// RUN: [ "$(cat %t2 | grep -c ttnn.deallocate)" -eq 3 ]
+// RUN: grep -c ttnn.deallocate %t | grep -x 5
+// RUN: grep -c ttnn.deallocate %t2 | grep -x 3
 //
 // Test for --ttnn-adjust-deallocs pass.
 // The test runs the --ttir-to-ttnn-backend-pipeline twice, and follows up with --ttnn-adjust-deallocs for the second run.

--- a/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/ttml_sdpa_validation.mlir
@@ -119,10 +119,13 @@ module {
       %key: tensor<1x8x128x64xbf16>,
       %value: tensor<1x8x128x64xbf16>)
       -> tensor<1x8x128x64xbf16> {
+    // The query reaches sdpa_fw through a single reshard: the multiply runs in
+    // its own layout and one to_memory_config converts straight to the
+    // interleaved layout sdpa_fw requires. This used to take two chained
+    // to_memory_config ops; the intermediate hop is now folded away.
     // CHECK-LABEL: func.func @sdpa_fw_query_from_l1_producer
     // CHECK: %[[MUL:.*]] = "ttnn.multiply"
-    // CHECK: %[[INTERLEAVED:.*]] = "ttnn.to_memory_config"(%[[MUL]])
-    // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[INTERLEAVED]])
+    // CHECK: %[[RESHARD:.*]] = "ttnn.to_memory_config"(%[[MUL]])
     // CHECK: "ttnn.sdpa_fw"(%[[RESHARD]],
     %query = "ttir.multiply"(%q0, %q1)
         : (tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>)

--- a/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
+++ b/test/unittests/Optimizer/TestL1SpillManagementMockAllocator.cpp
@@ -398,8 +398,34 @@ TEST_F(MockAllocatorViewTripwireTest, PadViewReportsL1Address0) {
 
   EXPECT_TRUE(mlir::tt::ttnn::canPadBeView(pad));
   EXPECT_TRUE(mlir::tt::ttnn::isAliasingViewOp(pad));
-  EXPECT_TRUE(queryReportsL1Address0(pad, inLayout, outLayout))
-      << "TILE-view ttnn.pad must report an L1 output at address 0";
+
+  // XFAIL (strict), https://github.com/tenstorrent/tt-metal/issues/54475.
+  //
+  // The address contract below cannot be evaluated on the mock right now: this
+  // pad places onto node (0,7), legal under the mock's ETH-dispatch 8x8 grid,
+  // but Metal 2.0's ValidateNodeBounds bounds-checks against a
+  // default-constructed DispatchCoreConfig (WORKER, 8x7) and rejects it. The
+  // OpConstraintValidation workaround for
+  // https://github.com/tenstorrent/tt-mlir/issues/9235 turns that abort into a
+  // notImplemented result, so the query never reports an address. The contract
+  // is unevaluated, NOT violated -- isAliasingViewOp is not known to be stale.
+  //
+  // Asserted strictly so a metal-side fix breaks this and forces cleanup:
+  // when it does, drop this block, restore the EXPECT_TRUE below, and remove
+  // the mockProgramSpecGridMismatch workaround.
+  auto result = mlir::tt::ttnn::op_constraint_validation::validateOperation(
+      pad, /*inputLayouts=*/{inLayout}, mlir::tt::ttnn::OpConfig(outLayout),
+      /*liveRecords=*/
+      llvm::ArrayRef<mlir::tt::ttnn::op_model::OpModelAllocationRecord>{},
+      /*additionalL1Usage=*/0);
+  EXPECT_TRUE(result.isNotImplemented())
+      << "expected the mock dispatch-core-config grid mismatch "
+         "(tt-metal#54475); if the query now resolves, this XFAIL and the "
+         "OpConstraintValidation workaround should both be removed";
+
+  // Re-enable once tt-metal#54475 is fixed:
+  // EXPECT_TRUE(queryReportsL1Address0(pad, inLayout, outLayout))
+  //     << "TILE-view ttnn.pad must report an L1 output at address 0";
 }
 
 // Repeat: an all-ones repetition is a strict no-op (repeat.cpp:196).

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "d5f9bc4a43b1287523458f1af6a470c6b2adc180")
+set(TT_METAL_VERSION "b64aae9d5259238afb6072df3f80ee0fd53be70e")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "b64aae9d5259238afb6072df3f80ee0fd53be70e")
+set(TT_METAL_VERSION "58342a6f63d822599484977d61dcd8f3993350f0")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the 58342a6f63d822599484977d61dcd8f3993350f0

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/33109162052
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/33109159210
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): #9260, #9259, https://github.com/tenstorrent/tt-metal/issues/54639, https://github.com/tenstorrent/tt-metal/issues/54475, https://github.com/tenstorrent/tt-xla/issues/6015
  - [ ] **Frontend fix PRs** ready (if needed by this uplift): tt-xla skip prepared on `akhan/skip-mnist-sigfpe-54639`, offered in tt-xla#6015. Left unmerged, both tests still pass on tt-xla main.

Two test changes were needed to get MLIR CI green. `cd17ec2947` strict-xfails `MockAllocatorViewTripwireTest.PadViewReportsL1Address0`: the #9235 mock grid mismatch makes the query return `notImplemented`, so the address contract is unevaluated rather than violated. tt-metal#54475. `4f483740c1` updates a CHECK in `ttml_sdpa_validation.mlir`, the optimizer now emits one `to_memory_config` before `sdpa_fw` instead of two.

tt-xla, MNIST CNN crashes with SIGFPE on n150, p150 and n300. Divide by zero in ttnn `create_simple_matmul_program_config`, `per_core_M` is 0 for fc1 (`4x9216 @ 9216x128`). tt-metal#54639 has a `ttmlir-opt` repro, tracked in #9260.

tt-xla `test_batch_norm_decomposition_conv2d` is not from this uplift, it fails on main too. Bisected to #9242, filed as #9259. The main baseline run is https://github.com/tenstorrent/tt-xla/actions/runs/33092555340, green on the
SIGFPE jobs and red only on fusion.

On forge onnx, 10 of the 16 failures are tests this uplift fixes:
`test_reduce_sum` x12, `test_reduce_mean` x6 and `test_divide[shape1]` were marked xfail, but now pass. Patch on `akhan/drop-stale-xfails-mlir-uplift`. The other 6 are the same `test_reduce_max` failures as the previous baselines. The `pr_models_regression` failure is infra, submodule checkout after hugepages didn't start.

`@tenstorrent/forge-developers-mlir-optimizer` for the two test changes above.