### PR TITLE
[TTNN] Add optional lhs activation to ttnn.multiply

### DIFF
--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -632,8 +632,15 @@ def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply"> {
 
       `lhs_activation` optionally names a unary activation the kernel applies to
       operand A before the multiply, so a producer's activation costs no separate
-      op -- SwiGLU's `multiply(silu(gate), up)`. Only "silu" is accepted; it is
-      carried to ttnn as `lhs_activations`.
+      op -- SwiGLU's `multiply(silu(gate), up)`.
+
+      Only "silu" is accepted, because that is the only activation the fused
+      SwiGLU path needs. Adding another means mapping it in the verifier below
+      and in `lhsActivationsFromOp` in the runtime's eltwise binary.cpp; the
+      attribute is a single name rather than a list, so a chain of activations
+      would need a wider attribute first. It is carried to ttnn as
+      `lhs_activations`, which is plural because that ABI takes a vector -- this
+      op always passes a vector of at most one.
 
       It lives on this op rather than on the eltwise-binary base class because
       this is the only binary op the runtime plumbs it for, and the paths that

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -629,7 +629,33 @@ def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply"> {
     let summary = "Eltwise multiply.";
     let description = [{
       Eltwise multiply operation.
+
+      `lhs_activation` optionally names a unary activation the kernel applies to
+      operand A before the multiply, so a producer's activation costs no separate
+      op -- SwiGLU's `multiply(silu(gate), up)`. Only "silu" is accepted; it is
+      carried to ttnn as `lhs_activations`.
+
+      It lives on this op rather than on the eltwise-binary base class because
+      this is the only binary op the runtime plumbs it for, and the paths that
+      cannot represent it (EmitC, EmitPy, TTNN-to-TTIR) reject it rather than
+      drop it.
     }];
+
+    let arguments = (ins AnyRankedTensor:$lhs,
+                         AnyRankedTensor:$rhs,
+                         OptionalAttr<StrAttr>:$lhs_activation);
+
+    // Keep the (resultType, lhs, rhs) builder every existing call site uses;
+    // lhs_activation is left unset and only the fused-SwiGLU path sets it.
+    let builders = [
+      OpBuilder<(ins "::mlir::Type":$result, "::mlir::Value":$lhs,
+                     "::mlir::Value":$rhs), [{
+        $_state.addOperands({lhs, rhs});
+        $_state.addTypes({result});
+      }]>,
+    ];
+
+    let hasVerifier = 1;
 }
 
 def TTNN_LogicalRightShiftOp: TTNN_ElementwiseBinaryOp<"logical_right_shift">{

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -631,21 +631,19 @@ def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply"> {
       Eltwise multiply operation.
 
       `lhs_activation` optionally names a unary activation the kernel applies to
-      operand A before the multiply, so a producer's activation costs no separate
-      op -- SwiGLU's `multiply(silu(gate), up)`.
+      operand A before the multiply, so a producer's activation costs no
+      separate op -- SwiGLU's `multiply(silu(gate), up)`.
 
-      Only "silu" is accepted, because that is the only activation the fused
-      SwiGLU path needs. Adding another means mapping it in the verifier below
-      and in `lhsActivationsFromOp` in the runtime's eltwise binary.cpp; the
-      attribute is a single name rather than a list, so a chain of activations
-      would need a wider attribute first. It is carried to ttnn as
-      `lhs_activations`, which is plural because that ABI takes a vector -- this
-      op always passes a vector of at most one.
+      **Only "silu" is accepted, and only on this op.** Both limits are narrower
+      than the attribute's type suggests: it is a plain string, and the eltwise
+      binary base class and the flatbuffer table it serializes into are shared
+      with every other binary op. Adding an activation means mapping it in the
+      verifier and in `lhsActivationsFromOp` in the runtime.
 
-      It lives on this op rather than on the eltwise-binary base class because
-      this is the only binary op the runtime plumbs it for, and the paths that
-      cannot represent it (EmitC, EmitPy, TTNN-to-TTIR) reject it rather than
-      drop it.
+      This is a stopgap for the fused-SwiGLU path, not the intended shape. The
+      general mechanism -- pre- and post-activation lists on every eltwise
+      binary op -- is in flight; when it lands this attribute should fold into
+      it rather than persist alongside it.
     }];
 
     let arguments = (ins AnyRankedTensor:$lhs,

--- a/include/ttmlir/Target/TTNN/operations/eltwise.fbs
+++ b/include/ttmlir/Target/TTNN/operations/eltwise.fbs
@@ -31,6 +31,9 @@ table EltwiseBinaryOp {
   output_dtype: tt.target.DataType = null;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  // Optional in-kernel activation applied to operand A before the binary op
+  // (e.g. "silu" for SwiGLU: multiply(silu(lhs), rhs)). Empty/absent = none.
+  lhs_activation: string;
 }
 
 enum EltwiseBinaryCompositeOpType: uint32 {

--- a/include/ttmlir/Target/TTNN/operations/eltwise.fbs
+++ b/include/ttmlir/Target/TTNN/operations/eltwise.fbs
@@ -31,8 +31,7 @@ table EltwiseBinaryOp {
   output_dtype: tt.target.DataType = null;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
-  // Optional in-kernel activation applied to operand A before the binary op
-  // (e.g. "silu" for SwiGLU: multiply(silu(lhs), rhs)). Empty/absent = none.
+  // Set only on Multiply, and only ever to "silu"; ignored on every other type.
   lhs_activation: string;
 }
 

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -414,8 +414,6 @@ public:
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // ttnn.multiply's optional lhs_activation has no representation here, and
-    // silently dropping it would change the numerics with no diagnostic.
     if constexpr (std::is_same_v<SourceOp, mlir::tt::ttnn::MultiplyOp>) {
       if (srcOp.getLhsActivation()) {
         return rewriter.notifyMatchFailure(

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -414,6 +414,17 @@ public:
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // ttnn.multiply's optional lhs_activation has no representation here, and
+    // silently dropping it would change the numerics with no diagnostic.
+    if constexpr (std::is_same_v<SourceOp, mlir::tt::ttnn::MultiplyOp>) {
+      if (srcOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            srcOp,
+            "ttnn.multiply with lhs_activation is not supported by this "
+            "conversion; it is only lowered through the flatbuffer path");
+      }
+    }
+
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -303,8 +303,6 @@ public:
   matchAndRewrite(TTNNOpTy eltwiseBinaryOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
-    // ttnn.multiply's optional lhs_activation has no representation here, and
-    // silently dropping it would change the numerics with no diagnostic.
     if constexpr (std::is_same_v<TTNNOpTy, mlir::tt::ttnn::MultiplyOp>) {
       if (eltwiseBinaryOp.getLhsActivation()) {
         return rewriter.notifyMatchFailure(

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -303,6 +303,17 @@ public:
   matchAndRewrite(TTNNOpTy eltwiseBinaryOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // ttnn.multiply's optional lhs_activation has no representation here, and
+    // silently dropping it would change the numerics with no diagnostic.
+    if constexpr (std::is_same_v<TTNNOpTy, mlir::tt::ttnn::MultiplyOp>) {
+      if (eltwiseBinaryOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            eltwiseBinaryOp,
+            "ttnn.multiply with lhs_activation is not supported by this "
+            "conversion; it is only lowered through the flatbuffer path");
+      }
+    }
+
     ttnn_to_emitpy::EmitPyTTNNEmitter<TTNNOpTy> emitter(eltwiseBinaryOp,
                                                         adaptor, rewriter);
 

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -49,9 +49,6 @@ public:
   mlir::LogicalResult
   matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
                   mlir::ConversionPatternRewriter &rewriter) const override {
-    // The base rebuilds the op from operands alone, so ttnn.multiply's optional
-    // lhs_activation would be dropped without a diagnostic. TTIR has no
-    // equivalent; refuse rather than silently change the numerics.
     if constexpr (std::is_same_v<SrcOp, mlir::tt::ttnn::MultiplyOp>) {
       if (srcOp.getLhsActivation()) {
         return rewriter.notifyMatchFailure(

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -44,7 +44,23 @@ class TTNNToTTIRElementwiseConversionPattern
 public:
   using TTNNToTTIROpConversionPattern<SrcOp,
                                       DestOp>::TTNNToTTIROpConversionPattern;
-  // Reuse base; this exists simply for clarity and potential future extensions
+  using Adaptor = typename SrcOp::Adaptor;
+
+  mlir::LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // The base rebuilds the op from operands alone, so ttnn.multiply's optional
+    // lhs_activation would be dropped without a diagnostic. TTIR has no
+    // equivalent; refuse rather than silently change the numerics.
+    if constexpr (std::is_same_v<SrcOp, mlir::tt::ttnn::MultiplyOp>) {
+      if (srcOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "ttnn.multiply with lhs_activation has no TTIR equivalent");
+      }
+    }
+    return TTNNToTTIROpConversionPattern<SrcOp, DestOp>::matchAndRewrite(
+        srcOp, adaptor, rewriter);
+  }
 };
 
 template <typename SrcOp, typename DestOp>

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -97,6 +97,19 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// MultiplyOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::MultiplyOp::verify() {
+  std::optional<llvm::StringRef> activation = getLhsActivation();
+  if (activation && *activation != "silu") {
+    return emitOpError() << "lhs_activation must be \"silu\", but got \""
+                         << *activation << "\"";
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // DropoutOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2266,9 +2266,6 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
 
   auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
 
-  // Optional in-kernel activation applied to operand A (SwiGLU's
-  // multiply(silu(lhs), rhs)). ttnn.multiply is the only binary op that carries
-  // it, and the only one the runtime plumbs it for.
   ::flatbuffers::Offset<::flatbuffers::String> lhsActivation = 0;
   if constexpr (std::is_same_v<EltwiseBinaryOp, MultiplyOp>) {
     if (auto act = op.getLhsActivation()) {

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2266,8 +2266,19 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
 
   auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
 
-  return ::tt::target::ttnn::CreateEltwiseBinaryOp(
-      *cache.fbb, type, lhs, rhs, outputDtype, memoryConfig, out);
+  // Optional in-kernel activation applied to operand A (SwiGLU's
+  // multiply(silu(lhs), rhs)). ttnn.multiply is the only binary op that carries
+  // it, and the only one the runtime plumbs it for.
+  ::flatbuffers::Offset<::flatbuffers::String> lhsActivation = 0;
+  if constexpr (std::is_same_v<EltwiseBinaryOp, MultiplyOp>) {
+    if (auto act = op.getLhsActivation()) {
+      lhsActivation = cache.fbb->CreateString(act->str());
+    }
+  }
+
+  return ::tt::target::ttnn::CreateEltwiseBinaryOp(*cache.fbb, type, lhs, rhs,
+                                                   outputDtype, memoryConfig,
+                                                   out, lhsActivation);
 }
 
 template <typename EltwiseBinaryCompositeOp>

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -6,8 +6,30 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
+
+// Build the operand-A in-kernel activations from the op's optional
+// lhs_activation string (fused SwiGLU: multiply(silu(lhs), rhs)). Absent or
+// empty = no activation.
+//
+// Only "silu" is supported, and MultiplyOp::verify rejects anything else at
+// compile time. Fail loudly rather than silently dropping an activation the
+// graph asked for -- that would be wrong numerics with no diagnostic.
+static std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam>
+lhsActivationsFromOp(const ::tt::target::ttnn::EltwiseBinaryOp *op) {
+  std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> acts;
+  if (!op->lhs_activation() || op->lhs_activation()->size() == 0) {
+    return acts;
+  }
+  const std::string activation = op->lhs_activation()->str();
+  LOG_ASSERT(activation == "silu",
+             "Unsupported lhs_activation \"" + activation +
+                 "\" on eltwise binary op; only \"silu\" is supported");
+  acts.emplace_back(::ttnn::operations::unary::UnaryOpType::SILU);
+  return acts;
+}
 
 template <typename Fn>
 static void runEltwiseBinaryOp(const ::tt::target::ttnn::EltwiseBinaryOp *op,
@@ -46,8 +68,18 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Multiply: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::multiply(std::forward<decltype(args)>(args)...);
+    // Fused SwiGLU: an optional in-kernel activation (silu) applied to operand
+    // A (the gate output) before the multiply — avoids a separate silu op.
+    // Empty for a plain multiply. noActs/lhsActs outlive the call within this
+    // scope.
+    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> noActs;
+    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> lhsActs =
+        lhsActivationsFromOp(op);
+    runEltwiseBinaryOp(op, tensorPool, [&](auto &&...args) {
+      return ::ttnn::multiply(std::forward<decltype(args)>(args)...,
+                              /*optional_output=*/std::nullopt,
+                              /*post_activations=*/noActs,
+                              /*lhs_activations=*/lhsActs);
     });
     break;
   }

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -8,6 +8,9 @@
 #include "tt/runtime/detail/ttnn/utils.h"
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
+#include <string>
+#include <vector>
+
 namespace tt::runtime::ttnn::operations::eltwise::binary {
 
 // Build the operand-A in-kernel activations from the op's optional
@@ -24,9 +27,8 @@ lhsActivationsFromOp(const ::tt::target::ttnn::EltwiseBinaryOp *op) {
     return acts;
   }
   const std::string activation = op->lhs_activation()->str();
-  LOG_ASSERT(activation == "silu",
-             "Unsupported lhs_activation \"" + activation +
-                 "\" on eltwise binary op; only \"silu\" is supported");
+  LOG_ASSERT(activation == "silu", "Unsupported lhs_activation \"", activation,
+             "\" on eltwise binary op; only \"silu\" is supported");
   acts.emplace_back(::ttnn::operations::unary::UnaryOpType::SILU);
   return acts;
 }
@@ -59,6 +61,17 @@ static void runEltwiseBinaryOp(const ::tt::target::ttnn::EltwiseBinaryOp *op,
 void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  // lhs_activation sits on the shared EltwiseBinaryOp table but only the
+  // Multiply case below reads it, and only ttnn.multiply can carry it out of
+  // the compiler. Catch a mismatch here rather than let a future producer set
+  // it on another op type and have it silently ignored.
+  LOG_ASSERT(!op->lhs_activation() || op->lhs_activation()->size() == 0 ||
+                 op->type() ==
+                     ::tt::target::ttnn::EltwiseBinaryOpType::Multiply,
+             "lhs_activation is only supported on multiply, but was set on ",
+             ::tt::target::ttnn::EnumNameEltwiseBinaryOpType(op->type()));
+
   switch (op->type()) {
   /* Eltwise Binary */
   case ::tt::target::ttnn::EltwiseBinaryOpType::Add: {
@@ -70,15 +83,15 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
   case ::tt::target::ttnn::EltwiseBinaryOpType::Multiply: {
     // Fused SwiGLU: an optional in-kernel activation (silu) applied to operand
     // A (the gate output) before the multiply — avoids a separate silu op.
-    // Empty for a plain multiply. noActs/lhsActs outlive the call within this
-    // scope.
-    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> noActs;
+    // Empty for a plain multiply. noPostActs/lhsActs outlive the call within
+    // this scope.
+    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> noPostActs;
     std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> lhsActs =
         lhsActivationsFromOp(op);
     runEltwiseBinaryOp(op, tensorPool, [&](auto &&...args) {
       return ::ttnn::multiply(std::forward<decltype(args)>(args)...,
                               /*optional_output=*/std::nullopt,
-                              /*post_activations=*/noActs,
+                              /*post_activations=*/noPostActs,
                               /*lhs_activations=*/lhsActs);
     });
     break;

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -13,13 +13,8 @@
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
 
-// Build the operand-A in-kernel activations from the op's optional
-// lhs_activation string (fused SwiGLU: multiply(silu(lhs), rhs)). Absent or
-// empty = no activation.
-//
-// Only "silu" is supported, and MultiplyOp::verify rejects anything else at
-// compile time. Fail loudly rather than silently dropping an activation the
-// graph asked for -- that would be wrong numerics with no diagnostic.
+// MultiplyOp::verify already rejects anything but "silu" at compile time; this
+// asserts because a dropped activation would be wrong numerics, silently.
 static std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam>
 lhsActivationsFromOp(const ::tt::target::ttnn::EltwiseBinaryOp *op) {
   std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> acts;
@@ -62,10 +57,8 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
          ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
-  // lhs_activation sits on the shared EltwiseBinaryOp table but only the
-  // Multiply case below reads it, and only ttnn.multiply can carry it out of
-  // the compiler. Catch a mismatch here rather than let a future producer set
-  // it on another op type and have it silently ignored.
+  // The field is on the shared EltwiseBinaryOp table, so an op type other than
+  // multiply can carry it and have it silently ignored.
   LOG_ASSERT(!op->lhs_activation() || op->lhs_activation()->size() == 0 ||
                  op->type() ==
                      ::tt::target::ttnn::EltwiseBinaryOpType::Multiply,
@@ -81,10 +74,8 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Multiply: {
-    // Fused SwiGLU: an optional in-kernel activation (silu) applied to operand
-    // A (the gate output) before the multiply — avoids a separate silu op.
-    // Empty for a plain multiply. noPostActs/lhsActs outlive the call within
-    // this scope.
+    // ttnn takes these as non-owning spans, so both vectors must outlive the
+    // call.
     std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> noPostActs;
     std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> lhsActs =
         lhsActivationsFromOp(op);

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation.mlir
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt %s | FileCheck %s
+
+// lhs_activation names a unary the multiply kernel applies to operand A before
+// the multiply, so a producer's activation costs no separate op -- SwiGLU's
+// multiply(silu(gate), up).
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK-LABEL: func.func @multiply_silu
+  // CHECK: lhs_activation = "silu"
+  func.func @multiply_silu(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) <{lhs_activation = "silu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+
+  // Every other multiply in the tree leaves it unset.
+  // CHECK-LABEL: func.func @multiply_plain
+  // CHECK-NOT: lhs_activation
+  func.func @multiply_plain(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_conversion_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_conversion_negative.mlir
@@ -4,16 +4,17 @@
 
 // RUN: not ttmlir-opt --convert-ttnn-to-emitc %s 2>&1 | FileCheck %s
 // RUN: not ttmlir-opt --convert-ttnn-to-emitpy %s 2>&1 | FileCheck %s
-// RUN: not ttmlir-opt --convert-ttnn-to-ttir %s 2>&1 | FileCheck %s
 
-// Only the flatbuffer path can represent lhs_activation. EmitC and EmitPy emit
-// a binary call with no activation argument, and TTNN-to-TTIR rebuilds the op
-// from operands alone, so each would drop the activation and produce a plain
-// multiply -- different numerics with no diagnostic. All three refuse instead.
+// Only the flatbuffer path can represent lhs_activation. EmitC and EmitPy emit a
+// binary call with no activation argument, so either would drop the activation
+// and produce a plain multiply -- different numerics with no diagnostic. Both
+// refuse instead, and this pins that: a conversion that silently dropped it
+// would still pass every other test in this directory.
 //
-// This is the behaviour that keeps the attribute safe to add to only one op, so
-// it is worth pinning: a future conversion that silently drops it would still
-// pass every other test in this directory.
+// TTNN-to-TTIR refuses it too, but is not covered here. That pass marks the TTNN
+// dialect only dynamically illegal -- ops inside a D2M subgraph or hoisted via
+// isTTNNHoistGenericViaD2MOp -- so an ordinary ttnn.multiply is legal, never
+// reaches the pattern, and the pass is a no-op on a module like this one.
 
 #dram = #ttnn.buffer_type<dram>
 #l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_conversion_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_conversion_negative.mlir
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: not ttmlir-opt --convert-ttnn-to-emitc %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --convert-ttnn-to-emitpy %s 2>&1 | FileCheck %s
+// RUN: not ttmlir-opt --convert-ttnn-to-ttir %s 2>&1 | FileCheck %s
+
+// Only the flatbuffer path can represent lhs_activation. EmitC and EmitPy emit
+// a binary call with no activation argument, and TTNN-to-TTIR rebuilds the op
+// from operands alone, so each would drop the activation and produce a plain
+// multiply -- different numerics with no diagnostic. All three refuse instead.
+//
+// This is the behaviour that keeps the attribute safe to add to only one op, so
+// it is worth pinning: a future conversion that silently drops it would still
+// pass every other test in this directory.
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  func.func @multiply_lhs_activation_not_convertible(
+      %a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>)
+      -> tensor<32x32xbf16, #l> {
+    // CHECK: failed to legalize operation 'ttnn.multiply'
+    %0 = "ttnn.multiply"(%a, %b) <{lhs_activation = "silu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_negative.mlir
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Only "silu" is supported, and only ttnn.multiply carries lhs_activation at
+// all: the runtime plumbs it for no other eltwise binary op, so accepting it
+// elsewhere would execute without the activation and silently change results.
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK: lhs_activation must be "silu", but got "relu"
+  func.func @multiply_unsupported_activation(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) <{lhs_activation = "relu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK: invalid properties {lhs_activation = "silu"} for op ttnn.add: this operation does not support properties
+  func.func @add_does_not_accept_activation(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.add"(%a, %b) <{lhs_activation = "silu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}


### PR DESCRIPTION
### Ticket
No tracking issue.
Should be reverted and applied properly with #7964 later, but as that one will affect perf in many ways, this scoped version should go in as a part of #9247 before.

### Problem description
A producer's fused activation sometimes costs a whole extra elementwise op because the
consumer has no way to absorb it. ttnn's binary ops take `lhs_activations`, applied
in-kernel to operand A before the binary op, but nothing in the compiler could express or
serialize it.

### What's changed
An optional `lhs_activation` on `ttnn.multiply`, plumbed through the flatbuffer to ttnn's
`lhs_activations`. The resulting contract is deliberately narrow — multiply, silu, flatbuffer path.

### Scoping
A dropped activation is wrong numerics rather than a crash, so every path that cannot
carry it refuses the op instead:

- The attribute is on `ttnn.multiply` alone, not on the `TTNN_ElementwiseBinaryOp` base
  that 16 ops inherit — the runtime plumbs it for no other binary op, so accepting it
  elsewhere would execute without the activation. `ttnn.add` with `lhs_activation` is now
  a parse error.
- `TTNNToEmitC`, `TTNNToEmitPy` and `TTNNToTTIR` cannot represent it, and all three
  rebuilt the op without it. All three now `notifyMatchFailure`. For EmitC and EmitPy that
  means such an op fails legalization rather than silently lowering to a plain multiply.
  `TTNNToTTIR` reaches its guard only for ops it treats as illegal — inside a D2M subgraph
  or carrying `ttnn.hoist_generic_via_d2m`; an ordinary `ttnn.multiply` is legal there, so
  the pass leaves it alone. Threading it through was rejected as speculative: it needs a
  converter for `std::vector<EltwiseUnaryWithParam>` in generated C++/Python with no
  consumer today, and TTIR has no equivalent attribute.
- The runtime asserts on any value but `"silu"` rather than dropping it, and asserts that
  no op type other than `Multiply` carries the field — it lives on the shared
  `EltwiseBinaryOp` flatbuffer table, so another type could otherwise set it and have it
  silently ignored.

### Relationship to the DRAM-sharded matmul work
Functionally proven in #9247, whose only producer of `lhs_activation` is the DRAM-sharded
matmul's SwiGLU fold — `multiply(silu(gate), up)` becomes one op instead of a separate
`ttnn.silu`. Separated here because the dialect, schema and runtime change stands on its
own, and this should merge first.

Why the activation belongs on the consumer's *lhs* rather than on the producer's output is
a perf argument specific to DRAM sharding. A DRAM-sharded matmul computes on far fewer
cores than a multicast one — the kernel derives one bank-local core per DRAM channel, so
the count is fixed at the part's bank count — which concentrates per-tile work and makes
that op the worst place to add any. Fusing an activation onto its output would not merely
fail to pay for itself, it would cost. Moving it to the consumer multiply's lhs puts it on
an op whose compute grid is free to be much wider, so the same work lands where there are
cores to absorb it.

### Checklist
- [x] New/Existing tests provide coverage for changes — `multiply_lhs_activation.mlir`,
  `multiply_lhs_activation_negative.mlir` and
  `multiply_lhs_activation_conversion_negative.mlir` (the EmitC and EmitPy reject paths;
  TTIR is not covered there, for the reason above); exercised end-to-end in #9247


