### PR TITLE
[Optimizer] Integrate DRAM-sharded matmul into the greedy layout optimizer

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
@@ -24,6 +24,77 @@ namespace mlir::tt::ttnn {
 std::optional<mlir::Attribute>
 generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout);
 
+// ============================================================================
+// DRAM-sharded matmul config generation
+// ============================================================================
+//
+// Primitives that build a DRAM-sharded matmul
+// (MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig): the weight (in1) is
+// width-sharded across DRAM banks and the activation (in0) is width-sharded
+// across L1 cores. The optimizer's DRAM-shard rule book (MatmulRules.cpp)
+// decides *whether* a matmul is eligible and orchestrates the reshards; these
+// functions own the *how* — the shard geometry, layouts, and configs.
+
+// Geometry describing how an M×K×N matmul is sharded for DRAM-sharded
+// execution. Produced by computeShardParams; consumed by the builders below
+// and by the rule book (which reads e.g. perCoreN to size the output grid).
+struct DRAMShardParams {
+  int64_t K;
+  int64_t N;
+  int64_t M;
+  int64_t numBanks;
+  int64_t numIn0Cores;
+  int64_t numOutCores;
+  int64_t nPadded;
+  int64_t shardH;
+  int64_t shardW;
+  int64_t kTiles;
+  int64_t shardWTiles;
+  int64_t in0BlockW;
+  int64_t perCoreM;
+  int64_t perCoreN;
+  ttcore::DataType weightDataType;
+};
+
+// Compute the shard geometry and a circular-buffer-fitting in0_block_w for an
+// M×K×N matmul whose weight is BFP and DRAM-interleaved. The weight is sharded
+// across `numBanks` DRAM banks and the activation across `numIn0Cores` L1
+// cores; `numOutCores` bounds the output storage grid. `l1Available` is the L1
+// budget the circular buffers must fit. Returns nullopt when no in0_block_w
+// fits. K/kTileSize must be divisible by numIn0Cores (the caller's eligibility
+// gate enforces this).
+std::optional<DRAMShardParams>
+computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
+                   int64_t numIn0Cores, int64_t numOutCores,
+                   ttcore::DataType weightDataType, int64_t l1Available);
+
+// Build the DRAM width-sharded layout for the weight (in1) of `tensorShape`,
+// sharded across `p.numBanks` DRAM banks.
+TTNNLayoutAttr buildDRAMShardedWeightLayout(MLIRContext *ctx,
+                                            TTNNLayoutAttr origLayout,
+                                            llvm::ArrayRef<int64_t> tensorShape,
+                                            const DRAMShardParams &p,
+                                            ttcore::DeviceAttr deviceAttr);
+
+// Build an L1 width-sharded layout for `tensorShape` over `numCores`, using
+// canonical core placement that wraps across the worker grid (a single-row
+// placement would be invalid once numCores exceeds the grid width).
+TTNNLayoutAttr buildL1ShardedLayout(MLIRContext *ctx, TTNNLayoutAttr origLayout,
+                                    llvm::ArrayRef<int64_t> tensorShape,
+                                    int64_t numCores,
+                                    ttcore::DeviceAttr deviceAttr);
+
+// Build the DRAM-sharded program config from computed shard params.
+MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
+                              UnaryWithParamAttr fusedAct);
+
+// Build the compute-kernel config for a DRAM-sharded matmul (math fidelity
+// follows the weight dtype; fp32 dest-accumulate and packer-L1-accumulate
+// enabled).
+DeviceComputeKernelConfigAttr
+buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_MATMULPROGRAMCONFIG_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
@@ -90,8 +90,8 @@ buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
                               UnaryWithParamAttr fusedAct);
 
 // Build the compute-kernel config for a DRAM-sharded matmul (math fidelity
-// follows the weight dtype; fp32 dest-accumulate and packer-L1-accumulate
-// enabled).
+// follows the weight dtype; bf16 partials through the packer, with
+// packer-L1-accumulate enabled).
 DeviceComputeKernelConfigAttr
 buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType);
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -73,6 +73,16 @@ struct LayoutScore {
   /// Memory footprint from ValidationResult (for tie-breaking).
   uint64_t outputL1Usage = 0;
 
+  /// DRAM-sharded matmul candidate. When both candidates are L1+sharded, this
+  /// wins over normal candidates regardless of core count — architecturally
+  /// superior for decode.
+  bool isDRAMShardedCandidate = false;
+
+  /// Set when isDRAMShardedCandidate and in0 is already the canonical
+  /// 1×kNumStorageCores L1 width-sharded layout (no in0 reshard needed).
+  /// Tiebreaker within DS candidates.
+  bool hasCanonicalDSIn0 = false;
+
   /// Higher score is better.
   bool operator>(const LayoutScore &other) const;
   bool operator==(const LayoutScore &other) const;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -79,7 +79,7 @@ struct LayoutScore {
   bool isDRAMShardedCandidate = false;
 
   /// Set when isDRAMShardedCandidate and in0 is already the canonical
-  /// 1×kNumStorageCores L1 width-sharded layout (no in0 reshard needed).
+  /// 1×kNumIn0Cores L1 width-sharded layout (no in0 reshard needed).
   /// Tiebreaker within DS candidates.
   bool hasCanonicalDSIn0 = false;
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -55,6 +55,11 @@ inline bool requireTiled(TTNNLayoutAttr layout) {
   return layout.getLayout() == Layout::Tile;
 }
 
+/// Reject L1 layouts; DRAM-sharded and DRAM-interleaved pass through.
+inline bool rejectAllL1(TTNNLayoutAttr layout) {
+  return !layout.hasL1BufferType();
+}
+
 /// Reject width-sharded layouts. Returns true if the layout should be kept.
 inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   auto ml = layout.getMemLayout();

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
@@ -9,6 +9,8 @@
 
 namespace mlir::tt::ttnn {
 
+class MatmulOp;
+
 //===----------------------------------------------------------------------===//
 // Matmul/Linear rules:
 //
@@ -24,17 +26,55 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 
 struct MatmulRuleBook : OpRuleBook {
-  /// Output hints: partial configs without L1-interleaved.
+  /// Output hints: for DS-eligible matmuls, the DS hint is included alongside
+  /// the normal partial configs. adjustScore drives DS preference via
+  /// isDRAMShardedCandidate. For non-eligible matmuls: normal behavior.
   OutputHints
   getOutputHints(Operation *op,
                  const std::vector<OpConfig> &legalConfigs) const override;
 
-  /// Reject all sharded RHS inputs (operand 1). LHS and bias are unrestricted.
+  /// Operand 1 (weight): reject L1. DRAM layouts (interleaved and
+  /// width-sharded) are accepted; the DRAM width-sharded(DS) layout is injected
+  /// via getExtraInputReshardCandidates.
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 
   /// Apply MatmulProgramConfig + fused activation dedup.
+  /// For DS candidates: set program/compute config and split fused activation.
   void applyOpSpecificAttrs(Operation *op,
                             const BeamCandidate &candidate) const override;
+
+  /// Reject the DS hint for input combinations that aren't the correct DS
+  /// layouts (L1 width-sharded in0, DRAM width-sharded in1). The tt-metal op
+  /// model crashes (TT_FATAL) rather than returning a failure when given a DS
+  /// program config with incompatible input layouts.
+  bool isValidOutputHintForInputs(
+      const OpConfig &hint,
+      llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const override;
+
+  /// Set isDRAMShardedCandidate / hasCanonicalDSIn0 for DS candidates.
+  LayoutScore adjustScore(Operation *op, LayoutScore base,
+                          const OpConfig &config,
+                          llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                          bool requiresReshard) const override;
+
+  /// Inject DS-specific input layouts into the candidate pool:
+  ///   operand 0 → L1 width-sharded 1×kNumIn0Cores
+  ///   operand 1 → DRAM width-sharded 1×numBanks, padded; numBanks comes
+  ///               from the device's DRAM grid
+  std::vector<TTNNLayoutAttr>
+  getExtraInputReshardCandidates(Operation *op,
+                                 unsigned operandIdx) const override;
+
+private:
+  /// Build the DS output hint (L1 width-sharded 1×kNumIn0Cores + DS program
+  /// config). Returns nullopt if not eligible or params don't fit L1.
+  std::optional<OpConfig> buildDRAMShardingHint(Operation *op) const;
+
+  /// Set program/compute config and split fused activation for a DS matmul.
+  /// Takes a generic Operation* because the DS path covers both ttnn.matmul and
+  /// bias-free ttnn.linear (see getDSOperands).
+  void applyDRAMShardedTransformation(Operation *op,
+                                      const MatmulAttrs &matmulAttrs) const;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
@@ -72,7 +72,7 @@ private:
 
   /// Set program/compute config and split fused activation for a DS matmul.
   /// Takes a generic Operation* because the DS path covers both ttnn.matmul and
-  /// bias-free ttnn.linear (see getDSOperands).
+  /// bias-free ttnn.linear (see getMatmulOperands).
   void applyDRAMShardedTransformation(Operation *op,
                                       const MatmulAttrs &matmulAttrs) const;
 };

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
@@ -39,7 +39,7 @@ struct MatmulRuleBook : OpRuleBook {
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 
   /// Apply MatmulProgramConfig + fused activation dedup.
-  /// For DS candidates: set program/compute config and split fused activation.
+  /// For DS candidates: set program/compute config only.
   void applyOpSpecificAttrs(Operation *op,
                             const BeamCandidate &candidate) const override;
 
@@ -69,12 +69,6 @@ private:
   /// Build the DS output hint (L1 width-sharded 1×kNumIn0Cores + DS program
   /// config). Returns nullopt if not eligible or params don't fit L1.
   std::optional<OpConfig> buildDRAMShardingHint(Operation *op) const;
-
-  /// Set program/compute config and split fused activation for a DS matmul.
-  /// Takes a generic Operation* because the DS path covers both ttnn.matmul and
-  /// bias-free ttnn.linear (see getMatmulOperands).
-  void applyDRAMShardedTransformation(Operation *op,
-                                      const MatmulAttrs &matmulAttrs) const;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -90,13 +90,22 @@ struct OpRuleBook {
                                const BeamCandidate &b) const;
 
   /// Adjust a candidate's LayoutScore after the base scorer computed it.
-  /// Receives the output config, all operand input
-  /// layouts, and the reshard flag.
+  /// Receives the output config, all operand input layouts, and the reshard
+  /// flag. Used by MatmulRuleBook to set isDRAMShardedCandidate /
+  /// hasCanonicalDSIn0.
   virtual LayoutScore adjustScore(Operation *op, LayoutScore base,
                                   const OpConfig &config,
                                   llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                                   bool requiresReshard) const {
     return base;
+  }
+
+  /// Extra input reshard candidates that go beyond what
+  /// generateReshardCandidates produces from tensorTypePossibleLayouts. Called
+  /// per-operand from getInputCandidateSets. Default returns nothing.
+  virtual std::vector<TTNNLayoutAttr>
+  getExtraInputReshardCandidates(Operation *op, unsigned operandIdx) const {
+    return {};
   }
 };
 

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -250,6 +250,15 @@ struct TTIRToTTNNCommonPipelineOptions
                      "Analysis and Memory Layout Analysis. [0.0-1.0]"),
       llvm::cl::init(0.95f)};
 
+  // Option to disable generation of DRAM-sharded matmuls in the optimizer.
+  // When set, the matmul DRAM-shard rule book is suppressed and matmuls fall
+  // back to the other (1D/2D mcast) program configs.
+  Option<bool> disableDRAMShardedMatmul{
+      *this, OptionNames::disableDramShardedMatmul,
+      llvm::cl::desc(
+          "Disable generation of DRAM-sharded matmuls in the optimizer."),
+      llvm::cl::init(false)};
+
   // Option to enable/disable the workaround pass.
   //
   Option<bool> disableWorkarounds{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -250,13 +250,15 @@ struct TTIRToTTNNCommonPipelineOptions
                      "Analysis and Memory Layout Analysis. [0.0-1.0]"),
       llvm::cl::init(0.95f)};
 
-  // Option to disable generation of DRAM-sharded matmuls in the optimizer.
-  // When set, the matmul DRAM-shard rule book is suppressed and matmuls fall
-  // back to the other (1D/2D mcast) program configs.
-  Option<bool> disableDRAMShardedMatmul{
-      *this, OptionNames::disableDramShardedMatmul,
+  // Option to enable generation of DRAM-sharded matmuls in the optimizer. Off
+  // by default: DS trades compute width for per-bank read efficiency, and
+  // whether that pays depends on the part's bank-to-worker ratio. Unset, the
+  // matmul DRAM-shard rule book is suppressed and matmuls take the other
+  // (1D/2D mcast) program configs.
+  Option<bool> enableDRAMShardedMatmul{
+      *this, OptionNames::enableDramShardedMatmul,
       llvm::cl::desc(
-          "Disable generation of DRAM-sharded matmuls in the optimizer."),
+          "Enable generation of DRAM-sharded matmuls in the optimizer."),
       llvm::cl::init(false)};
 
   // Option to enable/disable the workaround pass.

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -254,11 +254,16 @@ struct TTIRToTTNNCommonPipelineOptions
   // by default: DS trades compute width for per-bank read efficiency, and
   // whether that pays depends on the part's bank-to-worker ratio. Unset, the
   // matmul DRAM-shard rule book is suppressed and matmuls take the other
-  // (1D/2D mcast) program configs.
-  Option<bool> enableDRAMShardedMatmul{
+  // (1D/2D mcast) program configs. Takes effect only with memory layout
+  // analysis enabled (optimization level 2): DS relies on the L1 sharded
+  // layouts and the L1 spill management that only that tier runs, so the
+  // option is forced off below it once the level is resolved, for the optimizer
+  // and the fusing pass alike.
+  mutable Option<bool> enableDRAMShardedMatmul{
       *this, OptionNames::enableDramShardedMatmul,
-      llvm::cl::desc(
-          "Enable generation of DRAM-sharded matmuls in the optimizer."),
+      llvm::cl::desc("Enable generation of DRAM-sharded matmuls in the "
+                     "optimizer. Requires memory-layout-analysis-enabled "
+                     "(optimization level 2)."),
       llvm::cl::init(false)};
 
   // Option to enable/disable the workaround pass.
@@ -594,6 +599,9 @@ struct TTIRToTTNNCommonPipelineOptions
     }
     if (!memoryLayoutAnalysisEnabled.hasValue()) {
       memoryLayoutAnalysisEnabled = (optimizationLevel >= 2);
+    }
+    if (!memoryLayoutAnalysisEnabled) {
+      enableDRAMShardedMatmul = false;
     }
     if (!computeCfgMathFidelity.hasValue() && optimizationLevel > 0) {
       computeCfgMathFidelity = OptionalMathFidelity::Undefined;

--- a/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
@@ -24,6 +24,10 @@ struct DevicePassesWrapperOptions {
   // This is set as a module attribute by DevicePassesWrapper, making it
   // accessible to all nested passes via utils::getTensorL1UsageCap()
   float tensorL1UsageCap = 0.95f;
+  // When true, suppresses generation of DRAM-sharded matmuls in the optimizer.
+  // This is set as a module attribute by DevicePassesWrapper, making it
+  // accessible to the matmul rule book via utils::isDRAMShardedMatmulDisabled()
+  bool disableDRAMShardedMatmul = false;
 };
 
 // Creates a pass that wraps device-dependent passes with device lifecycle

--- a/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
@@ -24,10 +24,10 @@ struct DevicePassesWrapperOptions {
   // This is set as a module attribute by DevicePassesWrapper, making it
   // accessible to all nested passes via utils::getTensorL1UsageCap()
   float tensorL1UsageCap = 0.95f;
-  // When true, suppresses generation of DRAM-sharded matmuls in the optimizer.
+  // When true, allows generation of DRAM-sharded matmuls in the optimizer.
   // This is set as a module attribute by DevicePassesWrapper, making it
-  // accessible to the matmul rule book via utils::isDRAMShardedMatmulDisabled()
-  bool disableDRAMShardedMatmul = false;
+  // accessible to the matmul rule book via utils::isDRAMShardedMatmulEnabled()
+  bool enableDRAMShardedMatmul = false;
 };
 
 // Creates a pass that wraps device-dependent passes with device lifecycle

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -371,13 +371,12 @@ def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
             "enable-eltwise-activation-fusion",
             "bool", /*default=*/"false",
             "Fuse unary activation ops into eltwise binary ops.">,
-    Option<"disableDRAMShardedMatmul",
-            "disable-dram-sharded-matmul",
-            "bool", /*default=*/"true",
-            "The pipeline's disable-dram-sharded-matmul, threaded through so "
-            "fusing can keep an activation off a producer matmul. Defaults to "
-            "true: DRAM sharding is chosen by the optimizer, so a standalone "
-            "ttnn-fusing run has no DRAM-sharded matmuls.">
+    Option<"enableDRAMShardedMatmul",
+            "enable-dram-sharded-matmul",
+            "bool", /*default=*/"false",
+            "The pipeline's enable-dram-sharded-matmul, threaded through so "
+            "fusing can keep an activation off a producer matmul that the "
+            "optimizer may give a DRAM-sharded config.">
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -370,7 +370,14 @@ def TTNNFusing: Pass<"ttnn-fusing", "::mlir::ModuleOp">
     Option<"enableEltwiseActivationFusion",
             "enable-eltwise-activation-fusion",
             "bool", /*default=*/"false",
-            "Fuse unary activation ops into eltwise binary ops.">
+            "Fuse unary activation ops into eltwise binary ops.">,
+    Option<"disableDRAMShardedMatmul",
+            "disable-dram-sharded-matmul",
+            "bool", /*default=*/"true",
+            "The pipeline's disable-dram-sharded-matmul, threaded through so "
+            "fusing can keep an activation off a producer matmul. Defaults to "
+            "true: DRAM sharding is chosen by the optimizer, so a standalone "
+            "ttnn-fusing run has no DRAM-sharded matmuls.">
   ];
 }
 

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -32,6 +32,8 @@ struct OptionNames {
   static constexpr StringRef meshTopology = "mesh-topology";
   static constexpr StringRef tuplifyInputIfEmpty = "tuplify-input-if-empty";
   static constexpr StringRef tensorL1UsageCap = "tensor-l1-usage-cap";
+  static constexpr StringRef disableDramShardedMatmul =
+      "disable-dram-sharded-matmul";
   static constexpr StringRef ttnnPerfMetricsOutputFile =
       "ttnn-perf-metrics-output-file";
   static constexpr StringRef ttnnPerfMetricsVerboseOutputEnabled =

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -32,8 +32,8 @@ struct OptionNames {
   static constexpr StringRef meshTopology = "mesh-topology";
   static constexpr StringRef tuplifyInputIfEmpty = "tuplify-input-if-empty";
   static constexpr StringRef tensorL1UsageCap = "tensor-l1-usage-cap";
-  static constexpr StringRef disableDramShardedMatmul =
-      "disable-dram-sharded-matmul";
+  static constexpr StringRef enableDramShardedMatmul =
+      "enable-dram-sharded-matmul";
   static constexpr StringRef ttnnPerfMetricsOutputFile =
       "ttnn-perf-metrics-output-file";
   static constexpr StringRef ttnnPerfMetricsVerboseOutputEnabled =

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -32,9 +32,17 @@ inline constexpr llvm::StringLiteral g_L1ConstEvalUsageAttrName =
 inline constexpr llvm::StringLiteral g_ConstEvalAllowedAttrName =
     "ttnn.const_eval_allowed";
 
+// Attribute name for the flag that disables DRAM-sharded matmul generation.
+inline constexpr llvm::StringLiteral g_DisableDRAMShardedMatmulAttrName =
+    "ttnn.disable_dram_sharded_matmul";
+
 // Helper function to retrieve tensor L1 usage cap from module attribute.
 // Returns the configured cap if found, otherwise returns the default value.
 float getTensorL1UsageCap(Operation *op, float defaultValue = 0.95f);
+
+// Whether DRAM-sharded matmul generation is disabled, per the module attribute
+// set by DevicePassesWrapper. Returns false when the attribute is absent.
+bool isDRAMShardedMatmulDisabled(Operation *op);
 
 // Helper function to retrieve the per-core L1 usage reserved for the retained
 // (permanent) tensors.

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -32,17 +32,18 @@ inline constexpr llvm::StringLiteral g_L1ConstEvalUsageAttrName =
 inline constexpr llvm::StringLiteral g_ConstEvalAllowedAttrName =
     "ttnn.const_eval_allowed";
 
-// Attribute name for the flag that disables DRAM-sharded matmul generation.
-inline constexpr llvm::StringLiteral g_DisableDRAMShardedMatmulAttrName =
-    "ttnn.disable_dram_sharded_matmul";
+// Attribute name for the flag that enables DRAM-sharded matmul generation.
+inline constexpr llvm::StringLiteral g_EnableDRAMShardedMatmulAttrName =
+    "ttnn.enable_dram_sharded_matmul";
 
 // Helper function to retrieve tensor L1 usage cap from module attribute.
 // Returns the configured cap if found, otherwise returns the default value.
 float getTensorL1UsageCap(Operation *op, float defaultValue = 0.95f);
 
-// Whether DRAM-sharded matmul generation is disabled, per the module attribute
-// set by DevicePassesWrapper. Returns false when the attribute is absent.
-bool isDRAMShardedMatmulDisabled(Operation *op);
+// Whether DRAM-sharded matmul generation is enabled, per the module attribute
+// set by DevicePassesWrapper. Returns false when the attribute is absent, so
+// the path stays off unless something asked for it.
+bool isDRAMShardedMatmulEnabled(Operation *op);
 
 // Helper function to retrieve the per-core L1 usage reserved for the retained
 // (permanent) tensors.

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -847,6 +847,29 @@ bool AddressSimSpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 // evictUntil
 //===----------------------------------------------------------------------===//
 
+// A DRAM-sharded matmul requires its in0 activation to be L1 width-sharded and
+// its output to stay sharded. Spilling either to DRAM is never a legal state
+// for this op, and probing it through the op-model backend hits an uncatchable
+// tt-metal abort rather than returning a catchable error. Callers must
+// therefore recognize this op up front (reshard in0 / keep output sharded)
+// instead of validating or demoting it.
+//
+// MatmulRules assigns the DS config to a bias-free ttnn.linear as well, so both
+// op types are matched here.
+static bool isDRAMShardedMatmul(Operation *op) {
+  std::optional<mlir::Attribute> pc;
+  if (auto matmulOp = mlir::dyn_cast<MatmulOp>(op)) {
+    pc = matmulOp.getMatmulProgramConfig();
+  } else if (auto linearOp = mlir::dyn_cast<LinearOp>(op)) {
+    pc = linearOp.getMatmulProgramConfig();
+  } else {
+    return false;
+  }
+  return pc.has_value() && *pc &&
+         mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+             *pc);
+}
+
 template <typename MemoryTracker>
 bool L1SpillManagementBase<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
@@ -954,7 +977,10 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
       // positionMap, which can rehash and invalidate posIt.
       int64_t consumerPos = posIt->second;
       bool isPastConsumer = consumerPos < pos;
-      bool needsReshard = isPastConsumer;
+      // A DRAM-sharded matmul requires L1 width-sharded in0; probing it after a
+      // spill would abort uncatchably, so force the reshard instead of
+      // validating.
+      bool needsReshard = isPastConsumer || isDRAMShardedMatmul(consumer);
       if (!needsReshard) {
         auto consumerInputs = utils::extractInputLayouts(consumer);
         auto consumerConfig = extractOpConfigFromIR(consumer);
@@ -1250,6 +1276,44 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
   // Eviction was exhausted (op's own output won't fit / CB still overlaps).
   // Demote this op's output to DRAM rather than ship a clashing layout.
   if (!fitsAfterEviction) {
+    // Never demote a DRAM-sharded matmul's output: tt-metal requires a sharded
+    // output config. evictUntil folds two distinct failure modes into this one
+    // flag, and for a DS matmul they need opposite handling.
+    if (isDRAMShardedMatmul(op)) {
+      auto freshOutputAddr = memoryTracker.wouldAllocateAt(outputL1Size);
+      if (!freshOutputAddr) {
+        // No contiguous L1 slot for the matmul's own sharded output, with
+        // eviction already exhausted. Nothing can rescue this: demotion is
+        // illegal, and spilling does not help either — spillToDram inserts a
+        // ToMemoryConfigOp *after* the matmul, so the matmul still produces an
+        // L1-sharded result that needs this very slot. Fail loudly rather than
+        // ship a clashing layout or leave an address-less tensor in the tracker
+        // (allocateAddress llvm_unreachable's on a no-fit).
+        op->emitError(
+            "L1SpillManagement: DRAM-sharded matmul output has no contiguous "
+            "L1 "
+            "placement after evicting every spillable tensor, and cannot be "
+            "demoted to DRAM (tt-metal requires a sharded output config)");
+        compilationFailed = true;
+        return 0;
+      }
+      // The output has a slot, so what evictUntil could not satisfy is the
+      // CB/tensor overlap check. Spill the output to DRAM: that ends its L1
+      // live range at the spill op and raises the lowest occupied address,
+      // giving the CB region room. Whether that is enough depends on how much
+      // of the overshoot was the cbFragCushion safety margin rather than real
+      // CB demand, which we cannot tell apart here — take the spill and accept
+      // the residual runtime risk, since demoting is not an option.
+      spillToDram(op->getResult(0));
+      TTMLIR_DEBUG(
+          ttmlir::LogComponent::GreedyOptimizer,
+          "    DS_SPILL_OUTPUT: CB overlap after eviction (cushioned "
+          "cb={0}, raw cb={1}, lowest={2}); matmul output kept sharded "
+          "and spilled to DRAM",
+          cushionedCBUsage, cbPeakUsage,
+          std::min(*freshOutputAddr, memoryTracker.getLowestOccupiedAddress()));
+      return 0;
+    }
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1271,6 +1335,19 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
                  "    FRAG_RESOLVED: L1 now {0}/{1}",
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
     return freshL1;
+  }
+
+  // A DRAM-sharded matmul must never be pushed all-DRAM: it requires L1
+  // width-sharded in0 and a sharded output. The homogeneous-spill + demote
+  // fallback below is for concat-like ops; applying it here would invalidate
+  // the DS config. Its in0 is restored to L1 by the eviction reshard path, and
+  // its raw CB fits, so keep it L1-sharded.
+  if (isDRAMShardedMatmul(op)) {
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "    DS_KEEP_SHARDED: not applying homogeneous-spill/demote to "
+        "DS matmul; keeping L1-sharded");
+    return outputL1Size;
   }
 
   // If validation failed with a backend constraint error (not OOM) after

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -977,9 +977,8 @@ bool L1SpillManagementBase<MemoryTracker>::evictValue(
       // positionMap, which can rehash and invalidate posIt.
       int64_t consumerPos = posIt->second;
       bool isPastConsumer = consumerPos < pos;
-      // A DRAM-sharded matmul requires L1 width-sharded in0; probing it after a
-      // spill would abort uncatchably, so force the reshard instead of
-      // validating.
+      // Force the reshard for a DS matmul rather than validating it (see
+      // isDRAMShardedMatmul).
       bool needsReshard = isPastConsumer || isDRAMShardedMatmul(consumer);
       if (!needsReshard) {
         auto consumerInputs = utils::extractInputLayouts(consumer);
@@ -1276,9 +1275,8 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
   // Eviction was exhausted (op's own output won't fit / CB still overlaps).
   // Demote this op's output to DRAM rather than ship a clashing layout.
   if (!fitsAfterEviction) {
-    // Never demote a DRAM-sharded matmul's output: tt-metal requires a sharded
-    // output config. evictUntil folds two distinct failure modes into this one
-    // flag, and for a DS matmul they need opposite handling.
+    // evictUntil folds two distinct failure modes into this one flag, and for a
+    // DS matmul they need opposite handling (see isDRAMShardedMatmul).
     if (isDRAMShardedMatmul(op)) {
       auto freshOutputAddr = memoryTracker.wouldAllocateAt(outputL1Size);
       if (!freshOutputAddr) {
@@ -1337,11 +1335,10 @@ uint64_t AddressSimSpillManagement<MemoryTracker>::handleFragmentation(
     return freshL1;
   }
 
-  // A DRAM-sharded matmul must never be pushed all-DRAM: it requires L1
-  // width-sharded in0 and a sharded output. The homogeneous-spill + demote
-  // fallback below is for concat-like ops; applying it here would invalidate
-  // the DS config. Its in0 is restored to L1 by the eviction reshard path, and
-  // its raw CB fits, so keep it L1-sharded.
+  // The homogeneous-spill + demote fallback below is for concat-like ops and
+  // would invalidate a DS config (see isDRAMShardedMatmul). A DS matmul's in0
+  // is restored to L1 by the eviction reshard path and its raw CB fits, so keep
+  // it L1-sharded.
   if (isDRAMShardedMatmul(op)) {
     TTMLIR_DEBUG(
         ttmlir::LogComponent::GreedyOptimizer,

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -9,11 +9,10 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir::tt::ttnn {
-
-static inline int64_t divUp(int64_t a, int64_t b) { return (a + b - 1) / b; }
 
 // Compute the maximum number of tiles that can fit in the destination register.
 // This depends on the compute kernel config settings:
@@ -108,9 +107,9 @@ generateMatmul1DProgramConfig(MLIRContext *ctx, int64_t Mt, int64_t Nt,
 
   if (mcastIn0) {
     perCoreM = Mt;
-    perCoreN = divUp(Nt, numCores);
+    perCoreN = llvm::divideCeil(Nt, numCores);
   } else {
-    perCoreM = divUp(Mt, numCores);
+    perCoreM = llvm::divideCeil(Mt, numCores);
     perCoreN = Nt;
   }
 
@@ -162,8 +161,8 @@ generateMatmul2DProgramConfig(MLIRContext *ctx, int64_t Mt, int64_t Nt,
                               int64_t maxSubblockSize, bool fuseBatch) {
   auto [gridX, gridY] = utils::getPhysicalGridDimensions(outputLayout);
 
-  int64_t perCoreM = divUp(Mt, gridY);
-  int64_t perCoreN = divUp(Nt, gridX);
+  int64_t perCoreM = llvm::divideCeil(Mt, gridY);
+  int64_t perCoreN = llvm::divideCeil(Nt, gridX);
 
   int64_t in0BlockW = (Kt % 2 == 0) ? 2 : 1;
   int64_t outSubblockH = 1;
@@ -252,9 +251,9 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   int64_t M = outShape[outShape.size() - 2];
   int64_t N = outShape[outShape.size() - 1];
   int64_t K = aShape[aShape.size() - 1];
-  int64_t Mt = divUp(M, TILE_HEIGHT);
-  int64_t Nt = divUp(N, TILE_WIDTH);
-  int64_t Kt = divUp(K, TILE_WIDTH);
+  int64_t Mt = llvm::divideCeil(M, TILE_HEIGHT);
+  int64_t Nt = llvm::divideCeil(N, TILE_WIDTH);
+  int64_t Kt = llvm::divideCeil(K, TILE_WIDTH);
 
   MLIRContext *ctx = op->getContext();
   UnaryWithParamAttr fusedActivation =
@@ -298,6 +297,176 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   return generateMatmul1DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,
                                        outputMemLayout, fusedActivation,
                                        maxSubblockSize, fuseBatch);
+}
+
+// ============================================================================
+// DRAM-sharded matmul config generation
+// ============================================================================
+
+static constexpr int64_t kTileSize = 32;
+
+// Smallest in0_block_w the DS path will accept, as a divisor of kPerCore: the
+// fitted block width must be at least kPerCore / kMinBlockWidthFraction.
+//
+// The kernel's block loop runs num_blocks = kTiles / in0_block_w rounds of
+// mcast + compute, so a width the L1 budget forced below kPerCore costs
+// proportionally more. Below half of kPerCore the DS config is a loss against
+// the 1D/2D mcast configs it would replace. A policy number, determined
+// experimentally on p150, not derived.
+static constexpr int64_t kMinBlockWidthFraction = 2;
+
+static int64_t padToDRAMBanks(int64_t n, int64_t numBanks) {
+  int64_t lcm = kTileSize * numBanks;
+  return ((n + lcm - 1) / lcm) * lcm;
+}
+
+std::optional<DRAMShardParams>
+computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
+                   int64_t numIn0Cores, int64_t numOutCores,
+                   ttcore::DataType weightDataType, int64_t l1Available) {
+  DRAMShardParams p;
+  p.K = K;
+  p.N = N;
+  p.M = M;
+  p.numBanks = numBanks;
+  p.numIn0Cores = numIn0Cores;
+  p.numOutCores = numOutCores;
+  p.nPadded = padToDRAMBanks(N, numBanks);
+  p.shardH = K;
+  p.shardW = p.nPadded / numBanks;
+  p.kTiles = K / kTileSize;
+  p.shardWTiles = p.shardW / kTileSize;
+  // Round up: a sub-tile activation (a decode batch of 1..31) is still one tile
+  // row, and tt-metal pads it to one. Truncating would yield per_core_M = 0 and
+  // a degenerate config.
+  p.perCoreM = llvm::divideCeil(M, kTileSize);
+  p.perCoreN = (N / kTileSize + numOutCores - 1) / numOutCores; // div_up
+  p.weightDataType = weightDataType;
+
+  static constexpr int64_t kBf16Tile = 2048; // 32×32 × 2 B
+  static constexpr int64_t kBfp8Tile = 1088; // 32×32 × 1 B + 64 B row exponents
+  static constexpr int64_t kBfp4Tile =
+      576; // 32×32 × 0.5 B + 64 B row exponents
+  static constexpr int64_t kFp32Tile = 4096; // 32×32 × 4 B
+
+  int64_t kWeightTile =
+      (weightDataType == ttcore::DataType::BFP_BFloat4) ? kBfp4Tile : kBfp8Tile;
+
+  assert(p.kTiles % numIn0Cores == 0 &&
+         "kTiles must be divisible by numIn0Cores before the per-core divide");
+  int64_t kPerCore = p.kTiles / numIn0Cores;
+  // perCoreNCompute: tiles computed per DRAM-bank/compute core (= weight shard
+  // width per bank). Used for CB sizing — this is what the compute kernel
+  // actually accumulates per core before scattering to output storage cores.
+  int64_t perCoreNCompute = p.shardWTiles;
+
+  // Use numIn0Cores for the output tensor buffer estimate to keep the budget
+  // conservative and avoid inflating in0BlockW (which doubles in1CB per step).
+  // perCoreNStorage is only used for the output layout grid, not CB sizing.
+  int64_t outTensorBufPerCore =
+      p.perCoreM * ((N / kTileSize) / numIn0Cores) * kBf16Tile;
+  int64_t in0TensorBuf = p.perCoreM * kPerCore * kBf16Tile;
+  int64_t cbBudget = l1Available - in0TensorBuf - outTensorBufPerCore;
+
+  // Fixed CBs (independent of in0BlockW).
+  int64_t outCB = p.perCoreM * perCoreNCompute * kBf16Tile;
+  int64_t interm0CB = p.perCoreM * perCoreNCompute * kFp32Tile;
+  int64_t fixedCost = outCB + interm0CB;
+
+  if (fixedCost > cbBudget) {
+    return std::nullopt;
+  }
+
+  p.in0BlockW = kPerCore;
+  bool found = false;
+  while (p.in0BlockW >= 1) {
+    int64_t numBlocks = p.kTiles / p.in0BlockW;
+    bool doubleBuf = numBlocks > 1;
+
+    int64_t in0CB = p.in0BlockW * p.perCoreM * kBf16Tile * (doubleBuf ? 2 : 1);
+    int64_t in1CB = p.in0BlockW * perCoreNCompute * kWeightTile *
+                    (doubleBuf ? 3 : 1); // weight shard per DRAM bank
+
+    if (fixedCost + in0CB + in1CB <= cbBudget && kPerCore % p.in0BlockW == 0) {
+      found = true;
+      break;
+    }
+    if (p.in0BlockW == 1) {
+      break;
+    }
+    p.in0BlockW--;
+    while (p.in0BlockW > 1 && kPerCore % p.in0BlockW != 0) {
+      p.in0BlockW--;
+    }
+  }
+
+  if (!found) {
+    return std::nullopt;
+  }
+
+  // Decline rather than emit a degenerate block width. Falling back to the
+  // 1D/2D mcast configs is measurably better than a DS config whose block loop
+  // has been stretched out by L1 pressure (see kMinBlockWidthFraction).
+  if (p.in0BlockW * kMinBlockWidthFraction < kPerCore) {
+    return std::nullopt;
+  }
+
+  return p;
+}
+
+TTNNLayoutAttr buildDRAMShardedWeightLayout(MLIRContext *ctx,
+                                            TTNNLayoutAttr origLayout,
+                                            llvm::ArrayRef<int64_t> tensorShape,
+                                            const DRAMShardParams &p,
+                                            ttcore::DeviceAttr deviceAttr) {
+  return TTNNLayoutAttr::Builder(origLayout, tensorShape)
+      .setBufferType(BufferType::DRAM)
+      .setMemoryLayout(
+          TensorMemoryLayoutAttr::get(ctx, TensorMemoryLayout::WidthSharded))
+      .setGridShape({1, p.numBanks})
+      // Drop the seed's placement explicitly: buildWithCanonicalCorePlacement
+      // only fills a *null* core range set, and the setters above each
+      // early-return when the value already matches, so a seed that is already
+      // DRAM width-sharded on this grid would otherwise keep its own placement.
+      .setCoreRangeSet(nullptr)
+      .buildWithCanonicalCorePlacement(deviceAttr);
+}
+
+TTNNLayoutAttr buildL1ShardedLayout(MLIRContext *ctx, TTNNLayoutAttr origLayout,
+                                    llvm::ArrayRef<int64_t> tensorShape,
+                                    int64_t numCores,
+                                    ttcore::DeviceAttr deviceAttr) {
+  return TTNNLayoutAttr::Builder(origLayout, tensorShape)
+      .setBufferType(BufferType::L1)
+      .setMemoryLayout(
+          TensorMemoryLayoutAttr::get(ctx, TensorMemoryLayout::WidthSharded))
+      .setGridShape({1, numCores})
+      // As above: force canonical placement rather than inheriting the seed's.
+      .setCoreRangeSet(nullptr)
+      .buildWithCanonicalCorePlacement(deviceAttr);
+}
+
+MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
+                              UnaryWithParamAttr fusedAct) {
+  return MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr::get(
+      ctx, p.in0BlockW, p.perCoreM, p.perCoreN, fusedAct);
+}
+
+DeviceComputeKernelConfigAttr
+buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType) {
+  // bfp4 weights run at LoFi, bfp8 at HiFi2 — the split models are observed to
+  // need in practice, rather than a rule derived from the formats.
+  MathFidelity fidelity = (weightDataType == ttcore::DataType::BFP_BFloat4)
+                              ? MathFidelity::LoFi
+                              : MathFidelity::HiFi2;
+  return DeviceComputeKernelConfigAttr::get(
+      ctx,
+      /*mathFidelity=*/fidelity,
+      /*mathApproxMode=*/mlir::BoolAttr{},
+      /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, true),
+      /*packerL1Acc=*/mlir::BoolAttr::get(ctx, true),
+      /*dstFullSyncEn=*/mlir::BoolAttr{});
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -360,15 +360,28 @@ computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
   // actually accumulates per core before scattering to output storage cores.
   int64_t perCoreNCompute = p.shardWTiles;
 
-  // Use numIn0Cores for the output tensor buffer estimate to keep the budget
-  // conservative and avoid inflating in0BlockW (which doubles in1CB per step).
-  // perCoreNStorage is only used for the output layout grid, not CB sizing.
+  // Deliberately over-reserved. tt-metal allocates per_core_M *
+  // per_core_N_storage for the output shard -- p.perCoreN here -- but this
+  // reserves against the in0 core count, which is numWorkerCores / numIn0Cores
+  // times larger.
+  //
+  // The margin makes computeShardParams decline DS on shapes whose L1 is tight,
+  // and that is what keeps a DS matmul out of a state L1SpillManagement cannot
+  // resolve: it can neither demote nor spill one (tt-metal requires the sharded
+  // in0 and the sharded output), so it fails the compilation instead. See
+  // #9264. Once that pass can demote a DS matmul to a multicast config, this
+  // becomes p.perCoreM * p.perCoreN * kBf16Tile.
   int64_t outTensorBufPerCore =
       p.perCoreM * ((N / kTileSize) / numIn0Cores) * kBf16Tile;
   int64_t in0TensorBuf = p.perCoreM * kPerCore * kBf16Tile;
   int64_t cbBudget = l1Available - in0TensorBuf - outTensorBufPerCore;
 
   // Fixed CBs (independent of in0BlockW).
+  //
+  // Also over-reserved, and part of the same margin as outTensorBufPerCore:
+  // with bf16 partials the intermediate format equals the output format, so
+  // tt-metal puts both in one shared buffer rather than the two sized here. See
+  // #9264.
   int64_t outCB = p.perCoreM * perCoreNCompute * kBf16Tile;
   int64_t interm0CB = p.perCoreM * perCoreNCompute * kFp32Tile;
   int64_t fixedCost = outCB + interm0CB;
@@ -464,7 +477,9 @@ buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType) {
       ctx,
       /*mathFidelity=*/fidelity,
       /*mathApproxMode=*/mlir::BoolAttr{},
-      /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, true),
+      // bf16 partials through the packer are what tt-metal defaults a
+      // bf16-output matmul to.
+      /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, false),
       /*packerL1Acc=*/mlir::BoolAttr::get(ctx, true),
       /*dstFullSyncEn=*/mlir::BoolAttr{});
 }

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -372,7 +372,7 @@ computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
   // #9264. Once that pass can demote a DS matmul to a multicast config, this
   // becomes p.perCoreM * p.perCoreN * kBf16Tile.
   int64_t outTensorBufPerCore =
-      p.perCoreM * ((N / kTileSize) / numIn0Cores) * kBf16Tile;
+      p.perCoreM * llvm::divideCeil(N / kTileSize, numIn0Cores) * kBf16Tile;
   int64_t in0TensorBuf = p.perCoreM * kPerCore * kBf16Tile;
   int64_t cbBudget = l1Available - in0TensorBuf - outTensorBufPerCore;
 

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -441,6 +441,8 @@ TTNNLayoutAttr buildDRAMShardedWeightLayout(MLIRContext *ctx,
       // only fills a *null* core range set, and the setters above each
       // early-return when the value already matches, so a seed that is already
       // DRAM width-sharded on this grid would otherwise keep its own placement.
+      // Defensive rather than observed: sharded layouts in the IR are always
+      // canonically placed, so the seed's placement and this one agree today.
       .setCoreRangeSet(nullptr)
       .buildWithCanonicalCorePlacement(deviceAttr);
 }

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1592,25 +1592,12 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
     }
   }
 
-  // Use reshardLayout directly instead of rebuilding it from the producer's
-  // layout via Builder. reshardLayout is already a complete layout for this
-  // tensor -- it is the layout the rule book asked for and the op model
-  // validated against -- so reconstructing it from a different seed can only
-  // diverge from it.
-  //
-  // The Builder path seeded from the producer and copied over only the buffer
-  // type, memory layout, grid and element type. Each of those setters
-  // early-returns when the value is unchanged, and only a *null* core range set
-  // gets filled by buildWithCanonicalCorePlacement, so a producer that already
-  // matches the target's buffer type, memory layout and grid would keep its own
-  // placement. That is latent rather than observed: every sharded layout in the
-  // IR is canonically placed, so a matching grid implies a matching placement
-  // in practice. What the direct path removes is the dependence on that, and on
-  // the derived shard width continuing to equal what the candidates state.
-  //
-  // This also subsumes the page-layout (element type) override that path
-  // needed: reshardLayout carries its own element type, so a tile -> row-major
-  // sibling reshard materializes without reconstructing it.
+  // Use reshardLayout directly rather than rebuilding it from the producer's
+  // layout. It is already a complete layout for this tensor -- the one the rule
+  // book asked for and the op model validated against -- so reconstructing it
+  // from another seed can only diverge from it. It also carries its own element
+  // type, so a tile -> row-major sibling reshard materializes without a
+  // separate page-layout override.
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(producerTensorType, reshardLayout);
 

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1602,8 +1602,11 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   // type, memory layout, grid and element type. Each of those setters
   // early-returns when the value is unchanged, and only a *null* core range set
   // gets filled by buildWithCanonicalCorePlacement, so a producer that already
-  // matches the target's buffer type, memory layout and grid keeps its own
-  // placement rather than taking the target's.
+  // matches the target's buffer type, memory layout and grid would keep its own
+  // placement. That is latent rather than observed: every sharded layout in the
+  // IR is canonically placed, so a matching grid implies a matching placement
+  // in practice. What the direct path removes is the dependence on that, and on
+  // the derived shard width continuing to equal what the candidates state.
   //
   // This also subsumes the page-layout (element type) override that path
   // needed: reshardLayout carries its own element type, so a tile -> row-major

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1021,6 +1021,31 @@ MemoryLayoutPropagation::getInputCandidateSets(Operation *op) {
                                 maxInputCandidatesPerOperand);
     }
 
+    // Inject op-specific extra reshard candidates (e.g. DRAM width-sharded
+    // weight and L1 1x8 activation for DS matmul) before standard reshards so
+    // they are not displaced when the candidate list reaches the cap.
+    for (TTNNLayoutAttr extraLayout :
+         getRuleBook(op).getExtraInputReshardCandidates(op, operandIdx)) {
+      bool alreadyPresent =
+          llvm::any_of(candidatesForOperand, [&](const InputCandidate &ic) {
+            return ic.layout == extraLayout;
+          });
+      if (alreadyPresent) {
+        continue;
+      }
+      size_t producerBeamSize = producerBeam ? producerBeam->size() : 1;
+      for (size_t pIdx = 0; pIdx < producerBeamSize; ++pIdx) {
+        if (candidatesForOperand.size() >= maxInputCandidatesPerOperand) {
+          break;
+        }
+        InputCandidate ic;
+        ic.layout = extraLayout;
+        ic.producerCandidateIndex = pIdx;
+        ic.isReshard = true;
+        candidatesForOperand.push_back(ic);
+      }
+    }
+
     addReshardCandidates(candidatesForOperand, op, operandIdx, operand,
                          currentLayout, tensorType, producerBeam, producerOp,
                          resultIdx, maxInputCandidatesPerOperand);
@@ -1567,23 +1592,24 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
     }
   }
 
-  // Take the producer's layout and apply the reshard target's buffer type,
-  // memory layout, grid, and page layout (element type). Tracking the element
-  // type is what lets a tile -> row-major sibling reshard materialize.
-  TTNNLayoutAttr producerLayout =
-      utils::getLayoutAttrFromTensor(producerTensorType);
-  Type reshardElementType = ttnn::utils::getElementType(
-      reshardLayout.getContext(), reshardLayout.getLayout(),
-      reshardLayout.getDataType());
-  TTNNLayoutAttr outputLayout =
-      TTNNLayoutAttr::Builder(producerLayout, producerTensorType.getShape())
-          .setBufferType(reshardLayout.getBufferType())
-          .setMemoryLayout(reshardLayout.getMemLayout())
-          .setGridShape(reshardLayout.getGridShape())
-          .setElementType(reshardElementType)
-          .buildWithCanonicalCorePlacement(deviceAttr);
+  // Use reshardLayout directly instead of rebuilding it from the producer's
+  // layout via Builder. reshardLayout is already a complete layout for this
+  // tensor -- it is the layout the rule book asked for and the op model
+  // validated against -- so reconstructing it from a different seed can only
+  // diverge from it.
+  //
+  // The Builder path seeded from the producer and copied over only the buffer
+  // type, memory layout, grid and element type. Each of those setters
+  // early-returns when the value is unchanged, and only a *null* core range set
+  // gets filled by buildWithCanonicalCorePlacement, so a producer that already
+  // matches the target's buffer type, memory layout and grid keeps its own
+  // placement rather than taking the target's.
+  //
+  // This also subsumes the page-layout (element type) override that path
+  // needed: reshardLayout carries its own element type, so a tile -> row-major
+  // sibling reshard materializes without reconstructing it.
   RankedTensorType newTensorType =
-      utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
+      utils::RankedTensorTypeFactory::create(producerTensorType, reshardLayout);
 
   // A tile <-> row-major page-layout change (RowMajor input siblings) is a
   // retile, which ttnn.to_memory_config does not do -- emit a
@@ -1591,7 +1617,8 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   // untilize/tilize + memory-config sequence. Pure memory-config reshards stay
   // ttnn.to_memory_config.
   bool pageLayoutChanges =
-      producerLayout.getLayout() != outputLayout.getLayout();
+      utils::getLayoutAttrFromTensor(producerTensorType).getLayout() !=
+      reshardLayout.getLayout();
 
   // Dedup: reuse a shared reshard for consumers of the same producer requesting
   // the same target layout. Only the ttnn.to_memory_config path is shared.

--- a/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
@@ -34,27 +34,42 @@ bool LayoutScore::operator>(const LayoutScore &other) const {
     return isSharded;
   }
 
-  // 3. Less DRAM input transfer > more DRAM input transfer.
+  // 3. DRAM-sharded matmul wins when both are L1+sharded — architecturally
+  // superior for decode when available.
+  if (isDRAMShardedCandidate != other.isDRAMShardedCandidate) {
+    return isDRAMShardedCandidate;
+  }
+
+  // 3a. Among DS candidates, prefer the one with empirically optimal 1×8 in0.
+  // Only meaningful when isDRAMShardedCandidate is set for both, so this is a
+  // tiebreaker within DS.
+  if (isDRAMShardedCandidate && hasCanonicalDSIn0 != other.hasCanonicalDSIn0) {
+    return hasCanonicalDSIn0;
+  }
+
+  // 4. Less DRAM input transfer > more DRAM input transfer.
   if (inputDramBytes != other.inputDramBytes) {
     return inputDramBytes < other.inputDramBytes;
   }
 
-  // 4. No reshard > reshard.
+  // 5. No reshard > reshard.
   if (requiresReshard != other.requiresReshard) {
     return !requiresReshard;
   }
 
-  // 5. More cores > fewer cores.
+  // 6. More cores > fewer cores.
   if (coreCount != other.coreCount) {
     return coreCount > other.coreCount;
   }
 
-  // 6. Lower L1 usage is better (leaves more room for other tensors).
+  // 7. Lower L1 usage is better (leaves more room for other tensors).
   return outputL1Usage < other.outputL1Usage;
 }
 
 bool LayoutScore::operator==(const LayoutScore &other) const {
   return isL1 == other.isL1 && isSharded == other.isSharded &&
+         isDRAMShardedCandidate == other.isDRAMShardedCandidate &&
+         hasCanonicalDSIn0 == other.hasCanonicalDSIn0 &&
          inputDramBytes == other.inputDramBytes &&
          requiresReshard == other.requiresReshard &&
          coreCount == other.coreCount && outputL1Usage == other.outputL1Usage;

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -446,27 +446,68 @@ void MatmulRuleBook::applyDRAMShardedTransformation(
   // --- 2. Handle the fused activation ---
   // Fusing the activation into the DS matmul kernel is significantly slower
   // (measured: the 12-core DS matmul applies silu much slower than an op on all
-  // 64 cores), so strip it off the matmul and run it as a separate elementwise
-  // op across all cores.
+  // 64 cores). So strip it off the matmul and either (a) fold it into a
+  // consuming multiply as its operand-A activation — SwiGLU:
+  // multiply(silu(gate), up) — which runs on the full grid (cheapest), or (b)
+  // fall back to a separate elementwise op.
   if (activationAttr) {
     StringRef actStr = activationAttr.getValue();
     Value matmulResult = op->getResult(0);
 
-    StringRef opName;
+    // (a) Try to fold silu into a consuming ttnn.multiply as an operand-A
+    // activation. Only when the matmul result's sole non-dealloc consumer is a
+    // multiply (either operand — multiply is commutative, so we normalize the
+    // silu'd value to operand A). Silu only: it is the activation SwiGLU puts
+    // there, and the one the eltwise activation path is exercised for.
+    MultiplyOp fuseInto = nullptr;
     if (actStr == "silu") {
-      opName = "ttnn.silu";
-    } else if (actStr == "relu") {
-      opName = "ttnn.relu";
-    } else if (actStr == "gelu") {
-      opName = "ttnn.gelu";
+      Operation *soleUser = nullptr;
+      bool multiUse = false;
+      for (Operation *u : matmulResult.getUsers()) {
+        if (isa<DeallocateOp>(u)) {
+          continue;
+        }
+        if (soleUser) {
+          multiUse = true;
+          break;
+        }
+        soleUser = u;
+      }
+      if (!multiUse && soleUser) {
+        fuseInto = dyn_cast<MultiplyOp>(soleUser);
+      }
     }
-    if (!opName.empty()) {
-      builder.setInsertionPointAfter(op);
-      auto *activationOp = builder.create(
-          op->getLoc(), StringAttr::get(ctx, opName), ValueRange{matmulResult},
-          TypeRange{matmulResult.getType()});
-      matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
-                                        activationOp);
+
+    ArrayAttr existingActs =
+        fuseInto ? fuseInto.getInputTensorAActivations() : nullptr;
+    if (fuseInto && (!existingActs || existingActs.empty()) &&
+        (fuseInto.getLhs() == matmulResult ||
+         fuseInto.getRhs() == matmulResult)) {
+      // Normalize the silu'd (matmul) value to operand A, then add the
+      // activation there.
+      Value other = fuseInto.getLhs() == matmulResult ? fuseInto.getRhs()
+                                                      : fuseInto.getLhs();
+      fuseInto.getLhsMutable().assign(matmulResult);
+      fuseInto.getRhsMutable().assign(other);
+      fuseInto.addInputTensorAActivation(UnaryOpType::Silu, /*params=*/{});
+    } else {
+      // (b) Fallback: separate elementwise op running across all cores.
+      StringRef opName;
+      if (actStr == "silu") {
+        opName = "ttnn.silu";
+      } else if (actStr == "relu") {
+        opName = "ttnn.relu";
+      } else if (actStr == "gelu") {
+        opName = "ttnn.gelu";
+      }
+      if (!opName.empty()) {
+        builder.setInsertionPointAfter(op);
+        auto *activationOp = builder.create(
+            op->getLoc(), StringAttr::get(ctx, opName),
+            ValueRange{matmulResult}, TypeRange{matmulResult.getType()});
+        matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
+                                          activationOp);
+      }
     }
   }
 }

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -467,9 +467,8 @@ OutputHints MatmulRuleBook::getOutputHints(
     filtered.push_back(cfg);
   }
 
-  // Prepend the DS hint when eligible. adjustScore gives it priority over the
-  // normal hints via isDRAMShardedCandidate; normal hints remain as fallback
-  // in case DS validation fails for a given input combination.
+  // Prepend the DS hint when eligible. The normal hints stay behind it as a
+  // fallback, in case DS validation fails for a given input combination.
   if (auto dramHint = buildDRAMShardingHint(op)) {
     filtered.insert(filtered.begin(), *dramHint);
   }
@@ -482,9 +481,6 @@ OutputHints MatmulRuleBook::getOutputHints(
 // ============================================================================
 
 LayoutFilterFn MatmulRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
-  // Weight (operand 1): reject L1.
-  // DRAM WIDTH_SHARDED is allowed for the DRAM-sharded matmul path.
-  // DRAM interleaved is always allowed.
   if (operandIdx == 1) {
     return layout_filter_utils::rejectAllL1;
   }
@@ -569,12 +565,8 @@ void MatmulRuleBook::applyOpSpecificAttrs(
 // ============================================================================
 
 // Reject in0 whose shard width is incompatible with the config's in0_block_w.
-// tt-metal needs (tiles): K % per_core_K == 0 and per_core_K % in0_block_w ==
-// 0. Guards all in0 candidates the cross-product pairs with the DS hint; though
-// our injected in0 is valid by construction. tt-metal should be patched to
-// reject a bad combo catchably — until then it TT_FATALs (uncatchable abort),
-// so we must gate here. per_core_K = in0 shard width (tiles); K (tiles) = in1
-// shard height.
+// tt-metal needs, in tiles, K % per_core_K == 0 and per_core_K % in0_block_w ==
+// 0, where per_core_K is the in0 shard width and K the in1 shard height.
 static bool dsIn0CompatibleWithConfig(
     TTNNLayoutAttr in0, TTNNLayoutAttr in1,
     MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr dsCfg) {
@@ -601,12 +593,9 @@ bool MatmulRuleBook::isValidOutputHintForInputs(
           attrs->matmulProgramConfig.value())) {
     return true;
   }
-  // DS hint: only the canonical DS input combination is valid — L1
-  // width-sharded in0, DRAM width-sharded in1, with an in0 shard width
-  // compatible with the config's in0_block_w (see dsIn0CompatibleWithConfig).
-  // This runs for every in0 the cross-product pairs with the DS hint, not just
-  // the one we inject in getExtraInputReshardCandidates (that one is valid by
-  // construction).
+  // Runs for every in0 the cross-product pairs with the DS hint, not just the
+  // one getExtraInputReshardCandidates injects — that one is valid by
+  // construction.
   if (inputLayouts.size() < 2) {
     return false;
   }

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -292,14 +292,14 @@ struct DSPlan {
 static std::optional<DSPlan> buildDSPlan(Operation *op) {
   [[maybe_unused]] StringRef opName = op->getName().getStringRef();
 
-  // Respect the disable-dram-sharded-matmul pipeline option (set as a module
+  // Respect the enable-dram-sharded-matmul pipeline option (set as a module
   // attribute by DevicePassesWrapper). This is the choke point for the whole DS
   // path: the output hint and the input reshard candidates both need a plan,
   // and the apply and hint-validation paths only ever see a program config one
   // of those produced. Declining here therefore costs nothing downstream.
-  if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
+  if (!ttnn::utils::isDRAMShardedMatmulEnabled(op)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "DS declined ({0}): disabled by disable-dram-sharded-matmul",
+                 "DS declined ({0}): enable-dram-sharded-matmul is off",
                  opName);
     return std::nullopt;
   }

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -156,16 +156,6 @@ static std::optional<std::pair<Value, Value>> getMatmulOperands(Operation *op) {
 static bool isDSEligible(Operation *op, Value activation, Value weight) {
   [[maybe_unused]] StringRef opName = op->getName().getStringRef();
 
-  // Respect the disable-dram-sharded-matmul pipeline option (set as a module
-  // attribute by DevicePassesWrapper). Every DS entry point reaches this
-  // through buildDSPlan, so gating here covers all of them.
-  if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
-    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
-                 "DS declined ({0}): disabled by disable-dram-sharded-matmul",
-                 opName);
-    return false;
-  }
-
   if (!isBfpDRAMInterleaved(weight)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): weight is not a tiled bfp4/bfp8 "
@@ -301,6 +291,19 @@ struct DSPlan {
 // matmul (both operands and the output hint).
 static std::optional<DSPlan> buildDSPlan(Operation *op) {
   [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  // Respect the disable-dram-sharded-matmul pipeline option (set as a module
+  // attribute by DevicePassesWrapper). This is the choke point for the whole DS
+  // path: the output hint and the input reshard candidates both need a plan,
+  // and the transformation and hint-validation paths only ever see a program
+  // config one of those produced. Declining here therefore costs nothing
+  // downstream.
+  if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): disabled by disable-dram-sharded-matmul",
+                 opName);
+    return std::nullopt;
+  }
 
   std::optional<std::pair<Value, Value>> operands = getMatmulOperands(op);
   if (!operands) {

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -3,26 +3,340 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+#include "ttmlir/Utils.h"
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
+
+#include <cmath>
+#include <optional>
 
 namespace mlir::tt::ttnn {
 
-LayoutFilterFn MatmulRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
-  // Operand 1 (RHS/weights): reject all sharded layouts.
-  // DRAM width-sharded RHS is a special case in tt-metal but not yet
-  // supported by our program config generation.
-  if (operandIdx == 1) {
-    return layout_filter_utils::rejectAllSharded;
+// ============================================================================
+// DRAM-sharded matmul policy constants
+// ============================================================================
+//
+// The shard geometry, layout, and config *generation* lives in
+// MatmulProgramConfig.{h,cpp} (computeShardParams, buildDRAMSharded*). These
+// are the rule book's policy inputs: they drive eligibility and are passed into
+// computeShardParams as numBanks / numIn0Cores.
+
+static constexpr int64_t kTileSize = 32;
+// Single source of truth for how many cores the DS-matmul activation (in0) is
+// width-sharded across. Drives the in0 shard width, the K-divisibility
+// eligibility gate, and the in0 L1 tensor-buffer reservation in
+// computeShardParams. Keep these uses consistent.
+static constexpr int64_t kNumIn0Cores = 8;
+
+// Number of DRAM banks the weight is width-sharded across: every bank the
+// device exposes. Deliberately the same source deriveCanonicalDramCoreRangeSet
+// reads to build the layout's core range set, so the bank count and the
+// placement cannot disagree.
+//
+// Returns nullopt when the grid is not a shape canonical DRAM placement can
+// express (it requires a single row), so the DS path declines instead of
+// tripping the assert inside deriveCanonicalDramCoreRangeSet.
+static std::optional<int64_t> getNumDRAMBanks(ttcore::DeviceAttr deviceAttr) {
+  if (!deviceAttr) {
+    return std::nullopt;
+  }
+  llvm::ArrayRef<int64_t> dramGrid = deviceAttr.getDramGrid().getShape();
+  if (dramGrid.size() != 2 || dramGrid[0] != 1 || dramGrid[1] < 1) {
+    return std::nullopt;
+  }
+  return dramGrid[1];
+}
+
+// ============================================================================
+// Eligibility helpers
+// ============================================================================
+
+// The weight's TTNN layout, or null when its type does not carry one. The
+// layout is where the on-device tiling and dtype live, so it is the single
+// thing the checks below need.
+static TTNNLayoutAttr getWeightLayout(Value weight) {
+  auto rtt = mlir::dyn_cast<RankedTensorType>(weight.getType());
+  if (!rtt) {
+    return {};
+  }
+  return mlir::dyn_cast_or_null<TTNNLayoutAttr>(rtt.getEncoding());
+}
+
+// Whether the weight is a tiled, DRAM-interleaved tensor of a data type the DS
+// kernel is offered for.
+//
+// bfp4/bfp8 only. tt-metal imposes no dtype constraint on the DS config (there
+// is no dtype TT_FATAL in the DRAM-sharded validation block), so this is a
+// heuristic trying to prevent DRAM OOM, not a legality check.
+static bool isBfpDRAMInterleaved(Value weight) {
+  TTNNLayoutAttr layout = getWeightLayout(weight);
+  if (!layout || !layout.isTiled()) {
+    return false;
+  }
+  ttcore::DataType dt = layout.getDataType();
+  if (dt != ttcore::DataType::BFP_BFloat8 &&
+      dt != ttcore::DataType::BFP_BFloat4) {
+    return false;
+  }
+  return layout.hasInterleavedDRAMTensorMemoryLayout();
+}
+
+// A weight is DS-shaped when it is a plain 2-D matrix, possibly carrying
+// leading unit batch dims: ttnn models routinely hold projection weights as [1,
+// 1, K, N], which is the same matrix as [K, N] — same element count, same tile
+// grid, and TTNN already collapses both to a 2-D memref in the layout.
+//
+// A non-unit leading dim is a genuinely batched matmul, which this path does
+// not emit: tt-metal serves that case with a different config,
+// MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig.
+static bool isDSWeightShaped(RankedTensorType rtt) {
+  llvm::ArrayRef<int64_t> shape = rtt.getShape();
+  if (shape.size() < 2) {
+    return false;
+  }
+  return llvm::all_of(shape.drop_back(2), [](int64_t dim) { return dim == 1; });
+}
+
+static std::pair<int64_t, int64_t> getWeightKN(RankedTensorType rtt) {
+  llvm::ArrayRef<int64_t> shape = rtt.getShape();
+  assert(isDSWeightShaped(rtt) && "Expected a 2-D (or unit-batched) weight");
+  return {shape[shape.size() - 2], shape[shape.size() - 1]};
+}
+
+static int64_t getActivationM(RankedTensorType rtt) {
+  int64_t M = 1;
+  for (int64_t dim : rtt.getShape().drop_back()) {
+    M *= dim;
+  }
+  return M;
+}
+
+// The (activation, weight) pair for a matmul-like op the DS kernel could
+// implement, or nullopt if `op` is not one.
+//
+// ttnn.matmul and ttnn.linear alike: a bias-free linear IS the matmul the DS
+// kernel implements, and ttnn decoders write their projections as ttnn.linear.
+//
+// A bias is rejected even though tt-metal's DS kernel supports one. The kernel
+// reads it per DRAM bank at a bank-local offset and adds it on the DRAM-bank
+// compute cores, so it needs a DRAM width-sharded layout for operand 2 that
+// nothing here produces yet; a DRAM-interleaved bias would be read as a strided
+// subset of itself, which is wrong results rather than a crash.
+static std::optional<std::pair<Value, Value>> getMatmulOperands(Operation *op) {
+  if (auto matmulOp = dyn_cast<MatmulOp>(op)) {
+    if (matmulOp.getTransposeA() || matmulOp.getTransposeB()) {
+      return std::nullopt;
+    }
+    return std::make_pair(matmulOp.getA(), matmulOp.getB());
+  }
+  if (auto linearOp = dyn_cast<LinearOp>(op)) {
+    if (linearOp.getBias() || linearOp.getTransposeA() ||
+        linearOp.getTransposeB()) {
+      return std::nullopt;
+    }
+    return std::make_pair(linearOp.getA(), linearOp.getB());
+  }
+  return std::nullopt;
+}
+
+// Whether the DS path is offered for `op` with these operands. Logs the reason
+// on every decline.
+static bool isDSEligible(Operation *op, Value activation, Value weight) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  if (!isBfpDRAMInterleaved(weight)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight is not a tiled bfp4/bfp8 "
+                 "DRAM-interleaved tensor",
+                 opName);
+    return false;
+  }
+  if (!ttcore::valueTracesToConstantArgs(weight)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight does not trace to constant args",
+                 opName);
+    return false;
+  }
+  auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+  if (!isDSWeightShaped(weightType)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight rank {1} has a non-unit batch dim, "
+                 "so it is not a 2-D (optionally unit-batched) matrix",
+                 opName, weightType.getRank());
+    return false;
   }
 
-  // Sharding activation/bias operands is supported.
-  return nullptr;
+  auto in0Type = mlir::cast<RankedTensorType>(activation.getType());
+  int64_t M = getActivationM(in0Type);
+  auto [K, N] = getWeightKN(weightType);
+
+  if (K % kTileSize != 0 || N % kTileSize != 0) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): K={1} / N={2} not tile-aligned", opName, K,
+                 N);
+    return false;
+  }
+  // K is the contraction dim, width-sharded across the in0 cores, so it must
+  // divide evenly by the in0 core count (same requirement computeShardParams
+  // enforces via kTiles % numIn0Cores). Gate on it here so an ineligible op is
+  // rejected up front rather than deep in shard-param computation — and so that
+  // computeShardParams' assert holds by construction rather than by contract.
+  if ((K / kTileSize) % kNumIn0Cores != 0) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): K tiles {1} not divisible by the in0 core "
+                 "count {2}",
+                 opName, K / kTileSize, kNumIn0Cores);
+    return false;
+  }
+  // Decode-only, and this is tt-metal's constraint rather than a proxy for it:
+  // the DS validation asserts TT_FATAL(M == 1) on the activation height in
+  // tiles, i.e. exactly one tile row. Note M here is the logical row count with
+  // leading dims collapsed, so this accepts a sub-tile batch (1..31, padded up
+  // to one tile row by tt-metal) and rejects anything taller. The assert is
+  // uncatchable, so the rejection has to happen here rather than in the op
+  // model.
+  if (llvm::divideCeil(M, kTileSize) != 1) {
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "DS declined ({0}): activation M={1} is more than one tile row", opName,
+        M);
+    return false;
+  }
+
+  return true;
 }
+
+// What the shard geometry needs from the device and the system descriptor.
+struct DSDeviceContext {
+  ttcore::DeviceAttr deviceAttr;
+  int64_t numDRAMBanks;
+  int64_t numWorkerCores;
+  int64_t l1Available;
+};
+
+// Returns nullopt, having logged the reason, when the module carries no system
+// descriptor or the device's DRAM grid is not one canonical placement can
+// express.
+static std::optional<DSDeviceContext> getDSDeviceContext(Operation *op) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  if (!moduleOp) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): op has no parent module", opName);
+    return std::nullopt;
+  }
+  auto systemDescAttr = moduleOp->getAttr(ttcore::SystemDescAttr::name);
+  if (!systemDescAttr) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): module has no system descriptor", opName);
+    return std::nullopt;
+  }
+
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
+  std::optional<int64_t> numDRAMBanks = getNumDRAMBanks(deviceAttr);
+  if (!numDRAMBanks) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): device DRAM grid is not a single row that "
+                 "canonical DRAM placement can express",
+                 opName);
+    return std::nullopt;
+  }
+
+  auto systemDesc = mlir::cast<ttcore::SystemDescAttr>(systemDescAttr);
+  int64_t l1Available =
+      static_cast<int64_t>(ttnn::utils::getTensorL1UsageCap(moduleOp) *
+                           systemDesc.getChipDescs()[0].getUsableL1Size());
+
+  return DSDeviceContext{
+      deviceAttr, *numDRAMBanks,
+      ttmlir::utils::volume(deviceAttr.getWorkerGrid().getShape()),
+      l1Available};
+}
+
+// Everything the DS path derives from an op: the operand types and the shard
+// geometry.
+//
+// The output hint and the input reshard candidates are both built from one of
+// these, which is what keeps them consistent: the in0 layout's shard width has
+// to match the config's in0_block_w, and the weight layout's bank count has to
+// match the one the geometry was computed for.
+struct DSPlan {
+  RankedTensorType in0Type;
+  RankedTensorType weightType;
+  DRAMShardParams params;
+  ttcore::DeviceAttr deviceAttr;
+};
+
+// Returns nullopt, having logged the reason, when the op is not DS-eligible or
+// the shard geometry does not fit L1.
+//
+// Derived afresh on every query rather than cached. Rule books are
+// process-global singletons reached through const methods, and a plan is a
+// function of the operand layouts, which the optimizer rewrites between
+// invocations — a cache would either go stale or key on a recycled Operation *.
+// The cost is a use-def walk plus a bounded divisor search, run three times per
+// matmul (both operands and the output hint).
+static std::optional<DSPlan> buildDSPlan(Operation *op) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  std::optional<std::pair<Value, Value>> operands = getMatmulOperands(op);
+  if (!operands) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): not a bias-free, non-transposed "
+                 "matmul/linear",
+                 opName);
+    return std::nullopt;
+  }
+  auto [activation, weight] = *operands;
+
+  if (!isDSEligible(op, activation, weight)) {
+    return std::nullopt;
+  }
+  std::optional<DSDeviceContext> device = getDSDeviceContext(op);
+  if (!device) {
+    return std::nullopt;
+  }
+
+  auto in0Type = mlir::cast<RankedTensorType>(activation.getType());
+  auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+  int64_t M = getActivationM(in0Type);
+  auto [K, N] = getWeightKN(weightType);
+
+  std::optional<DRAMShardParams> params = computeShardParams(
+      M, K, N, device->numDRAMBanks, kNumIn0Cores, device->numWorkerCores,
+      getWeightLayout(weight).getDataType(), device->l1Available);
+  if (!params) {
+    // Either no in0_block_w dividing K-per-core leaves room for the circular
+    // buffers, or the largest one that does is a degenerate fraction of
+    // K-per-core (see kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): no in0_block_w both fits L1 and avoids a "
+                 "degenerate block count (M={1} K={2} "
+                 "N={3} banks={4} in0Cores={5} cores={6} l1Available={7})",
+                 opName, M, K, N, device->numDRAMBanks, kNumIn0Cores,
+                 device->numWorkerCores, device->l1Available);
+    return std::nullopt;
+  }
+
+  return DSPlan{in0Type, weightType, *params, device->deviceAttr};
+}
+
+// ============================================================================
+// MatmulRuleBook — existing helpers
+// ============================================================================
 
 static bool isL1Interleaved(const OpConfig &config) {
   if (!config.outputLayout) {
@@ -49,29 +363,125 @@ static bool hasMatmulProgramConfig(const OpConfig &config) {
   return false;
 }
 
+// ============================================================================
+// MatmulRuleBook — private DRAM-sharding helpers
+// ============================================================================
+//
+// buildDRAMShardingHint produces the DS output hint consumed by getOutputHints;
+// applyDRAMShardedTransformation rewrites the op at apply time and is called by
+// applyOpSpecificAttrs. Both are defined ahead of their callers below.
+
+std::optional<OpConfig>
+MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
+  std::optional<DSPlan> plan = buildDSPlan(op);
+  if (!plan) {
+    return std::nullopt;
+  }
+  const DRAMShardParams &p = plan->params;
+  ttcore::DeviceAttr deviceAttr = plan->deviceAttr;
+
+  auto *ctx = op->getContext();
+  auto outLayout = mlir::cast<TTNNLayoutAttr>(
+      mlir::cast<RankedTensorType>(op->getResult(0).getType()).getEncoding());
+  auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+
+  // numOutputCores = div_up(N_tiles, per_core_N_storage): exactly how many
+  // output cores compute_output_specs will allocate, ensuring no assertion
+  // fire.
+  int64_t numOutputCores = llvm::divideCeil(p.N / kTileSize, p.perCoreN);
+
+  llvm::SmallVector<int64_t, 2> outputGrid = {1, numOutputCores};
+  TTNNLayoutAttr l1OutLayout =
+      TTNNLayoutAttr::Builder(outLayout, resultType.getShape())
+          .setBufferType(BufferType::L1)
+          .setMemoryLayout(TensorMemoryLayoutAttr::get(
+              ctx, TensorMemoryLayout::WidthSharded))
+          .setGridShape(outputGrid)
+          .buildWithCanonicalCorePlacement(deviceAttr);
+
+  // Activation is handled as a separate elementwise op after the DS matmul
+  // (see applyDRAMShardedTransformation). Fusing it into the DS kernel is
+  // significantly slower. The op model is told no activation so it validates
+  // the DS config cleanly; the activation attribute on the op is stripped and
+  // a separate op is inserted at apply time.
+  UnaryWithParamAttr fusedAct;
+  auto progConfig = buildDRAMShardedProgramConfig(ctx, p, fusedAct);
+  auto computeConfig = buildComputeConfig(ctx, p.weightDataType);
+
+  return OpConfig(l1OutLayout, MatmulAttrs{progConfig, computeConfig});
+}
+
+void MatmulRuleBook::applyDRAMShardedTransformation(
+    Operation *op, const MatmulAttrs &matmulAttrs) const {
+  auto *ctx = op->getContext();
+  // Input reshards (activation → L1 1×kNumIn0Cores, weight → DRAM 1×numBanks)
+  // handled by pass-2 in applyToIR via reshardLayouts populated from the input
+  // candidates injected by getExtraInputReshardCandidates.
+
+  OpBuilder builder(op);
+
+  // --- 1. Set program config and compute config ---
+  // ttnn.matmul and ttnn.linear both carry matmul_program_config,
+  // compute_config and activation, so the DS rewrite is identical for either
+  // (see getMatmulOperands).
+  auto dsProgConfig =
+      mlir::cast<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          matmulAttrs.matmulProgramConfig.value());
+  StringAttr activationAttr =
+      llvm::TypeSwitch<Operation *, StringAttr>(op)
+          .Case<MatmulOp, LinearOp>([&](auto concreteOp) {
+            concreteOp.setMatmulProgramConfigAttr(dsProgConfig);
+            if (matmulAttrs.computeKernelConfig.has_value()) {
+              concreteOp.setComputeConfigAttr(*matmulAttrs.computeKernelConfig);
+            }
+            // Strip the activation here and hand it back; step 2 re-homes it.
+            StringAttr act = concreteOp.getActivationAttr();
+            if (act) {
+              concreteOp.removeActivationAttr();
+            }
+            return act;
+          })
+          .Default([](Operation *) { return StringAttr(); });
+
+  // --- 2. Handle the fused activation ---
+  // Fusing the activation into the DS matmul kernel is significantly slower
+  // (measured: the 12-core DS matmul applies silu much slower than an op on all
+  // 64 cores), so strip it off the matmul and run it as a separate elementwise
+  // op across all cores.
+  if (activationAttr) {
+    StringRef actStr = activationAttr.getValue();
+    Value matmulResult = op->getResult(0);
+
+    StringRef opName;
+    if (actStr == "silu") {
+      opName = "ttnn.silu";
+    } else if (actStr == "relu") {
+      opName = "ttnn.relu";
+    } else if (actStr == "gelu") {
+      opName = "ttnn.gelu";
+    }
+    if (!opName.empty()) {
+      builder.setInsertionPointAfter(op);
+      auto *activationOp = builder.create(
+          op->getLoc(), StringAttr::get(ctx, opName), ValueRange{matmulResult},
+          TypeRange{matmulResult.getType()});
+      matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
+                                        activationOp);
+    }
+  }
+}
+
+// ============================================================================
+// MatmulRuleBook::getOutputHints
+// ============================================================================
+
 OutputHints MatmulRuleBook::getOutputHints(
-    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
-  // Use partial configs: deduplicate by (bufferType, memLayout),
-  // set ignorePhysicalLayout=true. Backend decides physical layout.
+    Operation *op, const std::vector<OpConfig> &legalConfigs) const {
+
   auto partialConfigs =
       optimizer_utils::getUniqueTestConfigsForMatmulLinear(legalConfigs);
 
-  // Remove L1-interleaved hints for matmul/linear output.
-  //
-  // L1-interleaved output is "worst of both worlds" for matmul:
-  //  - generateMatmulProgramConfig() returns nullopt for non-sharded
-  //    output, so no program config is emitted by the compiler.
-  //  - tt-metal runtime falls back to MatmulMultiCoreProgramConfig{}
-  //    with hardcoded HiFi4 math fidelity (the slowest kernel path).
-  //  - Same NOC write overhead as DRAM interleaved (not eliminated
-  //    like sharded), loses bias fusion, optimized mcast program
-  //    configs, and narrow-shape 1D optimization.
-  //  - Subject to L1 capacity constraints unlike DRAM interleaved.
-  //
-  // DRAM-interleaved is the safe default: full bias fusion, optimized
-  // 1D/2D mcast configs, and no L1 pressure from the output tensor.
-  // L1-sharded is best when applicable (eliminates NOC writes entirely).
-  // https://github.com/tenstorrent/tt-mlir/issues/7682
+  // Filter out L1-interleaved and sharded configs without a program config.
   std::vector<OpConfig> filtered;
   for (const auto &cfg : partialConfigs) {
     if (isL1Interleaved(cfg)) {
@@ -92,8 +502,33 @@ OutputHints MatmulRuleBook::getOutputHints(
     filtered.push_back(cfg);
   }
 
+  // Prepend the DS hint when eligible. adjustScore gives it priority over the
+  // normal hints via isDRAMShardedCandidate; normal hints remain as fallback
+  // in case DS validation fails for a given input combination.
+  if (auto dramHint = buildDRAMShardingHint(op)) {
+    filtered.insert(filtered.begin(), *dramHint);
+  }
+
   return OutputHints{filtered, {}};
 }
+
+// ============================================================================
+// MatmulRuleBook::getInputLayoutFilter
+// ============================================================================
+
+LayoutFilterFn MatmulRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Weight (operand 1): reject L1.
+  // DRAM WIDTH_SHARDED is allowed for the DRAM-sharded matmul path.
+  // DRAM interleaved is always allowed.
+  if (operandIdx == 1) {
+    return layout_filter_utils::rejectAllL1;
+  }
+  return nullptr;
+}
+
+// ============================================================================
+// MatmulRuleBook::applyOpSpecificAttrs
+// ============================================================================
 
 void MatmulRuleBook::applyOpSpecificAttrs(
     Operation *op, const BeamCandidate &candidate) const {
@@ -112,8 +547,20 @@ void MatmulRuleBook::applyOpSpecificAttrs(
   if (!matmulAttrs.matmulProgramConfig.has_value()) {
     return;
   }
+
   auto programConfig = matmulAttrs.matmulProgramConfig.value();
 
+  // DRAM-sharded path: weight reshard, program/compute config, activation
+  // split.
+  bool isDRAMSharded =
+      mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          programConfig);
+  if (isDRAMSharded) {
+    applyDRAMShardedTransformation(op, matmulAttrs);
+    return;
+  }
+
+  // Non-DRAM-sharded path: set program config, handle fused activation dedup.
   auto setConfigAndFixup = [&](auto concreteOp) {
     concreteOp.setMatmulProgramConfigAttr(programConfig);
     // Workaround for tt-metal issue #35060: if the program config carries a
@@ -121,10 +568,8 @@ void MatmulRuleBook::applyOpSpecificAttrs(
     // double application.
     bool hasFusedActivation =
         llvm::TypeSwitch<mlir::Attribute, bool>(programConfig)
-            .template Case<
-                MatmulMultiCoreReuseMultiCastProgramConfigAttr,
-                MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
-                MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            .template Case<MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+                           MatmulMultiCoreReuseMultiCast1DProgramConfigAttr>(
                 [](auto config) {
                   return config.getFusedActivation() != nullptr;
                 })
@@ -139,6 +584,135 @@ void MatmulRuleBook::applyOpSpecificAttrs(
   } else {
     setConfigAndFixup(linearOp);
   }
+}
+
+// ============================================================================
+// MatmulRuleBook::isValidOutputHintForInputs
+// ============================================================================
+
+// Reject in0 whose shard width is incompatible with the config's in0_block_w.
+// tt-metal needs (tiles): K % per_core_K == 0 and per_core_K % in0_block_w ==
+// 0. Guards all in0 candidates the cross-product pairs with the DS hint; though
+// our injected in0 is valid by construction. tt-metal should be patched to
+// reject a bad combo catchably — until then it TT_FATALs (uncatchable abort),
+// so we must gate here. per_core_K = in0 shard width (tiles); K (tiles) = in1
+// shard height.
+static bool dsIn0CompatibleWithConfig(
+    TTNNLayoutAttr in0, TTNNLayoutAttr in1,
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr dsCfg) {
+  auto in0Shard = in0.getShardShape();
+  auto in1Shard = in1.getShardShape();
+  if (in0Shard.size() != 2 || in1Shard.size() != 2) {
+    // Cannot read the shard width, so cannot verify the combo is legal. A
+    // width-sharded in0/in1 for these matmuls is always 2-D (and our injected
+    // in0 always is), so reject rather than risk a tt-metal abort.
+    return false;
+  }
+  int64_t perCoreK = in0Shard[1];
+  int64_t kTiles = in1Shard[0];
+  int64_t in0BlockW = static_cast<int64_t>(dsCfg.getIn0BlockW());
+  return perCoreK != 0 && in0BlockW != 0 && kTiles % perCoreK == 0 &&
+         perCoreK % in0BlockW == 0;
+}
+
+bool MatmulRuleBook::isValidOutputHintForInputs(
+    const OpConfig &hint, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const {
+  const auto *attrs = std::get_if<MatmulAttrs>(&hint.opSpecificAttrs);
+  if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+      !mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value())) {
+    return true;
+  }
+  // DS hint: only the canonical DS input combination is valid — L1
+  // width-sharded in0, DRAM width-sharded in1, with an in0 shard width
+  // compatible with the config's in0_block_w (see dsIn0CompatibleWithConfig).
+  // This runs for every in0 the cross-product pairs with the DS hint, not just
+  // the one we inject in getExtraInputReshardCandidates (that one is valid by
+  // construction).
+  if (inputLayouts.size() < 2) {
+    return false;
+  }
+  auto in0 = inputLayouts[0];
+  auto in1 = inputLayouts[1];
+  if (!in0 || !in1) {
+    return false;
+  }
+  auto ml0 = in0.getMemLayoutOpt();
+  if (!in0.hasL1BufferType() || !ml0 ||
+      *ml0 != TensorMemoryLayout::WidthSharded) {
+    return false;
+  }
+  auto ml1 = in1.getMemLayoutOpt();
+  if (in1.hasL1BufferType() || !ml1 ||
+      *ml1 != TensorMemoryLayout::WidthSharded) {
+    return false;
+  }
+  auto dsCfg =
+      mlir::cast<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value());
+  return dsIn0CompatibleWithConfig(in0, in1, dsCfg);
+}
+
+// ============================================================================
+// MatmulRuleBook::adjustScore
+// ============================================================================
+
+LayoutScore
+MatmulRuleBook::adjustScore(Operation * /*op*/, LayoutScore base,
+                            const OpConfig &config,
+                            llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                            bool /*requiresReshard*/) const {
+  const auto *attrs = std::get_if<MatmulAttrs>(&config.opSpecificAttrs);
+  if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+      !attrs->matmulProgramConfig.value()) {
+    return base;
+  }
+  if (!mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value())) {
+    return base;
+  }
+  base.isDRAMShardedCandidate = true;
+  if (!inputLayouts.empty()) {
+    auto in0 = inputLayouts[0];
+    if (in0 && in0.hasL1BufferType()) {
+      auto ml = in0.getMemLayoutOpt();
+      if (ml && *ml == TensorMemoryLayout::WidthSharded) {
+        auto shape = in0.getGridShape();
+        if (shape.size() == 2 && shape[0] == 1 && shape[1] == kNumIn0Cores) {
+          base.hasCanonicalDSIn0 = true;
+        }
+      }
+    }
+  }
+  return base;
+}
+
+// ============================================================================
+// MatmulRuleBook::getExtraInputReshardCandidates
+// ============================================================================
+
+std::vector<TTNNLayoutAttr>
+MatmulRuleBook::getExtraInputReshardCandidates(Operation *op,
+                                               unsigned operandIdx) const {
+  std::optional<DSPlan> plan = buildDSPlan(op);
+  if (!plan) {
+    return {};
+  }
+
+  auto *ctx = op->getContext();
+  if (operandIdx == 0) {
+    auto in0Layout = mlir::cast<TTNNLayoutAttr>(plan->in0Type.getEncoding());
+    return {buildL1ShardedLayout(ctx, in0Layout, plan->in0Type.getShape(),
+                                 kNumIn0Cores, plan->deviceAttr)};
+  }
+  if (operandIdx == 1) {
+    auto weightLayout =
+        mlir::cast<TTNNLayoutAttr>(plan->weightType.getEncoding());
+    return {buildDRAMShardedWeightLayout(ctx, weightLayout,
+                                         plan->weightType.getShape(),
+                                         plan->params, plan->deviceAttr)};
+  }
+  return {};
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -156,6 +156,16 @@ static std::optional<std::pair<Value, Value>> getMatmulOperands(Operation *op) {
 static bool isDSEligible(Operation *op, Value activation, Value weight) {
   [[maybe_unused]] StringRef opName = op->getName().getStringRef();
 
+  // Respect the disable-dram-sharded-matmul pipeline option (set as a module
+  // attribute by DevicePassesWrapper). Every DS entry point reaches this
+  // through buildDSPlan, so gating here covers all of them.
+  if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): disabled by disable-dram-sharded-matmul",
+                 opName);
+    return false;
+  }
+
   if (!isBfpDRAMInterleaved(weight)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): weight is not a tiled bfp4/bfp8 "

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -295,13 +295,29 @@ static std::optional<DSPlan> buildDSPlan(Operation *op) {
   // Respect the disable-dram-sharded-matmul pipeline option (set as a module
   // attribute by DevicePassesWrapper). This is the choke point for the whole DS
   // path: the output hint and the input reshard candidates both need a plan,
-  // and the transformation and hint-validation paths only ever see a program
-  // config one of those produced. Declining here therefore costs nothing
-  // downstream.
+  // and the apply and hint-validation paths only ever see a program config one
+  // of those produced. Declining here therefore costs nothing downstream.
   if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): disabled by disable-dram-sharded-matmul",
                  opName);
+    return std::nullopt;
+  }
+
+  // Decline a matmul that still carries a fused activation. A DS program
+  // config's fused_activation is always null, so the op model validates the
+  // config without the activation while the runtime forwards it to
+  // ::ttnn::matmul -- validating one thing and running another. A 1D/2D mcast
+  // config folds it into its own fused_activation instead.
+  StringAttr fusedActivation =
+      llvm::TypeSwitch<Operation *, StringAttr>(op)
+          .Case<MatmulOp, LinearOp>(
+              [](auto concreteOp) { return concreteOp.getActivationAttr(); })
+          .Default([](Operation *) { return StringAttr(); });
+  if (fusedActivation) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): op carries a fused activation '{1}'",
+                 opName, fusedActivation.getValue());
     return std::nullopt;
   }
 
@@ -380,9 +396,8 @@ static bool hasMatmulProgramConfig(const OpConfig &config) {
 // MatmulRuleBook — private DRAM-sharding helpers
 // ============================================================================
 //
-// buildDRAMShardingHint produces the DS output hint consumed by getOutputHints;
-// applyDRAMShardedTransformation rewrites the op at apply time and is called by
-// applyOpSpecificAttrs. Both are defined ahead of their callers below.
+// buildDRAMShardingHint produces the DS output hint consumed by getOutputHints,
+// and is defined ahead of its caller below.
 
 std::optional<OpConfig>
 MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
@@ -412,117 +427,13 @@ MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
           .setGridShape(outputGrid)
           .buildWithCanonicalCorePlacement(deviceAttr);
 
-  // Activation is handled as a separate elementwise op after the DS matmul
-  // (see applyDRAMShardedTransformation). Fusing it into the DS kernel is
-  // significantly slower. The op model is told no activation so it validates
-  // the DS config cleanly; the activation attribute on the op is stripped and
-  // a separate op is inserted at apply time.
+  // No fused activation, and none is possible: buildDSPlan declines a matmul
+  // that carries one, so the op model validates the DS config without it.
   UnaryWithParamAttr fusedAct;
   auto progConfig = buildDRAMShardedProgramConfig(ctx, p, fusedAct);
   auto computeConfig = buildComputeConfig(ctx, p.weightDataType);
 
   return OpConfig(l1OutLayout, MatmulAttrs{progConfig, computeConfig});
-}
-
-void MatmulRuleBook::applyDRAMShardedTransformation(
-    Operation *op, const MatmulAttrs &matmulAttrs) const {
-  auto *ctx = op->getContext();
-  // Input reshards (activation → L1 1×kNumIn0Cores, weight → DRAM 1×numBanks)
-  // handled by pass-2 in applyToIR via reshardLayouts populated from the input
-  // candidates injected by getExtraInputReshardCandidates.
-
-  OpBuilder builder(op);
-
-  // --- 1. Set program config and compute config ---
-  // ttnn.matmul and ttnn.linear both carry matmul_program_config,
-  // compute_config and activation, so the DS rewrite is identical for either
-  // (see getMatmulOperands).
-  auto dsProgConfig =
-      mlir::cast<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
-          matmulAttrs.matmulProgramConfig.value());
-  StringAttr activationAttr =
-      llvm::TypeSwitch<Operation *, StringAttr>(op)
-          .Case<MatmulOp, LinearOp>([&](auto concreteOp) {
-            concreteOp.setMatmulProgramConfigAttr(dsProgConfig);
-            if (matmulAttrs.computeKernelConfig.has_value()) {
-              concreteOp.setComputeConfigAttr(*matmulAttrs.computeKernelConfig);
-            }
-            // Strip the activation here and hand it back; step 2 re-homes it.
-            StringAttr act = concreteOp.getActivationAttr();
-            if (act) {
-              concreteOp.removeActivationAttr();
-            }
-            return act;
-          })
-          .Default([](Operation *) { return StringAttr(); });
-
-  // --- 2. Handle the fused activation ---
-  // Fusing the activation into the DS matmul kernel is significantly slower
-  // (measured: the 12-core DS matmul applies silu much slower than an op on all
-  // 64 cores). So strip it off the matmul and either (a) fold it into a
-  // consuming multiply as its operand-A activation — SwiGLU:
-  // multiply(silu(gate), up) — which runs on the full grid (cheapest), or (b)
-  // fall back to a separate elementwise op.
-  if (activationAttr) {
-    StringRef actStr = activationAttr.getValue();
-    Value matmulResult = op->getResult(0);
-
-    // (a) Try to fold silu into a consuming ttnn.multiply as an operand-A
-    // activation. Only when the matmul result's sole non-dealloc consumer is a
-    // multiply (either operand — multiply is commutative, so we normalize the
-    // silu'd value to operand A). Silu only: it is the activation SwiGLU puts
-    // there, and the one the eltwise activation path is exercised for.
-    MultiplyOp fuseInto = nullptr;
-    if (actStr == "silu") {
-      Operation *soleUser = nullptr;
-      bool multiUse = false;
-      for (Operation *u : matmulResult.getUsers()) {
-        if (isa<DeallocateOp>(u)) {
-          continue;
-        }
-        if (soleUser) {
-          multiUse = true;
-          break;
-        }
-        soleUser = u;
-      }
-      if (!multiUse && soleUser) {
-        fuseInto = dyn_cast<MultiplyOp>(soleUser);
-      }
-    }
-
-    ArrayAttr existingActs =
-        fuseInto ? fuseInto.getInputTensorAActivations() : nullptr;
-    if (fuseInto && (!existingActs || existingActs.empty()) &&
-        (fuseInto.getLhs() == matmulResult ||
-         fuseInto.getRhs() == matmulResult)) {
-      // Normalize the silu'd (matmul) value to operand A, then add the
-      // activation there.
-      Value other = fuseInto.getLhs() == matmulResult ? fuseInto.getRhs()
-                                                      : fuseInto.getLhs();
-      fuseInto.getLhsMutable().assign(matmulResult);
-      fuseInto.getRhsMutable().assign(other);
-      fuseInto.addInputTensorAActivation(UnaryOpType::Silu, /*params=*/{});
-    } else {
-      // (b) Fallback: separate elementwise op running across all cores.
-      StringRef opName;
-      if (actStr == "silu") {
-        opName = "ttnn.silu";
-      } else if (actStr == "relu") {
-        opName = "ttnn.relu";
-      } else if (actStr == "gelu") {
-        opName = "ttnn.gelu";
-      }
-      if (!opName.empty()) {
-        builder.setInsertionPointAfter(op);
-        auto *activationOp = builder.create(
-            op->getLoc(), StringAttr::get(ctx, opName),
-            ValueRange{matmulResult}, TypeRange{matmulResult.getType()});
-        matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
-                                          activationOp);
-      }
-    }
-  }
 }
 
 // ============================================================================
@@ -604,13 +515,26 @@ void MatmulRuleBook::applyOpSpecificAttrs(
 
   auto programConfig = matmulAttrs.matmulProgramConfig.value();
 
-  // DRAM-sharded path: weight reshard, program/compute config, activation
-  // split.
+  // DRAM-sharded path: program/compute config only. The input reshards
+  // (activation → L1 1×kNumIn0Cores, weight → DRAM 1×numBanks) are handled by
+  // pass-2 in applyToIR via reshardLayouts populated from the input candidates
+  // injected by getExtraInputReshardCandidates. A DS candidate is only offered
+  // for a matmul carrying no activation, so there is none to handle here.
   bool isDRAMSharded =
       mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
           programConfig);
   if (isDRAMSharded) {
-    applyDRAMShardedTransformation(op, matmulAttrs);
+    auto setDSConfig = [&](auto concreteOp) {
+      concreteOp.setMatmulProgramConfigAttr(programConfig);
+      if (matmulAttrs.computeKernelConfig.has_value()) {
+        concreteOp.setComputeConfigAttr(*matmulAttrs.computeKernelConfig);
+      }
+    };
+    if (matmulOp) {
+      setDSConfig(matmulOp);
+    } else {
+      setDSConfig(linearOp);
+    }
     return;
   }
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -112,7 +112,7 @@ void createTTNNPipelineAnalysisPasses(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
-    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
+    wrapperOptions.enableDRAMShardedMatmul = options.enableDRAMShardedMatmul;
 
     ttnn::TTNNOperationValidationAndFallbackOptions validationOptions;
     validationOptions.maxFallbackAttempts = options.maxFallbackAttempts;
@@ -214,7 +214,7 @@ void createTTNNResolveCompositesPass(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
-    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
+    wrapperOptions.enableDRAMShardedMatmul = options.enableDRAMShardedMatmul;
     pm.addPass(createDevicePassesWrapper(
         [](OpPassManager &innerPm) {
           TTNNResolveCompositesOptions resolveOptions;
@@ -249,8 +249,7 @@ void createTTNNFusingPass(OpPassManager &pm,
       DevicePassesWrapperOptions wrapperOptions;
       wrapperOptions.devicePtr = options.devicePtr;
       wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
-      wrapperOptions.disableDRAMShardedMatmul =
-          options.disableDRAMShardedMatmul;
+      wrapperOptions.enableDRAMShardedMatmul = options.enableDRAMShardedMatmul;
 
       uint32_t fallbackAttempts = options.maxFallbackAttempts;
       bool enableEltwiseActivationFusion =
@@ -258,16 +257,16 @@ void createTTNNFusingPass(OpPassManager &pm,
       // Fusing needs to know whether DRAM sharding is on so it can keep an
       // activation off a producer matmul. Only the optimizer selects DS
       // configs, so the non-optimizer path below leaves the pass default alone.
-      bool disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
+      bool enableDRAMShardedMatmul = options.enableDRAMShardedMatmul;
       pm.addPass(createDevicePassesWrapper(
           [fallbackAttempts, enableEltwiseActivationFusion,
-           disableDRAMShardedMatmul](OpPassManager &innerPm) {
+           enableDRAMShardedMatmul](OpPassManager &innerPm) {
             TTNNFusingOptions fusingOptions;
             fusingOptions.enableOpConstraints = true;
             fusingOptions.maxFallbackAttempts = fallbackAttempts;
             fusingOptions.enableEltwiseActivationFusion =
                 enableEltwiseActivationFusion;
-            fusingOptions.disableDRAMShardedMatmul = disableDRAMShardedMatmul;
+            fusingOptions.enableDRAMShardedMatmul = enableDRAMShardedMatmul;
             innerPm.addPass(mlir::tt::ttnn::createTTNNFusing(fusingOptions));
           },
           wrapperOptions));
@@ -399,8 +398,8 @@ void createTTIRToTTNNCommonPipeline(
         DevicePassesWrapperOptions decompWrapperOptions;
         decompWrapperOptions.devicePtr = options.devicePtr;
         decompWrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
-        decompWrapperOptions.disableDRAMShardedMatmul =
-            options.disableDRAMShardedMatmul;
+        decompWrapperOptions.enableDRAMShardedMatmul =
+            options.enableDRAMShardedMatmul;
 
         uint32_t decompFallbackAttempts = options.maxFallbackAttempts;
         devicePm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -112,6 +112,7 @@ void createTTNNPipelineAnalysisPasses(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
 
     ttnn::TTNNOperationValidationAndFallbackOptions validationOptions;
     validationOptions.maxFallbackAttempts = options.maxFallbackAttempts;
@@ -213,6 +214,7 @@ void createTTNNResolveCompositesPass(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
     pm.addPass(createDevicePassesWrapper(
         [](OpPassManager &innerPm) {
           TTNNResolveCompositesOptions resolveOptions;
@@ -247,6 +249,8 @@ void createTTNNFusingPass(OpPassManager &pm,
       DevicePassesWrapperOptions wrapperOptions;
       wrapperOptions.devicePtr = options.devicePtr;
       wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+      wrapperOptions.disableDRAMShardedMatmul =
+          options.disableDRAMShardedMatmul;
 
       uint32_t fallbackAttempts = options.maxFallbackAttempts;
       bool enableEltwiseActivationFusion =
@@ -390,6 +394,8 @@ void createTTIRToTTNNCommonPipeline(
         DevicePassesWrapperOptions decompWrapperOptions;
         decompWrapperOptions.devicePtr = options.devicePtr;
         decompWrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+        decompWrapperOptions.disableDRAMShardedMatmul =
+            options.disableDRAMShardedMatmul;
 
         uint32_t decompFallbackAttempts = options.maxFallbackAttempts;
         devicePm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -255,14 +255,19 @@ void createTTNNFusingPass(OpPassManager &pm,
       uint32_t fallbackAttempts = options.maxFallbackAttempts;
       bool enableEltwiseActivationFusion =
           options.enableEltwiseActivationFusion;
+      // Fusing needs to know whether DRAM sharding is on so it can keep an
+      // activation off a producer matmul. Only the optimizer selects DS
+      // configs, so the non-optimizer path below leaves the pass default alone.
+      bool disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
       pm.addPass(createDevicePassesWrapper(
-          [fallbackAttempts,
-           enableEltwiseActivationFusion](OpPassManager &innerPm) {
+          [fallbackAttempts, enableEltwiseActivationFusion,
+           disableDRAMShardedMatmul](OpPassManager &innerPm) {
             TTNNFusingOptions fusingOptions;
             fusingOptions.enableOpConstraints = true;
             fusingOptions.maxFallbackAttempts = fallbackAttempts;
             fusingOptions.enableEltwiseActivationFusion =
                 enableEltwiseActivationFusion;
+            fusingOptions.disableDRAMShardedMatmul = disableDRAMShardedMatmul;
             innerPm.addPass(mlir::tt::ttnn::createTTNNFusing(fusingOptions));
           },
           wrapperOptions));

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
@@ -28,7 +28,8 @@ public:
                       const DevicePassesWrapperOptions &options)
       : populatePipeline(std::move(populatePipeline)),
         externalDevice(options.devicePtr),
-        tensorL1UsageCap(options.tensorL1UsageCap) {}
+        tensorL1UsageCap(options.tensorL1UsageCap),
+        disableDRAMShardedMatmul(options.disableDRAMShardedMatmul) {}
 
   StringRef getArgument() const override { return "device-passes-wrapper"; }
 
@@ -42,6 +43,7 @@ public:
     copy->externalDevice = externalDevice;
     copy->populatePipeline = populatePipeline;
     copy->tensorL1UsageCap = tensorL1UsageCap;
+    copy->disableDRAMShardedMatmul = disableDRAMShardedMatmul;
     return copy;
   }
 
@@ -64,6 +66,8 @@ public:
     OpBuilder builder(op->getContext());
     op->setAttr(utils::g_TensorL1UsageCapAttrName,
                 builder.getF32FloatAttr(tensorL1UsageCap));
+    op->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
+                builder.getBoolAttr(disableDRAMShardedMatmul));
 
     // Create nested pass manager and populate it.
     OpPassManager nestedPm(getOperation()->getName());
@@ -96,14 +100,16 @@ public:
       return;
     }
 
-    // Clean up the attribute after the nested passes complete.
+    // Clean up the attributes after the nested passes complete.
     op->removeAttr(utils::g_TensorL1UsageCapAttrName);
+    op->removeAttr(utils::g_DisableDRAMShardedMatmulAttrName);
   }
 
 private:
   std::function<void(OpPassManager &)> populatePipeline;
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> externalDevice;
   float tensorL1UsageCap;
+  bool disableDRAMShardedMatmul;
 };
 } // namespace
 

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
@@ -29,7 +29,7 @@ public:
       : populatePipeline(std::move(populatePipeline)),
         externalDevice(options.devicePtr),
         tensorL1UsageCap(options.tensorL1UsageCap),
-        disableDRAMShardedMatmul(options.disableDRAMShardedMatmul) {}
+        enableDRAMShardedMatmul(options.enableDRAMShardedMatmul) {}
 
   StringRef getArgument() const override { return "device-passes-wrapper"; }
 
@@ -43,7 +43,7 @@ public:
     copy->externalDevice = externalDevice;
     copy->populatePipeline = populatePipeline;
     copy->tensorL1UsageCap = tensorL1UsageCap;
-    copy->disableDRAMShardedMatmul = disableDRAMShardedMatmul;
+    copy->enableDRAMShardedMatmul = enableDRAMShardedMatmul;
     return copy;
   }
 
@@ -66,8 +66,8 @@ public:
     OpBuilder builder(op->getContext());
     op->setAttr(utils::g_TensorL1UsageCapAttrName,
                 builder.getF32FloatAttr(tensorL1UsageCap));
-    op->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
-                builder.getBoolAttr(disableDRAMShardedMatmul));
+    op->setAttr(utils::g_EnableDRAMShardedMatmulAttrName,
+                builder.getBoolAttr(enableDRAMShardedMatmul));
 
     // Create nested pass manager and populate it.
     OpPassManager nestedPm(getOperation()->getName());
@@ -102,14 +102,14 @@ public:
 
     // Clean up the attributes after the nested passes complete.
     op->removeAttr(utils::g_TensorL1UsageCapAttrName);
-    op->removeAttr(utils::g_DisableDRAMShardedMatmulAttrName);
+    op->removeAttr(utils::g_EnableDRAMShardedMatmulAttrName);
   }
 
 private:
   std::function<void(OpPassManager &)> populatePipeline;
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> externalDevice;
   float tensorL1UsageCap;
-  bool disableDRAMShardedMatmul;
+  bool enableDRAMShardedMatmul;
 };
 } // namespace
 

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -210,10 +210,15 @@ bool hasInterveningWrite(Value value, Operation *from, Operation *to) {
 
 class TTNNBinaryOpInputsActivation
     : public mlir::OpInterfaceRewritePattern<ElementwiseBinaryActivations> {
-  using TTNNBinaryOpInputsActivation::OpInterfaceRewritePattern<
-      ElementwiseBinaryActivations>::OpInterfaceRewritePattern;
-
 public:
+  // restrictToMatmulProducer keeps the pattern to unaries fed by a matmul or
+  // linear, which is all the DRAM-sharded path needs.
+  // enable-eltwise-activation-fusion asks for the general behaviour instead.
+  TTNNBinaryOpInputsActivation(mlir::MLIRContext *ctx,
+                               bool restrictToMatmulProducer)
+      : mlir::OpInterfaceRewritePattern<ElementwiseBinaryActivations>(ctx),
+        restrictToMatmulProducer(restrictToMatmulProducer) {}
+
   mlir::LogicalResult
   matchAndRewrite(ElementwiseBinaryActivations binaryOpWithActivations,
                   mlir::PatternRewriter &rewriter) const final {
@@ -245,7 +250,15 @@ private:
     }
 
     auto unaryOp = operand.getDefiningOp<ElementwiseUnary>();
-    if (unaryOp && unaryOp.getUnaryOpType() != UnaryOpType::Unknown &&
+    if (!unaryOp) {
+      return {};
+    }
+    if (restrictToMatmulProducer &&
+        !unaryOp.getInput().getDefiningOp<MatmulOp>() &&
+        !unaryOp.getInput().getDefiningOp<LinearOp>()) {
+      return {};
+    }
+    if (unaryOp.getUnaryOpType() != UnaryOpType::Unknown &&
         !hasInterveningWrite(unaryOp.getInput(), unaryOp.getOperation(),
                              binaryOp)) {
       return unaryOp;
@@ -268,6 +281,8 @@ private:
       rewriter.replaceOp(unaryOp, unaryOp.getInput());
     });
   }
+
+  bool restrictToMatmulProducer;
 };
 } // namespace
 
@@ -672,10 +687,18 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     RewritePatternSet firstPatterns(&getContext());
+    // firstPatterns reaches a fixpoint before the matmul and conv activation
+    // patterns below, so registering the input activations here claims the
+    // unary for the consuming binary op and leaves the producer matmul clean.
+    // A DRAM-sharded matmul computes on only as many cores as the part has DRAM
+    // banks, which is why its activation is better off on the binary op.
     if (enableEltwiseActivationFusion) {
-      firstPatterns
-          .add<TTNNBinaryOpInputsActivation, TTNNBinaryOpOutputActivation>(
-              &getContext());
+      firstPatterns.add<TTNNBinaryOpInputsActivation>(
+          &getContext(), /*restrictToMatmulProducer=*/false);
+      firstPatterns.add<TTNNBinaryOpOutputActivation>(&getContext());
+    } else if (!disableDRAMShardedMatmul) {
+      firstPatterns.add<TTNNBinaryOpInputsActivation>(
+          &getContext(), /*restrictToMatmulProducer=*/true);
     }
     // TODO(mvasiljevic): Add HardsigmoidOp once tt-metal issue is resolved
     // https://github.com/tenstorrent/tt-metal/issues/30973

--- a/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNFusing.cpp
@@ -696,7 +696,7 @@ public:
       firstPatterns.add<TTNNBinaryOpInputsActivation>(
           &getContext(), /*restrictToMatmulProducer=*/false);
       firstPatterns.add<TTNNBinaryOpOutputActivation>(&getContext());
-    } else if (!disableDRAMShardedMatmul) {
+    } else if (enableDRAMShardedMatmul) {
       firstPatterns.add<TTNNBinaryOpInputsActivation>(
           &getContext(), /*restrictToMatmulProducer=*/true);
     }

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -51,12 +51,12 @@ float getTensorL1UsageCap(Operation *op, float defaultValue) {
   return defaultValue;
 }
 
-bool isDRAMShardedMatmulDisabled(Operation *op) {
+bool isDRAMShardedMatmulEnabled(Operation *op) {
   ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
 
   if (moduleOp) {
     if (auto attr = moduleOp->getAttrOfType<BoolAttr>(
-            g_DisableDRAMShardedMatmulAttrName)) {
+            g_EnableDRAMShardedMatmulAttrName)) {
       return attr.getValue();
     }
   }

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -51,6 +51,19 @@ float getTensorL1UsageCap(Operation *op, float defaultValue) {
   return defaultValue;
 }
 
+bool isDRAMShardedMatmulDisabled(Operation *op) {
+  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+
+  if (moduleOp) {
+    if (auto attr = moduleOp->getAttrOfType<BoolAttr>(
+            g_DisableDRAMShardedMatmulAttrName)) {
+      return attr.getValue();
+    }
+  }
+
+  return false;
+}
+
 uint64_t getReservedL1Usage(Operation *op) {
   ModuleOp moduleOp = getPolicyModule(op);
 

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -422,9 +422,12 @@ getMemoryConfig(const MemoryConfigAttr &memConfigAttr) {
 
 bool validateTensorSpec(const ::tt::tt_metal::TensorSpec &tensorSpec,
                         const ::tt::tt_metal::CoreCoord &computeGridSize) {
-  // Check the shard bounding box
+  // Check the shard bounding box against the compute grid.
+  // DRAM-sharded tensors use DRAM bank addresses which are outside the compute
+  // core address space, so skip this check for DRAM buffers.
   auto memoryConfig = tensorSpec.memory_config();
-  if (memoryConfig.is_sharded() && memoryConfig.shard_spec().has_value()) {
+  if (memoryConfig.is_sharded() && memoryConfig.shard_spec().has_value() &&
+      memoryConfig.buffer_type() != ::tt::tt_metal::BufferType::DRAM) {
     ::tt::tt_metal::CoreRange shardBoundingBox =
         memoryConfig.shard_spec().value().grid.bounding_box();
     ::tt::tt_metal::CoreRangeSet deviceWorkerCores{::tt::tt_metal::CoreRange{

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -5314,17 +5314,8 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
 
-  // For DS program config, activation is applied as a separate elementwise op
-  // after the matmul (see MatmulRules::applyDRAMShardedTransformation), so the
-  // DS kernel must not receive it — same logic as programCarriesFusedActivation
-  // for fused configs (e.g. gate_proj in SwiGLU carries activation='silu').
-  bool isDSConfig =
-      programConfigAttr &&
-      mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
-          *programConfigAttr);
   std::optional<std::string> activationStr;
-  if (activation && !detail::programCarriesFusedActivation(programConfig) &&
-      !isDSConfig) {
+  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
     activationStr = activation->str();
   }
 

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -5314,8 +5314,17 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
 
+  // For DS program config, activation is applied as a separate elementwise op
+  // after the matmul (see MatmulRules::applyDRAMShardedTransformation), so the
+  // DS kernel must not receive it — same logic as programCarriesFusedActivation
+  // for fused configs (e.g. gate_proj in SwiGLU carries activation='silu').
+  bool isDSConfig =
+      programConfigAttr &&
+      mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          *programConfigAttr);
   std::optional<std::string> activationStr;
-  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
+  if (activation && !detail::programCarriesFusedActivation(programConfig) &&
+      !isDSConfig) {
     activationStr = activation->str();
   }
 

--- a/test/ttmlir/Dialect/TTNN/fusing/binary_input_activation_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/binary_input_activation_fusing.mlir
@@ -1,0 +1,88 @@
+// RUN: ttmlir-opt --ttnn-fusing="disable-dram-sharded-matmul=false" -o %t.ds %s
+// RUN: FileCheck %s --input-file=%t.ds --check-prefix=DSON
+// RUN: ttmlir-opt --ttnn-fusing="enable-eltwise-activation-fusion=true" -o %t.gen %s
+// RUN: FileCheck %s --input-file=%t.gen --check-prefix=GEN
+// RUN: ttmlir-opt --ttnn-fusing -o %t.off %s
+// RUN: FileCheck %s --input-file=%t.off --check-prefix=DSOFF
+
+// Binary input-activation fusing has two callers with different scopes.
+//
+// enable-eltwise-activation-fusion asks for the general behaviour: any
+// single-use unary folds into any binary op's operand, and output activations
+// fuse too.
+//
+// DRAM sharding needs only to keep an activation off a matmul the optimizer may
+// hand a DS config, so there the pattern is restricted to unaries fed by a
+// matmul or linear.
+//
+// The pass defaults to true: DRAM sharding is chosen by the optimizer, so a bare
+// ttnn-fusing run has no DS matmuls and leaves both halves off.
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // Unaries fed by block arguments, not by a matmul.
+  // DSON-LABEL: func.func @unary_from_block_arg
+  // DSON: "ttnn.relu"
+  // DSON: "ttnn.sigmoid"
+  // DSON: "ttnn.add"
+  // DSON-SAME: input_tensor_a_activations = []
+  // DSON-SAME: input_tensor_b_activations = []
+  // DSON: "ttnn.tanh"
+
+  // GEN-LABEL: func.func @unary_from_block_arg
+  // GEN: "ttnn.add"
+  // GEN-SAME: activations = [#ttnn.unary_with_param<op_type = tanh>]
+  // GEN-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = relu>]
+  // GEN-SAME: input_tensor_b_activations = [#ttnn.unary_with_param<op_type = sigmoid>]
+  // GEN-NOT: "ttnn.relu"
+  func.func @unary_from_block_arg(%arg0: tensor<32x32xbf16, #l>, %arg1: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.relu"(%arg0) : (tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %1 = "ttnn.sigmoid"(%arg1) : (tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %2 = "ttnn.add"(%0, %1) <{activations = [], input_tensor_a_activations = [], input_tensor_b_activations = []}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %3 = "ttnn.tanh"(%2) : (tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %3 : tensor<32x32xbf16, #l>
+  }
+
+  // SwiGLU: the silu is fed by a matmul, so it folds in both modes. With the
+  // option at its default the matmul pattern claims it instead, which is the
+  // pre-existing behaviour.
+  // DSON-LABEL: func.func @swiglu_silu_from_matmul
+  // DSON: "ttnn.matmul"
+  // DSON-NOT: activation = "silu"
+  // DSON: "ttnn.multiply"
+  // DSON-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = silu>]
+
+  // GEN-LABEL: func.func @swiglu_silu_from_matmul
+  // GEN: "ttnn.multiply"
+  // GEN-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = silu>]
+
+  // DSOFF-LABEL: func.func @swiglu_silu_from_matmul
+  // DSOFF: "ttnn.matmul"
+  // DSOFF-SAME: activation = "silu"
+  // DSOFF-NOT: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = silu>]
+  func.func @swiglu_silu_from_matmul(%act: tensor<32x32xbf16, #l>, %gate_w: tensor<32x32xbf16, #l>, %up: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.matmul"(%act, %gate_w) <{transpose_a = false, transpose_b = false}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %1 = "ttnn.silu"(%0) : (tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %2 = "ttnn.multiply"(%1, %up) <{activations = [], input_tensor_a_activations = [], input_tensor_b_activations = []}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %2 : tensor<32x32xbf16, #l>
+  }
+
+  // Gemma-2's logit soft cap in miniature: the unary is fed by a divide, so the
+  // DRAM-sharded scope leaves it alone and the general scope takes it.
+  // DSON-LABEL: func.func @soft_cap_tanh_from_divide
+  // DSON: "ttnn.tanh"
+  // DSON: "ttnn.multiply"
+  // DSON-SAME: input_tensor_a_activations = []
+
+  // GEN-LABEL: func.func @soft_cap_tanh_from_divide
+  // GEN: "ttnn.multiply"
+  // GEN-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = tanh>]
+  func.func @soft_cap_tanh_from_divide(%logits: tensor<32x32xbf16, #l>, %cap: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.divide"(%logits, %cap) <{activations = [], input_tensor_a_activations = [], input_tensor_b_activations = []}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %1 = "ttnn.tanh"(%0) : (tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    %2 = "ttnn.multiply"(%1, %cap) <{activations = [], input_tensor_a_activations = [], input_tensor_b_activations = []}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %2 : tensor<32x32xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/fusing/binary_input_activation_fusing.mlir
+++ b/test/ttmlir/Dialect/TTNN/fusing/binary_input_activation_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttnn-fusing="disable-dram-sharded-matmul=false" -o %t.ds %s
+// RUN: ttmlir-opt --ttnn-fusing="enable-dram-sharded-matmul=true" -o %t.ds %s
 // RUN: FileCheck %s --input-file=%t.ds --check-prefix=DSON
 // RUN: ttmlir-opt --ttnn-fusing="enable-eltwise-activation-fusion=true" -o %t.gen %s
 // RUN: FileCheck %s --input-file=%t.gen --check-prefix=GEN
@@ -15,8 +15,8 @@
 // hand a DS config, so there the pattern is restricted to unaries fed by a
 // matmul or linear.
 //
-// The pass defaults to true: DRAM sharding is chosen by the optimizer, so a bare
-// ttnn-fusing run has no DS matmuls and leaves both halves off.
+// The pass defaults to false, as DRAM sharding is opt-in, so a bare ttnn-fusing
+// run leaves both halves off.
 
 #dram = #ttnn.buffer_type<dram>
 #l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=wormhole_b0" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=wormhole_b0 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t --check-prefix=WH12
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t2 %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole enable-dram-sharded-matmul=true" -o %t2 %s
 // RUN: FileCheck %s --input-file=%t2 --check-prefix=BH8
 
 // The DS weight layout is width-sharded across exactly the DRAM banks the

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
@@ -1,0 +1,40 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=wormhole_b0" -o %t %s
+// RUN: FileCheck %s --input-file=%t --check-prefix=WH12
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t2 %s
+// RUN: FileCheck %s --input-file=%t2 --check-prefix=BH8
+
+// The DS weight layout is width-sharded across exactly the DRAM banks the
+// *device* has, and its shard width follows from that count.
+//
+// Wormhole exposes 12 banks, Blackhole 8. A hardcoded count produces a weight
+// layout that cannot be allocated on a part with a different one: tensor
+// creation aborts in get_dram_channel_from_logical_core ("Logical DRAM core ...
+// is outside valid range"), and nothing before silicon catches it because
+// validateTensorSpec deliberately skips the shard bounding-box check for DRAM
+// buffers.
+//
+// The N padding differs per bank count, which is what makes the two cases
+// distinct:
+//   WH: pad 4096 up to a multiple of 32*12=384 -> 4224, /12 = 352 = 11 tiles
+//   BH: pad 4096 up to a multiple of 32*8 =256 -> 4096, /8  = 512 = 16 tiles
+// K is 4096 = 128 tiles in both.
+//
+// WH12-DAG: #ttnn.ttnn_layout<{{.*}}<1x12>, memref<128x11x!ttcore.tile<32x32, bfp_bf8>, #dram>, <width_sharded>
+// BH8-DAG: #ttnn.ttnn_layout<{{.*}}<1x8>, memref<128x16x!ttcore.tile<32x32, bfp_bf8>, #dram>, <width_sharded>
+
+module attributes {} {
+  // WH12-LABEL: func.func @ds_matmul_bank_count
+  // WH12: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // BH8-LABEL: func.func @ds_matmul_bank_count
+  // BH8: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  func.func @ds_matmul_bank_count(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
@@ -5,10 +5,12 @@
 // The disable-dram-sharded-matmul kill switch suppresses the DS path.
 //
 // This is the same IR as dram_sharded_matmul_eligible_m32.mlir, which does get a
-// DS config, so the only difference is the option. isDRAMShardEligible is the
-// single choke point for the DS path, which is what makes one check here
-// sufficient: buildDRAMShardingHint and getExtraInputReshardCandidates both gate
-// on it, and getOutputHints reaches DS only through buildDRAMShardingHint.
+// DS config, so the only difference is the option. buildDSPlan is the single
+// choke point for the DS path, which is what makes one check here sufficient:
+// both entry points need a plan -- buildDRAMShardingHint for the output hint
+// (the only route by which getOutputHints reaches DS) and
+// getExtraInputReshardCandidates for the input candidates -- and the transform
+// and hint-validation paths only ever see a config one of those produced.
 //
 // The matmul must still get *some* program config -- the option falls back to the
 // 1D/2D mcast configs rather than disabling program-config selection entirely.

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
@@ -1,8 +1,9 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 disable-dram-sharded-matmul=true" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// The disable-dram-sharded-matmul kill switch suppresses the DS path.
+// enable-dram-sharded-matmul=false suppresses the DS path. The flag is also off
+// by default, so this is what an ordinary opt-2 compile does.
 //
 // This is the same IR as dram_sharded_matmul_eligible_m32.mlir, which does get a
 // DS config, so the only difference is the option. buildDSPlan is the single

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 disable-dram-sharded-matmul=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The disable-dram-sharded-matmul kill switch suppresses the DS path.
+//
+// This is the same IR as dram_sharded_matmul_eligible_m32.mlir, which does get a
+// DS config, so the only difference is the option. isDRAMShardEligible is the
+// single choke point for the DS path, which is what makes one check here
+// sufficient: buildDRAMShardingHint and getExtraInputReshardCandidates both gate
+// on it, and getOutputHints reaches DS only through buildDRAMShardingHint.
+//
+// The matmul must still get *some* program config -- the option falls back to the
+// 1D/2D mcast configs rather than disabling program-config selection entirely.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_disabled
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_disabled(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t --check-prefix=BFP8
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t2 %s
+// RUN: FileCheck %s --input-file=%t2 --check-prefix=BF16
+
+// The DS path is offered for bfp4/bfp8 weights only. Identical IR, two weight
+// dtypes.
+//
+// This is a bandwidth policy, not a legality constraint: tt-metal imposes no
+// dtype TT_FATAL on the DRAM-sharded config, and bf16 weights do run. But DS
+// streams the weights out of DRAM, so bf16 moves 2x the bytes of bfp8 and 4x
+// bfp4 -- the regime where 1D-mcast wins -- and the optimizer has no runtime
+// estimate with which to rank the two. The conservative set stays hardcoded.
+
+module attributes {} {
+  // BFP8-LABEL: func.func @ds_matmul_dtype
+  // BFP8: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // BF16-LABEL: func.func @ds_matmul_dtype
+  // BF16-NOT: dram_sharded_program_config
+  func.func @ds_matmul_dtype(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t --check-prefix=BFP8
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t2 %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 enable-dram-sharded-matmul=true" -o %t2 %s
 // RUN: FileCheck %s --input-file=%t2 --check-prefix=BF16
 
 // The DS path is offered for bfp4/bfp8 weights only. Identical IR, two weight

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Baseline DRAM-sharded (DS) matmul: a decode-shaped projection with a bfp8
+// constant weight. The activation is exactly one tile row (batch 32), K and N
+// are tile-aligned, and K in tiles (128) is divisible by the in0 core count (8),
+// so every eligibility gate passes and the optimizer offers the DS config.
+//
+// per_core_m must be 1: tt-metal asserts M == per_core_M and M == 1 for the
+// DRAM-sharded program config.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_m32
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_m32(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    // Consumer op to form an L1 chain, matching optimizer/matmul_program_config.mlir.
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Baseline DRAM-sharded (DS) matmul: a decode-shaped projection with a bfp8

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // A sub-tile decode batch is still one tile row, so it is DS-eligible.

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A sub-tile decode batch is still one tile row, so it is DS-eligible.
+//
+// tt-metal's constraint is on the activation height in *tiles*
+// (TT_FATAL(M == 1)), and it pads a 1..31-row activation up to one tile row, so
+// the gate is divUp(M, 32) == 1 rather than a tile-alignment check on M. Any
+// batch in 1..32 qualifies, and per_core_M comes out as 1 for all of them
+// (computeShardParams rounds up, so a sub-tile M cannot truncate to a
+// degenerate 0).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_batch1
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_batch1(
+      %act: tensor<1x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<1x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<1x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<1x4096xbf16>, tensor<1x4096xbf16>) -> tensor<1x4096xbf16>
+    return %1 : tensor<1x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
@@ -1,0 +1,25 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A [1, 1, K, N] weight is the same matrix as [K, N] and is DS-eligible.
+//
+// ttnn models routinely hold projection weights with leading unit batch dims,
+// and such a weight has the same element count, the same tile grid and the same
+// collapsed 2-D memref in the layout as the rank-2 form. Only a *non-unit*
+// leading dim is a real batched matmul (see
+// dram_sharded_matmul_reject_batched_weight.mlir).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_unit_batched_weight
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_unit_batched_weight(
+      %act: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<1x1x4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x1x32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x1x32x4096xbf16>, tensor<1x1x4096x4096xbf16>) -> tensor<1x1x32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<1x1x32x4096xbf16>, tensor<1x1x32x4096xbf16>) -> tensor<1x1x32x4096xbf16>
+    return %1 : tensor<1x1x32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // A [1, 1, K, N] weight is the same matrix as [K, N] and is DS-eligible.

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // A weight with a non-unit batch dim is a real batched matmul and is not

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A weight with a non-unit batch dim is a real batched matmul and is not
+// DS-eligible.
+//
+// tt-metal serves that case with a different program config
+// (MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig) which this path
+// does not emit, so accepting a [2, 1, K, N] weight here would build a config
+// for the wrong kernel.
+//
+// The activation deliberately stays at one tile row (M = 1*1*32 = 32) so this
+// test isolates the weight-shape gate rather than tripping the M gate.
+
+module attributes {} {
+  // The positive anchor matters: with only a CHECK-NOT this test would still
+  // pass if the matmul vanished or the pipeline broke upstream.
+  // CHECK-LABEL: func.func @ds_matmul_batched_weight
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_batched_weight(
+      %act: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<2x1x4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<2x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<2x1x32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x1x32x4096xbf16>, tensor<2x1x4096x4096xbf16>) -> tensor<2x1x32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<2x1x32x4096xbf16>, tensor<2x1x32x4096xbf16>) -> tensor<2x1x32x4096xbf16>
+    return %1 : tensor<2x1x32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // The DS path declines when the CB budget collapses in0_block_w (see
@@ -15,7 +15,7 @@
 // in1 CB fits at in0_block_w = 43, and the collapse never happens -- which is why
 // none of the Wormhole benchmarks regressed.
 //
-// As with the disable-dram-sharded-matmul kill switch, the matmul must still get
+// As when enable-dram-sharded-matmul is off, the matmul must still get
 // *some* program config; declining DS falls back to the 1D/2D mcast configs
 // rather than disabling program-config selection entirely.
 

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The DS path declines when the CB budget collapses in0_block_w (see
+// kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+//
+// K = 11008 is 344 tiles, so K-per-core is 344/8 = 43 -- a prime, leaving 43 and
+// 1 as the only legal block widths. On an 8-bank part the in1 CB at in0_block_w
+// = 43 needs ~1.35 MB against a ~1.30 MB budget, so the search would otherwise
+// settle on in0_block_w = 1: 344 serialized mcast+compute rounds instead of 8.
+// That shape is qwen_2_5_3b's down-projection, measured at -28.1% e2e on p150.
+//
+// Blackhole specifically: with 12 banks the per-bank weight shard is narrower, the
+// in1 CB fits at in0_block_w = 43, and the collapse never happens -- which is why
+// none of the Wormhole benchmarks regressed.
+//
+// As with the disable-dram-sharded-matmul kill switch, the matmul must still get
+// *some* program config; declining DS falls back to the 1D/2D mcast configs
+// rather than disabling program-config selection entirely.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_block_collapse
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_block_collapse(
+      %act: tensor<32x11008xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<11008x2048xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x2048xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x2048xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x11008xbf16>, tensor<11008x2048xbf16>) -> tensor<32x2048xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x2048xbf16>, tensor<32x2048xbf16>) -> tensor<32x2048xbf16>
+    return %1 : tensor<32x2048xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_fused_activation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_fused_activation.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A matmul that still carries a fused activation must be declined by the DS gate.
+//
+// Here the silu has no binary consumer to fold into, so it stays on the matmul
+// and survives to the optimizer. A DS config's fused_activation is always null,
+// so the op model would validate the config without the activation while the
+// runtime hands op->activation() to ::ttnn::matmul alongside it.
+//
+// Declining hands the op to a 1D/2D mcast config, which folds the activation
+// into its own fused_activation. Everything else matches the eligible baseline,
+// so the fused activation is the only reason DS is absent.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_fused_activation
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: fused_activation = #ttnn.unary_with_param<op_type = silu>
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_fused_activation(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.silu"(%0) : (tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_fused_activation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_fused_activation.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // A matmul that still carries a fused activation must be declined by the DS gate.

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
@@ -1,0 +1,36 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Known limitation, pinned deliberately: the DS activation is width-sharded
+// across a fixed 8 in0 cores, so K in tiles must be divisible by 8.
+//
+// K = 2880 is 90 tiles, and 90 % 8 != 0, so this shape gets no DS config even
+// though it is otherwise a textbook decode projection (this is the gpt-oss hidden
+// size). Deriving the in0 core count from K would admit it -- 90 is divisible by
+// 9, 6, 5 and more -- but picking *which* divisor is a cost question the
+// optimizer cannot answer yet: it has no runtime estimate, and the candidates are
+// all legal. Rather than bake in an arbitrary pick, the gate stays at 8.
+//
+// The gate also keeps computeShardParams' kTiles % numIn0Cores assertion true by
+// construction instead of by caller contract, which matters because that assert
+// is a no-op in a release build.
+//
+// If this test starts failing because DS *is* now offered, that is the in0-core
+// search landing -- update it to assert the chosen split instead of its absence.
+
+module attributes {} {
+  // The positive anchor matters: with only a CHECK-NOT this test would still
+  // pass if the matmul vanished or the pipeline broke upstream.
+  // CHECK-LABEL: func.func @ds_matmul_k_not_divisible
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_k_not_divisible(
+      %act: tensor<32x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<2880x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x2880xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x2880xbf16>, tensor<2880x2880xbf16>) -> tensor<32x2880xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x2880xbf16>, tensor<32x2880xbf16>) -> tensor<32x2880xbf16>
+    return %1 : tensor<32x2880xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Known limitation, pinned deliberately: the DS activation is width-sharded

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// An activation taller than one tile row must be declined at compile time.
+//
+// tt-metal's DRAM-sharded validation asserts TT_FATAL(M == 1) on the activation
+// height in tiles, and a TT_FATAL is an uncatchable abort rather than a failure
+// the op model can report. So this has to be rejected by the eligibility gate:
+// deferring to tt-metal would turn a compile-time decline into a crash on
+// silicon. This is the prefill / large-batch shape.
+//
+// Everything else here is identical to the eligible baseline, so the only reason
+// DS is absent is M = 64 (2 tile rows).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_m64
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_m64(
+      %act: tensor<64x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<64x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<64x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<64x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<64x4096xbf16>, tensor<64x4096xbf16>) -> tensor<64x4096xbf16>
+    return %1 : tensor<64x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // An activation taller than one tile row must be declined at compile time.

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_requires_memory_layout_analysis.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_requires_memory_layout_analysis.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=1 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t.o1 %s
+// RUN: FileCheck %s --input-file=%t.o1 --check-prefix=O1
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t.o2 %s
+// RUN: FileCheck %s --input-file=%t.o2 --check-prefix=O2
+
+module attributes {} {
+  // O1-LABEL: func.func @ds_matmul_requires_mla
+  // O1: "ttnn.matmul"
+  // O1-SAME: activation = "silu"
+  // O1-NOT: dram_sharded_program_config
+  // O1: "ttnn.multiply"
+  // O1-SAME: input_tensor_a_activations = []
+  // O1-SAME: input_tensor_b_activations = []
+
+  // O2-LABEL: func.func @ds_matmul_requires_mla
+  // O2: "ttnn.matmul"
+  // O2-SAME: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // O2: "ttnn.multiply"
+  // O2-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = silu>]
+  func.func @ds_matmul_requires_mla(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %gate_w: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %up: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %gate_w) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.silu"(%0) : (tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    %2 = "ttir.multiply"(%1, %up) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %2 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold.mlir
@@ -1,5 +1,5 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t --implicit-check-not='"ttnn.silu"' --implicit-check-not='activation = "silu"'
 
 // SwiGLU: the silu lands on the consuming multiply's operand rather than in the
@@ -11,7 +11,7 @@
 // before the matmul patterns can have it: TTNNBinaryOpInputsActivation is in
 // firstPatterns, which reaches a fixpoint before the second set holding
 // TTNNMatmulAndLinearWithActivation ever runs. With DRAM sharding on the
-// pipeline enables that pattern, threading disable-dram-sharded-matmul into
+// pipeline enables that pattern, threading enable-dram-sharded-matmul into
 // ttnn-fusing.
 //
 // The IR is the eligible-m32 baseline with a silu between the matmul and the

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold.mlir
@@ -1,0 +1,65 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t --implicit-check-not='"ttnn.silu"' --implicit-check-not='activation = "silu"'
+
+// SwiGLU: the silu lands on the consuming multiply's operand rather than in the
+// matmul kernel, so that the matmul is free to take a DS config.
+//
+// A DS matmul computes on as many cores as the part has DRAM banks, so an output
+// activation runs on that narrow set, while the consumer multiply is free to use
+// the whole worker grid. TTNNFusing therefore claims the silu for the multiply
+// before the matmul patterns can have it: TTNNBinaryOpInputsActivation is in
+// firstPatterns, which reaches a fixpoint before the second set holding
+// TTNNMatmulAndLinearWithActivation ever runs. With DRAM sharding on the
+// pipeline enables that pattern, threading disable-dram-sharded-matmul into
+// ttnn-fusing.
+//
+// The IR is the eligible-m32 baseline with a silu between the matmul and the
+// multiply.
+//
+// The two implicit-check-not patterns are the failure modes, and they are why
+// they are stated that way rather than as CHECK-NOT lines: attributes print in
+// alphabetical order, so a surviving `activation` on the matmul appears *before*
+// matmul_program_config on the same line, where a CHECK-NOT anchored after the
+// program config would not see it. `fused_activation` inside the program config
+// is not a third mode -- buildDRAMShardingHint passes a null one deliberately,
+// so the op model validates the DS config without an activation.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_swiglu
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // The fold is positional: the silu'd value is the multiply's LHS here, so the
+  // activation lands on operand A. Operand B is covered below.
+  // CHECK: "ttnn.multiply"
+  // CHECK-SAME: input_tensor_a_activations = [#ttnn.unary_with_param<op_type = silu>]
+  func.func @ds_matmul_swiglu(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %gate_w: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %up: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %gate_w) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.silu"(%0) : (tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    %2 = "ttir.multiply"(%1, %up) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %2 : tensor<32x4096xbf16>
+  }
+
+  // Same graph with the multiply's operands the other way round. Nothing
+  // normalizes the silu'd value onto operand A, so it folds onto operand B --
+  // which the flatbuffer, runtime, EmitC and EmitPy paths all carry.
+  // CHECK-LABEL: func.func @ds_matmul_swiglu_rhs
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // CHECK: "ttnn.multiply"
+  // CHECK-SAME: input_tensor_b_activations = [#ttnn.unary_with_param<op_type = silu>]
+  func.func @ds_matmul_swiglu_rhs(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %gate_w: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %up: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %gate_w) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.silu"(%0) : (tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    %2 = "ttir.multiply"(%up, %1) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %2 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold_ds_off.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold_ds_off.mlir
@@ -1,0 +1,43 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 disable-dram-sharded-matmul=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t --implicit-check-not='"ttnn.silu"'
+
+// The DS-off half of dram_sharded_matmul_swiglu_fold.mlir, same IR and same
+// pipeline but for the kill switch.
+//
+// With DRAM sharding off there is no narrow-grid matmul to keep the activation
+// away from, so the silu goes where it did before: onto the matmul, via
+// TTNNMatmulAndLinearWithActivation. That pattern is registered unconditionally
+// and only ever loses the silu to TTNNBinaryOpInputsActivation, which the
+// pipeline enables solely when DRAM sharding is on.
+//
+// This is what pins the ordering. Both patterns can claim the same silu, and
+// which one wins is decided by firstPatterns reaching a fixpoint before the
+// second set runs -- not by anything in the greedy driver's own ordering. Assert
+// both halves or a regression that dropped the split registration would still
+// pass the DS-on test.
+
+module attributes {} {
+  // The activation ends up inside the program config rather than as an op-level
+  // attribute: the non-DS apply path folds it into fused_activation and then
+  // removes the attribute, so it is not applied twice (tt-metal #35060).
+  // CHECK-LABEL: func.func @ds_matmul_swiglu_ds_off
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: fused_activation = #ttnn.unary_with_param<op_type = silu>
+  // CHECK-NOT: dram_sharded_program_config
+
+  // The multiply is left with empty activation lists: with the inputs pattern
+  // off, nothing folds onto its operands.
+  // CHECK: "ttnn.multiply"
+  // CHECK-SAME: input_tensor_a_activations = []
+  // CHECK-SAME: input_tensor_b_activations = []
+  func.func @ds_matmul_swiglu_ds_off(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %gate_w: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %up: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %gate_w) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.silu"(%0) : (tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    %2 = "ttir.multiply"(%1, %up) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %2 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold_ds_off.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_swiglu_fold_ds_off.mlir
@@ -1,9 +1,9 @@
 // REQUIRES: opmodel
-// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 disable-dram-sharded-matmul=true" -o %t %s
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 enable-dram-sharded-matmul=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t --implicit-check-not='"ttnn.silu"'
 
 // The DS-off half of dram_sharded_matmul_swiglu_fold.mlir, same IR and same
-// pipeline but for the kill switch.
+// pipeline but for the flag.
 //
 // With DRAM sharding off there is no narrow-grid matmul to keep the activation
 // away from, so the silu goes where it did before: onto the matmul, via

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_unittest(OptimizerTests
     TestConv2dConfigGenerator.cpp
     TestConv3dConfigHeuristic.cpp
     TestPipelineOptionResolution.cpp
+    TestMatmulProgramConfig.cpp
     PARTIAL_SOURCES_INTENDED
 )
 

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -23,6 +23,7 @@ if (TTMLIR_ENABLE_OPMODEL)
         TestOpModelStrategy.cpp
         TestBeamSearch.cpp
         TestReshardCandidates.cpp
+        TestDRAMShardedMatmulEligibility.cpp
         PARTIAL_SOURCES_INTENDED
     )
 

--- a/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
+++ b/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
@@ -70,6 +70,10 @@ public:
     ttcore::registerDevice(module.get(), arch);
     module->getOperation()->setAttr(utils::g_TensorL1UsageCapAttrName,
                                     builder.getF32FloatAttr(0.95f));
+    // The DS path is off unless asked for, and the pipeline always sets this
+    // attribute explicitly, so opt in here for the eligibility tests below.
+    module->getOperation()->setAttr(utils::g_EnableDRAMShardedMatmulAttrName,
+                                    builder.getBoolAttr(true));
   }
 
   TTNNLayoutAttr dramInterleaved(llvm::ArrayRef<int64_t> shape,
@@ -273,15 +277,18 @@ TEST_F(DRAMShardedEligibilityTest, KTilesNotDivisibleByIn0CoresDeclined) {
   EXPECT_FALSE(isDSEligible(op, {32, 2880}));
 }
 
-// The kill switch short-circuits the single choke point, so nothing downstream
-// can reintroduce DS.
+// The flag short-circuits the single choke point, so nothing downstream can
+// reintroduce DS. Also covers the default: an absent attribute reads as off.
 TEST_F(DRAMShardedEligibilityTest, DisableOptionSuppressesDS) {
   auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
                         ttcore::DataType::BFP_BFloat8);
   ASSERT_TRUE(isDSEligible(op, {32, 4096}));
 
-  module->getOperation()->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
-                                  builder.getBoolAttr(true));
+  module->getOperation()->setAttr(utils::g_EnableDRAMShardedMatmulAttrName,
+                                  builder.getBoolAttr(false));
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+
+  module->getOperation()->removeAttr(utils::g_EnableDRAMShardedMatmulAttrName);
   EXPECT_FALSE(isDSEligible(op, {32, 4096}));
 }
 

--- a/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
+++ b/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt;
+using namespace mlir::tt::ttnn;
+
+// DRAM-sharded (DS) matmul eligibility and weight geometry, exercised through
+// the matmul rule book.
+//
+// These build a real func.func because DS requires the weight to be const-eval
+// traceable (valueTracesToConstantArgs), which means a function argument marked
+// as a parameter -- the module-level ops the other strategy tests build cannot
+// express that.
+//
+// The bias-free ttnn.linear case is only reachable here, not from lit: a
+// bias-free ttir.linear canonicalizes into ttir.matmul (TTIROps.cpp), so no
+// bias-free ttnn.linear survives the TTIR->TTNN pipeline. TTNN-level entry
+// points (ttnn tracing, the shard advisor) are where it appears.
+namespace {
+
+constexpr int64_t kTile = 32;
+
+// Shared scaffolding. Deliberately does not open a metal device: every path
+// under test (eligibility, weight layout) needs only a DeviceAttr and the
+// system descriptor.
+//
+// These are the fast, device-free check of the per-architecture layout the rule
+// book derives; optimizer/dram_sharded_matmul_bank_count.mlir covers the same
+// ground end-to-end through the pipeline.
+class DSTestBase : public ::testing::Test {
+public:
+  mlir::MLIRContext context;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+  mlir::OpBuilder builder = mlir::OpBuilder(&context);
+  int funcCounter = 0;
+
+  void SetUp() override {
+    context.loadDialect<ttcore::TTCoreDialect>();
+    context.loadDialect<ttnn::TTNNDialect>();
+    context.loadDialect<mlir::func::FuncDialect>();
+    initModule(ttcore::Arch::WormholeB0);
+  }
+
+  void initModule(ttcore::Arch arch) {
+    module = mlir::ModuleOp::create(builder.getUnknownLoc());
+    builder.setInsertionPointToStart(&module->getBodyRegion().front());
+    ttcore::registerDevice(module.get(), arch);
+    module->getOperation()->setAttr(utils::g_TensorL1UsageCapAttrName,
+                                    builder.getF32FloatAttr(0.95f));
+  }
+
+  TTNNLayoutAttr dramInterleaved(llvm::ArrayRef<int64_t> shape,
+                                 ttcore::DataType dt) {
+    auto elementType = ttcore::TileType::get(&context, {kTile, kTile}, dt);
+    auto deviceAttr = ttcore::lookupDevice(module.get());
+    return TTNNLayoutAttr::Builder(&context, shape, elementType)
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .setGridShape({1, 1})
+        .buildWithCanonicalCorePlacement(deviceAttr);
+  }
+
+  mlir::RankedTensorType tensorOf(llvm::ArrayRef<int64_t> shape,
+                                  ttcore::DataType dt) {
+    return mlir::RankedTensorType::get(shape, builder.getBF16Type(),
+                                       dramInterleaved(shape, dt));
+  }
+
+  // Opens a func whose arg 1 (the weight) is marked as a parameter, and leaves
+  // the builder positioned inside it.
+  mlir::Block *openFunc(llvm::ArrayRef<mlir::Type> argTypes,
+                        mlir::Type resultType) {
+    builder.setInsertionPointToEnd(&module->getBodyRegion().front());
+    auto funcType = builder.getFunctionType(argTypes, {resultType});
+    auto func = builder.create<mlir::func::FuncOp>(
+        builder.getUnknownLoc(), "ds_test_" + std::to_string(funcCounter++),
+        funcType);
+    func.setArgAttr(1, ttcore::ArgumentTypeAttr::name,
+                    ttcore::ArgumentTypeAttr::get(
+                        &context, ttcore::ArgumentType::Parameter));
+    mlir::Block *block = func.addEntryBlock();
+    builder.setInsertionPointToStart(block);
+    return block;
+  }
+
+  MatmulOp buildMatmul(llvm::ArrayRef<int64_t> actShape,
+                       llvm::ArrayRef<int64_t> weightShape,
+                       llvm::ArrayRef<int64_t> outShape,
+                       ttcore::DataType weightDt) {
+    auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
+    auto weightType = tensorOf(weightShape, weightDt);
+    auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
+    mlir::Block *block = openFunc({actType, weightType}, outType);
+    auto op = builder.create<MatmulOp>(
+        builder.getUnknownLoc(), outType, block->getArgument(0),
+        block->getArgument(1), /*transpose_a=*/false, /*transpose_b=*/false,
+        /*matmul_program_config=*/mlir::Attribute(),
+        /*activation=*/mlir::StringAttr());
+    builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                         op.getResult());
+    return op;
+  }
+
+  LinearOp buildLinear(llvm::ArrayRef<int64_t> actShape,
+                       llvm::ArrayRef<int64_t> weightShape,
+                       llvm::ArrayRef<int64_t> outShape,
+                       ttcore::DataType weightDt, bool withBias) {
+    auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
+    auto weightType = tensorOf(weightShape, weightDt);
+    auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
+
+    llvm::SmallVector<int64_t> biasShape{1, weightShape.back()};
+    auto biasType = tensorOf(biasShape, ttcore::DataType::BFloat16);
+
+    llvm::SmallVector<mlir::Type> argTypes{actType, weightType};
+    if (withBias) {
+      argTypes.push_back(biasType);
+    }
+    mlir::Block *block = openFunc(argTypes, outType);
+
+    mlir::Value bias = withBias ? block->getArgument(2) : mlir::Value();
+    auto op = builder.create<LinearOp>(
+        builder.getUnknownLoc(), outType, block->getArgument(0),
+        block->getArgument(1), bias, /*transpose_a=*/false,
+        /*transpose_b=*/false, /*activation=*/mlir::StringAttr());
+    builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                         op.getResult());
+    return op;
+  }
+
+  std::vector<OpConfig> legalConfigs(llvm::ArrayRef<int64_t> outShape) {
+    std::vector<OpConfig> configs;
+    configs.emplace_back(dramInterleaved(outShape, ttcore::DataType::BFloat16));
+    return configs;
+  }
+
+  // Whether any hint carries a DRAM-sharded matmul program config.
+  static bool hasDSHint(const OutputHints &hints) {
+    for (const auto &hint : hints.hints) {
+      const auto *attrs = std::get_if<MatmulAttrs>(&hint.opSpecificAttrs);
+      if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+          !attrs->matmulProgramConfig.value()) {
+        continue;
+      }
+      if (mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+              attrs->matmulProgramConfig.value())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isDSEligible(mlir::Operation *op, llvm::ArrayRef<int64_t> outShape) {
+    return hasDSHint(getOutputHints(op, legalConfigs(outShape)));
+  }
+};
+
+class DRAMShardedEligibilityTest : public DSTestBase {};
+
+//===----------------------------------------------------------------------===//
+// Eligibility
+//===----------------------------------------------------------------------===//
+
+// Baseline: a decode-shaped bfp8 projection is DS-eligible.
+TEST_F(DRAMShardedEligibilityTest, MatmulEligible) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// A bias-free ttnn.linear is the same computation the DS kernel implements, so
+// it must be offered the DS config too. ttnn decoders write their projections
+// as ttnn.linear, so this is the shape the path sees in practice.
+TEST_F(DRAMShardedEligibilityTest, BiasFreeLinearEligible) {
+  auto op = buildLinear({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8, /*withBias=*/false);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// A biased linear is declined. tt-metal's DS kernel does support a bias, but it
+// reads it per DRAM bank at a bank-local offset, so the bias must be DRAM
+// width-sharded across the same bank grid as the weight. Nothing produces such
+// a layout for operand 2 yet, and a DRAM-interleaved bias would be read as a
+// strided subset of itself -- wrong results rather than a crash, with no
+// tt-metal validation to catch it.
+TEST_F(DRAMShardedEligibilityTest, BiasedLinearDeclined) {
+  auto op = buildLinear({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8, /*withBias=*/true);
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+// [1, 1, K, N] is the same matrix as [K, N]; ttnn models routinely hold
+// projection weights that way.
+TEST_F(DRAMShardedEligibilityTest, UnitBatchedWeightEligible) {
+  auto op = buildMatmul({1, 1, 32, 4096}, {1, 1, 4096, 4096}, {1, 1, 32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {1, 1, 32, 4096}));
+}
+
+// A non-unit batch dim is a real batched matmul, which tt-metal serves with a
+// different program config that this path does not emit.
+TEST_F(DRAMShardedEligibilityTest, BatchedWeightDeclined) {
+  auto op = buildMatmul({1, 1, 32, 4096}, {2, 1, 4096, 4096}, {2, 1, 32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {2, 1, 32, 4096}));
+}
+
+// A sub-tile decode batch is still one tile row, so it is eligible: tt-metal
+// pads a 1..31-row activation up to one tile row and runs it.
+TEST_F(DRAMShardedEligibilityTest, SubTileBatchEligible) {
+  auto op = buildMatmul({1, 4096}, {4096, 4096}, {1, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {1, 4096}));
+}
+
+// More than one tile row must be declined at compile time: tt-metal's
+// TT_FATAL(M == 1) is an uncatchable abort, so deferring to it would crash on
+// silicon rather than fall back to another config.
+TEST_F(DRAMShardedEligibilityTest, MultiTileMDeclined) {
+  auto op = buildMatmul({64, 4096}, {4096, 4096}, {64, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {64, 4096}));
+}
+
+// bfp4/bfp8 only. bf16 is legal for tt-metal, but DS streams the weights out of
+// DRAM, so bf16 moves 2x the bytes and the optimizer has no runtime estimate
+// with which to rank it against 1D-mcast.
+TEST_F(DRAMShardedEligibilityTest, Bf16WeightDeclined) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFloat16);
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+TEST_F(DRAMShardedEligibilityTest, Bfp4WeightEligible) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat4);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// Known limitation, pinned deliberately: the activation is width-sharded across
+// a fixed 8 in0 cores, so K in tiles must be divisible by 8. 2880 is 90 tiles
+// (the gpt-oss hidden size) and is declined. Deriving the core count from K
+// would admit it -- 90 has several usable divisors -- but choosing among them
+// is a cost question the optimizer cannot answer yet.
+TEST_F(DRAMShardedEligibilityTest, KTilesNotDivisibleByIn0CoresDeclined) {
+  auto op = buildMatmul({32, 2880}, {2880, 2880}, {32, 2880},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {32, 2880}));
+}
+
+// The kill switch short-circuits the single choke point, so nothing downstream
+// can reintroduce DS.
+TEST_F(DRAMShardedEligibilityTest, DisableOptionSuppressesDS) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  ASSERT_TRUE(isDSEligible(op, {32, 4096}));
+
+  module->getOperation()->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
+                                  builder.getBoolAttr(true));
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+//===----------------------------------------------------------------------===//
+// Weight geometry follows the device's DRAM bank count
+//===----------------------------------------------------------------------===//
+
+class DRAMShardedBankCountTest : public DSTestBase {
+public:
+  // The DS weight layout injected for operand 1.
+  TTNNLayoutAttr weightReshardLayout(mlir::Operation *op) {
+    std::vector<TTNNLayoutAttr> candidates =
+        getRuleBook(op).getExtraInputReshardCandidates(op, /*operandIdx=*/1);
+    EXPECT_EQ(candidates.size(), 1u);
+    return candidates.empty() ? TTNNLayoutAttr() : candidates.front();
+  }
+};
+
+// Wormhole exposes 12 DRAM banks, so N=4096 pads up to a multiple of 32*12=384
+// (4224) and each bank holds 4224/12 = 352 = 11 tiles of weight width.
+TEST_F(DRAMShardedBankCountTest, WormholeUses12Banks) {
+  initModule(ttcore::Arch::WormholeB0);
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+
+  TTNNLayoutAttr layout = weightReshardLayout(op);
+  ASSERT_TRUE(layout);
+  EXPECT_EQ(layout.getGridShape(), llvm::ArrayRef<int64_t>({1, 12}));
+  EXPECT_EQ(layout.getShardShape(), llvm::ArrayRef<int64_t>({128, 11}));
+  EXPECT_EQ(layout.getBufferType(), BufferType::DRAM);
+}
+
+// Blackhole exposes 8. 32*8=256 already divides 4096, so there is no padding
+// and each bank holds 4096/8 = 512 = 16 tiles.
+//
+// The count has to come from the device: a layout sharded across more banks
+// than the part has is unallocatable (tensor creation aborts in
+// get_dram_channel_from_logical_core), and validateTensorSpec skips the shard
+// bounding-box check for DRAM buffers, so nothing before silicon would notice.
+TEST_F(DRAMShardedBankCountTest, BlackholeUses8Banks) {
+  initModule(ttcore::Arch::Blackhole);
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+
+  TTNNLayoutAttr layout = weightReshardLayout(op);
+  ASSERT_TRUE(layout);
+  EXPECT_EQ(layout.getGridShape(), llvm::ArrayRef<int64_t>({1, 8}));
+  EXPECT_EQ(layout.getShardShape(), llvm::ArrayRef<int64_t>({128, 16}));
+  EXPECT_EQ(layout.getBufferType(), BufferType::DRAM);
+}
+
+// The DS layout builders must land on canonical core placement whatever the
+// layout they are seeded from carried. buildWithCanonicalCorePlacement only
+// fills a *null* core range set, and Builder's setters each early-return when
+// the value is unchanged, so a seed that already matches the target's buffer
+// type, memory layout and grid would otherwise keep its own placement. No lit
+// test reaches this: every DS operand starts DRAM-interleaved, so the memory
+// layout always changes and invalidates the core range set on the way through.
+TEST_F(DSTestBase, L1ShardedLayoutForcesCanonicalPlacement) {
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(module.get());
+  llvm::SmallVector<int64_t, 2> shape{kTile, 4096};
+  auto elementType = ttcore::TileType::get(&context, {kTile, kTile},
+                                           ttcore::DataType::BFloat16);
+
+  // Same buffer type, memory layout and grid as the target, but deliberately
+  // placed on row 1 rather than the canonical row 0.
+  auto offRow = CoreRangeSetAttr::get(
+      &context,
+      {CoreRangeAttr::get(&context, CoreCoordAttr::get(&context, 0, 1),
+                          CoreCoordAttr::get(&context, 7, 1))});
+  TTNNLayoutAttr seed = TTNNLayoutAttr::Builder(&context, shape, elementType)
+                            .setBufferType(BufferType::L1)
+                            .setMemoryLayout(TensorMemoryLayout::WidthSharded)
+                            .setGridShape({1, 8})
+                            .setCoreRangeSet(offRow)
+                            .build();
+  ASSERT_EQ(seed.getCoreRangeSet(), offRow);
+
+  TTNNLayoutAttr out =
+      buildL1ShardedLayout(&context, seed, shape, /*numCores=*/8, deviceAttr);
+
+  TTNNLayoutAttr canonical =
+      TTNNLayoutAttr::Builder(&context, shape, elementType)
+          .setBufferType(BufferType::L1)
+          .setMemoryLayout(TensorMemoryLayout::WidthSharded)
+          .setGridShape({1, 8})
+          .buildWithCanonicalCorePlacement(deviceAttr);
+
+  EXPECT_EQ(out.getCoreRangeSet(), canonical.getCoreRangeSet());
+  EXPECT_NE(out.getCoreRangeSet(), offRow);
+}
+
+} // namespace

--- a/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
+++ b/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
@@ -109,7 +109,8 @@ public:
   MatmulOp buildMatmul(llvm::ArrayRef<int64_t> actShape,
                        llvm::ArrayRef<int64_t> weightShape,
                        llvm::ArrayRef<int64_t> outShape,
-                       ttcore::DataType weightDt) {
+                       ttcore::DataType weightDt,
+                       mlir::StringAttr activation = mlir::StringAttr()) {
     auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
     auto weightType = tensorOf(weightShape, weightDt);
     auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
@@ -118,7 +119,7 @@ public:
         builder.getUnknownLoc(), outType, block->getArgument(0),
         block->getArgument(1), /*transpose_a=*/false, /*transpose_b=*/false,
         /*matmul_program_config=*/mlir::Attribute(),
-        /*activation=*/mlir::StringAttr());
+        /*activation=*/activation);
     builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
                                          op.getResult());
     return op;
@@ -127,7 +128,8 @@ public:
   LinearOp buildLinear(llvm::ArrayRef<int64_t> actShape,
                        llvm::ArrayRef<int64_t> weightShape,
                        llvm::ArrayRef<int64_t> outShape,
-                       ttcore::DataType weightDt, bool withBias) {
+                       ttcore::DataType weightDt, bool withBias,
+                       mlir::StringAttr activation = mlir::StringAttr()) {
     auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
     auto weightType = tensorOf(weightShape, weightDt);
     auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
@@ -145,7 +147,7 @@ public:
     auto op = builder.create<LinearOp>(
         builder.getUnknownLoc(), outType, block->getArgument(0),
         block->getArgument(1), bias, /*transpose_a=*/false,
-        /*transpose_b=*/false, /*activation=*/mlir::StringAttr());
+        /*transpose_b=*/false, /*activation=*/activation);
     builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
                                          op.getResult());
     return op;
@@ -280,6 +282,30 @@ TEST_F(DRAMShardedEligibilityTest, DisableOptionSuppressesDS) {
 
   module->getOperation()->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
                                   builder.getBoolAttr(true));
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+// A matmul that still carries a fused activation must be declined. TTNNFusing
+// normally places the unary on a consuming binary op's operand, so an
+// activation that reaches the optimizer had no such consumer. Taking DS anyway
+// would be inconsistent rather than merely slow: the op model validates a DS
+// config without the activation, while the runtime forwards it to
+// ::ttnn::matmul, since a DS program config's fused_activation is always null.
+TEST_F(DRAMShardedEligibilityTest, FusedActivationOnMatmulDeclined) {
+  auto op =
+      buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                  ttcore::DataType::BFP_BFloat8, builder.getStringAttr("silu"));
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+// Same for a bias-free ttnn.linear, which the DS path also covers. This is the
+// case lit cannot reach -- a bias-free ttir.linear canonicalizes to ttir.matmul
+// -- and it is the one where the op model has no DS guard on the activation at
+// all, so the decline is what keeps validation and execution in agreement.
+TEST_F(DRAMShardedEligibilityTest, FusedActivationOnLinearDeclined) {
+  auto op = buildLinear({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8, /*withBias=*/false,
+                        builder.getStringAttr("silu"));
   EXPECT_FALSE(isDSEligible(op, {32, 4096}));
 }
 

--- a/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
+++ b/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+
+#include "mlir/IR/MLIRContext.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt;
+using namespace mlir::tt::ttnn;
+
+// These tests pin the DRAM-sharded shard geometry and compute-kernel config,
+// which nothing else in the tree covers. computeShardParams is pure arithmetic
+// over the matmul dims and the L1 budget, so most of them need no MLIRContext
+// and no device.
+namespace {
+
+// Wormhole-ish L1 budget: 0.95 * usable L1 (1499136).
+constexpr int64_t kL1Available = 1424179;
+
+// A decode-shaped 32x4096x4096 projection, the shape the DS path is built for.
+constexpr int64_t kM = 32;
+constexpr int64_t kK = 4096;
+constexpr int64_t kN = 4096;
+
+constexpr int64_t kWormholeBanks = 12;
+constexpr int64_t kBlackholeBanks = 8;
+constexpr int64_t kNumIn0Cores = 8;
+constexpr int64_t kWormholeCores = 64;
+constexpr int64_t kBlackholeCores = 110;
+
+TEST(MatmulDRAMShardParams, WormholeBaseline) {
+  auto p = computeShardParams(kM, kK, kN, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // N is padded up to a multiple of tile*banks = 32*12 = 384: 4096 -> 4224,
+  // giving 4224/12 = 352 = 11 tiles of weight per bank.
+  EXPECT_EQ(p->nPadded, 4224);
+  EXPECT_EQ(p->shardW, 352);
+  EXPECT_EQ(p->shardWTiles, 11);
+
+  EXPECT_EQ(p->kTiles, 128);
+  EXPECT_EQ(p->shardH, kK);
+
+  // tt-metal requires M == per_core_M == 1 for the DS config.
+  EXPECT_EQ(p->perCoreM, 1);
+  // per_core_N is the *storage* split: div_up(128 N-tiles, 64 cores).
+  EXPECT_EQ(p->perCoreN, 2);
+
+  // in0_block_w must divide K-per-core (128/8 = 16) and fit the CBs.
+  EXPECT_GT(p->in0BlockW, 0);
+  EXPECT_EQ((kK / 32) / kNumIn0Cores % p->in0BlockW, 0);
+}
+
+// A sub-tile decode batch must still yield per_core_M == 1: tt-metal pads the
+// activation up to one tile row. Truncating M/32 would give 0 here and build a
+// degenerate config.
+TEST(MatmulDRAMShardParams, SubTileBatchRoundsPerCoreMUp) {
+  for (int64_t m : {1, 2, 15, 31, 32}) {
+    auto p = computeShardParams(m, kK, kN, kWormholeBanks, kNumIn0Cores,
+                                kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                                kL1Available);
+    ASSERT_TRUE(p.has_value()) << "M=" << m;
+    EXPECT_EQ(p->perCoreM, 1) << "M=" << m;
+  }
+}
+
+// The bank count changes the weight shard width, which is why it must come from
+// the device rather than a constant: on 8 banks 4096 needs no padding at all.
+TEST(MatmulDRAMShardParams, BlackholeBankCountChangesShardWidth) {
+  auto p = computeShardParams(kM, kK, kN, kBlackholeBanks, kNumIn0Cores,
+                              kBlackholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // 32*8 = 256 already divides 4096, so nPadded == N.
+  EXPECT_EQ(p->nPadded, kN);
+  EXPECT_EQ(p->shardW, 512);
+  EXPECT_EQ(p->shardWTiles, 16);
+  EXPECT_EQ(p->numBanks, kBlackholeBanks);
+  EXPECT_EQ(p->perCoreM, 1);
+}
+
+// bfp4 weight tiles are roughly half the bytes of bfp8, and the weight CB (in1)
+// is the term that dominates the L1 budget, so anywhere bfp8 fits bfp4 must too
+// — and there must be budgets where only bfp4 fits, or the dtype would not be
+// affecting the decision at all.
+//
+// Keep this a sweep. At any single generous budget the chosen in0_block_w is
+// capped at K-per-core for both dtypes, so comparing them there would assert
+// nothing. N is the wide case so the in1 CB dominates the budget.
+//
+// kWideN is 8192 rather than something larger because kMinBlockWidthFraction
+// declines a block width below half of K-per-core: at N=32768 neither dtype can
+// reach in0_block_w=8 within any swept budget, so both return nullopt and the
+// sweep stops discriminating. 8192 still puts in1 in charge of the budget while
+// leaving in0_block_w in the accepted range.
+TEST(MatmulDRAMShardParams, Bfp4NeverFitsWorseThanBfp8) {
+  constexpr int64_t kWideN = 8192;
+  bool sawBfp4OnlyFit = false;
+
+  for (int64_t l1 : {600000, 700000, 800000, 900000, 1000000, 1100000,
+                     static_cast<int>(kL1Available)}) {
+    auto bfp8 =
+        computeShardParams(kM, kK, kWideN, kWormholeBanks, kNumIn0Cores,
+                           kWormholeCores, ttcore::DataType::BFP_BFloat8, l1);
+    auto bfp4 =
+        computeShardParams(kM, kK, kWideN, kWormholeBanks, kNumIn0Cores,
+                           kWormholeCores, ttcore::DataType::BFP_BFloat4, l1);
+    if (bfp8.has_value()) {
+      EXPECT_TRUE(bfp4.has_value()) << "bfp8 fit but bfp4 did not, l1=" << l1;
+      EXPECT_EQ(bfp4->weightDataType, ttcore::DataType::BFP_BFloat4);
+    }
+    if (bfp4.has_value() && !bfp8.has_value()) {
+      sawBfp4OnlyFit = true;
+    }
+  }
+
+  EXPECT_TRUE(sawBfp4OnlyFit)
+      << "no swept budget separated bfp4 from bfp8, so this test is not "
+         "exercising the weight-dtype term of the CB budget any more";
+}
+
+// The fixed CBs (out + interm0) alone exceed a tiny budget, so no in0_block_w
+// can rescue it and the DS path declines rather than emitting a config that
+// would not fit L1.
+TEST(MatmulDRAMShardParams, DeclinesWhenFixedCBsExceedBudget) {
+  auto p = computeShardParams(kM, kK, kN, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              /*l1Available=*/100000);
+  EXPECT_FALSE(p.has_value());
+}
+
+// A wide N inflates the per-bank weight shard and therefore the in1 CB, forcing
+// the search to walk in0_block_w down from K-per-core (16) to something that
+// fits. Keep these assertions unconditional: guarding them behind
+// p.has_value() would let the test pass silently the moment the geometry stops
+// fitting, which is the regression worth catching.
+//
+// N=8192 walks down exactly one divisor, 16 -> 8, which is the widest reduction
+// kMinBlockWidthFraction still accepts. Anything wider is declined instead --
+// see WideNBlockCollapseDeclined.
+TEST(MatmulDRAMShardParams, WideNWalksIn0BlockWDown) {
+  auto p = computeShardParams(kM, kK, /*N=*/8192, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // 8192 pads to a multiple of 32*12=384 -> 8448, /12 = 704 = 22 tiles/bank.
+  EXPECT_EQ(p->nPadded, 8448);
+  EXPECT_EQ(p->shardWTiles, 22);
+
+  // The search starts at K-per-core (128/8 = 16) and must come down to fit.
+  EXPECT_LT(p->in0BlockW, 16);
+  EXPECT_EQ(p->in0BlockW, 8);
+
+  // Invariants tt-metal checks regardless of where the search lands.
+  EXPECT_EQ(p->perCoreM, 1);
+  EXPECT_GT(p->in0BlockW, 0);
+  EXPECT_EQ((kK / 32) / kNumIn0Cores % p->in0BlockW, 0);
+  EXPECT_EQ(p->nPadded % (32 * kWormholeBanks), 0);
+}
+
+// Past half of K-per-core the DS path declines instead of emitting the config.
+// N=32768 leaves room only for in0_block_w=2 out of K-per-core=16, i.e. 64
+// block iterations instead of 8.
+TEST(MatmulDRAMShardParams, WideNBlockCollapseDeclined) {
+  auto p = computeShardParams(kM, kK, /*N=*/32768, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  EXPECT_FALSE(p.has_value());
+}
+
+// The shape that motivated the guard: qwen_2_5_3b's down-projection on an
+// 8-bank part. K=11008 is 344 tiles, so K-per-core is the prime 43 and the only
+// legal block widths are 43 and 1. 43 does not fit, so the search would emit
+// in0_block_w=1 -- 344 serialized blocks instead of 8.
+TEST(MatmulDRAMShardParams, PrimeKPerCoreCollapseDeclined) {
+  constexpr int64_t kBlackholeL1Available = 1400832; // 0.95 * (1572864 - 98304)
+  auto p = computeShardParams(
+      kM, /*K=*/11008, /*N=*/2048, kBlackholeBanks, kNumIn0Cores,
+      kBlackholeCores, ttcore::DataType::BFP_BFloat8, kBlackholeL1Available);
+  EXPECT_FALSE(p.has_value());
+}
+
+// Math fidelity follows the weight dtype. Nothing else pins this: the DS lit
+// tests only FileCheck matmul_program_config, not the compute config.
+class MatmulDRAMComputeConfig : public ::testing::Test {
+protected:
+  void SetUp() override { context.loadDialect<TTNNDialect>(); }
+  mlir::MLIRContext context;
+};
+
+TEST_F(MatmulDRAMComputeConfig, Bfp4RunsLoFi) {
+  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat4);
+  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::LoFi);
+}
+
+TEST_F(MatmulDRAMComputeConfig, Bfp8RunsHiFi2) {
+  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat8);
+  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::HiFi2);
+}
+
+} // namespace


### PR DESCRIPTION
### Ticket
No tracking issue for the DRAM-sharded matmul work itself — to be filled in.

### Problem description
The DRAM-sharded (DS) matmul program config was not available to the TTNN greedy layout
optimizer, so decode projections fell back to 1D/2D-mcast configs even where the DS kernel
applies. The DS kernel width-shards the weight across DRAM banks and the activation across
L1 cores, which is the shape a decode projection already has.

### What's changed
The optimizer can select the DS program config for a decode projection, behind
`enable-dram-sharded-matmul`, and everything that requires:

- **Shard geometry and configs.** `computeShardParams` derives the shard geometry and an
  `in0_block_w` that fits L1, plus the DRAM width-sharded weight layout, the L1
  width-sharded activation layout, and the program and compute-kernel configs. DS matmuls
  take bf16 partials through the packer.
- **Getting the operand layouts in.** `getExtraInputReshardCandidates` lets a rule book
  inject operand layouts `generateReshardCandidates` cannot produce, ahead of the standard
  reshards so the per-operand cap cannot displace them. `insertReshardOp` now uses the
  requested layout verbatim instead of rebuilding it from the producer's.
- **Ranking.** `isDRAMShardedCandidate` outranks core count once both candidates are
  L1-sharded, with `hasCanonicalDSIn0` breaking ties within DS.
- **Op model.** `validateTensorSpec` no longer checks a DRAM-sharded tensor's grid against
  the compute grid.
- **Selection.** Eligibility, the DS output hint, the in0/weight reshard candidates and the
  apply-time config assignment. The decode-only gate is a compile-time decline because
  tt-metal asserts `TT_FATAL(M == 1)` uncatchably; the same is true of a DS config paired
  with the wrong input layouts, hence `isValidOutputHintForInputs`.
- **L1 spill.** A DS matmul needs an L1 width-sharded in0 and a sharded output, and probing
  one that has lost either aborts inside tt-metal rather than returning a catchable error,
  so it is never demoted.
- **Activations.** SwiGLU's `multiply(silu(gate), up)` is folded in `TTNNFusing`: the
  `enable-dram-sharded-matmul` flag is threaded into the pass, which claims the unary for
  the consuming binary op before the matmul patterns run, leaving the producer matmul clean
  by construction. Restricted to unaries fed by a matmul or linear. `buildDSPlan` declines
  DS for a matmul that still carries an activation, since a DS config's `fused_activation`
  is always null and the runtime would forward the op-level one.
- **Level 2 only.** `enable-dram-sharded-matmul` is forced off once `optimization-level` resolves
  unless memory layout analysis is enabled. Below that tier the legal layout table holds no L1
  layouts and no L1 spill management runs, but the DS hint bypasses that table, so a level-1 DS
  compile carried L1-sharded tensors with nothing modelling the allocator behind them.

### Opt-in, off by default
`enable-dram-sharded-matmul` defaults to false. Whether DS pays depends on the shape of the
matmul and on how that shape divides across the device's grids — the DRAM bank count and the
worker grid both differ between p150 and n150, and again on qb2 and other configurations,
each of which needs more testing for gain, problems and improvement before the path could be
turned on by default. At the current head the opt-in gives three modest gains and no regressions on n150
(llama_3_2_3b, gemma_1_1_2b, falcon3_3b, +3% to +4%), regresses 12 of 15 DS-carrying models on
p150 with six beyond 6%, and on qb2 gives llama_3_1_70b_tp +9.4% against one −3.3% loss. The
clear wins seen earlier came from models the benchmark compiles at level 1, which the gate now
excludes (see Measurements). The follow-up brings the larger improvement for Blackhole. A finite number of models was tested either way, so the choice to
opt in belongs to the consumer rather than to a default.

### Prerequisites
All merged: #9248, #9249, #8970, and #7964, whose general eltwise activation arrays replace
the narrower #9250.

### Measurements

Accuracy, DS off vs on across 21 models: TOP1 is unchanged at the mean and median
(mean −0.33 tokens of 64, median 0), with 10 models identical and 11 moving by one to three
tokens in either direction. TOP5 is flat, within ±1 on every model. Those single-token
movements are around the level of run-to-run nondeterminism and should be read per model
rather than as an aggregate.

The one outlier is `gemma_2_2b`, which loses 5 TOP1 tokens (96.88% → 89.06%, reproduced).
This is a consequence of the general fusing approach rather than of DS itself. The activation
is moved onto the consuming binary op for *all* matmuls, because at fusing time it is not yet
known which will get a DS config — so a matmul that only just fails the conservative
DRAM-sharded memory condition keeps the moved activation while taking a different program
config. It is the only model where this exploration saw the move make a significant accuracy
difference; #9264 covers the conservative condition itself.

Throughput at the PR head, tt-xla manual-benchmark on tt-xla 911872c9, optimization level 2, bs32
isl128. Opt-in arm: the head with `enable-dram-sharded-matmul` on (`c8b802c973`, one line off
`599351c387`). Off arm: run twice, `ffdc3d63cb` and `599351c387`, which compile to identical graphs
and give the run-to-run noise floor. A model counts as changed only when the opt-in result lies
beyond both off runs in the same direction by more than that model's own baseline swing and the
architecture's mean swing (n150 1.3%, p150 1.5%, qb2 0.9%); "clear" means beyond the largest swing
seen (3.8%, 4.8%, 1.3%). Change is against the mean of the two off runs. Samples/sec is decode
iterations per second; only models the benchmark compiles at level 2 are compared.

- **n150 (wormhole): three modest gains, no regressions.** llama_3_2_3b +3.7%, gemma_1_1_2b +4.1%,
  falcon3_3b +3.0%, each against off runs that agree within 1.2%. qwen_3_4b +4.3% is borderline
  because its own off runs differ by 3.7%. The other eleven, including the three `ttnn.linear`
  controls, are inside noise; the aggregate median is +0.4%.
- **p150 (blackhole): 12 of 15 DS-carrying models regress, none gain.** Clear: llama_3_2_1b −10.5%,
  falcon3_1b −10.4%, llama_3_2_3b −10.4%, qwen_3_4b −10.0%, falcon3_3b −8.1%, qwen_2_5_3b −6.7%.
  Beyond the floor: gemma_1_1_2b −4.5%, qwen_3_0_6b −3.7%, qwen_3_1_7b −3.3%, qwen_3_8b −2.8%,
  ministral_8b −2.0%, mistral_7b −1.9%. Median −3.2%.
- **qb2 (blackhole, 4-chip TP): one real gain, one real loss.** llama_3_1_70b_tp +9.4%, seven times
  the largest baseline swing; llama_3_1_8b_instruct_tp −3.3%. mistral_small_24b_tp +1.8% and
  falcon3_7b_tp −1.6% sit at the threshold and are not claimed. The rest are inside noise.

TTFT is flat everywhere; prefill never takes a DS config. The SwiGLU fold moved as designed: every
model that fused SiLU into the gate matmul has zero `fused_activation` there with DS on and the
identical count on the multiply's input activations.

**Excluded: the three models the benchmark compiles at level 1** (qwen_2_5_1_5b, qwen_2_5_7b,
gpt_oss_120b_tp_qb2). The gate forces DS off below level 2, so they compile identically in
both arms. In the earlier DS-on runs, where DS applied at any level, they were the largest wins:
qwen_2_5_1_5b +24.9% on n150 and +13.0% on p150, qwen_2_5_7b +13.3% on n150. Restoring that,
either with L1 accounting for DS below level 2 or by moving those models back to level 2, is the
follow-up that would extend the gain to every model; #9252 adds the larger Blackhole improvement.

**Known limitations when enabled:**
- On the 12 GB n150, llama_3_1_8b runs out of DRAM in the PCC phase after the timed loop: its 128 DS
  weights are held width-sharded for decode and interleaved for prefill, about 3.4 GB extra. The
  same model passes on the 32 GB p150 and qb2. The shared-layout gather_in0 prefill path removes
  the duplicate.
- qwen_3_32b_tp_qb2 dies in warmup on a static circular buffer versus L1 buffer clash on core (0,0);
  see #9264.

Other opt-in failures were infrastructure (hugepages, host OOM loading gpt_oss_120b, fabric
mapping). The `TT_FATAL: MatmulMultiCoreReuseMultiCastProgramConfig: per_core_M …` log lines are
compile-time op-model validation rejections and appear in passing jobs too.

Limits: the opt-in arm ran once per architecture, so the n150 gains rest on one run; the p150
regressions and the qb2 70B gain do not. Both off arms are this branch, so this compares the flag
on against off, not the PR against main. Per-model tables, both baselines and the decode-graph
counts are in the Three-Arch Perf Delta report (fifth leg):
https://claude.ai/code/artifact/0d085416-7200-4c59-ae3e-d22175cbf2d4

### Follow-up, not in this PR
#9252 · related issue #9264

### Deliberately not included
- **Bias on `ttnn.linear`.** tt-metal's DS kernel supports one, but reads it per DRAM bank
  at a bank-local offset, so it needs a DRAM width-sharded layout for operand 2 that nothing
  produces yet. A DRAM-interleaved bias would be read as a strided subset of itself — wrong
  results, not a crash, with no tt-metal validation to catch it.
- **Deriving the in0 core count from K.** Fixed at 8, so a K whose tile count is not a
  multiple of 8 is declined (pinned by a test). Choosing among the legal divisors needs a
  cost model.
- **A cost model.** DS is a fixed preference in `LayoutScore`, not a ranked choice.

Supersedes #9150, which carried the same work as one unreviewable branch.

### Checklist
- [x] New/Existing tests provide coverage for changes, lit and unit
- [x] n150 benchmark: [DS off](https://github.com/tenstorrent/tt-xla/actions/runs/33870517807), [DS off, repeat](https://github.com/tenstorrent/tt-xla/actions/runs/34125964702) / [DS on](https://github.com/tenstorrent/tt-xla/actions/runs/34119891836)
- [x] p150 benchmark: [DS off](https://github.com/tenstorrent/tt-xla/actions/runs/33870539571), [DS off, repeat](https://github.com/tenstorrent/tt-xla/actions/runs/34125989986) / [DS on](https://github.com/tenstorrent/tt-xla/actions/runs/34119917834)
- [x] qb2-blackhole benchmark: [DS off](https://github.com/tenstorrent/tt-xla/actions/runs/33870558868), [DS off, repeat](https://github.com/tenstorrent/tt-xla/actions/runs/34126032863) / [DS on](https://github.com/tenstorrent/tt-xla/actions/runs/34119943977)

