### PR TITLE
[TTCore] Correct the default Blackhole worker grid to 10x11

### DIFF
--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -89,7 +89,7 @@ SystemDescAttr createDefaultBlackholeSystemDesc(
                       std::multiplies<int64_t>());
 
   // Populate dummy values for single chip or multi chip config.
-  llvm::SmallVector<std::int64_t> gridShape = {10, 13};
+  llvm::SmallVector<std::int64_t> gridShape = {10, 11};
   llvm::SmallVector<std::int64_t> dramGridShape = {1, 8};
 
   // Captured from a p150 device. Blackhole's optimal mapping is identical

--- a/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
@@ -7,50 +7,58 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=blackhole disable-tolayout-folding=1 use-tensor-accessor-dma=1 force-compile-time-args=0" -o %t.bh_ta.mlir %s
 // RUN: FileCheck %s --check-prefix=CHECK-BH-TA --input-file=%t.bh_ta.mlir
 
-#layout = #ttcore.metal_layout<logical_shape = 128x384, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+// The 1x9 grid in the chain below is what makes the two architectures diverge,
+// and the width is chosen for that: 9 exceeds Wormhole's 8 worker columns, so the
+// grid cannot be placed in one row and gets a virtual-grid mapping plus a wrapped
+// 3x3 core range; it fits inside Blackhole's 11, so there the buffer is placed
+// directly as a single 1x9 row with no mapping at all. Keep it strictly between
+// the two column counts if the shape ever changes, or the architectures stop
+// taking different paths and this test degenerates into two copies of the same
+// expectation.
+#layout = #ttcore.metal_layout<logical_shape = 128x288, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 
 module {
   // CHECK-WH-NO-TA-LABEL: func.func @tensor_accessor_vgm
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 3x4>
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 3x3>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 2x3>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
 
   // CHECK-WH-TA-LABEL: func.func @tensor_accessor_vgm
-  // CHECK-WH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
-  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x4>{{.*}}ct_args = [<tensor_accessor_args[0]>]
-  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-WH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
   // CHECK-WH-TA: const uint32_t page_id_{{[0-9]+}}
 
   // CHECK-BH-NO-TA-LABEL: func.func @tensor_accessor_vgm
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x12>
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x9>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x3>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
 
   // CHECK-BH-TA-LABEL: func.func @tensor_accessor_vgm
-  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
-  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x12>{{.*}}ct_args = [<tensor_accessor_args[0]>]
-  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x9>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-BH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
   // CHECK-BH-TA: const uint32_t page_id_{{[0-9]+}}
 
-  func.func @tensor_accessor_vgm(%arg0: tensor<128x384xf32>) -> tensor<128x384xf32> {
-    %0 = ttir.empty() : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
-    %1 = ttir.to_layout %arg0, %0 : tensor<128x384xf32> into tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
-    %2 = ttir.empty() : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
-    %3 = ttir.to_layout %1, %2 : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> into tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
-    %4 = ttir.empty() : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
-    %5 = ttir.to_layout %3, %4 : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> into tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
-    %6 = ttir.empty() : tensor<128x384xf32>
-    %7 = ttir.to_layout %5, %6 : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> into tensor<128x384xf32> -> tensor<128x384xf32>
-    return %7 : tensor<128x384xf32>
+  func.func @tensor_accessor_vgm(%arg0: tensor<128x288xf32>) -> tensor<128x288xf32> {
+    %0 = ttir.empty() : tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout>
+    %1 = ttir.to_layout %arg0, %0 : tensor<128x288xf32> into tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout>
+    %2 = ttir.empty() : tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %3 = ttir.to_layout %1, %2 : tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout> into tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %4 = ttir.empty() : tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout>
+    %5 = ttir.to_layout %3, %4 : tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout> into tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout>
+    %6 = ttir.empty() : tensor<128x288xf32>
+    %7 = ttir.to_layout %5, %6 : tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout> into tensor<128x288xf32> -> tensor<128x288xf32>
+    return %7 : tensor<128x288xf32>
   }
 }

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
@@ -3,9 +3,9 @@
 
 module {
   // CHECK-LABEL: func.func @slice_f32_virtual_grid_host_transfers
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_virtual_grid_host_transfers(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
@@ -4,8 +4,8 @@
 module {
   // CHECK-LABEL: func.func @slice_f32_cb_page_compatible
   // CHECK-NOT: memref<8x8x384x4xf32
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_cb_page_compatible(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
+++ b/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
@@ -24,7 +24,7 @@
 // RUN: cat %t.dir/trace.json | FileCheck %s
 
 // Llama 3.1 8B single decoder layer on Blackhole. Different hardware
-// constants than n150 (512 GB/s DRAM, 1.35 GHz, 130 Tensix cores) so the
+// constants than n150 (512 GB/s DRAM, 1.35 GHz, 110 Tensix cores) so the
 // roofline shrinks vs the Wormhole companion test even though the model
 // is the same. At default opt level SDPA is not fused, so 6 dram-bound
 // weight matmuls + 2 skipped activation@activation matmuls. (The third,
@@ -38,7 +38,7 @@
 // CHECK: "dram_bandwidth_bytes_per_sec": 512000000000
 // CHECK: "dram_bound_ops": 6
 // CHECK: "num_chips": 1
-// CHECK: "num_tensix_cores": 130
+// CHECK: "num_tensix_cores": 110
 // CHECK: "params_count": 743440384
 // CHECK: "params_memory_bytes": 789905408
 // CHECK: "roofline_ms": 1.542784


### PR DESCRIPTION
### Ticket
Fixes the failure mentioned in #8767 but more recently relevant in DRAM-sharded work

### Problem description
The default Blackhole system descriptor claimed a 10x13 = 130 worker grid while metal's
Blackhole (p150) mock reports 10x11 = 110. Nothing reconciles the two: the descriptor is
pushed into the op model and `refreshComputeGridShape` only reads the device back to
compare, so opening the mock device tripped `validateComputeGridAgainstSystemDesc` and
killed any Blackhole run that reached the optimizer. It reproduces on a dozen lines of
hand-written matmul and is not specific to `ttnn.full`.

### What's changed
`num_tensix_cores` 130 -> 110 in the default Blackhole descriptor, with every dependent
expectation moved in the same commit so the tree stays green:

- `perf_targets/llama_3_1_8b_blackhole.mlir` — `num_tensix_cores` and the header comment
  that quotes it. `roofline_ms` and the compute-vs-DRAM-bound split are unchanged: all six
  ops in that test are DRAM-bound, so the core count does not enter the result.
- `D2MToTTMetal` virtual-grid goldens — one f32 slice decomposition re-factors over the
  narrower grid; volume and page strides unchanged.
- `D2MToTTMetal/tensor_accessor_vgm.mlir` — the chain's pivotal grid moves from 1x12 to
  1x9, so it still exceeds Wormhole's 8 columns and still fits inside Blackhole's 11,
  which is what makes the two architectures take different paths in that test.

### Relationship to the DRAM-sharded matmul work
Functionally proven in #9247, which is where this was found: its Blackhole lit tests run
`mock-system-desc-arch=blackhole` through the optimizer and cannot pass without this fix.
Separated here because the descriptor is wrong independently of DRAM sharding, and this
should merge first.

### Checklist
- [x] New/Existing tests provide coverage for changes
