### PR TITLE
[Optimizer] Use LoFi for every DRAM-sharded matmul

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
@@ -89,11 +89,9 @@ MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
 buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
                               UnaryWithParamAttr fusedAct);
 
-// Build the compute-kernel config for a DRAM-sharded matmul (math fidelity
-// follows the weight dtype; fp32 dest-accumulate and packer-L1-accumulate
-// enabled).
-DeviceComputeKernelConfigAttr
-buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType);
+// Build the compute-kernel config for a DRAM-sharded matmul (LoFi; fp32
+// dest-accumulate and packer-L1-accumulate enabled).
+DeviceComputeKernelConfigAttr buildComputeConfig(MLIRContext *ctx);
 
 } // namespace mlir::tt::ttnn
 

--- a/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
@@ -24,6 +24,77 @@ namespace mlir::tt::ttnn {
 std::optional<mlir::Attribute>
 generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout);
 
+// ============================================================================
+// DRAM-sharded matmul config generation
+// ============================================================================
+//
+// Primitives that build a DRAM-sharded matmul
+// (MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig): the weight (in1) is
+// width-sharded across DRAM banks and the activation (in0) is width-sharded
+// across L1 cores. The optimizer's DRAM-shard rule book (MatmulRules.cpp)
+// decides *whether* a matmul is eligible and orchestrates the reshards; these
+// functions own the *how* — the shard geometry, layouts, and configs.
+
+// Geometry describing how an M×K×N matmul is sharded for DRAM-sharded
+// execution. Produced by computeShardParams; consumed by the builders below
+// and by the rule book (which reads e.g. perCoreN to size the output grid).
+struct DRAMShardParams {
+  int64_t K;
+  int64_t N;
+  int64_t M;
+  int64_t numBanks;
+  int64_t numIn0Cores;
+  int64_t numOutCores;
+  int64_t nPadded;
+  int64_t shardH;
+  int64_t shardW;
+  int64_t kTiles;
+  int64_t shardWTiles;
+  int64_t in0BlockW;
+  int64_t perCoreM;
+  int64_t perCoreN;
+  ttcore::DataType weightDataType;
+};
+
+// Compute the shard geometry and a circular-buffer-fitting in0_block_w for an
+// M×K×N matmul whose weight is BFP and DRAM-interleaved. The weight is sharded
+// across `numBanks` DRAM banks and the activation across `numIn0Cores` L1
+// cores; `numOutCores` bounds the output storage grid. `l1Available` is the L1
+// budget the circular buffers must fit. Returns nullopt when no in0_block_w
+// fits. K/kTileSize must be divisible by numIn0Cores (the caller's eligibility
+// gate enforces this).
+std::optional<DRAMShardParams>
+computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
+                   int64_t numIn0Cores, int64_t numOutCores,
+                   ttcore::DataType weightDataType, int64_t l1Available);
+
+// Build the DRAM width-sharded layout for the weight (in1) of `tensorShape`,
+// sharded across `p.numBanks` DRAM banks.
+TTNNLayoutAttr buildDRAMShardedWeightLayout(MLIRContext *ctx,
+                                            TTNNLayoutAttr origLayout,
+                                            llvm::ArrayRef<int64_t> tensorShape,
+                                            const DRAMShardParams &p,
+                                            ttcore::DeviceAttr deviceAttr);
+
+// Build an L1 width-sharded layout for `tensorShape` over `numCores`, using
+// canonical core placement that wraps across the worker grid (a single-row
+// placement would be invalid once numCores exceeds the grid width).
+TTNNLayoutAttr buildL1ShardedLayout(MLIRContext *ctx, TTNNLayoutAttr origLayout,
+                                    llvm::ArrayRef<int64_t> tensorShape,
+                                    int64_t numCores,
+                                    ttcore::DeviceAttr deviceAttr);
+
+// Build the DRAM-sharded program config from computed shard params.
+MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
+                              UnaryWithParamAttr fusedAct);
+
+// Build the compute-kernel config for a DRAM-sharded matmul (math fidelity
+// follows the weight dtype; fp32 dest-accumulate and packer-L1-accumulate
+// enabled).
+DeviceComputeKernelConfigAttr
+buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType);
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_MATMULPROGRAMCONFIG_H

--- a/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MemoryLayoutPropagation.h
@@ -85,6 +85,17 @@ private:
   /// Maps op -> index into beamState[op]. For K=1, always 0.
   llvm::DenseMap<Operation *, size_t> finalChoice;
 
+  /// Reshard dedup cache for the reshard pass in applyToIR: (producer value,
+  /// target layout) -> the shared reshard result (a ToMemoryConfigOp, or a
+  /// ToLayoutOp when the page layout changes). Lets consumers requesting the
+  /// same reshard (e.g. q/k/v slices off a fused-QKV matmul) reuse one op.
+  /// Keying on the target layout is what keeps the op kind consistent per
+  /// entry: whether a retile is needed is a pure function of the producer
+  /// layout and the target layout. Empty by construction: run() executes once
+  /// per instance.
+  llvm::DenseMap<std::pair<mlir::Value, mlir::Attribute>, mlir::Value>
+      reshardCache;
+
   /// Observer (NullObject pattern: always non-null, no-op when tracing
   /// disabled).
   std::unique_ptr<LayoutPropagationObserver> observer;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h
@@ -73,6 +73,16 @@ struct LayoutScore {
   /// Memory footprint from ValidationResult (for tie-breaking).
   uint64_t outputL1Usage = 0;
 
+  /// DRAM-sharded matmul candidate. When both candidates are L1+sharded, this
+  /// wins over normal candidates regardless of core count — architecturally
+  /// superior for decode.
+  bool isDRAMShardedCandidate = false;
+
+  /// Set when isDRAMShardedCandidate and in0 is already the canonical
+  /// 1×kNumStorageCores L1 width-sharded layout (no in0 reshard needed).
+  /// Tiebreaker within DS candidates.
+  bool hasCanonicalDSIn0 = false;
+
   /// Higher score is better.
   bool operator>(const LayoutScore &other) const;
   bool operator==(const LayoutScore &other) const;

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h
@@ -50,6 +50,11 @@ inline bool requireRowMajor(TTNNLayoutAttr layout) {
   return layout.getLayout() == Layout::RowMajor;
 }
 
+/// Reject L1 layouts; DRAM-sharded and DRAM-interleaved pass through.
+inline bool rejectAllL1(TTNNLayoutAttr layout) {
+  return !layout.hasL1BufferType();
+}
+
 /// Reject width-sharded layouts. Returns true if the layout should be kept.
 inline bool rejectWidthSharded(TTNNLayoutAttr layout) {
   auto ml = layout.getMemLayout();

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h
@@ -9,6 +9,8 @@
 
 namespace mlir::tt::ttnn {
 
+class MatmulOp;
+
 //===----------------------------------------------------------------------===//
 // Matmul/Linear rules:
 //
@@ -24,17 +26,55 @@ namespace mlir::tt::ttnn {
 //===----------------------------------------------------------------------===//
 
 struct MatmulRuleBook : OpRuleBook {
-  /// Output hints: partial configs without L1-interleaved.
+  /// Output hints: for DS-eligible matmuls, the DS hint is included alongside
+  /// the normal partial configs. adjustScore drives DS preference via
+  /// isDRAMShardedCandidate. For non-eligible matmuls: normal behavior.
   OutputHints
   getOutputHints(Operation *op,
                  const std::vector<OpConfig> &legalConfigs) const override;
 
-  /// Reject all sharded RHS inputs (operand 1). LHS and bias are unrestricted.
+  /// Operand 1 (weight): reject L1. DRAM layouts (interleaved and
+  /// width-sharded) are accepted; the DRAM width-sharded(DS) layout is injected
+  /// via getExtraInputReshardCandidates.
   LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
 
   /// Apply MatmulProgramConfig + fused activation dedup.
+  /// For DS candidates: set program/compute config and split fused activation.
   void applyOpSpecificAttrs(Operation *op,
                             const BeamCandidate &candidate) const override;
+
+  /// Reject the DS hint for input combinations that aren't the correct DS
+  /// layouts (L1 width-sharded in0, DRAM width-sharded in1). The tt-metal op
+  /// model crashes (TT_FATAL) rather than returning a failure when given a DS
+  /// program config with incompatible input layouts.
+  bool isValidOutputHintForInputs(
+      const OpConfig &hint,
+      llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const override;
+
+  /// Set isDRAMShardedCandidate / hasCanonicalDSIn0 for DS candidates.
+  LayoutScore adjustScore(Operation *op, LayoutScore base,
+                          const OpConfig &config,
+                          llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                          bool requiresReshard) const override;
+
+  /// Inject DS-specific input layouts into the candidate pool:
+  ///   operand 0 → L1 width-sharded 1×kNumIn0Cores
+  ///   operand 1 → DRAM width-sharded 1×numBanks, padded; numBanks comes
+  ///               from the device's DRAM grid
+  std::vector<TTNNLayoutAttr>
+  getExtraInputReshardCandidates(Operation *op,
+                                 unsigned operandIdx) const override;
+
+private:
+  /// Build the DS output hint (L1 width-sharded 1×kNumIn0Cores + DS program
+  /// config). Returns nullopt if not eligible or params don't fit L1.
+  std::optional<OpConfig> buildDRAMShardingHint(Operation *op) const;
+
+  /// Set program/compute config and split fused activation for a DS matmul.
+  /// Takes a generic Operation* because the DS path covers both ttnn.matmul and
+  /// bias-free ttnn.linear (see getDSOperands).
+  void applyDRAMShardedTransformation(Operation *op,
+                                      const MatmulAttrs &matmulAttrs) const;
 };
 
 } // namespace mlir::tt::ttnn

--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h
@@ -90,13 +90,22 @@ struct OpRuleBook {
                                const BeamCandidate &b) const;
 
   /// Adjust a candidate's LayoutScore after the base scorer computed it.
-  /// Receives the output config, all operand input
-  /// layouts, and the reshard flag.
+  /// Receives the output config, all operand input layouts, and the reshard
+  /// flag. Used by MatmulRuleBook to set isDRAMShardedCandidate /
+  /// hasCanonicalDSIn0.
   virtual LayoutScore adjustScore(Operation *op, LayoutScore base,
                                   const OpConfig &config,
                                   llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
                                   bool requiresReshard) const {
     return base;
+  }
+
+  /// Extra input reshard candidates that go beyond what
+  /// generateReshardCandidates produces from tensorTypePossibleLayouts. Called
+  /// per-operand from getInputCandidateSets. Default returns nothing.
+  virtual std::vector<TTNNLayoutAttr>
+  getExtraInputReshardCandidates(Operation *op, unsigned operandIdx) const {
+    return {};
   }
 };
 

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -591,7 +591,33 @@ def TTNN_MultiplyOp : TTNN_ElementwiseBinaryOp<"multiply"> {
     let summary = "Eltwise multiply.";
     let description = [{
       Eltwise multiply operation.
+
+      `lhs_activation` optionally names a unary activation the kernel applies to
+      operand A before the multiply, so a producer's activation costs no separate
+      op -- SwiGLU's `multiply(silu(gate), up)`. Only "silu" is accepted; it is
+      carried to ttnn as `lhs_activations`.
+
+      It lives on this op rather than on the eltwise-binary base class because
+      this is the only binary op the runtime plumbs it for, and the paths that
+      cannot represent it (EmitC, EmitPy, TTNN-to-TTIR) reject it rather than
+      drop it.
     }];
+
+    let arguments = (ins AnyRankedTensor:$lhs,
+                         AnyRankedTensor:$rhs,
+                         OptionalAttr<StrAttr>:$lhs_activation);
+
+    // Keep the (resultType, lhs, rhs) builder every existing call site uses;
+    // lhs_activation is left unset and only the fused-SwiGLU path sets it.
+    let builders = [
+      OpBuilder<(ins "::mlir::Type":$result, "::mlir::Value":$lhs,
+                     "::mlir::Value":$rhs), [{
+        $_state.addOperands({lhs, rhs});
+        $_state.addTypes({result});
+      }]>,
+    ];
+
+    let hasVerifier = 1;
 }
 
 def TTNN_LogicalRightShiftOp: TTNN_ElementwiseBinaryOp<"logical_right_shift">{

--- a/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
+++ b/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h
@@ -250,6 +250,15 @@ struct TTIRToTTNNCommonPipelineOptions
                      "Analysis and Memory Layout Analysis. [0.0-1.0]"),
       llvm::cl::init(0.95f)};
 
+  // Option to disable generation of DRAM-sharded matmuls in the optimizer.
+  // When set, the matmul DRAM-shard rule book is suppressed and matmuls fall
+  // back to the other (1D/2D mcast) program configs.
+  Option<bool> disableDRAMShardedMatmul{
+      *this, OptionNames::disableDramShardedMatmul,
+      llvm::cl::desc(
+          "Disable generation of DRAM-sharded matmuls in the optimizer."),
+      llvm::cl::init(false)};
+
   // Option to enable/disable the workaround pass.
   //
   Option<bool> disableWorkarounds{

--- a/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
+++ b/include/ttmlir/Dialect/TTNN/Transforms/DevicePassesWrapper.h
@@ -24,6 +24,10 @@ struct DevicePassesWrapperOptions {
   // This is set as a module attribute by DevicePassesWrapper, making it
   // accessible to all nested passes via utils::getTensorL1UsageCap()
   float tensorL1UsageCap = 0.95f;
+  // When true, suppresses generation of DRAM-sharded matmuls in the optimizer.
+  // This is set as a module attribute by DevicePassesWrapper, making it
+  // accessible to the matmul rule book via utils::isDRAMShardedMatmulDisabled()
+  bool disableDRAMShardedMatmul = false;
 };
 
 // Creates a pass that wraps device-dependent passes with device lifecycle

--- a/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/PassOverrides.h
@@ -32,6 +32,8 @@ struct OptionNames {
   static constexpr StringRef meshTopology = "mesh-topology";
   static constexpr StringRef tuplifyInputIfEmpty = "tuplify-input-if-empty";
   static constexpr StringRef tensorL1UsageCap = "tensor-l1-usage-cap";
+  static constexpr StringRef disableDramShardedMatmul =
+      "disable-dram-sharded-matmul";
   static constexpr StringRef ttnnPerfMetricsOutputFile =
       "ttnn-perf-metrics-output-file";
   static constexpr StringRef ttnnPerfMetricsVerboseOutputEnabled =

--- a/include/ttmlir/Dialect/TTNN/Utils/Utils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/Utils.h
@@ -32,9 +32,17 @@ inline constexpr llvm::StringLiteral g_L1ConstEvalUsageAttrName =
 inline constexpr llvm::StringLiteral g_ConstEvalAllowedAttrName =
     "ttnn.const_eval_allowed";
 
+// Attribute name for the flag that disables DRAM-sharded matmul generation.
+inline constexpr llvm::StringLiteral g_DisableDRAMShardedMatmulAttrName =
+    "ttnn.disable_dram_sharded_matmul";
+
 // Helper function to retrieve tensor L1 usage cap from module attribute.
 // Returns the configured cap if found, otherwise returns the default value.
 float getTensorL1UsageCap(Operation *op, float defaultValue = 0.95f);
+
+// Whether DRAM-sharded matmul generation is disabled, per the module attribute
+// set by DevicePassesWrapper. Returns false when the attribute is absent.
+bool isDRAMShardedMatmulDisabled(Operation *op);
 
 // Helper function to retrieve the per-core L1 usage reserved for the retained
 // (permanent) tensors.

--- a/include/ttmlir/Target/TTNN/operations/eltwise.fbs
+++ b/include/ttmlir/Target/TTNN/operations/eltwise.fbs
@@ -31,6 +31,9 @@ table EltwiseBinaryOp {
   output_dtype: tt.target.DataType = null;
   memory_config: tt.target.ttnn.MemoryConfig;
   out: tt.target.ttnn.TensorRef;
+  // Optional in-kernel activation applied to operand A before the binary op
+  // (e.g. "silu" for SwiGLU: multiply(silu(lhs), rhs)). Empty/absent = none.
+  lhs_activation: string;
 }
 
 enum EltwiseBinaryCompositeOpType: uint32 {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -415,6 +415,17 @@ public:
   matchAndRewrite(SourceOp srcOp, Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // ttnn.multiply's optional lhs_activation has no representation here, and
+    // silently dropping it would change the numerics with no diagnostic.
+    if constexpr (std::is_same_v<SourceOp, mlir::tt::ttnn::MultiplyOp>) {
+      if (srcOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            srcOp,
+            "ttnn.multiply with lhs_activation is not supported by this "
+            "conversion; it is only lowered through the flatbuffer path");
+      }
+    }
+
     ttnn_to_emitc::EmitCTTNNEmitter<SourceOp> emitter(srcOp, adaptor, rewriter);
 
     llvm::SmallVector<mlir::Attribute> args{

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -303,6 +303,17 @@ public:
   matchAndRewrite(TTNNOpTy eltwiseBinaryOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
 
+    // ttnn.multiply's optional lhs_activation has no representation here, and
+    // silently dropping it would change the numerics with no diagnostic.
+    if constexpr (std::is_same_v<TTNNOpTy, mlir::tt::ttnn::MultiplyOp>) {
+      if (eltwiseBinaryOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            eltwiseBinaryOp,
+            "ttnn.multiply with lhs_activation is not supported by this "
+            "conversion; it is only lowered through the flatbuffer path");
+      }
+    }
+
     ttnn_to_emitpy::EmitPyTTNNEmitter<TTNNOpTy> emitter(eltwiseBinaryOp,
                                                         adaptor, rewriter);
 

--- a/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
+++ b/lib/Conversion/TTNNToTTIR/TTNNToTTIRPatterns.cpp
@@ -44,7 +44,23 @@ class TTNNToTTIRElementwiseConversionPattern
 public:
   using TTNNToTTIROpConversionPattern<SrcOp,
                                       DestOp>::TTNNToTTIROpConversionPattern;
-  // Reuse base; this exists simply for clarity and potential future extensions
+  using Adaptor = typename SrcOp::Adaptor;
+
+  mlir::LogicalResult
+  matchAndRewrite(SrcOp srcOp, Adaptor adaptor,
+                  mlir::ConversionPatternRewriter &rewriter) const override {
+    // The base rebuilds the op from operands alone, so ttnn.multiply's optional
+    // lhs_activation would be dropped without a diagnostic. TTIR has no
+    // equivalent; refuse rather than silently change the numerics.
+    if constexpr (std::is_same_v<SrcOp, mlir::tt::ttnn::MultiplyOp>) {
+      if (srcOp.getLhsActivation()) {
+        return rewriter.notifyMatchFailure(
+            srcOp, "ttnn.multiply with lhs_activation has no TTIR equivalent");
+      }
+    }
+    return TTNNToTTIROpConversionPattern<SrcOp, DestOp>::matchAndRewrite(
+        srcOp, adaptor, rewriter);
+  }
 };
 
 template <typename SrcOp, typename DestOp>

--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -89,7 +89,7 @@ SystemDescAttr createDefaultBlackholeSystemDesc(
                       std::multiplies<int64_t>());
 
   // Populate dummy values for single chip or multi chip config.
-  llvm::SmallVector<std::int64_t> gridShape = {10, 13};
+  llvm::SmallVector<std::int64_t> gridShape = {10, 11};
   llvm::SmallVector<std::int64_t> dramGridShape = {1, 8};
 
   // Captured from a p150 device. Blackhole's optimal mapping is identical

--- a/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
+++ b/lib/Dialect/TTNN/Analysis/L1SpillManagement.cpp
@@ -795,6 +795,29 @@ bool L1SpillManagement<MemoryTracker>::replayFrom(size_t startIdx) {
 // evictUntil
 //===----------------------------------------------------------------------===//
 
+// A DRAM-sharded matmul requires its in0 activation to be L1 width-sharded and
+// its output to stay sharded. Spilling either to DRAM is never a legal state
+// for this op, and probing it through the op-model backend hits an uncatchable
+// tt-metal abort rather than returning a catchable error. Callers must
+// therefore recognize this op up front (reshard in0 / keep output sharded)
+// instead of validating or demoting it.
+//
+// MatmulRules assigns the DS config to a bias-free ttnn.linear as well, so both
+// op types are matched here.
+static bool isDRAMShardedMatmul(Operation *op) {
+  std::optional<mlir::Attribute> pc;
+  if (auto matmulOp = mlir::dyn_cast<MatmulOp>(op)) {
+    pc = matmulOp.getMatmulProgramConfig();
+  } else if (auto linearOp = mlir::dyn_cast<LinearOp>(op)) {
+    pc = linearOp.getMatmulProgramConfig();
+  } else {
+    return false;
+  }
+  return pc.has_value() && *pc &&
+         mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+             *pc);
+}
+
 template <typename MemoryTracker>
 bool L1SpillManagement<MemoryTracker>::evictValue(
     Value victim, int64_t pos, ScheduleData &data, size_t &campaignMin,
@@ -882,7 +905,10 @@ bool L1SpillManagement<MemoryTracker>::evictValue(
       // positionMap, which can rehash and invalidate posIt.
       int64_t consumerPos = posIt->second;
       bool isPastConsumer = consumerPos < pos;
-      bool needsReshard = isPastConsumer;
+      // A DRAM-sharded matmul requires L1 width-sharded in0; probing it after a
+      // spill would abort uncatchably, so force the reshard instead of
+      // validating.
+      bool needsReshard = isPastConsumer || isDRAMShardedMatmul(consumer);
       if (!needsReshard) {
         auto consumerInputs = utils::extractInputLayouts(consumer);
         auto consumerConfig = extractOpConfigFromIR(consumer);
@@ -1154,6 +1180,44 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
   // Eviction was exhausted (op's own output won't fit / CB still overlaps).
   // Demote this op's output to DRAM rather than ship a clashing layout.
   if (!fitsAfterEviction) {
+    // Never demote a DRAM-sharded matmul's output: tt-metal requires a sharded
+    // output config. evictUntil folds two distinct failure modes into this one
+    // flag, and for a DS matmul they need opposite handling.
+    if (isDRAMShardedMatmul(op)) {
+      auto freshOutputAddr = memoryTracker.wouldAllocateAt(outputL1Size);
+      if (!freshOutputAddr) {
+        // No contiguous L1 slot for the matmul's own sharded output, with
+        // eviction already exhausted. Nothing can rescue this: demotion is
+        // illegal, and spilling does not help either — spillToDram inserts a
+        // ToMemoryConfigOp *after* the matmul, so the matmul still produces an
+        // L1-sharded result that needs this very slot. Fail loudly rather than
+        // ship a clashing layout or leave an address-less tensor in the tracker
+        // (allocateAddress llvm_unreachable's on a no-fit).
+        op->emitError(
+            "L1SpillManagement: DRAM-sharded matmul output has no contiguous "
+            "L1 "
+            "placement after evicting every spillable tensor, and cannot be "
+            "demoted to DRAM (tt-metal requires a sharded output config)");
+        compilationFailed = true;
+        return 0;
+      }
+      // The output has a slot, so what evictUntil could not satisfy is the
+      // CB/tensor overlap check. Spill the output to DRAM: that ends its L1
+      // live range at the spill op and raises the lowest occupied address,
+      // giving the CB region room. Whether that is enough depends on how much
+      // of the overshoot was the cbFragCushion safety margin rather than real
+      // CB demand, which we cannot tell apart here — take the spill and accept
+      // the residual runtime risk, since demoting is not an option.
+      spillToDram(op->getResult(0));
+      TTMLIR_DEBUG(
+          ttmlir::LogComponent::GreedyOptimizer,
+          "    DS_SPILL_OUTPUT: CB overlap after eviction (cushioned "
+          "cb={0}, raw cb={1}, lowest={2}); matmul output kept sharded "
+          "and spilled to DRAM",
+          cushionedCBUsage, cbPeakUsage,
+          std::min(*freshOutputAddr, memoryTracker.getLowestOccupiedAddress()));
+      return 0;
+    }
     demoteToDram(op);
     evictForDramCBGrowth(op, pos, data);
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
@@ -1175,6 +1239,19 @@ uint64_t L1SpillManagement<MemoryTracker>::handleFragmentation(
                  "    FRAG_RESOLVED: L1 now {0}/{1}",
                  memoryTracker.getOccupiedL1(), l1BudgetPerCore);
     return freshL1;
+  }
+
+  // A DRAM-sharded matmul must never be pushed all-DRAM: it requires L1
+  // width-sharded in0 and a sharded output. The homogeneous-spill + demote
+  // fallback below is for concat-like ops; applying it here would invalidate
+  // the DS config. Its in0 is restored to L1 by the eviction reshard path, and
+  // its raw CB fits, so keep it L1-sharded.
+  if (isDRAMShardedMatmul(op)) {
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "    DS_KEEP_SHARDED: not applying homogeneous-spill/demote to "
+        "DS matmul; keeping L1-sharded");
+    return outputL1Size;
   }
 
   // If validation failed with a backend constraint error (not OOM) after

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -9,11 +9,10 @@
 #include "ttmlir/Dialect/TTNN/Types/Types.h"
 #include "ttmlir/Dialect/TTNN/Utils/Utils.h"
 
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir::tt::ttnn {
-
-static inline int64_t divUp(int64_t a, int64_t b) { return (a + b - 1) / b; }
 
 // Compute the maximum number of tiles that can fit in the destination register.
 // This depends on the compute kernel config settings:
@@ -108,9 +107,9 @@ generateMatmul1DProgramConfig(MLIRContext *ctx, int64_t Mt, int64_t Nt,
 
   if (mcastIn0) {
     perCoreM = Mt;
-    perCoreN = divUp(Nt, numCores);
+    perCoreN = llvm::divideCeil(Nt, numCores);
   } else {
-    perCoreM = divUp(Mt, numCores);
+    perCoreM = llvm::divideCeil(Mt, numCores);
     perCoreN = Nt;
   }
 
@@ -162,8 +161,8 @@ generateMatmul2DProgramConfig(MLIRContext *ctx, int64_t Mt, int64_t Nt,
                               int64_t maxSubblockSize, bool fuseBatch) {
   auto [gridX, gridY] = utils::getPhysicalGridDimensions(outputLayout);
 
-  int64_t perCoreM = divUp(Mt, gridY);
-  int64_t perCoreN = divUp(Nt, gridX);
+  int64_t perCoreM = llvm::divideCeil(Mt, gridY);
+  int64_t perCoreN = llvm::divideCeil(Nt, gridX);
 
   int64_t in0BlockW = (Kt % 2 == 0) ? 2 : 1;
   int64_t outSubblockH = 1;
@@ -252,9 +251,9 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   int64_t M = outShape[outShape.size() - 2];
   int64_t N = outShape[outShape.size() - 1];
   int64_t K = aShape[aShape.size() - 1];
-  int64_t Mt = divUp(M, TILE_HEIGHT);
-  int64_t Nt = divUp(N, TILE_WIDTH);
-  int64_t Kt = divUp(K, TILE_WIDTH);
+  int64_t Mt = llvm::divideCeil(M, TILE_HEIGHT);
+  int64_t Nt = llvm::divideCeil(N, TILE_WIDTH);
+  int64_t Kt = llvm::divideCeil(K, TILE_WIDTH);
 
   MLIRContext *ctx = op->getContext();
   UnaryWithParamAttr fusedActivation =
@@ -298,6 +297,176 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
   return generateMatmul1DProgramConfig(ctx, Mt, Nt, Kt, outputLayout,
                                        outputMemLayout, fusedActivation,
                                        maxSubblockSize, fuseBatch);
+}
+
+// ============================================================================
+// DRAM-sharded matmul config generation
+// ============================================================================
+
+static constexpr int64_t kTileSize = 32;
+
+// Smallest in0_block_w the DS path will accept, as a divisor of kPerCore: the
+// fitted block width must be at least kPerCore / kMinBlockWidthFraction.
+//
+// The kernel's block loop runs num_blocks = kTiles / in0_block_w rounds of
+// mcast + compute, so a width the L1 budget forced below kPerCore costs
+// proportionally more. Below half of kPerCore the DS config is a loss against
+// the 1D/2D mcast configs it would replace. A policy number, determined
+// experimentally on p150, not derived.
+static constexpr int64_t kMinBlockWidthFraction = 2;
+
+static int64_t padToDRAMBanks(int64_t n, int64_t numBanks) {
+  int64_t lcm = kTileSize * numBanks;
+  return ((n + lcm - 1) / lcm) * lcm;
+}
+
+std::optional<DRAMShardParams>
+computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
+                   int64_t numIn0Cores, int64_t numOutCores,
+                   ttcore::DataType weightDataType, int64_t l1Available) {
+  DRAMShardParams p;
+  p.K = K;
+  p.N = N;
+  p.M = M;
+  p.numBanks = numBanks;
+  p.numIn0Cores = numIn0Cores;
+  p.numOutCores = numOutCores;
+  p.nPadded = padToDRAMBanks(N, numBanks);
+  p.shardH = K;
+  p.shardW = p.nPadded / numBanks;
+  p.kTiles = K / kTileSize;
+  p.shardWTiles = p.shardW / kTileSize;
+  // Round up: a sub-tile activation (a decode batch of 1..31) is still one tile
+  // row, and tt-metal pads it to one. Truncating would yield per_core_M = 0 and
+  // a degenerate config.
+  p.perCoreM = llvm::divideCeil(M, kTileSize);
+  p.perCoreN = (N / kTileSize + numOutCores - 1) / numOutCores; // div_up
+  p.weightDataType = weightDataType;
+
+  static constexpr int64_t kBf16Tile = 2048; // 32×32 × 2 B
+  static constexpr int64_t kBfp8Tile = 1088; // 32×32 × 1 B + 64 B row exponents
+  static constexpr int64_t kBfp4Tile =
+      576; // 32×32 × 0.5 B + 64 B row exponents
+  static constexpr int64_t kFp32Tile = 4096; // 32×32 × 4 B
+
+  int64_t kWeightTile =
+      (weightDataType == ttcore::DataType::BFP_BFloat4) ? kBfp4Tile : kBfp8Tile;
+
+  assert(p.kTiles % numIn0Cores == 0 &&
+         "kTiles must be divisible by numIn0Cores before the per-core divide");
+  int64_t kPerCore = p.kTiles / numIn0Cores;
+  // perCoreNCompute: tiles computed per DRAM-bank/compute core (= weight shard
+  // width per bank). Used for CB sizing — this is what the compute kernel
+  // actually accumulates per core before scattering to output storage cores.
+  int64_t perCoreNCompute = p.shardWTiles;
+
+  // Use numIn0Cores for the output tensor buffer estimate to keep the budget
+  // conservative and avoid inflating in0BlockW (which doubles in1CB per step).
+  // perCoreNStorage is only used for the output layout grid, not CB sizing.
+  int64_t outTensorBufPerCore =
+      p.perCoreM * ((N / kTileSize) / numIn0Cores) * kBf16Tile;
+  int64_t in0TensorBuf = p.perCoreM * kPerCore * kBf16Tile;
+  int64_t cbBudget = l1Available - in0TensorBuf - outTensorBufPerCore;
+
+  // Fixed CBs (independent of in0BlockW).
+  int64_t outCB = p.perCoreM * perCoreNCompute * kBf16Tile;
+  int64_t interm0CB = p.perCoreM * perCoreNCompute * kFp32Tile;
+  int64_t fixedCost = outCB + interm0CB;
+
+  if (fixedCost > cbBudget) {
+    return std::nullopt;
+  }
+
+  p.in0BlockW = kPerCore;
+  bool found = false;
+  while (p.in0BlockW >= 1) {
+    int64_t numBlocks = p.kTiles / p.in0BlockW;
+    bool doubleBuf = numBlocks > 1;
+
+    int64_t in0CB = p.in0BlockW * p.perCoreM * kBf16Tile * (doubleBuf ? 2 : 1);
+    int64_t in1CB = p.in0BlockW * perCoreNCompute * kWeightTile *
+                    (doubleBuf ? 3 : 1); // weight shard per DRAM bank
+
+    if (fixedCost + in0CB + in1CB <= cbBudget && kPerCore % p.in0BlockW == 0) {
+      found = true;
+      break;
+    }
+    if (p.in0BlockW == 1) {
+      break;
+    }
+    p.in0BlockW--;
+    while (p.in0BlockW > 1 && kPerCore % p.in0BlockW != 0) {
+      p.in0BlockW--;
+    }
+  }
+
+  if (!found) {
+    return std::nullopt;
+  }
+
+  // Decline rather than emit a degenerate block width. Falling back to the
+  // 1D/2D mcast configs is measurably better than a DS config whose block loop
+  // has been stretched out by L1 pressure (see kMinBlockWidthFraction).
+  if (p.in0BlockW * kMinBlockWidthFraction < kPerCore) {
+    return std::nullopt;
+  }
+
+  return p;
+}
+
+TTNNLayoutAttr buildDRAMShardedWeightLayout(MLIRContext *ctx,
+                                            TTNNLayoutAttr origLayout,
+                                            llvm::ArrayRef<int64_t> tensorShape,
+                                            const DRAMShardParams &p,
+                                            ttcore::DeviceAttr deviceAttr) {
+  return TTNNLayoutAttr::Builder(origLayout, tensorShape)
+      .setBufferType(BufferType::DRAM)
+      .setMemoryLayout(
+          TensorMemoryLayoutAttr::get(ctx, TensorMemoryLayout::WidthSharded))
+      .setGridShape({1, p.numBanks})
+      // Drop the seed's placement explicitly: buildWithCanonicalCorePlacement
+      // only fills a *null* core range set, and the setters above each
+      // early-return when the value already matches, so a seed that is already
+      // DRAM width-sharded on this grid would otherwise keep its own placement.
+      .setCoreRangeSet(nullptr)
+      .buildWithCanonicalCorePlacement(deviceAttr);
+}
+
+TTNNLayoutAttr buildL1ShardedLayout(MLIRContext *ctx, TTNNLayoutAttr origLayout,
+                                    llvm::ArrayRef<int64_t> tensorShape,
+                                    int64_t numCores,
+                                    ttcore::DeviceAttr deviceAttr) {
+  return TTNNLayoutAttr::Builder(origLayout, tensorShape)
+      .setBufferType(BufferType::L1)
+      .setMemoryLayout(
+          TensorMemoryLayoutAttr::get(ctx, TensorMemoryLayout::WidthSharded))
+      .setGridShape({1, numCores})
+      // As above: force canonical placement rather than inheriting the seed's.
+      .setCoreRangeSet(nullptr)
+      .buildWithCanonicalCorePlacement(deviceAttr);
+}
+
+MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
+buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
+                              UnaryWithParamAttr fusedAct) {
+  return MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr::get(
+      ctx, p.in0BlockW, p.perCoreM, p.perCoreN, fusedAct);
+}
+
+DeviceComputeKernelConfigAttr
+buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType) {
+  // bfp4 weights run at LoFi, bfp8 at HiFi2 — the split models are observed to
+  // need in practice, rather than a rule derived from the formats.
+  MathFidelity fidelity = (weightDataType == ttcore::DataType::BFP_BFloat4)
+                              ? MathFidelity::LoFi
+                              : MathFidelity::HiFi2;
+  return DeviceComputeKernelConfigAttr::get(
+      ctx,
+      /*mathFidelity=*/fidelity,
+      /*mathApproxMode=*/mlir::BoolAttr{},
+      /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, true),
+      /*packerL1Acc=*/mlir::BoolAttr::get(ctx, true),
+      /*dstFullSyncEn=*/mlir::BoolAttr{});
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -453,16 +453,10 @@ buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
       ctx, p.in0BlockW, p.perCoreM, p.perCoreN, fusedAct);
 }
 
-DeviceComputeKernelConfigAttr
-buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType) {
-  // bfp4 weights run at LoFi, bfp8 at HiFi2 — the split models are observed to
-  // need in practice, rather than a rule derived from the formats.
-  MathFidelity fidelity = (weightDataType == ttcore::DataType::BFP_BFloat4)
-                              ? MathFidelity::LoFi
-                              : MathFidelity::HiFi2;
+DeviceComputeKernelConfigAttr buildComputeConfig(MLIRContext *ctx) {
   return DeviceComputeKernelConfigAttr::get(
       ctx,
-      /*mathFidelity=*/fidelity,
+      /*mathFidelity=*/MathFidelity::LoFi,
       /*mathApproxMode=*/mlir::BoolAttr{},
       /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, true),
       /*packerL1Acc=*/mlir::BoolAttr::get(ctx, true),

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -1389,7 +1389,7 @@ void MemoryLayoutPropagation::applyToIR() {
     applyOpConfig(op, *chosen);
   });
 
-  // Second pass: insert reshard ops.
+  // Second pass: insert reshard ops (deduped per producer via reshardCache).
   func->walk([&](Operation *op) {
     const BeamCandidate *chosen = getChosenCandidate(op);
     if (!chosen) {
@@ -1503,6 +1503,23 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   RankedTensorType newTensorType =
       utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
 
+  // Dedup: reuse a shared reshard for consumers of the same producer requesting
+  // the same target layout.
+  // Stays correct downstream: TTNNDeallocate frees it after its last consumer,
+  // and if the L1 spill pass evicts it for space it re-splits into per-consumer
+  // reshards.
+  std::pair<mlir::Value, mlir::Attribute> cacheKey{operand, reshardLayout};
+  if (auto it = reshardCache.find(cacheKey); it != reshardCache.end()) {
+    if (Operation *cachedOp = it->second.getDefiningOp();
+        cachedOp && cachedOp->getBlock() == consumerOp->getBlock() &&
+        cachedOp->isBeforeInBlock(consumerOp)) {
+      consumerOp->setOperand(operandIndex, it->second);
+      TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
+                   "Reused shared memory reconfig op: {0}", cachedOp);
+      return;
+    }
+  }
+
   OpBuilder builder(consumerOp);
   Location loc = ttmlir::utils::appendLocationSuffix(consumerOp->getLoc(),
                                                      "_mem_reconfig");
@@ -1522,6 +1539,7 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
                 .getOperation();
 
   consumerOp->setOperand(operandIndex, reshardOp->getResult(0));
+  reshardCache[cacheKey] = reshardOp->getResult(0);
 
   TTMLIR_TRACE(ttmlir::LogComponent::GreedyOptimizer,
                "Inserted reshard op: {0}", *reshardOp);

--- a/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
+++ b/lib/Dialect/TTNN/Analysis/MemoryLayoutPropagation.cpp
@@ -970,6 +970,31 @@ MemoryLayoutPropagation::getInputCandidateSets(Operation *op) {
                                 maxInputCandidatesPerOperand);
     }
 
+    // Inject op-specific extra reshard candidates (e.g. DRAM width-sharded
+    // weight and L1 1x8 activation for DS matmul) before standard reshards so
+    // they are not displaced when the candidate list reaches the cap.
+    for (TTNNLayoutAttr extraLayout :
+         getRuleBook(op).getExtraInputReshardCandidates(op, operandIdx)) {
+      bool alreadyPresent =
+          llvm::any_of(candidatesForOperand, [&](const InputCandidate &ic) {
+            return ic.layout == extraLayout;
+          });
+      if (alreadyPresent) {
+        continue;
+      }
+      size_t producerBeamSize = producerBeam ? producerBeam->size() : 1;
+      for (size_t pIdx = 0; pIdx < producerBeamSize; ++pIdx) {
+        if (candidatesForOperand.size() >= maxInputCandidatesPerOperand) {
+          break;
+        }
+        InputCandidate ic;
+        ic.layout = extraLayout;
+        ic.producerCandidateIndex = pIdx;
+        ic.isReshard = true;
+        candidatesForOperand.push_back(ic);
+      }
+    }
+
     addReshardCandidates(candidatesForOperand, op, operandIdx, operand,
                          currentLayout, tensorType, producerBeam, producerOp,
                          resultIdx, maxInputCandidatesPerOperand);
@@ -1485,23 +1510,24 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
     }
   }
 
-  // Take the producer's layout and apply the reshard target's buffer type,
-  // memory layout, grid, and page layout (element type). Tracking the element
-  // type is what lets a tile -> row-major sibling reshard materialize.
-  TTNNLayoutAttr producerLayout =
-      utils::getLayoutAttrFromTensor(producerTensorType);
-  Type reshardElementType = ttnn::utils::getElementType(
-      reshardLayout.getContext(), reshardLayout.getLayout(),
-      reshardLayout.getDataType());
-  TTNNLayoutAttr outputLayout =
-      TTNNLayoutAttr::Builder(producerLayout, producerTensorType.getShape())
-          .setBufferType(reshardLayout.getBufferType())
-          .setMemoryLayout(reshardLayout.getMemLayout())
-          .setGridShape(reshardLayout.getGridShape())
-          .setElementType(reshardElementType)
-          .buildWithCanonicalCorePlacement(deviceAttr);
+  // Use reshardLayout directly instead of rebuilding it from the producer's
+  // layout via Builder. reshardLayout is already a complete layout for this
+  // tensor -- it is the layout the rule book asked for and the op model
+  // validated against -- so reconstructing it from a different seed can only
+  // diverge from it.
+  //
+  // The Builder path seeded from the producer and copied over only the buffer
+  // type, memory layout, grid and element type. Each of those setters
+  // early-returns when the value is unchanged, and only a *null* core range set
+  // gets filled by buildWithCanonicalCorePlacement, so a producer that already
+  // matches the target's buffer type, memory layout and grid keeps its own
+  // placement rather than taking the target's.
+  //
+  // This also subsumes the page-layout (element type) override that path
+  // needed: reshardLayout carries its own element type, so a tile -> row-major
+  // sibling reshard materializes without reconstructing it.
   RankedTensorType newTensorType =
-      utils::RankedTensorTypeFactory::create(producerTensorType, outputLayout);
+      utils::RankedTensorTypeFactory::create(producerTensorType, reshardLayout);
 
   // Dedup: reuse a shared reshard for consumers of the same producer requesting
   // the same target layout.
@@ -1530,7 +1556,7 @@ void MemoryLayoutPropagation::insertReshardOp(Operation *consumerOp,
   // sequence. Pure memory-config reshards stay ttnn.to_memory_config.
   bool pageLayoutChanges =
       utils::getLayoutAttrFromTensor(producerTensorType).getLayout() !=
-      outputLayout.getLayout();
+      reshardLayout.getLayout();
   Operation *reshardOp =
       pageLayoutChanges
           ? builder.create<ToLayoutOp>(loc, newTensorType, operand)

--- a/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpModelStrategy.cpp
@@ -34,27 +34,42 @@ bool LayoutScore::operator>(const LayoutScore &other) const {
     return isSharded;
   }
 
-  // 3. Less DRAM input transfer > more DRAM input transfer.
+  // 3. DRAM-sharded matmul wins when both are L1+sharded — architecturally
+  // superior for decode when available.
+  if (isDRAMShardedCandidate != other.isDRAMShardedCandidate) {
+    return isDRAMShardedCandidate;
+  }
+
+  // 3a. Among DS candidates, prefer the one with empirically optimal 1×8 in0.
+  // Only meaningful when isDRAMShardedCandidate is set for both, so this is a
+  // tiebreaker within DS.
+  if (isDRAMShardedCandidate && hasCanonicalDSIn0 != other.hasCanonicalDSIn0) {
+    return hasCanonicalDSIn0;
+  }
+
+  // 4. Less DRAM input transfer > more DRAM input transfer.
   if (inputDramBytes != other.inputDramBytes) {
     return inputDramBytes < other.inputDramBytes;
   }
 
-  // 4. No reshard > reshard.
+  // 5. No reshard > reshard.
   if (requiresReshard != other.requiresReshard) {
     return !requiresReshard;
   }
 
-  // 5. More cores > fewer cores.
+  // 6. More cores > fewer cores.
   if (coreCount != other.coreCount) {
     return coreCount > other.coreCount;
   }
 
-  // 6. Lower L1 usage is better (leaves more room for other tensors).
+  // 7. Lower L1 usage is better (leaves more room for other tensors).
   return outputL1Usage < other.outputL1Usage;
 }
 
 bool LayoutScore::operator==(const LayoutScore &other) const {
   return isL1 == other.isL1 && isSharded == other.isSharded &&
+         isDRAMShardedCandidate == other.isDRAMShardedCandidate &&
+         hasCanonicalDSIn0 == other.hasCanonicalDSIn0 &&
          inputDramBytes == other.inputDramBytes &&
          requiresReshard == other.requiresReshard &&
          coreCount == other.coreCount && outputL1Usage == other.outputL1Usage;

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -416,7 +416,7 @@ MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
   // a separate op is inserted at apply time.
   UnaryWithParamAttr fusedAct;
   auto progConfig = buildDRAMShardedProgramConfig(ctx, p, fusedAct);
-  auto computeConfig = buildComputeConfig(ctx, p.weightDataType);
+  auto computeConfig = buildComputeConfig(ctx);
 
   return OpConfig(l1OutLayout, MatmulAttrs{progConfig, computeConfig});
 }

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -3,26 +3,340 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/MatmulRules.h"
+
+#include "ttmlir/Dialect/TTCore/IR/Utils.h"
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/LayoutFilterUtils.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
 #include "ttmlir/Dialect/TTNN/Utils/OptimizerUtils.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/Support/Logger.h"
+#include "ttmlir/Utils.h"
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/TypeSwitch.h"
+
+#include <cmath>
+#include <optional>
 
 namespace mlir::tt::ttnn {
 
-LayoutFilterFn MatmulRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
-  // Operand 1 (RHS/weights): reject all sharded layouts.
-  // DRAM width-sharded RHS is a special case in tt-metal but not yet
-  // supported by our program config generation.
-  if (operandIdx == 1) {
-    return layout_filter_utils::rejectAllSharded;
+// ============================================================================
+// DRAM-sharded matmul policy constants
+// ============================================================================
+//
+// The shard geometry, layout, and config *generation* lives in
+// MatmulProgramConfig.{h,cpp} (computeShardParams, buildDRAMSharded*). These
+// are the rule book's policy inputs: they drive eligibility and are passed into
+// computeShardParams as numBanks / numIn0Cores.
+
+static constexpr int64_t kTileSize = 32;
+// Single source of truth for how many cores the DS-matmul activation (in0) is
+// width-sharded across. Drives the in0 shard width, the K-divisibility
+// eligibility gate, and the in0 L1 tensor-buffer reservation in
+// computeShardParams. Keep these uses consistent.
+static constexpr int64_t kNumIn0Cores = 8;
+
+// Number of DRAM banks the weight is width-sharded across: every bank the
+// device exposes. Deliberately the same source deriveCanonicalDramCoreRangeSet
+// reads to build the layout's core range set, so the bank count and the
+// placement cannot disagree.
+//
+// Returns nullopt when the grid is not a shape canonical DRAM placement can
+// express (it requires a single row), so the DS path declines instead of
+// tripping the assert inside deriveCanonicalDramCoreRangeSet.
+static std::optional<int64_t> getNumDRAMBanks(ttcore::DeviceAttr deviceAttr) {
+  if (!deviceAttr) {
+    return std::nullopt;
+  }
+  llvm::ArrayRef<int64_t> dramGrid = deviceAttr.getDramGrid().getShape();
+  if (dramGrid.size() != 2 || dramGrid[0] != 1 || dramGrid[1] < 1) {
+    return std::nullopt;
+  }
+  return dramGrid[1];
+}
+
+// ============================================================================
+// Eligibility helpers
+// ============================================================================
+
+// The weight's TTNN layout, or null when its type does not carry one. The
+// layout is where the on-device tiling and dtype live, so it is the single
+// thing the checks below need.
+static TTNNLayoutAttr getWeightLayout(Value weight) {
+  auto rtt = mlir::dyn_cast<RankedTensorType>(weight.getType());
+  if (!rtt) {
+    return {};
+  }
+  return mlir::dyn_cast_or_null<TTNNLayoutAttr>(rtt.getEncoding());
+}
+
+// Whether the weight is a tiled, DRAM-interleaved tensor of a data type the DS
+// kernel is offered for.
+//
+// bfp4/bfp8 only. tt-metal imposes no dtype constraint on the DS config (there
+// is no dtype TT_FATAL in the DRAM-sharded validation block), so this is a
+// heuristic trying to prevent DRAM OOM, not a legality check.
+static bool isBfpDRAMInterleaved(Value weight) {
+  TTNNLayoutAttr layout = getWeightLayout(weight);
+  if (!layout || !layout.isTiled()) {
+    return false;
+  }
+  ttcore::DataType dt = layout.getDataType();
+  if (dt != ttcore::DataType::BFP_BFloat8 &&
+      dt != ttcore::DataType::BFP_BFloat4) {
+    return false;
+  }
+  return layout.hasInterleavedDRAMTensorMemoryLayout();
+}
+
+// A weight is DS-shaped when it is a plain 2-D matrix, possibly carrying
+// leading unit batch dims: ttnn models routinely hold projection weights as [1,
+// 1, K, N], which is the same matrix as [K, N] — same element count, same tile
+// grid, and TTNN already collapses both to a 2-D memref in the layout.
+//
+// A non-unit leading dim is a genuinely batched matmul, which this path does
+// not emit: tt-metal serves that case with a different config,
+// MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig.
+static bool isDSWeightShaped(RankedTensorType rtt) {
+  llvm::ArrayRef<int64_t> shape = rtt.getShape();
+  if (shape.size() < 2) {
+    return false;
+  }
+  return llvm::all_of(shape.drop_back(2), [](int64_t dim) { return dim == 1; });
+}
+
+static std::pair<int64_t, int64_t> getWeightKN(RankedTensorType rtt) {
+  llvm::ArrayRef<int64_t> shape = rtt.getShape();
+  assert(isDSWeightShaped(rtt) && "Expected a 2-D (or unit-batched) weight");
+  return {shape[shape.size() - 2], shape[shape.size() - 1]};
+}
+
+static int64_t getActivationM(RankedTensorType rtt) {
+  int64_t M = 1;
+  for (int64_t dim : rtt.getShape().drop_back()) {
+    M *= dim;
+  }
+  return M;
+}
+
+// The (activation, weight) pair for a matmul-like op the DS kernel could
+// implement, or nullopt if `op` is not one.
+//
+// ttnn.matmul and ttnn.linear alike: a bias-free linear IS the matmul the DS
+// kernel implements, and ttnn decoders write their projections as ttnn.linear.
+//
+// A bias is rejected even though tt-metal's DS kernel supports one. The kernel
+// reads it per DRAM bank at a bank-local offset and adds it on the DRAM-bank
+// compute cores, so it needs a DRAM width-sharded layout for operand 2 that
+// nothing here produces yet; a DRAM-interleaved bias would be read as a strided
+// subset of itself, which is wrong results rather than a crash.
+static std::optional<std::pair<Value, Value>> getMatmulOperands(Operation *op) {
+  if (auto matmulOp = dyn_cast<MatmulOp>(op)) {
+    if (matmulOp.getTransposeA() || matmulOp.getTransposeB()) {
+      return std::nullopt;
+    }
+    return std::make_pair(matmulOp.getA(), matmulOp.getB());
+  }
+  if (auto linearOp = dyn_cast<LinearOp>(op)) {
+    if (linearOp.getBias() || linearOp.getTransposeA() ||
+        linearOp.getTransposeB()) {
+      return std::nullopt;
+    }
+    return std::make_pair(linearOp.getA(), linearOp.getB());
+  }
+  return std::nullopt;
+}
+
+// Whether the DS path is offered for `op` with these operands. Logs the reason
+// on every decline.
+static bool isDSEligible(Operation *op, Value activation, Value weight) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  if (!isBfpDRAMInterleaved(weight)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight is not a tiled bfp4/bfp8 "
+                 "DRAM-interleaved tensor",
+                 opName);
+    return false;
+  }
+  if (!ttcore::valueTracesToConstantArgs(weight)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight does not trace to constant args",
+                 opName);
+    return false;
+  }
+  auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+  if (!isDSWeightShaped(weightType)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): weight rank {1} has a non-unit batch dim, "
+                 "so it is not a 2-D (optionally unit-batched) matrix",
+                 opName, weightType.getRank());
+    return false;
   }
 
-  // Sharding activation/bias operands is supported.
-  return nullptr;
+  auto in0Type = mlir::cast<RankedTensorType>(activation.getType());
+  int64_t M = getActivationM(in0Type);
+  auto [K, N] = getWeightKN(weightType);
+
+  if (K % kTileSize != 0 || N % kTileSize != 0) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): K={1} / N={2} not tile-aligned", opName, K,
+                 N);
+    return false;
+  }
+  // K is the contraction dim, width-sharded across the in0 cores, so it must
+  // divide evenly by the in0 core count (same requirement computeShardParams
+  // enforces via kTiles % numIn0Cores). Gate on it here so an ineligible op is
+  // rejected up front rather than deep in shard-param computation — and so that
+  // computeShardParams' assert holds by construction rather than by contract.
+  if ((K / kTileSize) % kNumIn0Cores != 0) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): K tiles {1} not divisible by the in0 core "
+                 "count {2}",
+                 opName, K / kTileSize, kNumIn0Cores);
+    return false;
+  }
+  // Decode-only, and this is tt-metal's constraint rather than a proxy for it:
+  // the DS validation asserts TT_FATAL(M == 1) on the activation height in
+  // tiles, i.e. exactly one tile row. Note M here is the logical row count with
+  // leading dims collapsed, so this accepts a sub-tile batch (1..31, padded up
+  // to one tile row by tt-metal) and rejects anything taller. The assert is
+  // uncatchable, so the rejection has to happen here rather than in the op
+  // model.
+  if (llvm::divideCeil(M, kTileSize) != 1) {
+    TTMLIR_DEBUG(
+        ttmlir::LogComponent::GreedyOptimizer,
+        "DS declined ({0}): activation M={1} is more than one tile row", opName,
+        M);
+    return false;
+  }
+
+  return true;
 }
+
+// What the shard geometry needs from the device and the system descriptor.
+struct DSDeviceContext {
+  ttcore::DeviceAttr deviceAttr;
+  int64_t numDRAMBanks;
+  int64_t numWorkerCores;
+  int64_t l1Available;
+};
+
+// Returns nullopt, having logged the reason, when the module carries no system
+// descriptor or the device's DRAM grid is not one canonical placement can
+// express.
+static std::optional<DSDeviceContext> getDSDeviceContext(Operation *op) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  auto moduleOp = op->getParentOfType<ModuleOp>();
+  if (!moduleOp) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): op has no parent module", opName);
+    return std::nullopt;
+  }
+  auto systemDescAttr = moduleOp->getAttr(ttcore::SystemDescAttr::name);
+  if (!systemDescAttr) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): module has no system descriptor", opName);
+    return std::nullopt;
+  }
+
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(op);
+  std::optional<int64_t> numDRAMBanks = getNumDRAMBanks(deviceAttr);
+  if (!numDRAMBanks) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): device DRAM grid is not a single row that "
+                 "canonical DRAM placement can express",
+                 opName);
+    return std::nullopt;
+  }
+
+  auto systemDesc = mlir::cast<ttcore::SystemDescAttr>(systemDescAttr);
+  int64_t l1Available =
+      static_cast<int64_t>(ttnn::utils::getTensorL1UsageCap(moduleOp) *
+                           systemDesc.getChipDescs()[0].getUsableL1Size());
+
+  return DSDeviceContext{
+      deviceAttr, *numDRAMBanks,
+      ttmlir::utils::volume(deviceAttr.getWorkerGrid().getShape()),
+      l1Available};
+}
+
+// Everything the DS path derives from an op: the operand types and the shard
+// geometry.
+//
+// The output hint and the input reshard candidates are both built from one of
+// these, which is what keeps them consistent: the in0 layout's shard width has
+// to match the config's in0_block_w, and the weight layout's bank count has to
+// match the one the geometry was computed for.
+struct DSPlan {
+  RankedTensorType in0Type;
+  RankedTensorType weightType;
+  DRAMShardParams params;
+  ttcore::DeviceAttr deviceAttr;
+};
+
+// Returns nullopt, having logged the reason, when the op is not DS-eligible or
+// the shard geometry does not fit L1.
+//
+// Derived afresh on every query rather than cached. Rule books are
+// process-global singletons reached through const methods, and a plan is a
+// function of the operand layouts, which the optimizer rewrites between
+// invocations — a cache would either go stale or key on a recycled Operation *.
+// The cost is a use-def walk plus a bounded divisor search, run three times per
+// matmul (both operands and the output hint).
+static std::optional<DSPlan> buildDSPlan(Operation *op) {
+  [[maybe_unused]] StringRef opName = op->getName().getStringRef();
+
+  std::optional<std::pair<Value, Value>> operands = getMatmulOperands(op);
+  if (!operands) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): not a bias-free, non-transposed "
+                 "matmul/linear",
+                 opName);
+    return std::nullopt;
+  }
+  auto [activation, weight] = *operands;
+
+  if (!isDSEligible(op, activation, weight)) {
+    return std::nullopt;
+  }
+  std::optional<DSDeviceContext> device = getDSDeviceContext(op);
+  if (!device) {
+    return std::nullopt;
+  }
+
+  auto in0Type = mlir::cast<RankedTensorType>(activation.getType());
+  auto weightType = mlir::cast<RankedTensorType>(weight.getType());
+  int64_t M = getActivationM(in0Type);
+  auto [K, N] = getWeightKN(weightType);
+
+  std::optional<DRAMShardParams> params = computeShardParams(
+      M, K, N, device->numDRAMBanks, kNumIn0Cores, device->numWorkerCores,
+      getWeightLayout(weight).getDataType(), device->l1Available);
+  if (!params) {
+    // Either no in0_block_w dividing K-per-core leaves room for the circular
+    // buffers, or the largest one that does is a degenerate fraction of
+    // K-per-core (see kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): no in0_block_w both fits L1 and avoids a "
+                 "degenerate block count (M={1} K={2} "
+                 "N={3} banks={4} in0Cores={5} cores={6} l1Available={7})",
+                 opName, M, K, N, device->numDRAMBanks, kNumIn0Cores,
+                 device->numWorkerCores, device->l1Available);
+    return std::nullopt;
+  }
+
+  return DSPlan{in0Type, weightType, *params, device->deviceAttr};
+}
+
+// ============================================================================
+// MatmulRuleBook — existing helpers
+// ============================================================================
 
 static bool isL1Interleaved(const OpConfig &config) {
   if (!config.outputLayout) {
@@ -49,29 +363,125 @@ static bool hasMatmulProgramConfig(const OpConfig &config) {
   return false;
 }
 
+// ============================================================================
+// MatmulRuleBook — private DRAM-sharding helpers
+// ============================================================================
+//
+// buildDRAMShardingHint produces the DS output hint consumed by getOutputHints;
+// applyDRAMShardedTransformation rewrites the op at apply time and is called by
+// applyOpSpecificAttrs. Both are defined ahead of their callers below.
+
+std::optional<OpConfig>
+MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
+  std::optional<DSPlan> plan = buildDSPlan(op);
+  if (!plan) {
+    return std::nullopt;
+  }
+  const DRAMShardParams &p = plan->params;
+  ttcore::DeviceAttr deviceAttr = plan->deviceAttr;
+
+  auto *ctx = op->getContext();
+  auto outLayout = mlir::cast<TTNNLayoutAttr>(
+      mlir::cast<RankedTensorType>(op->getResult(0).getType()).getEncoding());
+  auto resultType = mlir::cast<RankedTensorType>(op->getResult(0).getType());
+
+  // numOutputCores = div_up(N_tiles, per_core_N_storage): exactly how many
+  // output cores compute_output_specs will allocate, ensuring no assertion
+  // fire.
+  int64_t numOutputCores = llvm::divideCeil(p.N / kTileSize, p.perCoreN);
+
+  llvm::SmallVector<int64_t, 2> outputGrid = {1, numOutputCores};
+  TTNNLayoutAttr l1OutLayout =
+      TTNNLayoutAttr::Builder(outLayout, resultType.getShape())
+          .setBufferType(BufferType::L1)
+          .setMemoryLayout(TensorMemoryLayoutAttr::get(
+              ctx, TensorMemoryLayout::WidthSharded))
+          .setGridShape(outputGrid)
+          .buildWithCanonicalCorePlacement(deviceAttr);
+
+  // Activation is handled as a separate elementwise op after the DS matmul
+  // (see applyDRAMShardedTransformation). Fusing it into the DS kernel is
+  // significantly slower. The op model is told no activation so it validates
+  // the DS config cleanly; the activation attribute on the op is stripped and
+  // a separate op is inserted at apply time.
+  UnaryWithParamAttr fusedAct;
+  auto progConfig = buildDRAMShardedProgramConfig(ctx, p, fusedAct);
+  auto computeConfig = buildComputeConfig(ctx, p.weightDataType);
+
+  return OpConfig(l1OutLayout, MatmulAttrs{progConfig, computeConfig});
+}
+
+void MatmulRuleBook::applyDRAMShardedTransformation(
+    Operation *op, const MatmulAttrs &matmulAttrs) const {
+  auto *ctx = op->getContext();
+  // Input reshards (activation → L1 1×kNumIn0Cores, weight → DRAM 1×numBanks)
+  // handled by pass-2 in applyToIR via reshardLayouts populated from the input
+  // candidates injected by getExtraInputReshardCandidates.
+
+  OpBuilder builder(op);
+
+  // --- 1. Set program config and compute config ---
+  // ttnn.matmul and ttnn.linear both carry matmul_program_config,
+  // compute_config and activation, so the DS rewrite is identical for either
+  // (see getMatmulOperands).
+  auto dsProgConfig =
+      mlir::cast<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          matmulAttrs.matmulProgramConfig.value());
+  StringAttr activationAttr =
+      llvm::TypeSwitch<Operation *, StringAttr>(op)
+          .Case<MatmulOp, LinearOp>([&](auto concreteOp) {
+            concreteOp.setMatmulProgramConfigAttr(dsProgConfig);
+            if (matmulAttrs.computeKernelConfig.has_value()) {
+              concreteOp.setComputeConfigAttr(*matmulAttrs.computeKernelConfig);
+            }
+            // Strip the activation here and hand it back; step 2 re-homes it.
+            StringAttr act = concreteOp.getActivationAttr();
+            if (act) {
+              concreteOp.removeActivationAttr();
+            }
+            return act;
+          })
+          .Default([](Operation *) { return StringAttr(); });
+
+  // --- 2. Handle the fused activation ---
+  // Fusing the activation into the DS matmul kernel is significantly slower
+  // (measured: the 12-core DS matmul applies silu much slower than an op on all
+  // 64 cores), so strip it off the matmul and run it as a separate elementwise
+  // op across all cores.
+  if (activationAttr) {
+    StringRef actStr = activationAttr.getValue();
+    Value matmulResult = op->getResult(0);
+
+    StringRef opName;
+    if (actStr == "silu") {
+      opName = "ttnn.silu";
+    } else if (actStr == "relu") {
+      opName = "ttnn.relu";
+    } else if (actStr == "gelu") {
+      opName = "ttnn.gelu";
+    }
+    if (!opName.empty()) {
+      builder.setInsertionPointAfter(op);
+      auto *activationOp = builder.create(
+          op->getLoc(), StringAttr::get(ctx, opName), ValueRange{matmulResult},
+          TypeRange{matmulResult.getType()});
+      matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
+                                        activationOp);
+    }
+  }
+}
+
+// ============================================================================
+// MatmulRuleBook::getOutputHints
+// ============================================================================
+
 OutputHints MatmulRuleBook::getOutputHints(
-    Operation * /*op*/, const std::vector<OpConfig> &legalConfigs) const {
-  // Use partial configs: deduplicate by (bufferType, memLayout),
-  // set ignorePhysicalLayout=true. Backend decides physical layout.
+    Operation *op, const std::vector<OpConfig> &legalConfigs) const {
+
   auto partialConfigs =
       optimizer_utils::getUniqueTestConfigsForMatmulLinear(legalConfigs);
 
-  // Remove L1-interleaved hints for matmul/linear output.
-  //
-  // L1-interleaved output is "worst of both worlds" for matmul:
-  //  - generateMatmulProgramConfig() returns nullopt for non-sharded
-  //    output, so no program config is emitted by the compiler.
-  //  - tt-metal runtime falls back to MatmulMultiCoreProgramConfig{}
-  //    with hardcoded HiFi4 math fidelity (the slowest kernel path).
-  //  - Same NOC write overhead as DRAM interleaved (not eliminated
-  //    like sharded), loses bias fusion, optimized mcast program
-  //    configs, and narrow-shape 1D optimization.
-  //  - Subject to L1 capacity constraints unlike DRAM interleaved.
-  //
-  // DRAM-interleaved is the safe default: full bias fusion, optimized
-  // 1D/2D mcast configs, and no L1 pressure from the output tensor.
-  // L1-sharded is best when applicable (eliminates NOC writes entirely).
-  // https://github.com/tenstorrent/tt-mlir/issues/7682
+  // Filter out L1-interleaved and sharded configs without a program config.
   std::vector<OpConfig> filtered;
   for (const auto &cfg : partialConfigs) {
     if (isL1Interleaved(cfg)) {
@@ -92,8 +502,33 @@ OutputHints MatmulRuleBook::getOutputHints(
     filtered.push_back(cfg);
   }
 
+  // Prepend the DS hint when eligible. adjustScore gives it priority over the
+  // normal hints via isDRAMShardedCandidate; normal hints remain as fallback
+  // in case DS validation fails for a given input combination.
+  if (auto dramHint = buildDRAMShardingHint(op)) {
+    filtered.insert(filtered.begin(), *dramHint);
+  }
+
   return OutputHints{filtered, {}};
 }
+
+// ============================================================================
+// MatmulRuleBook::getInputLayoutFilter
+// ============================================================================
+
+LayoutFilterFn MatmulRuleBook::getInputLayoutFilter(unsigned operandIdx) const {
+  // Weight (operand 1): reject L1.
+  // DRAM WIDTH_SHARDED is allowed for the DRAM-sharded matmul path.
+  // DRAM interleaved is always allowed.
+  if (operandIdx == 1) {
+    return layout_filter_utils::rejectAllL1;
+  }
+  return nullptr;
+}
+
+// ============================================================================
+// MatmulRuleBook::applyOpSpecificAttrs
+// ============================================================================
 
 void MatmulRuleBook::applyOpSpecificAttrs(
     Operation *op, const BeamCandidate &candidate) const {
@@ -112,8 +547,20 @@ void MatmulRuleBook::applyOpSpecificAttrs(
   if (!matmulAttrs.matmulProgramConfig.has_value()) {
     return;
   }
+
   auto programConfig = matmulAttrs.matmulProgramConfig.value();
 
+  // DRAM-sharded path: weight reshard, program/compute config, activation
+  // split.
+  bool isDRAMSharded =
+      mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          programConfig);
+  if (isDRAMSharded) {
+    applyDRAMShardedTransformation(op, matmulAttrs);
+    return;
+  }
+
+  // Non-DRAM-sharded path: set program config, handle fused activation dedup.
   auto setConfigAndFixup = [&](auto concreteOp) {
     concreteOp.setMatmulProgramConfigAttr(programConfig);
     // Workaround for tt-metal issue #35060: if the program config carries a
@@ -121,10 +568,8 @@ void MatmulRuleBook::applyOpSpecificAttrs(
     // double application.
     bool hasFusedActivation =
         llvm::TypeSwitch<mlir::Attribute, bool>(programConfig)
-            .template Case<
-                MatmulMultiCoreReuseMultiCastProgramConfigAttr,
-                MatmulMultiCoreReuseMultiCast1DProgramConfigAttr,
-                MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+            .template Case<MatmulMultiCoreReuseMultiCastProgramConfigAttr,
+                           MatmulMultiCoreReuseMultiCast1DProgramConfigAttr>(
                 [](auto config) {
                   return config.getFusedActivation() != nullptr;
                 })
@@ -139,6 +584,135 @@ void MatmulRuleBook::applyOpSpecificAttrs(
   } else {
     setConfigAndFixup(linearOp);
   }
+}
+
+// ============================================================================
+// MatmulRuleBook::isValidOutputHintForInputs
+// ============================================================================
+
+// Reject in0 whose shard width is incompatible with the config's in0_block_w.
+// tt-metal needs (tiles): K % per_core_K == 0 and per_core_K % in0_block_w ==
+// 0. Guards all in0 candidates the cross-product pairs with the DS hint; though
+// our injected in0 is valid by construction. tt-metal should be patched to
+// reject a bad combo catchably — until then it TT_FATALs (uncatchable abort),
+// so we must gate here. per_core_K = in0 shard width (tiles); K (tiles) = in1
+// shard height.
+static bool dsIn0CompatibleWithConfig(
+    TTNNLayoutAttr in0, TTNNLayoutAttr in1,
+    MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr dsCfg) {
+  auto in0Shard = in0.getShardShape();
+  auto in1Shard = in1.getShardShape();
+  if (in0Shard.size() != 2 || in1Shard.size() != 2) {
+    // Cannot read the shard width, so cannot verify the combo is legal. A
+    // width-sharded in0/in1 for these matmuls is always 2-D (and our injected
+    // in0 always is), so reject rather than risk a tt-metal abort.
+    return false;
+  }
+  int64_t perCoreK = in0Shard[1];
+  int64_t kTiles = in1Shard[0];
+  int64_t in0BlockW = static_cast<int64_t>(dsCfg.getIn0BlockW());
+  return perCoreK != 0 && in0BlockW != 0 && kTiles % perCoreK == 0 &&
+         perCoreK % in0BlockW == 0;
+}
+
+bool MatmulRuleBook::isValidOutputHintForInputs(
+    const OpConfig &hint, llvm::ArrayRef<TTNNLayoutAttr> inputLayouts) const {
+  const auto *attrs = std::get_if<MatmulAttrs>(&hint.opSpecificAttrs);
+  if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+      !mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value())) {
+    return true;
+  }
+  // DS hint: only the canonical DS input combination is valid — L1
+  // width-sharded in0, DRAM width-sharded in1, with an in0 shard width
+  // compatible with the config's in0_block_w (see dsIn0CompatibleWithConfig).
+  // This runs for every in0 the cross-product pairs with the DS hint, not just
+  // the one we inject in getExtraInputReshardCandidates (that one is valid by
+  // construction).
+  if (inputLayouts.size() < 2) {
+    return false;
+  }
+  auto in0 = inputLayouts[0];
+  auto in1 = inputLayouts[1];
+  if (!in0 || !in1) {
+    return false;
+  }
+  auto ml0 = in0.getMemLayoutOpt();
+  if (!in0.hasL1BufferType() || !ml0 ||
+      *ml0 != TensorMemoryLayout::WidthSharded) {
+    return false;
+  }
+  auto ml1 = in1.getMemLayoutOpt();
+  if (in1.hasL1BufferType() || !ml1 ||
+      *ml1 != TensorMemoryLayout::WidthSharded) {
+    return false;
+  }
+  auto dsCfg =
+      mlir::cast<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value());
+  return dsIn0CompatibleWithConfig(in0, in1, dsCfg);
+}
+
+// ============================================================================
+// MatmulRuleBook::adjustScore
+// ============================================================================
+
+LayoutScore
+MatmulRuleBook::adjustScore(Operation * /*op*/, LayoutScore base,
+                            const OpConfig &config,
+                            llvm::ArrayRef<TTNNLayoutAttr> inputLayouts,
+                            bool /*requiresReshard*/) const {
+  const auto *attrs = std::get_if<MatmulAttrs>(&config.opSpecificAttrs);
+  if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+      !attrs->matmulProgramConfig.value()) {
+    return base;
+  }
+  if (!mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          attrs->matmulProgramConfig.value())) {
+    return base;
+  }
+  base.isDRAMShardedCandidate = true;
+  if (!inputLayouts.empty()) {
+    auto in0 = inputLayouts[0];
+    if (in0 && in0.hasL1BufferType()) {
+      auto ml = in0.getMemLayoutOpt();
+      if (ml && *ml == TensorMemoryLayout::WidthSharded) {
+        auto shape = in0.getGridShape();
+        if (shape.size() == 2 && shape[0] == 1 && shape[1] == kNumIn0Cores) {
+          base.hasCanonicalDSIn0 = true;
+        }
+      }
+    }
+  }
+  return base;
+}
+
+// ============================================================================
+// MatmulRuleBook::getExtraInputReshardCandidates
+// ============================================================================
+
+std::vector<TTNNLayoutAttr>
+MatmulRuleBook::getExtraInputReshardCandidates(Operation *op,
+                                               unsigned operandIdx) const {
+  std::optional<DSPlan> plan = buildDSPlan(op);
+  if (!plan) {
+    return {};
+  }
+
+  auto *ctx = op->getContext();
+  if (operandIdx == 0) {
+    auto in0Layout = mlir::cast<TTNNLayoutAttr>(plan->in0Type.getEncoding());
+    return {buildL1ShardedLayout(ctx, in0Layout, plan->in0Type.getShape(),
+                                 kNumIn0Cores, plan->deviceAttr)};
+  }
+  if (operandIdx == 1) {
+    auto weightLayout =
+        mlir::cast<TTNNLayoutAttr>(plan->weightType.getEncoding());
+    return {buildDRAMShardedWeightLayout(ctx, weightLayout,
+                                         plan->weightType.getShape(),
+                                         plan->params, plan->deviceAttr)};
+  }
+  return {};
 }
 
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -156,6 +156,16 @@ static std::optional<std::pair<Value, Value>> getMatmulOperands(Operation *op) {
 static bool isDSEligible(Operation *op, Value activation, Value weight) {
   [[maybe_unused]] StringRef opName = op->getName().getStringRef();
 
+  // Respect the disable-dram-sharded-matmul pipeline option (set as a module
+  // attribute by DevicePassesWrapper). Every DS entry point reaches this
+  // through buildDSPlan, so gating here covers all of them.
+  if (ttnn::utils::isDRAMShardedMatmulDisabled(op)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): disabled by disable-dram-sharded-matmul",
+                 opName);
+    return false;
+  }
+
   if (!isBfpDRAMInterleaved(weight)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): weight is not a tiled bfp4/bfp8 "

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -446,27 +446,65 @@ void MatmulRuleBook::applyDRAMShardedTransformation(
   // --- 2. Handle the fused activation ---
   // Fusing the activation into the DS matmul kernel is significantly slower
   // (measured: the 12-core DS matmul applies silu much slower than an op on all
-  // 64 cores), so strip it off the matmul and run it as a separate elementwise
-  // op across all cores.
+  // 64 cores). So strip it off the matmul and either (a) fold it into a
+  // consuming multiply as its operand-A activation — SwiGLU:
+  // multiply(silu(gate), up) — which runs on the full grid (cheapest), or (b)
+  // fall back to a separate elementwise op.
   if (activationAttr) {
     StringRef actStr = activationAttr.getValue();
     Value matmulResult = op->getResult(0);
 
-    StringRef opName;
+    // (a) Try to fold silu into a consuming ttnn.multiply's lhs_activation.
+    // Only when the matmul result's sole non-dealloc consumer is a multiply
+    // (either operand — multiply is commutative, so we normalize the silu'd
+    // value to operand A). Currently silu only (runtime plumbs lhs_activation).
+    MultiplyOp fuseInto = nullptr;
     if (actStr == "silu") {
-      opName = "ttnn.silu";
-    } else if (actStr == "relu") {
-      opName = "ttnn.relu";
-    } else if (actStr == "gelu") {
-      opName = "ttnn.gelu";
+      Operation *soleUser = nullptr;
+      bool multiUse = false;
+      for (Operation *u : matmulResult.getUsers()) {
+        if (isa<DeallocateOp>(u)) {
+          continue;
+        }
+        if (soleUser) {
+          multiUse = true;
+          break;
+        }
+        soleUser = u;
+      }
+      if (!multiUse && soleUser) {
+        fuseInto = dyn_cast<MultiplyOp>(soleUser);
+      }
     }
-    if (!opName.empty()) {
-      builder.setInsertionPointAfter(op);
-      auto *activationOp = builder.create(
-          op->getLoc(), StringAttr::get(ctx, opName), ValueRange{matmulResult},
-          TypeRange{matmulResult.getType()});
-      matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
-                                        activationOp);
+
+    if (fuseInto && !fuseInto.getLhsActivation() &&
+        (fuseInto.getLhs() == matmulResult ||
+         fuseInto.getRhs() == matmulResult)) {
+      // Normalize the silu'd (matmul) value to operand A, then tag
+      // lhs_activation.
+      Value other = fuseInto.getLhs() == matmulResult ? fuseInto.getRhs()
+                                                      : fuseInto.getLhs();
+      fuseInto.getLhsMutable().assign(matmulResult);
+      fuseInto.getRhsMutable().assign(other);
+      fuseInto.setLhsActivationAttr(StringAttr::get(ctx, "silu"));
+    } else {
+      // (b) Fallback: separate elementwise op running across all cores.
+      StringRef opName;
+      if (actStr == "silu") {
+        opName = "ttnn.silu";
+      } else if (actStr == "relu") {
+        opName = "ttnn.relu";
+      } else if (actStr == "gelu") {
+        opName = "ttnn.gelu";
+      }
+      if (!opName.empty()) {
+        builder.setInsertionPointAfter(op);
+        auto *activationOp = builder.create(
+            op->getLoc(), StringAttr::get(ctx, opName),
+            ValueRange{matmulResult}, TypeRange{matmulResult.getType()});
+        matmulResult.replaceAllUsesExcept(activationOp->getResult(0),
+                                          activationOp);
+      }
     }
   }
 }

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -14,7 +14,7 @@
 #include "ttmlir/Dialect/TTNN/Analysis/OpRules/TypecastRules.h"
 #include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
 
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringMap.h"
 
 #include <mutex>
 
@@ -89,12 +89,11 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static PagedUpdateCacheRuleBook pagedUpdateCache;
   static ArgMaxRuleBook argMax;
 
-  static llvm::DenseMap<mlir::OperationName, const OpRuleBook *> registry;
+  static llvm::StringMap<const OpRuleBook *> registry;
   static std::once_flag initFlag;
   std::call_once(initFlag, [&] {
-    MLIRContext *ctx = op->getContext();
     auto reg = [&](StringRef name, const OpRuleBook *rb) {
-      registry[OperationName(name, ctx)] = rb;
+      registry[name] = rb;
     };
     reg(Conv2dOp::getOperationName(), &conv2d);
     reg(ConvTranspose2dOp::getOperationName(), &conv2d);
@@ -132,7 +131,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(PagedUpdateCacheOp::getOperationName(), &pagedUpdateCache);
     reg(ArgMaxOp::getOperationName(), &argMax);
   });
-  auto it = registry.find(op->getName());
+  auto it = registry.find(op->getName().getStringRef());
   return it != registry.end() ? *it->second : defaultRules;
 }
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -97,6 +97,19 @@ foldConsecutiveDataCastOps(T op, ::mlir::PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// MultiplyOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::MultiplyOp::verify() {
+  std::optional<llvm::StringRef> activation = getLhsActivation();
+  if (activation && *activation != "silu") {
+    return emitOpError() << "lhs_activation must be \"silu\", but got \""
+                         << *activation << "\"";
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // DropoutOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
+++ b/lib/Dialect/TTNN/Pipelines/TTNNPipelines.cpp
@@ -112,6 +112,7 @@ void createTTNNPipelineAnalysisPasses(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
 
     ttnn::TTNNOperationValidationAndFallbackOptions validationOptions;
     validationOptions.maxFallbackAttempts = options.maxFallbackAttempts;
@@ -212,6 +213,7 @@ void createTTNNResolveCompositesPass(
     DevicePassesWrapperOptions wrapperOptions;
     wrapperOptions.devicePtr = options.devicePtr;
     wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+    wrapperOptions.disableDRAMShardedMatmul = options.disableDRAMShardedMatmul;
     pm.addPass(createDevicePassesWrapper(
         [](OpPassManager &innerPm) {
           TTNNResolveCompositesOptions resolveOptions;
@@ -246,6 +248,8 @@ void createTTNNFusingPass(OpPassManager &pm,
       DevicePassesWrapperOptions wrapperOptions;
       wrapperOptions.devicePtr = options.devicePtr;
       wrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+      wrapperOptions.disableDRAMShardedMatmul =
+          options.disableDRAMShardedMatmul;
 
       uint32_t fallbackAttempts = options.maxFallbackAttempts;
       pm.addPass(createDevicePassesWrapper(
@@ -381,6 +385,8 @@ void createTTIRToTTNNCommonPipeline(
         DevicePassesWrapperOptions decompWrapperOptions;
         decompWrapperOptions.devicePtr = options.devicePtr;
         decompWrapperOptions.tensorL1UsageCap = options.tensorL1UsageCap;
+        decompWrapperOptions.disableDRAMShardedMatmul =
+            options.disableDRAMShardedMatmul;
 
         uint32_t decompFallbackAttempts = options.maxFallbackAttempts;
         devicePm.addPass(createDevicePassesWrapper(

--- a/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
+++ b/lib/Dialect/TTNN/Transforms/OptimizerPasses/DevicePassesWrapper.cpp
@@ -28,7 +28,8 @@ public:
                       const DevicePassesWrapperOptions &options)
       : populatePipeline(std::move(populatePipeline)),
         externalDevice(options.devicePtr),
-        tensorL1UsageCap(options.tensorL1UsageCap) {}
+        tensorL1UsageCap(options.tensorL1UsageCap),
+        disableDRAMShardedMatmul(options.disableDRAMShardedMatmul) {}
 
   StringRef getArgument() const override { return "device-passes-wrapper"; }
 
@@ -42,6 +43,7 @@ public:
     copy->externalDevice = externalDevice;
     copy->populatePipeline = populatePipeline;
     copy->tensorL1UsageCap = tensorL1UsageCap;
+    copy->disableDRAMShardedMatmul = disableDRAMShardedMatmul;
     return copy;
   }
 
@@ -64,6 +66,8 @@ public:
     OpBuilder builder(op->getContext());
     op->setAttr(utils::g_TensorL1UsageCapAttrName,
                 builder.getF32FloatAttr(tensorL1UsageCap));
+    op->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
+                builder.getBoolAttr(disableDRAMShardedMatmul));
 
     // Create nested pass manager and populate it.
     OpPassManager nestedPm(getOperation()->getName());
@@ -96,14 +100,16 @@ public:
       return;
     }
 
-    // Clean up the attribute after the nested passes complete.
+    // Clean up the attributes after the nested passes complete.
     op->removeAttr(utils::g_TensorL1UsageCapAttrName);
+    op->removeAttr(utils::g_DisableDRAMShardedMatmulAttrName);
   }
 
 private:
   std::function<void(OpPassManager &)> populatePipeline;
   std::shared_ptr<::tt::tt_metal::distributed::MeshDevice> externalDevice;
   float tensorL1UsageCap;
+  bool disableDRAMShardedMatmul;
 };
 } // namespace
 

--- a/lib/Dialect/TTNN/Utils/Utils.cpp
+++ b/lib/Dialect/TTNN/Utils/Utils.cpp
@@ -39,6 +39,19 @@ float getTensorL1UsageCap(Operation *op, float defaultValue) {
   return defaultValue;
 }
 
+bool isDRAMShardedMatmulDisabled(Operation *op) {
+  ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
+
+  if (moduleOp) {
+    if (auto attr = moduleOp->getAttrOfType<BoolAttr>(
+            g_DisableDRAMShardedMatmulAttrName)) {
+      return attr.getValue();
+    }
+  }
+
+  return false;
+}
+
 uint64_t getReservedL1Usage(Operation *op) {
   ModuleOp moduleOp = op->getParentOfType<ModuleOp>();
 

--- a/lib/OpModel/TTNN/Conversion.cpp
+++ b/lib/OpModel/TTNN/Conversion.cpp
@@ -422,9 +422,12 @@ getMemoryConfig(const MemoryConfigAttr &memConfigAttr) {
 
 bool validateTensorSpec(const ::ttnn::TensorSpec &tensorSpec,
                         const ::tt::tt_metal::CoreCoord &computeGridSize) {
-  // Check the shard bounding box
+  // Check the shard bounding box against the compute grid.
+  // DRAM-sharded tensors use DRAM bank addresses which are outside the compute
+  // core address space, so skip this check for DRAM buffers.
   auto memoryConfig = tensorSpec.memory_config();
-  if (memoryConfig.is_sharded() && memoryConfig.shard_spec().has_value()) {
+  if (memoryConfig.is_sharded() && memoryConfig.shard_spec().has_value() &&
+      memoryConfig.buffer_type() != ::tt::tt_metal::BufferType::DRAM) {
     ::tt::tt_metal::CoreRange shardBoundingBox =
         memoryConfig.shard_spec().value().grid.bounding_box();
     ::tt::tt_metal::CoreRangeSet deviceWorkerCores{::tt::tt_metal::CoreRange{

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -4595,8 +4595,17 @@ llvm::Expected<OpConstraints> OpModel<MatmulOp>::getOpConstraints(
       programConfigAttr ? conversion::getMatmulProgramConfig(*programConfigAttr)
                         : std::nullopt;
 
+  // For DS program config, activation is applied as a separate elementwise op
+  // after the matmul (see MatmulRules::applyDRAMShardedTransformation), so the
+  // DS kernel must not receive it — same logic as programCarriesFusedActivation
+  // for fused configs (e.g. gate_proj in SwiGLU carries activation='silu').
+  bool isDSConfig =
+      programConfigAttr &&
+      mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+          *programConfigAttr);
   std::optional<std::string> activationStr;
-  if (activation && !detail::programCarriesFusedActivation(programConfig)) {
+  if (activation && !detail::programCarriesFusedActivation(programConfig) &&
+      !isDSConfig) {
     activationStr = activation->str();
   }
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -2122,8 +2122,19 @@ createEltwiseBinaryOp(FlatbufferObjectCache &cache, EltwiseBinaryOp op) {
 
   auto memoryConfig = toFlatbuffer(cache, op.getMemoryConfigAttr());
 
-  return ::tt::target::ttnn::CreateEltwiseBinaryOp(
-      *cache.fbb, type, lhs, rhs, outputDtype, memoryConfig, out);
+  // Optional in-kernel activation applied to operand A (SwiGLU's
+  // multiply(silu(lhs), rhs)). ttnn.multiply is the only binary op that carries
+  // it, and the only one the runtime plumbs it for.
+  ::flatbuffers::Offset<::flatbuffers::String> lhsActivation = 0;
+  if constexpr (std::is_same_v<EltwiseBinaryOp, MultiplyOp>) {
+    if (auto act = op.getLhsActivation()) {
+      lhsActivation = cache.fbb->CreateString(act->str());
+    }
+  }
+
+  return ::tt::target::ttnn::CreateEltwiseBinaryOp(*cache.fbb, type, lhs, rhs,
+                                                   outputDtype, memoryConfig,
+                                                   out, lhsActivation);
 }
 
 template <typename EltwiseBinaryCompositeOp>

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -6,8 +6,30 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+#include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
+
+// Build the operand-A in-kernel activations from the op's optional
+// lhs_activation string (fused SwiGLU: multiply(silu(lhs), rhs)). Absent or
+// empty = no activation.
+//
+// Only "silu" is supported, and MultiplyOp::verify rejects anything else at
+// compile time. Fail loudly rather than silently dropping an activation the
+// graph asked for -- that would be wrong numerics with no diagnostic.
+static std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam>
+lhsActivationsFromOp(const ::tt::target::ttnn::EltwiseBinaryOp *op) {
+  std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> acts;
+  if (!op->lhs_activation() || op->lhs_activation()->size() == 0) {
+    return acts;
+  }
+  const std::string activation = op->lhs_activation()->str();
+  LOG_ASSERT(activation == "silu",
+             "Unsupported lhs_activation \"" + activation +
+                 "\" on eltwise binary op; only \"silu\" is supported");
+  acts.emplace_back(::ttnn::operations::unary::UnaryOpType::SILU);
+  return acts;
+}
 
 template <typename Fn>
 static void runEltwiseBinaryOp(const ::tt::target::ttnn::EltwiseBinaryOp *op,
@@ -46,8 +68,18 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
     break;
   }
   case ::tt::target::ttnn::EltwiseBinaryOpType::Multiply: {
-    runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::multiply(std::forward<decltype(args)>(args)...);
+    // Fused SwiGLU: an optional in-kernel activation (silu) applied to operand
+    // A (the gate output) before the multiply — avoids a separate silu op.
+    // Empty for a plain multiply. noActs/lhsActs outlive the call within this
+    // scope.
+    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> noActs;
+    std::vector<::ttnn::operations::unary::EltwiseUnaryWithParam> lhsActs =
+        lhsActivationsFromOp(op);
+    runEltwiseBinaryOp(op, tensorPool, [&](auto &&...args) {
+      return ::ttnn::multiply(std::forward<decltype(args)>(args)...,
+                              /*optional_output=*/std::nullopt,
+                              /*post_activations=*/noActs,
+                              /*lhs_activations=*/lhsActs);
     });
     break;
   }

--- a/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/tensor_accessor_vgm.mlir
@@ -7,50 +7,58 @@
 // RUN: ttmlir-opt --ttir-to-ttmetal-pipeline="mock-system-desc-arch=blackhole disable-tolayout-folding=1 use-tensor-accessor-dma=1 force-compile-time-args=0" -o %t.bh_ta.mlir %s
 // RUN: FileCheck %s --check-prefix=CHECK-BH-TA --input-file=%t.bh_ta.mlir
 
-#layout = #ttcore.metal_layout<logical_shape = 128x384, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
+// The 1x9 grid in the chain below is what makes the two architectures diverge,
+// and the width is chosen for that: 9 exceeds Wormhole's 8 worker columns, so the
+// grid cannot be placed in one row and gets a virtual-grid mapping plus a wrapped
+// 3x3 core range; it fits inside Blackhole's 11, so there the buffer is placed
+// directly as a single 1x9 row with no mapping at all. Keep it strictly between
+// the two column counts if the shape ever changes, or the architectures stop
+// taking different paths and this test degenerates into two copies of the same
+// expectation.
+#layout = #ttcore.metal_layout<logical_shape = 128x288, dim_alignments = 32x32, collapsed_intervals = dense<[[0, 1], [1, 2]]> : tensor<2x2xi64>, l1, sharded>
 
 module {
   // CHECK-WH-NO-TA-LABEL: func.func @tensor_accessor_vgm
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 3x4>
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 3x3>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
-  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-WH-NO-TA: #ttmetal.core_range<0x0, 2x3>
   // CHECK-WH-NO-TA-NOT: TensorAccessor
 
   // CHECK-WH-TA-LABEL: func.func @tensor_accessor_vgm
-  // CHECK-WH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
-  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x4>{{.*}}ct_args = [<tensor_accessor_args[0]>]
-  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 3x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-WH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-WH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
   // CHECK-WH-TA: const uint32_t page_id_{{[0-9]+}}
 
   // CHECK-BH-NO-TA-LABEL: func.func @tensor_accessor_vgm
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-NO-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x12>
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 1x9>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
-  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x6>
+  // CHECK-BH-NO-TA: #ttmetal.core_range<0x0, 2x3>
   // CHECK-BH-NO-TA-NOT: TensorAccessor
 
   // CHECK-BH-TA-LABEL: func.func @tensor_accessor_vgm
-  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x12x4x1x!ttcore.tile<32x32, f32>
-  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x12>{{.*}}ct_args = [<tensor_accessor_args[0]>]
-  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x6>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64}> : () -> memref<1x9x4x1x!ttcore.tile<32x32, f32>
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 1x9>{{.*}}ct_args = [<tensor_accessor_args[0]>]
+  // CHECK-BH-TA: "ttmetal.enqueue_program"{{.*}}#ttmetal.core_range<0x0, 2x3>{{.*}}ct_args = [<tensor_accessor_args[0]>]
   // CHECK-BH-TA: emitc.verbatim "constexpr auto {{.*}} TensorAccessorArgs
   // CHECK-BH-TA: const uint32_t page_id_{{[0-9]+}}
 
-  func.func @tensor_accessor_vgm(%arg0: tensor<128x384xf32>) -> tensor<128x384xf32> {
-    %0 = ttir.empty() : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
-    %1 = ttir.to_layout %arg0, %0 : tensor<128x384xf32> into tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout>
-    %2 = ttir.empty() : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
-    %3 = ttir.to_layout %1, %2 : tensor<1x1x4x12x!ttcore.tile<32x32, f32>, #layout> into tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout>
-    %4 = ttir.empty() : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
-    %5 = ttir.to_layout %3, %4 : tensor<1x12x4x1x!ttcore.tile<32x32, f32>, #layout> into tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout>
-    %6 = ttir.empty() : tensor<128x384xf32>
-    %7 = ttir.to_layout %5, %6 : tensor<2x6x2x2x!ttcore.tile<32x32, f32>, #layout> into tensor<128x384xf32> -> tensor<128x384xf32>
-    return %7 : tensor<128x384xf32>
+  func.func @tensor_accessor_vgm(%arg0: tensor<128x288xf32>) -> tensor<128x288xf32> {
+    %0 = ttir.empty() : tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout>
+    %1 = ttir.to_layout %arg0, %0 : tensor<128x288xf32> into tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout>
+    %2 = ttir.empty() : tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %3 = ttir.to_layout %1, %2 : tensor<1x1x4x9x!ttcore.tile<32x32, f32>, #layout> into tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout> -> tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout>
+    %4 = ttir.empty() : tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout>
+    %5 = ttir.to_layout %3, %4 : tensor<1x9x4x1x!ttcore.tile<32x32, f32>, #layout> into tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout> -> tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout>
+    %6 = ttir.empty() : tensor<128x288xf32>
+    %7 = ttir.to_layout %5, %6 : tensor<2x3x2x3x!ttcore.tile<32x32, f32>, #layout> into tensor<128x288xf32> -> tensor<128x288xf32>
+    return %7 : tensor<128x288xf32>
   }
 }

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_host_transfers.mlir
@@ -3,9 +3,9 @@
 
 module {
   // CHECK-LABEL: func.func @slice_f32_virtual_grid_host_transfers
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_write_buffer"{{.*}}memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}}memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_virtual_grid_host_transfers(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
+++ b/test/ttmlir/Conversion/D2MToTTMetal/virtual_grid_scalar_host_bounce.mlir
@@ -4,8 +4,8 @@
 module {
   // CHECK-LABEL: func.func @slice_f32_cb_page_compatible
   // CHECK-NOT: memref<8x8x384x4xf32
-  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<3x16x2x1x2x4x32x32xf32, #ttcore.shard<16384x4096x128x4, 1>, #l1>
-  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x32x1x1x1x1x32x32xf32, #ttcore.shard<4096x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.create_buffer"() <{address = {{[0-9]+}} : i64, virtualGridForwardMapping = #map{{[0-9]*}}, virtualGridInverseMapping = #map{{[0-9]*}}}> : () -> memref<1x32x2x1x6x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
+  // CHECK: "ttmetal.enqueue_read_buffer"{{.*}} : (memref<3x16x1x1x1x2x32x32xf32, #ttcore.shard<8192x4096x128x4, 1>, #l1>
   func.func @slice_f32_cb_page_compatible(%arg0: tensor<6x64x64x4xf32>) -> tensor<3x32x32x2xf32> {
     %0 = "ttir.slice_static"(%arg0) <{
       begins = [1 : i32, 15 : i32, 16 : i32, 2 : i32],

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation.mlir
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: ttmlir-opt %s | FileCheck %s
+
+// lhs_activation names a unary the multiply kernel applies to operand A before
+// the multiply, so a producer's activation costs no separate op -- SwiGLU's
+// multiply(silu(gate), up).
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK-LABEL: func.func @multiply_silu
+  // CHECK: lhs_activation = "silu"
+  func.func @multiply_silu(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) <{lhs_activation = "silu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+
+  // Every other multiply in the tree leaves it unset.
+  // CHECK-LABEL: func.func @multiply_plain
+  // CHECK-NOT: lhs_activation
+  func.func @multiply_plain(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/eltwise/binary/multiply_lhs_activation_negative.mlir
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// RUN: not ttmlir-opt --split-input-file %s 2>&1 | FileCheck %s
+
+// Only "silu" is supported, and only ttnn.multiply carries lhs_activation at
+// all: the runtime plumbs it for no other eltwise binary op, so accepting it
+// elsewhere would execute without the activation and silently change results.
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK: lhs_activation must be "silu", but got "relu"
+  func.func @multiply_unsupported_activation(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.multiply"(%a, %b) <{lhs_activation = "relu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}
+
+// -----
+
+#dram = #ttnn.buffer_type<dram>
+#l = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+module {
+  // CHECK: invalid properties {lhs_activation = "silu"} for op ttnn.add: this operation does not support properties
+  func.func @add_does_not_accept_activation(%a: tensor<32x32xbf16, #l>, %b: tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l> {
+    %0 = "ttnn.add"(%a, %b) <{lhs_activation = "silu"}> : (tensor<32x32xbf16, #l>, tensor<32x32xbf16, #l>) -> tensor<32x32xbf16, #l>
+    return %0 : tensor<32x32xbf16, #l>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_bank_count.mlir
@@ -1,0 +1,40 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=wormhole_b0" -o %t %s
+// RUN: FileCheck %s --input-file=%t --check-prefix=WH12
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t2 %s
+// RUN: FileCheck %s --input-file=%t2 --check-prefix=BH8
+
+// The DS weight layout is width-sharded across exactly the DRAM banks the
+// *device* has, and its shard width follows from that count.
+//
+// Wormhole exposes 12 banks, Blackhole 8. A hardcoded count produces a weight
+// layout that cannot be allocated on a part with a different one: tensor
+// creation aborts in get_dram_channel_from_logical_core ("Logical DRAM core ...
+// is outside valid range"), and nothing before silicon catches it because
+// validateTensorSpec deliberately skips the shard bounding-box check for DRAM
+// buffers.
+//
+// The N padding differs per bank count, which is what makes the two cases
+// distinct:
+//   WH: pad 4096 up to a multiple of 32*12=384 -> 4224, /12 = 352 = 11 tiles
+//   BH: pad 4096 up to a multiple of 32*8 =256 -> 4096, /8  = 512 = 16 tiles
+// K is 4096 = 128 tiles in both.
+//
+// WH12-DAG: #ttnn.ttnn_layout<{{.*}}<1x12>, memref<128x11x!ttcore.tile<32x32, bfp_bf8>, #dram>, <width_sharded>
+// BH8-DAG: #ttnn.ttnn_layout<{{.*}}<1x8>, memref<128x16x!ttcore.tile<32x32, bfp_bf8>, #dram>, <width_sharded>
+
+module attributes {} {
+  // WH12-LABEL: func.func @ds_matmul_bank_count
+  // WH12: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // BH8-LABEL: func.func @ds_matmul_bank_count
+  // BH8: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  func.func @ds_matmul_bank_count(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_disabled_option.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 disable-dram-sharded-matmul=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The disable-dram-sharded-matmul kill switch suppresses the DS path.
+//
+// This is the same IR as dram_sharded_matmul_eligible_m32.mlir, which does get a
+// DS config, so the only difference is the option. isDRAMShardEligible is the
+// single choke point for the DS path, which is what makes one check here
+// sufficient: buildDRAMShardingHint and getExtraInputReshardCandidates both gate
+// on it, and getOutputHints reaches DS only through buildDRAMShardingHint.
+//
+// The matmul must still get *some* program config -- the option falls back to the
+// 1D/2D mcast configs rather than disabling program-config selection entirely.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_disabled
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_disabled(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_dtype_gate.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t --check-prefix=BFP8
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t2 %s
+// RUN: FileCheck %s --input-file=%t2 --check-prefix=BF16
+
+// The DS path is offered for bfp4/bfp8 weights only. Identical IR, two weight
+// dtypes.
+//
+// This is a bandwidth policy, not a legality constraint: tt-metal imposes no
+// dtype TT_FATAL on the DRAM-sharded config, and bf16 weights do run. But DS
+// streams the weights out of DRAM, so bf16 moves 2x the bytes of bfp8 and 4x
+// bfp4 -- the regime where 1D-mcast wins -- and the optimizer has no runtime
+// estimate with which to rank the two. The conservative set stays hardcoded.
+
+module attributes {} {
+  // BFP8-LABEL: func.func @ds_matmul_dtype
+  // BFP8: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+
+  // BF16-LABEL: func.func @ds_matmul_dtype
+  // BF16-NOT: dram_sharded_program_config
+  func.func @ds_matmul_dtype(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Baseline DRAM-sharded (DS) matmul: a decode-shaped projection with a bfp8
+// constant weight. The activation is exactly one tile row (batch 32), K and N
+// are tile-aligned, and K in tiles (128) is divisible by the in0 core count (8),
+// so every eligibility gate passes and the optimizer offers the DS config.
+//
+// per_core_m must be 1: tt-metal asserts M == per_core_M and M == 1 for the
+// DRAM-sharded program config.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_m32
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_m32(
+      %act: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<32x4096xbf16>
+    // Consumer op to form an L1 chain, matching optimizer/matmul_program_config.mlir.
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x4096xbf16>, tensor<32x4096xbf16>) -> tensor<32x4096xbf16>
+    return %1 : tensor<32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_subtile_batch.mlir
@@ -1,0 +1,26 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A sub-tile decode batch is still one tile row, so it is DS-eligible.
+//
+// tt-metal's constraint is on the activation height in *tiles*
+// (TT_FATAL(M == 1)), and it pads a 1..31-row activation up to one tile row, so
+// the gate is divUp(M, 32) == 1 rather than a tile-alignment check on M. Any
+// batch in 1..32 qualifies, and per_core_M comes out as 1 for all of them
+// (computeShardParams rounds up, so a sub-tile M cannot truncate to a
+// degenerate 0).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_batch1
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_batch1(
+      %act: tensor<1x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<1x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<1x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<1x4096xbf16>, tensor<1x4096xbf16>) -> tensor<1x4096xbf16>
+    return %1 : tensor<1x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_unit_batched_weight.mlir
@@ -1,0 +1,25 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A [1, 1, K, N] weight is the same matrix as [K, N] and is DS-eligible.
+//
+// ttnn models routinely hold projection weights with leading unit batch dims,
+// and such a weight has the same element count, the same tile grid and the same
+// collapsed 2-D memref in the layout as the rank-2 form. Only a *non-unit*
+// leading dim is a real batched matmul (see
+// dram_sharded_matmul_reject_batched_weight.mlir).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_unit_batched_weight
+  // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
+  // CHECK-SAME: per_core_m = 1
+  func.func @ds_matmul_unit_batched_weight(
+      %act: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<1x1x4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<1x1x32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x1x32x4096xbf16>, tensor<1x1x4096x4096xbf16>) -> tensor<1x1x32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<1x1x32x4096xbf16>, tensor<1x1x32x4096xbf16>) -> tensor<1x1x32x4096xbf16>
+    return %1 : tensor<1x1x32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_batched_weight.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// A weight with a non-unit batch dim is a real batched matmul and is not
+// DS-eligible.
+//
+// tt-metal serves that case with a different program config
+// (MatmulMultiCoreReuseMultiCastBatchedDRAMShardedProgramConfig) which this path
+// does not emit, so accepting a [2, 1, K, N] weight here would build a config
+// for the wrong kernel.
+//
+// The activation deliberately stays at one tile row (M = 1*1*32 = 32) so this
+// test isolates the weight-shape gate rather than tripping the M gate.
+
+module attributes {} {
+  // The positive anchor matters: with only a CHECK-NOT this test would still
+  // pass if the matmul vanished or the pipeline broke upstream.
+  // CHECK-LABEL: func.func @ds_matmul_batched_weight
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_batched_weight(
+      %act: tensor<1x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<2x1x4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<2x1x32x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<2x1x32x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<1x1x32x4096xbf16>, tensor<2x1x4096x4096xbf16>) -> tensor<2x1x32x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<2x1x32x4096xbf16>, tensor<2x1x32x4096xbf16>) -> tensor<2x1x32x4096xbf16>
+    return %1 : tensor<2x1x32x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The DS path declines when the CB budget collapses in0_block_w (see
+// kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+//
+// K = 11008 is 344 tiles, so K-per-core is 344/8 = 43 -- a prime, leaving 43 and
+// 1 as the only legal block widths. On an 8-bank part the in1 CB at in0_block_w
+// = 43 needs ~1.35 MB against a ~1.30 MB budget, so the search would otherwise
+// settle on in0_block_w = 1: 344 serialized mcast+compute rounds instead of 8.
+// That shape is qwen_2_5_3b's down-projection, measured at -28.1% e2e on p150.
+//
+// Blackhole specifically: with 12 banks the per-bank weight shard is narrower, the
+// in1 CB fits at in0_block_w = 43, and the collapse never happens -- which is why
+// none of the Wormhole benchmarks regressed.
+//
+// As with the disable-dram-sharded-matmul kill switch, the matmul must still get
+// *some* program config; declining DS falls back to the 1D/2D mcast configs
+// rather than disabling program-config selection entirely.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_block_collapse
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_block_collapse(
+      %act: tensor<32x11008xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<11008x2048xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x2048xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x2048xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x11008xbf16>, tensor<11008x2048xbf16>) -> tensor<32x2048xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x2048xbf16>, tensor<32x2048xbf16>) -> tensor<32x2048xbf16>
+    return %1 : tensor<32x2048xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_k_not_divisible.mlir
@@ -1,0 +1,36 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Known limitation, pinned deliberately: the DS activation is width-sharded
+// across a fixed 8 in0 cores, so K in tiles must be divisible by 8.
+//
+// K = 2880 is 90 tiles, and 90 % 8 != 0, so this shape gets no DS config even
+// though it is otherwise a textbook decode projection (this is the gpt-oss hidden
+// size). Deriving the in0 core count from K would admit it -- 90 is divisible by
+// 9, 6, 5 and more -- but picking *which* divisor is a cost question the
+// optimizer cannot answer yet: it has no runtime estimate, and the candidates are
+// all legal. Rather than bake in an arbitrary pick, the gate stays at 8.
+//
+// The gate also keeps computeShardParams' kTiles % numIn0Cores assertion true by
+// construction instead of by caller contract, which matters because that assert
+// is a no-op in a release build.
+//
+// If this test starts failing because DS *is* now offered, that is the in0-core
+// search landing -- update it to assert the chosen split instead of its absence.
+
+module attributes {} {
+  // The positive anchor matters: with only a CHECK-NOT this test would still
+  // pass if the matmul vanished or the pipeline broke upstream.
+  // CHECK-LABEL: func.func @ds_matmul_k_not_divisible
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_k_not_divisible(
+      %act: tensor<32x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<2880x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x2880xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x2880xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x2880xbf16>, tensor<2880x2880xbf16>) -> tensor<32x2880xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x2880xbf16>, tensor<32x2880xbf16>) -> tensor<32x2880xbf16>
+    return %1 : tensor<32x2880xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_multi_tile_m.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// An activation taller than one tile row must be declined at compile time.
+//
+// tt-metal's DRAM-sharded validation asserts TT_FATAL(M == 1) on the activation
+// height in tiles, and a TT_FATAL is an uncatchable abort rather than a failure
+// the op model can report. So this has to be rejected by the eligibility gate:
+// deferring to tt-metal would turn a compile-time decline into a crash on
+// silicon. This is the prefill / large-batch shape.
+//
+// Everything else here is identical to the eligible baseline, so the only reason
+// DS is absent is M = 64 (2 tile rows).
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_m64
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_m64(
+      %act: tensor<64x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<4096x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<64x4096xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<64x4096xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<64x4096xbf16>, tensor<4096x4096xbf16>) -> tensor<64x4096xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<64x4096xbf16>, tensor<64x4096xbf16>) -> tensor<64x4096xbf16>
+    return %1 : tensor<64x4096xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
+++ b/test/ttmlir/Dialect/TTNN/perf_targets/llama_3_1_8b_blackhole.mlir
@@ -24,7 +24,7 @@
 // RUN: cat %t.dir/trace.json | FileCheck %s
 
 // Llama 3.1 8B single decoder layer on Blackhole. Different hardware
-// constants than n150 (512 GB/s DRAM, 1.35 GHz, 130 Tensix cores) so the
+// constants than n150 (512 GB/s DRAM, 1.35 GHz, 110 Tensix cores) so the
 // roofline shrinks vs the Wormhole companion test even though the model
 // is the same. At default opt level SDPA is not fused, so 6 dram-bound
 // weight matmuls + 2 skipped activation@activation matmuls. (The third,
@@ -38,7 +38,7 @@
 // CHECK: "dram_bandwidth_bytes_per_sec": 512000000000
 // CHECK: "dram_bound_ops": 6
 // CHECK: "num_chips": 1
-// CHECK: "num_tensix_cores": 130
+// CHECK: "num_tensix_cores": 110
 // CHECK: "params_count": 743440384
 // CHECK: "params_memory_bytes": 789905408
 // CHECK: "roofline_ms": 1.542784

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -21,6 +21,7 @@ if (TTMLIR_ENABLE_OPMODEL)
         TestOpModelStrategy.cpp
         TestBeamSearch.cpp
         TestReshardCandidates.cpp
+        TestDRAMShardedMatmulEligibility.cpp
         PARTIAL_SOURCES_INTENDED
     )
 

--- a/test/unittests/Optimizer/CMakeLists.txt
+++ b/test/unittests/Optimizer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_unittest(OptimizerTests
     TestLegalTensorLayoutAnalysis.cpp
     TestConv2dConfigGenerator.cpp
     TestConv3dConfigHeuristic.cpp
+    TestMatmulProgramConfig.cpp
     PARTIAL_SOURCES_INTENDED
 )
 

--- a/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
+++ b/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
@@ -1,0 +1,375 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/OpModelStrategy.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCore.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTCore/Transforms/Transforms.h"
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpConfig.h"
+#include "ttmlir/Dialect/TTNN/Analysis/OpRules/OpRuleBook.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOps.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNNOpsAttrs.h"
+#include "ttmlir/Dialect/TTNN/Utils/Utils.h"
+#include "ttmlir/OpModel/TTNN/SingletonDeviceContext.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt;
+using namespace mlir::tt::ttnn;
+
+// DRAM-sharded (DS) matmul eligibility and weight geometry, exercised through
+// the matmul rule book.
+//
+// These build a real func.func because DS requires the weight to be const-eval
+// traceable (valueTracesToConstantArgs), which means a function argument marked
+// as a parameter -- the module-level ops the other strategy tests build cannot
+// express that.
+//
+// The bias-free ttnn.linear case is only reachable here, not from lit: a
+// bias-free ttir.linear canonicalizes into ttir.matmul (TTIROps.cpp), so no
+// bias-free ttnn.linear survives the TTIR->TTNN pipeline. TTNN-level entry
+// points (ttnn tracing, the shard advisor) are where it appears.
+namespace {
+
+constexpr int64_t kTile = 32;
+
+// Shared scaffolding. Deliberately does not open a metal device: every path
+// under test (eligibility, weight layout) needs only a DeviceAttr and the
+// system descriptor.
+//
+// These are the fast, device-free check of the per-architecture layout the rule
+// book derives; optimizer/dram_sharded_matmul_bank_count.mlir covers the same
+// ground end-to-end through the pipeline.
+class DSTestBase : public ::testing::Test {
+public:
+  mlir::MLIRContext context;
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+  mlir::OpBuilder builder = mlir::OpBuilder(&context);
+  int funcCounter = 0;
+
+  void SetUp() override {
+    context.loadDialect<ttcore::TTCoreDialect>();
+    context.loadDialect<ttnn::TTNNDialect>();
+    context.loadDialect<mlir::func::FuncDialect>();
+    initModule(ttcore::Arch::WormholeB0);
+  }
+
+  void initModule(ttcore::Arch arch) {
+    module = mlir::ModuleOp::create(builder.getUnknownLoc());
+    builder.setInsertionPointToStart(&module->getBodyRegion().front());
+    ttcore::registerDevice(module.get(), arch);
+    module->getOperation()->setAttr(utils::g_TensorL1UsageCapAttrName,
+                                    builder.getF32FloatAttr(0.95f));
+  }
+
+  TTNNLayoutAttr dramInterleaved(llvm::ArrayRef<int64_t> shape,
+                                 ttcore::DataType dt) {
+    auto elementType = ttcore::TileType::get(&context, {kTile, kTile}, dt);
+    auto deviceAttr = ttcore::lookupDevice(module.get());
+    return TTNNLayoutAttr::Builder(&context, shape, elementType)
+        .setBufferType(BufferType::DRAM)
+        .setMemoryLayout(TensorMemoryLayout::Interleaved)
+        .setGridShape({1, 1})
+        .buildWithCanonicalCorePlacement(deviceAttr);
+  }
+
+  mlir::RankedTensorType tensorOf(llvm::ArrayRef<int64_t> shape,
+                                  ttcore::DataType dt) {
+    return mlir::RankedTensorType::get(shape, builder.getBF16Type(),
+                                       dramInterleaved(shape, dt));
+  }
+
+  // Opens a func whose arg 1 (the weight) is marked as a parameter, and leaves
+  // the builder positioned inside it.
+  mlir::Block *openFunc(llvm::ArrayRef<mlir::Type> argTypes,
+                        mlir::Type resultType) {
+    builder.setInsertionPointToEnd(&module->getBodyRegion().front());
+    auto funcType = builder.getFunctionType(argTypes, {resultType});
+    auto func = builder.create<mlir::func::FuncOp>(
+        builder.getUnknownLoc(), "ds_test_" + std::to_string(funcCounter++),
+        funcType);
+    func.setArgAttr(1, ttcore::ArgumentTypeAttr::name,
+                    ttcore::ArgumentTypeAttr::get(
+                        &context, ttcore::ArgumentType::Parameter));
+    mlir::Block *block = func.addEntryBlock();
+    builder.setInsertionPointToStart(block);
+    return block;
+  }
+
+  MatmulOp buildMatmul(llvm::ArrayRef<int64_t> actShape,
+                       llvm::ArrayRef<int64_t> weightShape,
+                       llvm::ArrayRef<int64_t> outShape,
+                       ttcore::DataType weightDt) {
+    auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
+    auto weightType = tensorOf(weightShape, weightDt);
+    auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
+    mlir::Block *block = openFunc({actType, weightType}, outType);
+    auto op = builder.create<MatmulOp>(
+        builder.getUnknownLoc(), outType, block->getArgument(0),
+        block->getArgument(1), /*transpose_a=*/false, /*transpose_b=*/false,
+        /*matmul_program_config=*/mlir::Attribute(),
+        /*activation=*/mlir::StringAttr());
+    builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                         op.getResult());
+    return op;
+  }
+
+  LinearOp buildLinear(llvm::ArrayRef<int64_t> actShape,
+                       llvm::ArrayRef<int64_t> weightShape,
+                       llvm::ArrayRef<int64_t> outShape,
+                       ttcore::DataType weightDt, bool withBias) {
+    auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
+    auto weightType = tensorOf(weightShape, weightDt);
+    auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
+
+    llvm::SmallVector<int64_t> biasShape{1, weightShape.back()};
+    auto biasType = tensorOf(biasShape, ttcore::DataType::BFloat16);
+
+    llvm::SmallVector<mlir::Type> argTypes{actType, weightType};
+    if (withBias) {
+      argTypes.push_back(biasType);
+    }
+    mlir::Block *block = openFunc(argTypes, outType);
+
+    mlir::Value bias = withBias ? block->getArgument(2) : mlir::Value();
+    auto op = builder.create<LinearOp>(
+        builder.getUnknownLoc(), outType, block->getArgument(0),
+        block->getArgument(1), bias, /*transpose_a=*/false,
+        /*transpose_b=*/false, /*activation=*/mlir::StringAttr());
+    builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                         op.getResult());
+    return op;
+  }
+
+  std::vector<OpConfig> legalConfigs(llvm::ArrayRef<int64_t> outShape) {
+    std::vector<OpConfig> configs;
+    configs.emplace_back(dramInterleaved(outShape, ttcore::DataType::BFloat16));
+    return configs;
+  }
+
+  // Whether any hint carries a DRAM-sharded matmul program config.
+  static bool hasDSHint(const OutputHints &hints) {
+    for (const auto &hint : hints.hints) {
+      const auto *attrs = std::get_if<MatmulAttrs>(&hint.opSpecificAttrs);
+      if (!attrs || !attrs->matmulProgramConfig.has_value() ||
+          !attrs->matmulProgramConfig.value()) {
+        continue;
+      }
+      if (mlir::isa<MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr>(
+              attrs->matmulProgramConfig.value())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isDSEligible(mlir::Operation *op, llvm::ArrayRef<int64_t> outShape) {
+    return hasDSHint(getOutputHints(op, legalConfigs(outShape)));
+  }
+};
+
+class DRAMShardedEligibilityTest : public DSTestBase {};
+
+//===----------------------------------------------------------------------===//
+// Eligibility
+//===----------------------------------------------------------------------===//
+
+// Baseline: a decode-shaped bfp8 projection is DS-eligible.
+TEST_F(DRAMShardedEligibilityTest, MatmulEligible) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// A bias-free ttnn.linear is the same computation the DS kernel implements, so
+// it must be offered the DS config too. ttnn decoders write their projections
+// as ttnn.linear, so this is the shape the path sees in practice.
+TEST_F(DRAMShardedEligibilityTest, BiasFreeLinearEligible) {
+  auto op = buildLinear({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8, /*withBias=*/false);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// A biased linear is declined. tt-metal's DS kernel does support a bias, but it
+// reads it per DRAM bank at a bank-local offset, so the bias must be DRAM
+// width-sharded across the same bank grid as the weight. Nothing produces such
+// a layout for operand 2 yet, and a DRAM-interleaved bias would be read as a
+// strided subset of itself -- wrong results rather than a crash, with no
+// tt-metal validation to catch it.
+TEST_F(DRAMShardedEligibilityTest, BiasedLinearDeclined) {
+  auto op = buildLinear({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8, /*withBias=*/true);
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+// [1, 1, K, N] is the same matrix as [K, N]; ttnn models routinely hold
+// projection weights that way.
+TEST_F(DRAMShardedEligibilityTest, UnitBatchedWeightEligible) {
+  auto op = buildMatmul({1, 1, 32, 4096}, {1, 1, 4096, 4096}, {1, 1, 32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {1, 1, 32, 4096}));
+}
+
+// A non-unit batch dim is a real batched matmul, which tt-metal serves with a
+// different program config that this path does not emit.
+TEST_F(DRAMShardedEligibilityTest, BatchedWeightDeclined) {
+  auto op = buildMatmul({1, 1, 32, 4096}, {2, 1, 4096, 4096}, {2, 1, 32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {2, 1, 32, 4096}));
+}
+
+// A sub-tile decode batch is still one tile row, so it is eligible: tt-metal
+// pads a 1..31-row activation up to one tile row and runs it.
+TEST_F(DRAMShardedEligibilityTest, SubTileBatchEligible) {
+  auto op = buildMatmul({1, 4096}, {4096, 4096}, {1, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_TRUE(isDSEligible(op, {1, 4096}));
+}
+
+// More than one tile row must be declined at compile time: tt-metal's
+// TT_FATAL(M == 1) is an uncatchable abort, so deferring to it would crash on
+// silicon rather than fall back to another config.
+TEST_F(DRAMShardedEligibilityTest, MultiTileMDeclined) {
+  auto op = buildMatmul({64, 4096}, {4096, 4096}, {64, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {64, 4096}));
+}
+
+// bfp4/bfp8 only. bf16 is legal for tt-metal, but DS streams the weights out of
+// DRAM, so bf16 moves 2x the bytes and the optimizer has no runtime estimate
+// with which to rank it against 1D-mcast.
+TEST_F(DRAMShardedEligibilityTest, Bf16WeightDeclined) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFloat16);
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+TEST_F(DRAMShardedEligibilityTest, Bfp4WeightEligible) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat4);
+  EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// Known limitation, pinned deliberately: the activation is width-sharded across
+// a fixed 8 in0 cores, so K in tiles must be divisible by 8. 2880 is 90 tiles
+// (the gpt-oss hidden size) and is declined. Deriving the core count from K
+// would admit it -- 90 has several usable divisors -- but choosing among them
+// is a cost question the optimizer cannot answer yet.
+TEST_F(DRAMShardedEligibilityTest, KTilesNotDivisibleByIn0CoresDeclined) {
+  auto op = buildMatmul({32, 2880}, {2880, 2880}, {32, 2880},
+                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {32, 2880}));
+}
+
+// The kill switch short-circuits the single choke point, so nothing downstream
+// can reintroduce DS.
+TEST_F(DRAMShardedEligibilityTest, DisableOptionSuppressesDS) {
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+  ASSERT_TRUE(isDSEligible(op, {32, 4096}));
+
+  module->getOperation()->setAttr(utils::g_DisableDRAMShardedMatmulAttrName,
+                                  builder.getBoolAttr(true));
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
+}
+
+//===----------------------------------------------------------------------===//
+// Weight geometry follows the device's DRAM bank count
+//===----------------------------------------------------------------------===//
+
+class DRAMShardedBankCountTest : public DSTestBase {
+public:
+  // The DS weight layout injected for operand 1.
+  TTNNLayoutAttr weightReshardLayout(mlir::Operation *op) {
+    std::vector<TTNNLayoutAttr> candidates =
+        getRuleBook(op).getExtraInputReshardCandidates(op, /*operandIdx=*/1);
+    EXPECT_EQ(candidates.size(), 1u);
+    return candidates.empty() ? TTNNLayoutAttr() : candidates.front();
+  }
+};
+
+// Wormhole exposes 12 DRAM banks, so N=4096 pads up to a multiple of 32*12=384
+// (4224) and each bank holds 4224/12 = 352 = 11 tiles of weight width.
+TEST_F(DRAMShardedBankCountTest, WormholeUses12Banks) {
+  initModule(ttcore::Arch::WormholeB0);
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+
+  TTNNLayoutAttr layout = weightReshardLayout(op);
+  ASSERT_TRUE(layout);
+  EXPECT_EQ(layout.getGridShape(), llvm::ArrayRef<int64_t>({1, 12}));
+  EXPECT_EQ(layout.getShardShape(), llvm::ArrayRef<int64_t>({128, 11}));
+  EXPECT_EQ(layout.getBufferType(), BufferType::DRAM);
+}
+
+// Blackhole exposes 8. 32*8=256 already divides 4096, so there is no padding
+// and each bank holds 4096/8 = 512 = 16 tiles.
+//
+// The count has to come from the device: a layout sharded across more banks
+// than the part has is unallocatable (tensor creation aborts in
+// get_dram_channel_from_logical_core), and validateTensorSpec skips the shard
+// bounding-box check for DRAM buffers, so nothing before silicon would notice.
+TEST_F(DRAMShardedBankCountTest, BlackholeUses8Banks) {
+  initModule(ttcore::Arch::Blackhole);
+  auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
+                        ttcore::DataType::BFP_BFloat8);
+
+  TTNNLayoutAttr layout = weightReshardLayout(op);
+  ASSERT_TRUE(layout);
+  EXPECT_EQ(layout.getGridShape(), llvm::ArrayRef<int64_t>({1, 8}));
+  EXPECT_EQ(layout.getShardShape(), llvm::ArrayRef<int64_t>({128, 16}));
+  EXPECT_EQ(layout.getBufferType(), BufferType::DRAM);
+}
+
+// The DS layout builders must land on canonical core placement whatever the
+// layout they are seeded from carried. buildWithCanonicalCorePlacement only
+// fills a *null* core range set, and Builder's setters each early-return when
+// the value is unchanged, so a seed that already matches the target's buffer
+// type, memory layout and grid would otherwise keep its own placement. No lit
+// test reaches this: every DS operand starts DRAM-interleaved, so the memory
+// layout always changes and invalidates the core range set on the way through.
+TEST_F(DSTestBase, L1ShardedLayoutForcesCanonicalPlacement) {
+  ttcore::DeviceAttr deviceAttr = ttcore::lookupDevice(module.get());
+  llvm::SmallVector<int64_t, 2> shape{kTile, 4096};
+  auto elementType = ttcore::TileType::get(&context, {kTile, kTile},
+                                           ttcore::DataType::BFloat16);
+
+  // Same buffer type, memory layout and grid as the target, but deliberately
+  // placed on row 1 rather than the canonical row 0.
+  auto offRow = CoreRangeSetAttr::get(
+      &context,
+      {CoreRangeAttr::get(&context, CoreCoordAttr::get(&context, 0, 1),
+                          CoreCoordAttr::get(&context, 7, 1))});
+  TTNNLayoutAttr seed = TTNNLayoutAttr::Builder(&context, shape, elementType)
+                            .setBufferType(BufferType::L1)
+                            .setMemoryLayout(TensorMemoryLayout::WidthSharded)
+                            .setGridShape({1, 8})
+                            .setCoreRangeSet(offRow)
+                            .build();
+  ASSERT_EQ(seed.getCoreRangeSet(), offRow);
+
+  TTNNLayoutAttr out =
+      buildL1ShardedLayout(&context, seed, shape, /*numCores=*/8, deviceAttr);
+
+  TTNNLayoutAttr canonical =
+      TTNNLayoutAttr::Builder(&context, shape, elementType)
+          .setBufferType(BufferType::L1)
+          .setMemoryLayout(TensorMemoryLayout::WidthSharded)
+          .setGridShape({1, 8})
+          .buildWithCanonicalCorePlacement(deviceAttr);
+
+  EXPECT_EQ(out.getCoreRangeSet(), canonical.getCoreRangeSet());
+  EXPECT_NE(out.getCoreRangeSet(), offRow);
+}
+
+} // namespace

--- a/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
+++ b/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
@@ -190,22 +190,18 @@ TEST(MatmulDRAMShardParams, PrimeKPerCoreCollapseDeclined) {
   EXPECT_FALSE(p.has_value());
 }
 
-// Math fidelity follows the weight dtype. Nothing else pins this: the DS lit
-// tests only FileCheck matmul_program_config, not the compute config.
+// Every DS matmul runs at LoFi regardless of weight dtype. Nothing else pins
+// this: the DS lit tests only FileCheck matmul_program_config, not the compute
+// config.
 class MatmulDRAMComputeConfig : public ::testing::Test {
 protected:
   void SetUp() override { context.loadDialect<TTNNDialect>(); }
   mlir::MLIRContext context;
 };
 
-TEST_F(MatmulDRAMComputeConfig, Bfp4RunsLoFi) {
-  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat4);
+TEST_F(MatmulDRAMComputeConfig, AlwaysLoFi) {
+  auto cfg = buildComputeConfig(&context);
   EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::LoFi);
-}
-
-TEST_F(MatmulDRAMComputeConfig, Bfp8RunsHiFi2) {
-  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat8);
-  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::HiFi2);
 }
 
 } // namespace

--- a/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
+++ b/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
+
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
+
+#include "mlir/IR/MLIRContext.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tt;
+using namespace mlir::tt::ttnn;
+
+// These tests pin the DRAM-sharded shard geometry and compute-kernel config,
+// which nothing else in the tree covers. computeShardParams is pure arithmetic
+// over the matmul dims and the L1 budget, so most of them need no MLIRContext
+// and no device.
+namespace {
+
+// Wormhole-ish L1 budget: 0.95 * usable L1 (1499136).
+constexpr int64_t kL1Available = 1424179;
+
+// A decode-shaped 32x4096x4096 projection, the shape the DS path is built for.
+constexpr int64_t kM = 32;
+constexpr int64_t kK = 4096;
+constexpr int64_t kN = 4096;
+
+constexpr int64_t kWormholeBanks = 12;
+constexpr int64_t kBlackholeBanks = 8;
+constexpr int64_t kNumIn0Cores = 8;
+constexpr int64_t kWormholeCores = 64;
+constexpr int64_t kBlackholeCores = 110;
+
+TEST(MatmulDRAMShardParams, WormholeBaseline) {
+  auto p = computeShardParams(kM, kK, kN, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // N is padded up to a multiple of tile*banks = 32*12 = 384: 4096 -> 4224,
+  // giving 4224/12 = 352 = 11 tiles of weight per bank.
+  EXPECT_EQ(p->nPadded, 4224);
+  EXPECT_EQ(p->shardW, 352);
+  EXPECT_EQ(p->shardWTiles, 11);
+
+  EXPECT_EQ(p->kTiles, 128);
+  EXPECT_EQ(p->shardH, kK);
+
+  // tt-metal requires M == per_core_M == 1 for the DS config.
+  EXPECT_EQ(p->perCoreM, 1);
+  // per_core_N is the *storage* split: div_up(128 N-tiles, 64 cores).
+  EXPECT_EQ(p->perCoreN, 2);
+
+  // in0_block_w must divide K-per-core (128/8 = 16) and fit the CBs.
+  EXPECT_GT(p->in0BlockW, 0);
+  EXPECT_EQ((kK / 32) / kNumIn0Cores % p->in0BlockW, 0);
+}
+
+// A sub-tile decode batch must still yield per_core_M == 1: tt-metal pads the
+// activation up to one tile row. Truncating M/32 would give 0 here and build a
+// degenerate config.
+TEST(MatmulDRAMShardParams, SubTileBatchRoundsPerCoreMUp) {
+  for (int64_t m : {1, 2, 15, 31, 32}) {
+    auto p = computeShardParams(m, kK, kN, kWormholeBanks, kNumIn0Cores,
+                                kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                                kL1Available);
+    ASSERT_TRUE(p.has_value()) << "M=" << m;
+    EXPECT_EQ(p->perCoreM, 1) << "M=" << m;
+  }
+}
+
+// The bank count changes the weight shard width, which is why it must come from
+// the device rather than a constant: on 8 banks 4096 needs no padding at all.
+TEST(MatmulDRAMShardParams, BlackholeBankCountChangesShardWidth) {
+  auto p = computeShardParams(kM, kK, kN, kBlackholeBanks, kNumIn0Cores,
+                              kBlackholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // 32*8 = 256 already divides 4096, so nPadded == N.
+  EXPECT_EQ(p->nPadded, kN);
+  EXPECT_EQ(p->shardW, 512);
+  EXPECT_EQ(p->shardWTiles, 16);
+  EXPECT_EQ(p->numBanks, kBlackholeBanks);
+  EXPECT_EQ(p->perCoreM, 1);
+}
+
+// bfp4 weight tiles are roughly half the bytes of bfp8, and the weight CB (in1)
+// is the term that dominates the L1 budget, so anywhere bfp8 fits bfp4 must too
+// — and there must be budgets where only bfp4 fits, or the dtype would not be
+// affecting the decision at all.
+//
+// Keep this a sweep. At any single generous budget the chosen in0_block_w is
+// capped at K-per-core for both dtypes, so comparing them there would assert
+// nothing. N is the wide case so the in1 CB dominates the budget.
+//
+// kWideN is 8192 rather than something larger because kMinBlockWidthFraction
+// declines a block width below half of K-per-core: at N=32768 neither dtype can
+// reach in0_block_w=8 within any swept budget, so both return nullopt and the
+// sweep stops discriminating. 8192 still puts in1 in charge of the budget while
+// leaving in0_block_w in the accepted range.
+TEST(MatmulDRAMShardParams, Bfp4NeverFitsWorseThanBfp8) {
+  constexpr int64_t kWideN = 8192;
+  bool sawBfp4OnlyFit = false;
+
+  for (int64_t l1 : {600000, 700000, 800000, 900000, 1000000, 1100000,
+                     static_cast<int>(kL1Available)}) {
+    auto bfp8 =
+        computeShardParams(kM, kK, kWideN, kWormholeBanks, kNumIn0Cores,
+                           kWormholeCores, ttcore::DataType::BFP_BFloat8, l1);
+    auto bfp4 =
+        computeShardParams(kM, kK, kWideN, kWormholeBanks, kNumIn0Cores,
+                           kWormholeCores, ttcore::DataType::BFP_BFloat4, l1);
+    if (bfp8.has_value()) {
+      EXPECT_TRUE(bfp4.has_value()) << "bfp8 fit but bfp4 did not, l1=" << l1;
+      EXPECT_EQ(bfp4->weightDataType, ttcore::DataType::BFP_BFloat4);
+    }
+    if (bfp4.has_value() && !bfp8.has_value()) {
+      sawBfp4OnlyFit = true;
+    }
+  }
+
+  EXPECT_TRUE(sawBfp4OnlyFit)
+      << "no swept budget separated bfp4 from bfp8, so this test is not "
+         "exercising the weight-dtype term of the CB budget any more";
+}
+
+// The fixed CBs (out + interm0) alone exceed a tiny budget, so no in0_block_w
+// can rescue it and the DS path declines rather than emitting a config that
+// would not fit L1.
+TEST(MatmulDRAMShardParams, DeclinesWhenFixedCBsExceedBudget) {
+  auto p = computeShardParams(kM, kK, kN, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              /*l1Available=*/100000);
+  EXPECT_FALSE(p.has_value());
+}
+
+// A wide N inflates the per-bank weight shard and therefore the in1 CB, forcing
+// the search to walk in0_block_w down from K-per-core (16) to something that
+// fits. Keep these assertions unconditional: guarding them behind
+// p.has_value() would let the test pass silently the moment the geometry stops
+// fitting, which is the regression worth catching.
+//
+// N=8192 walks down exactly one divisor, 16 -> 8, which is the widest reduction
+// kMinBlockWidthFraction still accepts. Anything wider is declined instead --
+// see WideNBlockCollapseDeclined.
+TEST(MatmulDRAMShardParams, WideNWalksIn0BlockWDown) {
+  auto p = computeShardParams(kM, kK, /*N=*/8192, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  ASSERT_TRUE(p.has_value());
+
+  // 8192 pads to a multiple of 32*12=384 -> 8448, /12 = 704 = 22 tiles/bank.
+  EXPECT_EQ(p->nPadded, 8448);
+  EXPECT_EQ(p->shardWTiles, 22);
+
+  // The search starts at K-per-core (128/8 = 16) and must come down to fit.
+  EXPECT_LT(p->in0BlockW, 16);
+  EXPECT_EQ(p->in0BlockW, 8);
+
+  // Invariants tt-metal checks regardless of where the search lands.
+  EXPECT_EQ(p->perCoreM, 1);
+  EXPECT_GT(p->in0BlockW, 0);
+  EXPECT_EQ((kK / 32) / kNumIn0Cores % p->in0BlockW, 0);
+  EXPECT_EQ(p->nPadded % (32 * kWormholeBanks), 0);
+}
+
+// Past half of K-per-core the DS path declines instead of emitting the config.
+// N=32768 leaves room only for in0_block_w=2 out of K-per-core=16, i.e. 64
+// block iterations instead of 8.
+TEST(MatmulDRAMShardParams, WideNBlockCollapseDeclined) {
+  auto p = computeShardParams(kM, kK, /*N=*/32768, kWormholeBanks, kNumIn0Cores,
+                              kWormholeCores, ttcore::DataType::BFP_BFloat8,
+                              kL1Available);
+  EXPECT_FALSE(p.has_value());
+}
+
+// The shape that motivated the guard: qwen_2_5_3b's down-projection on an
+// 8-bank part. K=11008 is 344 tiles, so K-per-core is the prime 43 and the only
+// legal block widths are 43 and 1. 43 does not fit, so the search would emit
+// in0_block_w=1 -- 344 serialized blocks instead of 8.
+TEST(MatmulDRAMShardParams, PrimeKPerCoreCollapseDeclined) {
+  constexpr int64_t kBlackholeL1Available = 1400832; // 0.95 * (1572864 - 98304)
+  auto p = computeShardParams(
+      kM, /*K=*/11008, /*N=*/2048, kBlackholeBanks, kNumIn0Cores,
+      kBlackholeCores, ttcore::DataType::BFP_BFloat8, kBlackholeL1Available);
+  EXPECT_FALSE(p.has_value());
+}
+
+// Math fidelity follows the weight dtype. Nothing else pins this: the DS lit
+// tests only FileCheck matmul_program_config, not the compute config.
+class MatmulDRAMComputeConfig : public ::testing::Test {
+protected:
+  void SetUp() override { context.loadDialect<TTNNDialect>(); }
+  mlir::MLIRContext context;
+};
+
+TEST_F(MatmulDRAMComputeConfig, Bfp4RunsLoFi) {
+  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat4);
+  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::LoFi);
+}
+
+TEST_F(MatmulDRAMComputeConfig, Bfp8RunsHiFi2) {
+  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat8);
+  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::HiFi2);
+}
+
+} // namespace


### PR DESCRIPTION
### Ticket

No tracking issue.

### Problem description

`buildComputeConfig` in `lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp` tied the math
fidelity of a DRAM-sharded matmul to its weight dtype: `BFP_BFloat4` weights got LoFi,
everything else got HiFi2. In a decoder layer that split the DRAM-sharded matmuls in half —
the two MLP projections carry `bfp_bf4` and already ran LoFi, while the attention
projections (fused QKV and o_proj) carry `bfp_bf8` and ran HiFi2.

On Blackhole that HiFi2 choice costs real decode throughput, and measurement across 20
models shows it buys nothing that survives at the token level. The weight dtype is a proxy
for "how much precision does this matmul need", and for DRAM-sharded matmuls specifically it
is the wrong proxy.

### What's changed

`buildComputeConfig` now returns `MathFidelity::LoFi` unconditionally for DRAM-sharded
matmuls. Because `weightDataType` was the only reason the function took a parameter, it is
dropped from the signature in
`include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h` and from its single call site,
`MatmulRuleBook::buildDRAMShardingHint` in
`lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp`.

Scope is narrow by construction: only matmuls that receive a
`matmul_multi_core_reuse_multi_cast_dram_sharded_program_config` are affected. Prefill
graphs carry no `compute_config` at all, so they are untouched — confirmed by prefill PCC
being bit-identical across arms in 16 of 17 models on n150.

### Stacking

This branch sits on top of #9247, which integrates the DRAM-sharded matmul path in the first
place and is where the dtype-dependent fidelity this PR removes is introduced. Against
`main` the diff therefore shows #9247's commits as well; the change proper is the single
last commit, `Use LoFi for every DRAM-sharded matmul`. Rebasing once #9247 lands reduces
this to that one commit.

### Measured effect

Controlled A/B in CI on dedicated hardware. Both arms sit on tt-xla `f6a38d652`; arm A is
this change (`f45c2ecf7f` on the branch it was first written on), arm B is its **parent**
`1fad065b83`, so the comparison isolates math fidelity and nothing else.

| Platform | Classic `test_llms.py` | Control group (diff provably cannot touch) |
|---|---|---|
| **p150-perf** (Blackhole) | median **+6.10%**, mean +8.81%, 14/15 positive, max +21.72% | non-LLM n=19: median +0.08%, range −1.46%..+2.46% |
| **qb2-blackhole** (TP, 1x4 mesh) | median **+4.28%**, mean +4.88%, 5/6 positive, max +10.45% | n=15: median +0.01% |
| **n150-perf** (Wormhole) | median +0.15%, mean −0.03%, 7/14 positive | non-LLM n=18: median −0.04%, range −3.28%..+1.38% |

Largest individual gains on p150: `llama_3_2_3b` +21.72%, `falcon3_3b` +21.29%,
`qwen_3_4b` +19.94%, `qwen_2_5_3b` +15.03%, `llama_3_1_8b` +5.99%.

**Wormhole sees no benefit.** This is a Blackhole-family win; on n150 the entire LLM spread
sits inside the control group's noise band. That reproduces the earlier Wormhole finding,
now with 14 models and a control group rather than a single run.

### Why this is not measurement noise

Three independent strands, each checkable from the artifacts:

1. **Built-in control group.** `phi1`, `phi1_5` and `phi2` emit *zero* DRAM-sharded matmuls,
   so this change cannot alter their generated code. They don't move (−0.25%..+0.36%,
   stdev 0.31 pp on a local 20-model sweep) and their decode PCC and TOP1/TOP5 are
   **bit-identical** across arms. On both CI platforms their rel_l2 delta is exactly 0.0%.
2. **Dose-response.** Speedup scales with how many matmuls the change actually flips —
   Spearman **+0.73** across the 17 affected models. `qwen_2_5_0_5b` flips 24 matmuls and
   gains +0.01%; `qwen_3_4b` flips 180 and gains ~+18-20%.
3. **Sign test.** On the local 20-model sweep every one of the 17 affected models got
   faster: 17/17, p = 7.6e-06 against a coin-flip null.

### Accuracy impact

Counting only models the change can touch (no-op models excluded — their delta is zero by
construction and would dilute any median toward zero):

| | n150 (n=14) | p150 (n=12) |
|---|---|---|
| decode PCC worse | 11 | 10 |
| decode PCC median delta | −0.000356 | −0.000263 |
| rel_l2 worse / better | 7 / 7 | 9 / 3 |
| rel_l2 median delta | +4.1% | +6.4% |
| **Models crossing the pass gate** | **0** | **0** |

Gates are 0.90 or 0.94 depending on the test. Observed PCC after the change spans
0.9684–0.9989, leaving every model **4.6–9.6 percentage points above its own gate**. The
largest margin *consumption* anywhere is `qwen_2_5_7b` on n150, which spent 0.0051 of its
0.0735 margin — 7% of available headroom; most models spent under 2%.

**Token-level accuracy is what matters. TOP5 never regresses; TOP1 moves both ways by one to
three tokens out of 64.** Across all 20 models on Blackhole:

| Metric | Identical | Better | Worse |
|---|---|---|---|
| TOP1 | 10 | 3 | 6 |
| TOP5 | 18 | 1 | **0** |

TOP1 is quantised at 1/64 = 1.5625 pp, so every "worse" entry is a one-to-three token
movement, and three models move the other way. The largest single TOP1 loss anywhere is
`llama_3_1_8b` on n150 at −4.69 pp (three tokens) — see the n150 table below.

The two models the continuous metrics flag as risks both come out clean:
`qwen_2_5_7b` (largest PCC loss, −0.005119) is **bit-identical** on TOP1 79.69% and TOP5
89.06%; `qwen_3_4b` (largest rel_l2 growth, +56.7%) loses exactly one token of 64 on TOP1
and nothing on TOP5.

**This is not an accuracy-for-speed dial.** Correlation between throughput gain and rel_l2
growth is Spearman **+0.12** on p150 and **−0.39** on n150 — no meaningful tradeoff. The
models that gain most are not the ones that degrade most: `qwen_3_4b` gains ~+20% while
consuming 0.0002 of margin.

Two models are actively *repaired* by this change: `mistral_7b` and `falcon3_7b`, which have
the worst baseline decode PCC in the n150 set, both improve materially under LoFi (see the
n150 table below). The stock weight-dtype heuristic appears to be picking the wrong fidelity
for those shapes.

For context on absolute levels, the error budget is dominated by weight quantization, not
fidelity. `llama_3_1_8b` sat at rel_l2 0.242 *before* this change. Decomposed under an
independence assumption, LoFi's own contribution is a median 39% of the pre-existing
baseline error, but because errors combine in quadrature the total rises only ~6% median.

#### n150 accuracy, from a repeat-heavy local study

A separate local n150 sweep (8 models, **three** perf repeats and one accuracy run per arm,
bs 32 / ISL 128, tt-mlir `1fad065b83`) adds the Wormhole accuracy picture and one result
that belongs in any review of this change:

| Model | Decode PCC stock | LoFi | Δ PCC | Δ rel_l2 | Δ TOP1 pp |
|---|---|---|---|---|---|
| mistral_7b | 0.989917 | 0.997532 | **+0.007615** | **−31.8%** | +0.00 |
| falcon3_7b | 0.982689 | 0.986149 | **+0.003460** | −7.4% | +0.00 |
| llama_3_1_8b | 0.987597 | 0.987768 | +0.000171 | −5.5% | **−4.69** |
| gemma_2_2b | 0.998786 | 0.998377 | −0.000409 | −1.8% | +3.12 |
| qwen_3_0_6b | 0.995404 | 0.995032 | −0.000372 | −2.5% | +1.56 |
| qwen_3_4b | 0.998643 | 0.998266 | −0.000377 | −3.7% | +1.56 |
| llama_3_2_1b | 0.997863 | 0.997367 | −0.000496 | +5.6% | −1.56 |
| phi2 (null ctrl) | 0.991955 | 0.991955 | +0.000000 | +0.0% | +0.00 |

Prefill is bit-identical across arms for all 8. Every model clears its gate with wide margin.
TOP1 is quantised at 1/64 = 1.5625 pp, so these are one-to-three token movements.

**Two models the stock heuristic was hurting.** `mistral_7b` and `falcon3_7b` have the worst
baseline decode PCC of the set, and both **improve materially** under LoFi (+0.0076 and
+0.0035, rel_l2 −31.8% and −7.4%). That points at the weight-dtype heuristic being wrong for
those shapes, which is an argument *for* this change beyond throughput.

**PCC does not predict token behaviour, in either direction.** `llama_3_1_8b` on n150 has
decode PCC *and* rel_l2 both improving while losing three TOP1 tokens; on p150, `qwen_2_5_7b`
has the worst PCC loss anywhere while being bit-identical on TOP1 and TOP5. Reviewers should
weigh the TOP1/TOP5 tables, not the PCC deltas.

**On throughput, n150 with three repeats confirms no effect** — median +0.23% across affected
models, 4/7 positive, and effect size does not track flip count (unlike Blackhole). Worth
recording that the very first single-run measurement of this change read llama_3_1_8b at
+0.24%; with three repeats the same model on the same code reads **−0.38%**. Single-run
deltas on n150 are not usable, which is why the Blackhole case rests on the control group,
the dose-response and 17/17 sign consistency rather than on any single number.

### Known limitation — this does nothing for vLLM

Reviewers should not merge this expecting production serving gains. **The vLLM path emits
zero DRAM-sharded matmuls**, so the change is structurally incapable of affecting it:

| Graph set | matmuls | DRAM-sharded | 1d | 2d |
|---|---|---|---|---|
| vllm llama-3.1-8b (11 graphs) | 268 | **0** | 140 | 96 |
| vllm qwen3-8b (11 graphs) | 300 | **0** | 156 | 108 |
| vllm **TP** qwen3-32b-qb2-tp (40 graphs) | 2616 | **0** | 952 | 1664 |

Measured vLLM effect matches: p150 median −0.39% (6/20 positive). The paired contrast is
stark — classic `qwen_3_8b` +5.53% vs `vllm_qwen3_8b` −1.96%.

**Why** vLLM declines DRAM-sharded matmuls is unresolved. It is *not* optimization level and
*not* weight dtype: standard vLLM configs use `optimization_level=2` and
`experimental_weight_dtype="bfp_bf8"`, the same as the classic path. The plausible remaining
candidate is the different activation geometry of the paged-attention decode step, but that
is untested. Arguably the larger opportunity is getting vLLM onto DRAM-sharded matmuls at
all.

### Checklist

- [x] New/Existing tests provide coverage for changes

`MatmulDRAMComputeConfig.AlwaysLoFi` in `test/unittests/Optimizer/TestMatmulProgramConfig.cpp`
asserts `buildComputeConfig` returns `MathFidelity::LoFi`. On #9247 that suite pins the
dtype-dependent behaviour instead (`Bfp4RunsLoFi` / `Bfp8RunsHiFi2`); this commit collapses
the two cases into one, so the fidelity contract stays pinned on both sides of the change.

The rest of the DS coverage — `dram_sharded_matmul_eligible_m32.mlir` and siblings
(`_bank_count`, `_reject_batched_weight`, `_reject_multi_tile_m`, `_disabled_option`), and
`test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp` — is unaffected and passes
unchanged.

Note for reviewers: there is an unrelated `buildComputeConfig` overload in
`lib/Dialect/TTNN/Transforms/Fusing/RoPEFusingPattern.cpp`. The signature change here
touches only the matmul one declared in
`include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h`.

### Reproduction

All six CI runs are `Performance Benchmark` workflow dispatches on tt-xla
`f6a38d652`, branch `bmalesevic/temp-dram-matmul-benchmark`, differing only in
`mlir_override`:

| Platform | Arm B — clean (`mlir_override=1fad065b83`) | Arm A — LoFi (`mlir_override=f45c2ecf7f`) |
|---|---|---|
| n150-perf | 32243412436 | 32674116770 |
| p150-perf | 32243026910 | 32674137429 |
| qb2-blackhole | 32239926886 | 32674159945 |

`f45c2ecf7f`'s parent **is** `1fad065b83`, so no other tt-mlir change sits between the arms.

The TOP1/TOP5 figures come from a local 20-model sweep run with the change applied by hand
before it was committed. That build was verified equivalent to the committed one by
comparing decode PCC and rel_l2 per model per arm against CI p150: **32/32 bit-exact
matches**, every digit, both arms. Two independent toolchain builds producing identical
numerics.

### Caveats worth stating

- One run per arm per platform in CI; no repeats. The control groups are what make single
  runs interpretable. CI noise is wider than a quiet local box (±1–3% from the non-LLM
  controls).
- Coverage is asymmetric — both arms had unrelated pre-existing failures, so some models
  appear on only one side and are excluded from the comparison.
- `ministral_8b` fails on **both** arms (`to_layout does not support device to device
  typecast for input layout: ROW_MAJOR`) — a pre-existing Blackhole bringup limitation, not
  a regression from this change.
- qb2 carries a large flake: `vllm_tp_benchmark[qwen3-32b-qb2-tp]` reads +52.32%, which
  cannot be caused by this change (that graph set has zero DRAM-sharded matmuls). Single qb2
  runs can be off by tens of percent; medians are quoted throughout for this reason.
- On n150, three vLLM jobs failed only under LoFi with
  `TT_THROW @ system_memory_manager.cpp:765` (a dispatch-level fault) while `mistral_7b`
  failed only under clean. That two-way asymmetry with an infra-shaped error reads as
  flakiness rather than a regression, but it is not ruled out.
- The measurements above were taken on `f45c2ecf7f`, the commit as first written. The commit
  on this branch is a rebase of it onto #9247 and is byte-identical in effect; it has not
  been re-benchmarked.
