### PR TITLE
[TTNN] Key the op rule book registry by op name

### DIFF
--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -15,7 +15,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
 
 #include <mutex>
 
@@ -93,12 +93,11 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static ArgMaxRuleBook argMax;
   static AdamWRuleBook adamW;
 
-  static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
+  static llvm::StringMap<const OpRuleBook *> registry;
   static std::once_flag initFlag;
   std::call_once(initFlag, [&] {
-    MLIRContext *ctx = op->getContext();
     auto reg = [&](StringRef name, const OpRuleBook *rb) {
-      registry[OperationName(name, ctx)] = rb;
+      registry[name] = rb;
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
@@ -139,7 +138,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(ArgMaxOp::getOperationName(), &argMax);
     reg(AdamWOp::getOperationName(), &adamW);
   });
-  auto it = registry.find(op->getName());
+  auto it = registry.find(op->getName().getStringRef());
   return it != registry.end() ? *it->second : defaultRules;
 }
 


### PR DESCRIPTION
### Ticket
No tracking issue; found while adding unit tests in #9247.

### Problem description
`getRuleBook`'s registry is a process-global populated once via `std::call_once`, using the
`MLIRContext` of whichever op is queried first. `mlir::OperationName` wraps a pointer
interned in one specific context, so a lookup issued from any other context matches nothing
and every op silently falls back to `defaultRules` — losing matmul program configs, DRAM
sharding, conv and SDPA rules.

Any process that compiles more than once is affected. The Python entry points construct a
`Context` per call (`tools/builder/base/builder_apis.py`,
`tools/ttnn-jit/_src/tracing_compiler.py`, the explorer), so the second and later compiles
lose all op-specific rules. `ttmlir-opt` uses a single context per process, which is why no
lit test observes it.

### What's changed
Key the registry by the op's name string instead. Op names are compile-time constants, so a
string key is context-independent.

### Relationship to the DRAM-sharded matmul work
Functionally proven in #9247, and its regression coverage lands there:
`DRAMShardedEligibilityTest` builds a fresh `MLIRContext` per test, so it fails against a
context-keyed registry. No lit test can catch this. Separated here because the bug predates
and is independent of DRAM sharding, and this should merge first.

### Checklist
- [x] New/Existing tests provide coverage for changes — coverage arrives with #9247
