### PR TITLE
[Optimizer] Leave the DRAM-sharded matmul compute config to tt-metal

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h
@@ -89,12 +89,6 @@ MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfigAttr
 buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
                               UnaryWithParamAttr fusedAct);
 
-// Build the compute-kernel config for a DRAM-sharded matmul (math fidelity
-// follows the weight dtype; bf16 partials through the packer, with
-// packer-L1-accumulate enabled).
-DeviceComputeKernelConfigAttr
-buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType);
-
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_MATMULPROGRAMCONFIG_H

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -468,22 +468,4 @@ buildDRAMShardedProgramConfig(MLIRContext *ctx, const DRAMShardParams &p,
       ctx, p.in0BlockW, p.perCoreM, p.perCoreN, fusedAct);
 }
 
-DeviceComputeKernelConfigAttr
-buildComputeConfig(MLIRContext *ctx, ttcore::DataType weightDataType) {
-  // bfp4 weights run at LoFi, bfp8 at HiFi2 — the split models are observed to
-  // need in practice, rather than a rule derived from the formats.
-  MathFidelity fidelity = (weightDataType == ttcore::DataType::BFP_BFloat4)
-                              ? MathFidelity::LoFi
-                              : MathFidelity::HiFi2;
-  return DeviceComputeKernelConfigAttr::get(
-      ctx,
-      /*mathFidelity=*/fidelity,
-      /*mathApproxMode=*/mlir::BoolAttr{},
-      // bf16 partials through the packer are what tt-metal defaults a
-      // bf16-output matmul to.
-      /*fp32DestAccEn=*/mlir::BoolAttr::get(ctx, false),
-      /*packerL1Acc=*/mlir::BoolAttr::get(ctx, true),
-      /*dstFullSyncEn=*/mlir::BoolAttr{});
-}
-
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
+++ b/lib/Dialect/TTNN/Analysis/MatmulProgramConfig.cpp
@@ -305,15 +305,19 @@ generateMatmulProgramConfig(Operation *op, TTNNLayoutAttr outputLayout) {
 
 static constexpr int64_t kTileSize = 32;
 
-// Smallest in0_block_w the DS path will accept, as a divisor of kPerCore: the
-// fitted block width must be at least kPerCore / kMinBlockWidthFraction.
+// Smallest in0_block_w the DS path will accept. Below it the per-bank read
+// burst is too short to keep the bank busy and the 1D/2D mcast configs win
+// instead.
 //
-// The kernel's block loop runs num_blocks = kTiles / in0_block_w rounds of
-// mcast + compute, so a width the L1 budget forced below kPerCore costs
-// proportionally more. Below half of kPerCore the DS config is a loss against
-// the 1D/2D mcast configs it would replace. A policy number, determined
-// experimentally on p150, not derived.
-static constexpr int64_t kMinBlockWidthFraction = 2;
+// An absolute floor rather than a fraction of kPerCore: measured at matched
+// math fidelity, the cost tracks the block width itself, not its ratio to
+// kPerCore. A calibrated policy number, determined experimentally, and the two
+// architectures do not quite agree on it -- Blackhole's knee sits higher than
+// Wormhole's, so this is the more permissive of the two.
+//
+// A shape whose kPerCore is below this floor can never satisfy it, so DS is
+// declined for it outright. That is intended.
+static constexpr int64_t kMinBlockWidth = 3;
 
 static int64_t padToDRAMBanks(int64_t n, int64_t numBanks) {
   int64_t lcm = kTileSize * numBanks;
@@ -417,10 +421,8 @@ computeShardParams(int64_t M, int64_t K, int64_t N, int64_t numBanks,
     return std::nullopt;
   }
 
-  // Decline rather than emit a degenerate block width. Falling back to the
-  // 1D/2D mcast configs is measurably better than a DS config whose block loop
-  // has been stretched out by L1 pressure (see kMinBlockWidthFraction).
-  if (p.in0BlockW * kMinBlockWidthFraction < kPerCore) {
+  // Decline rather than emit a degenerate block width (see kMinBlockWidth).
+  if (p.in0BlockW < kMinBlockWidth) {
     return std::nullopt;
   }
 

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -17,6 +17,8 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 #include <cmath>
@@ -266,6 +268,54 @@ static std::optional<DSDeviceContext> getDSDeviceContext(Operation *op) {
       l1Available};
 }
 
+// TTNN collectives. None of them implements the op-model interface: every one
+// carries OpModelExempt because tt-metal exposes no constraint or runtime query
+// for it (tt-mlir#4392, "MissingMetalDefinition").
+static bool isCCLOp(Operation *op) {
+  return mlir::isa<AllGatherOp, AllReduceOp, AllReduceAsyncOp, ReduceScatterOp,
+                   PointToPointOp>(op);
+}
+
+// Ops that hand their operand on unchanged for the purpose of finding the
+// consumer that actually constrains the producer's layout. Mirrors the
+// view-like set in TTNNActivationDtypeLowering, plus ToLayoutOp: a layout cast
+// does not re-establish a layout the collective would accept, it just moves the
+// reconciliation one op further down.
+static bool isLayoutForwardingOp(Operation *op) {
+  return mlir::isa<ReshapeOp, SliceStaticOp, ToMemoryConfigOp, ToLayoutOp>(op);
+}
+
+// Whether this op's result reaches a collective without passing through an op
+// that establishes a layout of its own.
+//
+// Declining DS here is a policy call, not a correctness one. The optimizer can
+// cost the matmul but not the collective behind it, so it will happily pick a
+// DRAM-sharded output and leave the mismatch to an inserted ToMemoryConfigOp --
+// which then sits on the collective's critical path. Measured on qb2 (Blackhole
+// TP=4) that reshard costs 49-71 us per op on the row-parallel down projections
+// of llama_3_1_70b and qwen_2_5_coder_32b, against 10 us where the same flip
+// lands on a column-parallel gate/up with no collective behind it, and a net
+// throughput gain on single-chip p150 where there is no collective at all.
+// Until the CCLs are costable, do not offer DS into one.
+static bool resultFeedsCCL(Operation *op) {
+  llvm::SmallVector<Operation *, 8> worklist(op->getUsers().begin(),
+                                             op->getUsers().end());
+  llvm::SmallPtrSet<Operation *, 8> seen;
+  while (!worklist.empty()) {
+    Operation *user = worklist.pop_back_val();
+    if (!seen.insert(user).second) {
+      continue;
+    }
+    if (isCCLOp(user)) {
+      return true;
+    }
+    if (isLayoutForwardingOp(user)) {
+      worklist.append(user->getUsers().begin(), user->getUsers().end());
+    }
+  }
+  return false;
+}
+
 // Everything the DS path derives from an op: the operand types and the shard
 // geometry.
 //
@@ -300,6 +350,18 @@ static std::optional<DSPlan> buildDSPlan(Operation *op) {
   if (!ttnn::utils::isDRAMShardedMatmulEnabled(op)) {
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): enable-dram-sharded-matmul is off",
+                 opName);
+    return std::nullopt;
+  }
+
+  // Same choke point, same reasoning: the optimizer has no op model for
+  // collectives, so it cannot weigh a DRAM-sharded output against what the
+  // collective needs and the mismatch becomes an inserted reshard on the
+  // collective's critical path. See resultFeedsCCL.
+  if (resultFeedsCCL(op)) {
+    TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
+                 "DS declined ({0}): result feeds a collective, which the "
+                 "optimizer cannot cost",
                  opName);
     return std::nullopt;
   }
@@ -349,8 +411,8 @@ static std::optional<DSPlan> buildDSPlan(Operation *op) {
       getWeightLayout(weight).getDataType(), device->l1Available);
   if (!params) {
     // Either no in0_block_w dividing K-per-core leaves room for the circular
-    // buffers, or the largest one that does is a degenerate fraction of
-    // K-per-core (see kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+    // buffers, or the largest one that does is below the accepted floor (see
+    // kMinBlockWidth in MatmulProgramConfig.cpp).
     TTMLIR_DEBUG(ttmlir::LogComponent::GreedyOptimizer,
                  "DS declined ({0}): no in0_block_w both fits L1 and avoids a "
                  "degenerate block count (M={1} K={2} "

--- a/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/MatmulRules.cpp
@@ -431,9 +431,14 @@ MatmulRuleBook::buildDRAMShardingHint(Operation *op) const {
   // that carries one, so the op model validates the DS config without it.
   UnaryWithParamAttr fusedAct;
   auto progConfig = buildDRAMShardedProgramConfig(ctx, p, fusedAct);
-  auto computeConfig = buildComputeConfig(ctx, p.weightDataType);
 
-  return OpConfig(l1OutLayout, MatmulAttrs{progConfig, computeConfig});
+  // No compute-kernel config, matching every other matmul the optimizer emits:
+  // math fidelity, fp32 dest-accumulate and packer-L1-accumulate are left to
+  // tt-metal's defaults. It derives them from the program config and the output
+  // dtype, and leaving them unset is also what lets the global
+  // compute-kernel-config pipeline options reach a DS matmul at all --
+  // TTNNSetComputeKernelConfig only fills knobs the op has not already set.
+  return OpConfig(l1OutLayout, MatmulAttrs{progConfig, std::nullopt});
 }
 
 // ============================================================================

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_m32.mlir
@@ -12,6 +12,11 @@
 
 module attributes {} {
   // CHECK-LABEL: func.func @ds_matmul_m32
+  // No compute-kernel config, same as every other matmul the optimizer emits:
+  // math fidelity and the accumulate knobs are tt-metal's to derive. Scoped
+  // ahead of the program config because compute_config would sort before it in
+  // the attribute dictionary.
+  // CHECK-NOT: compute_config
   // CHECK: matmul_program_config = #ttnn.matmul_multi_core_reuse_multi_cast_dram_sharded_program_config
   // CHECK-SAME: per_core_m = 1
   func.func @ds_matmul_m32(

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_no_ccl_consumer.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_eligible_no_ccl_consumer.mlir
@@ -1,0 +1,21 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole enable-dram-sharded-matmul=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// Control for dram_sharded_matmul_reject_ccl_consumer: the identical shape with
+// an ordinary consumer still takes the DS path, so the decline there is
+// attributable to the collective and not to the geometry.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_no_ccl
+  // CHECK: "ttnn.matmul"
+  // CHECK-SAME: dram_sharded_program_config
+  func.func @ds_matmul_no_ccl(
+      %act: tensor<32x7168xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<7168x8192xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>},
+      %other: tensor<32x8192xbf16> {ttcore.argument_type = #ttcore.argument_type<input>}) -> tensor<32x8192xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x7168xbf16>, tensor<7168x8192xbf16>) -> tensor<32x8192xbf16>
+    %1 = "ttir.multiply"(%0, %other) : (tensor<32x8192xbf16>, tensor<32x8192xbf16>) -> tensor<32x8192xbf16>
+    return %1 : tensor<32x8192xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_block_collapse.mlir
@@ -2,14 +2,15 @@
 // RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole enable-dram-sharded-matmul=true" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// The DS path declines when the CB budget collapses in0_block_w (see
-// kMinBlockWidthFraction in MatmulProgramConfig.cpp).
+// The DS path declines when the CB budget collapses in0_block_w below
+// kMinBlockWidth (see MatmulProgramConfig.cpp).
 //
 // K = 11008 is 344 tiles, so K-per-core is 344/8 = 43 -- a prime, leaving 43 and
 // 1 as the only legal block widths. On an 8-bank part the in1 CB at in0_block_w
 // = 43 needs ~1.35 MB against a ~1.30 MB budget, so the search would otherwise
 // settle on in0_block_w = 1: 344 serialized mcast+compute rounds instead of 8.
-// That shape is qwen_2_5_3b's down-projection, measured at -28.1% e2e on p150.
+// That shape is qwen_2_5_3b's down-projection. in0_block_w = 1 is the one width
+// whose cost does not move with math fidelity on either architecture.
 //
 // Blackhole specifically: with 12 banks the per-bank weight shard is narrower, the
 // in1 CB fits at in0_block_w = 43, and the collapse never happens -- which is why

--- a/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_ccl_consumer.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/dram_sharded_matmul_reject_ccl_consumer.mlir
@@ -1,0 +1,34 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2 experimental-weight-dtype=bfp_bf8 mock-system-desc-arch=blackhole enable-dram-sharded-matmul=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// The DS path declines when the matmul result feeds a collective.
+//
+// No CCL implements the op-model interface -- they all carry OpModelExempt
+// because tt-metal exposes no constraint query for them (tt-mlir#4392). The
+// optimizer can therefore cost the matmul but not the collective behind it, so
+// a DRAM-sharded output is chosen on the matmul's own merits and the layout
+// mismatch is left to an inserted ToMemoryConfigOp sitting on the collective's
+// critical path.
+//
+// The shape is llama_3_1_70b's row-parallel down projection under TP=4:
+// K = 7168 is 224 tiles, so K-per-core is 224/8 = 28 and the fitted
+// in0_block_w is 7 -- comfortably above kMinBlockWidth, i.e. this op is
+// declined for its consumer, not for its geometry. Measured on qb2 the reshard
+// costs ~71 us per op across the 80 layers.
+//
+// As with the other declines, the matmul must still get *some* program config;
+// falling back to the 1D/2D mcast configs is the point.
+
+module attributes {} {
+  // CHECK-LABEL: func.func @ds_matmul_feeds_all_reduce
+  // CHECK: "ttnn.matmul"
+  // CHECK-NOT: dram_sharded_program_config
+  func.func @ds_matmul_feeds_all_reduce(
+      %act: tensor<32x7168xbf16> {ttcore.argument_type = #ttcore.argument_type<input>},
+      %weight: tensor<7168x8192xbf16> {ttcore.argument_type = #ttcore.argument_type<parameter>}) -> tensor<32x8192xbf16> {
+    %0 = "ttir.matmul"(%act, %weight) : (tensor<32x7168xbf16>, tensor<7168x8192xbf16>) -> tensor<32x8192xbf16>
+    %1 = "ttir.all_reduce"(%0) <{cluster_axis = 0 : ui32, reduce_type = #ttcore.reduce_type<sum>}> : (tensor<32x8192xbf16>) -> tensor<32x8192xbf16>
+    return %1 : tensor<32x8192xbf16>
+  }
+}

--- a/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
+++ b/test/unittests/Optimizer/TestDRAMShardedMatmulEligibility.cpp
@@ -129,6 +129,36 @@ public:
     return op;
   }
 
+  // A matmul whose result is consumed by a collective rather than returned
+  // directly. The DS path declines these: no CCL implements the op-model
+  // interface (they all carry OpModelExempt, tt-mlir#4392), so the optimizer
+  // cannot weigh a DRAM-sharded output against what the collective needs and
+  // the mismatch becomes an inserted reshard on the collective's critical path.
+  MatmulOp buildMatmulFeedingAllReduce(llvm::ArrayRef<int64_t> actShape,
+                                       llvm::ArrayRef<int64_t> weightShape,
+                                       llvm::ArrayRef<int64_t> outShape,
+                                       ttcore::DataType weightDt) {
+    auto actType = tensorOf(actShape, ttcore::DataType::BFloat16);
+    auto weightType = tensorOf(weightShape, weightDt);
+    auto outType = tensorOf(outShape, ttcore::DataType::BFloat16);
+    mlir::Block *block = openFunc({actType, weightType}, outType);
+    auto op = builder.create<MatmulOp>(
+        builder.getUnknownLoc(), outType, block->getArgument(0),
+        block->getArgument(1), /*transpose_a=*/false, /*transpose_b=*/false,
+        /*matmul_program_config=*/mlir::Attribute(),
+        /*activation=*/mlir::StringAttr());
+    auto allReduce = builder.create<AllReduceOp>(
+        builder.getUnknownLoc(), outType, op.getResult(),
+        ttcore::ReduceTypeAttr::get(&context, ttcore::ReduceType::Sum),
+        /*cluster_axis=*/builder.getUI32IntegerAttr(0),
+        /*sub_device_id=*/mlir::IntegerAttr(),
+        /*num_links=*/mlir::IntegerAttr(),
+        /*topology=*/ttcore::TopologyAttr());
+    builder.create<mlir::func::ReturnOp>(builder.getUnknownLoc(),
+                                         allReduce.getResult());
+    return op;
+  }
+
   LinearOp buildLinear(llvm::ArrayRef<int64_t> actShape,
                        llvm::ArrayRef<int64_t> weightShape,
                        llvm::ArrayRef<int64_t> outShape,
@@ -195,6 +225,17 @@ TEST_F(DRAMShardedEligibilityTest, MatmulEligible) {
   auto op = buildMatmul({32, 4096}, {4096, 4096}, {32, 4096},
                         ttcore::DataType::BFP_BFloat8);
   EXPECT_TRUE(isDSEligible(op, {32, 4096}));
+}
+
+// The same decode-shaped projection that is eligible above is declined once its
+// result feeds a collective. Pairs with MatmulEligible as the control: the only
+// difference between the two is the consumer, so the decline is attributable to
+// the CCL and not to the geometry. See optimizer/dram_sharded_matmul_
+// reject_ccl_consumer.mlir for the end-to-end version.
+TEST_F(DRAMShardedEligibilityTest, MatmulFeedingCollectiveDeclined) {
+  auto op = buildMatmulFeedingAllReduce({32, 4096}, {4096, 4096}, {32, 4096},
+                                        ttcore::DataType::BFP_BFloat8);
+  EXPECT_FALSE(isDSEligible(op, {32, 4096}));
 }
 
 // A bias-free ttnn.linear is the same computation the DS kernel implements, so

--- a/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
+++ b/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
@@ -5,19 +5,15 @@
 #include "ttmlir/Dialect/TTNN/Analysis/MatmulProgramConfig.h"
 
 #include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
-#include "ttmlir/Dialect/TTNN/IR/TTNN.h"
-
-#include "mlir/IR/MLIRContext.h"
 
 #include "gtest/gtest.h"
 
 using namespace mlir::tt;
 using namespace mlir::tt::ttnn;
 
-// These tests pin the DRAM-sharded shard geometry and compute-kernel config,
-// which nothing else in the tree covers. computeShardParams is pure arithmetic
-// over the matmul dims and the L1 budget, so most of them need no MLIRContext
-// and no device.
+// computeShardParams is pure arithmetic over the matmul dims and the L1 budget,
+// so it needs no MLIRContext and no device. These tests pin the DRAM-sharded
+// shard geometry, which nothing else in the tree covers.
 namespace {
 
 // Wormhole-ish L1 budget: 0.95 * usable L1 (1499136).
@@ -188,24 +184,6 @@ TEST(MatmulDRAMShardParams, PrimeKPerCoreCollapseDeclined) {
       kM, /*K=*/11008, /*N=*/2048, kBlackholeBanks, kNumIn0Cores,
       kBlackholeCores, ttcore::DataType::BFP_BFloat8, kBlackholeL1Available);
   EXPECT_FALSE(p.has_value());
-}
-
-// Math fidelity follows the weight dtype. Nothing else pins this: the DS lit
-// tests only FileCheck matmul_program_config, not the compute config.
-class MatmulDRAMComputeConfig : public ::testing::Test {
-protected:
-  void SetUp() override { context.loadDialect<TTNNDialect>(); }
-  mlir::MLIRContext context;
-};
-
-TEST_F(MatmulDRAMComputeConfig, Bfp4RunsLoFi) {
-  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat4);
-  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::LoFi);
-}
-
-TEST_F(MatmulDRAMComputeConfig, Bfp8RunsHiFi2) {
-  auto cfg = buildComputeConfig(&context, ttcore::DataType::BFP_BFloat8);
-  EXPECT_EQ(cfg.getMathFidelity(), MathFidelity::HiFi2);
 }
 
 } // namespace

--- a/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
+++ b/test/unittests/Optimizer/TestMatmulProgramConfig.cpp
@@ -93,17 +93,18 @@ TEST(MatmulDRAMShardParams, BlackholeBankCountChangesShardWidth) {
 // capped at K-per-core for both dtypes, so comparing them there would assert
 // nothing. N is the wide case so the in1 CB dominates the budget.
 //
-// kWideN is 8192 rather than something larger because kMinBlockWidthFraction
-// declines a block width below half of K-per-core: at N=32768 neither dtype can
-// reach in0_block_w=8 within any swept budget, so both return nullopt and the
-// sweep stops discriminating. 8192 still puts in1 in charge of the budget while
-// leaving in0_block_w in the accepted range.
+// kWideN is 8192 rather than something larger so in1 still dominates the budget
+// while in0_block_w stays above kMinBlockWidth. The budgets reach down to
+// 425000 because that is where the dtype term separates the two: below it
+// bfp8's fitted width falls under the floor and is declined while bfp4 still
+// reaches 4. Above ~600000 both dtypes clear the floor, so a sweep that starts
+// there asserts nothing about the weight-dtype term.
 TEST(MatmulDRAMShardParams, Bfp4NeverFitsWorseThanBfp8) {
   constexpr int64_t kWideN = 8192;
   bool sawBfp4OnlyFit = false;
 
-  for (int64_t l1 : {600000, 700000, 800000, 900000, 1000000, 1100000,
-                     static_cast<int>(kL1Available)}) {
+  for (int64_t l1 : {425000, 500000, 600000, 700000, 800000, 900000, 1000000,
+                     1100000, static_cast<int>(kL1Available)}) {
     auto bfp8 =
         computeShardParams(kM, kK, kWideN, kWormholeBanks, kNumIn0Cores,
                            kWormholeCores, ttcore::DataType::BFP_BFloat8, l1);
@@ -141,8 +142,8 @@ TEST(MatmulDRAMShardParams, DeclinesWhenFixedCBsExceedBudget) {
 // fitting, which is the regression worth catching.
 //
 // N=8192 walks down exactly one divisor, 16 -> 8, which is the widest reduction
-// kMinBlockWidthFraction still accepts. Anything wider is declined instead --
-// see WideNBlockCollapseDeclined.
+// kMinBlockWidth still accepts. Anything wider is declined instead -- see
+// WideNBlockCollapseDeclined.
 TEST(MatmulDRAMShardParams, WideNWalksIn0BlockWDown) {
   auto p = computeShardParams(kM, kK, /*N=*/8192, kWormholeBanks, kNumIn0Cores,
                               kWormholeCores, ttcore::DataType::BFP_BFloat8,


### PR DESCRIPTION
### Ticket

No tracking issue.

### Problem description

The DRAM-sharded (DS) matmul was the only matmul the compiler gave a compute-kernel config:
HiFi2 for bfp8 weights, LoFi for bfp4, `packer_l1_acc` on, `fp32_dest_acc_en` off. Every other
matmul leaves those knobs to tt-metal, and because `TTNNSetComputeKernelConfig` only fills
knobs an op has not set, the compute-config pipeline options never reached a DS matmul. On
Blackhole the HiFi2 half is the whole of the DS decode regression.

### What's changed

A DS matmul emits no compute config any more. tt-metal derives LoFi for it (`increase_fidelity`
is false whenever a program config is set), with `packer_l1_acc` on and `fp32_dest_acc_en` off
as before, so the only behavioural change is bfp8-weight DS matmuls running at LoFi, and
`--math-fidelity`, `--fp32-dest-acc-en` and `--packer-l1-acc` now apply to them like any other
matmul.

DS is also declined where it does not pay off: when the fitted `in0_block_w` is below 3 tiles
(an absolute floor replacing the K-per-core/2 ratio, since the cost tracks the block width
itself), and when the matmul result feeds a collective, because no collective has an op model
and the optimizer cannot cost the reshard it would put on the collective's critical path. Both
are measured in the commit message.

Stacked on #9247. #9251 is the alternative that pins LoFi explicitly; one of the two should land.

### Measured effect

tt-xla manual-benchmark, bs 32 / ISL 128, samples/s, three tt-mlir states on tt-xla
`99aa9267ef`: DS off (main `2e003b00`), DS with the pinned config (`7d8f8f59`, the #9247 branch
of 2026-08-31, HiFi2 in the dumps) and DS with no config (`ea2b27a3`, the same plus the
compute-config commit; the two commits between them touch tests and comments only). Runs
from 2026-08-31 and 2026-09-01. The branches have since gained the optimization-level-2 gate,
which takes DS away from the level-1 models `qwen_2_5_1_5b` and `qwen_2_5_7b`, the activation
fusing onto binary consumers, the `in0_block_w` floor and the collective decline, and a rebase
over 164 main commits with a tt-metal uplift, so the per-model numbers describe that state,
not the current heads. The pinned-to-no-config contrast isolates the fidelity change either way.

| Platform | DS off → pinned | DS off → no config | pinned → no config (this PR) |
|---|---|---|---|
| n150 (17 models) | mean +3.54% | mean +3.51% | mean −0.04%, median −0.15%, 7/17 positive, all within ±2.4% |
| p150 (20 models) | mean −2.83% | mean +5.53% | mean +8.83%, median +8.06%, 18/20 positive, max +21.98% |
| qb2 TP 1x4 (7 models) | mean +0.77% | mean +5.48% | mean +4.74%, median +1.91%, 7/7 positive |

Wormhole is indifferent to the config. On Blackhole the pinned config was the DS regression: the
models that lost most with it gain most without it (`falcon3_3b` −8.4% → +11.7%, `qwen_3_4b`
−9.8% → +7.9%, `falcon3_1b` −10.6% → +4.9%, `qwen_2_5_3b` −10.7% → +1.2%). `phi1`, `phi1_5` and
`phi2` emit no DS matmul and move by at most 2.2%, which bounds the noise; the two p150 models
that moved less than that, `qwen_2_5_7b` and `qwen_2_5_0_5b`, carry the fewest DS matmuls.

Accuracy was checked on an earlier A/B of the same fidelity change (`f45c2ecf7f` against its
parent) and a local n150 sweep: no model crossed its PCC gate, TOP5 never regressed and TOP1
moved by one to three tokens of 64 in both directions. Those runs are not linked here.

<details><summary>Per-model samples/s</summary>

- n150: DS off [#2587](https://github.com/tenstorrent/tt-xla/actions/runs/33447377825), pinned [#2584](https://github.com/tenstorrent/tt-xla/actions/runs/33447202838), no config [#2590](https://github.com/tenstorrent/tt-xla/actions/runs/33568953567)
- p150: DS off [#2588](https://github.com/tenstorrent/tt-xla/actions/runs/33447408069), pinned [#2585](https://github.com/tenstorrent/tt-xla/actions/runs/33447231211), no config [#2591](https://github.com/tenstorrent/tt-xla/actions/runs/33568991894)
- qb2: DS off [#2589](https://github.com/tenstorrent/tt-xla/actions/runs/33447429748), pinned [#2586](https://github.com/tenstorrent/tt-xla/actions/runs/33447256892), no config [#2592](https://github.com/tenstorrent/tt-xla/actions/runs/33569025516)

```
n150
model           DS off   pinned   no cfg  off→pin   off→no   pin→no  DS matmuls
qwen_2_5_3b      29.52    29.69    30.12    +0.57    +2.02    +1.45  288
llama_3_2_3b     29.28    29.89    30.25    +2.08    +3.29    +1.18  280
qwen_3_1_7b      35.19    36.03    36.40    +2.39    +3.45    +1.04  280
qwen_2_5_1_5b    35.45    44.28    44.64   +24.92   +25.92    +0.80  224
llama_3_2_1b     62.89    63.33    63.66    +0.69    +1.23    +0.53  160
gemma_1_1_2b     37.48    38.30    38.37    +2.18    +2.36    +0.18  180
qwen_2_5_0_5b    69.14    68.28    68.36    -1.24    -1.12    +0.12  48
falcon3_1b       53.12    53.00    52.95    -0.23    -0.32    -0.09  180
phi1             19.82    19.79    19.76    -0.14    -0.29    -0.15  0
falcon3_3b       34.91    36.09    36.03    +3.40    +3.22    -0.17  220
qwen_2_5_7b      16.01    18.14    18.11   +13.30   +13.10    -0.18  56
phi1_5           19.92    19.91    19.87    -0.01    -0.24    -0.23  0
phi2              7.86     7.90     7.88    +0.56    +0.31    -0.24  0
mistral_7b       19.10    19.54    19.44    +2.31    +1.79    -0.51  128
falcon3_7b       18.06    18.23    18.10    +0.92    +0.18    -0.73  112
qwen_3_4b        21.75    22.62    22.35    +4.00    +2.75    -1.21  360
qwen_3_0_6b      47.28    49.38    48.20    +4.45    +1.95    -2.39  280

p150
model           DS off   pinned   no cfg  off→pin   off→no   pin→no  DS matmuls
falcon3_3b       64.97    59.50    72.57    -8.42   +11.71   +21.98  220
llama_3_2_3b     52.13    48.50    58.93    -6.96   +13.06   +21.51  280
qwen_3_4b        40.38    36.42    43.56    -9.81    +7.87   +19.60  360
falcon3_1b      101.39    90.60   106.37   -10.63    +4.91   +17.40  180
llama_3_2_1b    118.88   110.83   128.26    -6.78    +7.89   +15.73  160
qwen_2_5_3b      56.95    50.86    57.63   -10.70    +1.19   +13.32  216
qwen_3_1_7b      63.84    61.98    70.04    -2.92    +9.71   +13.01  280
qwen_2_5_1_5b    61.05    68.97    76.83   +12.97   +25.86   +11.41  224
ministral_8b     29.35    29.27    31.99    -0.27    +9.01    +9.30  144
llama_3_1_8b     36.79    35.22    38.24    -4.26    +3.94    +8.56  256
gemma_1_1_2b     75.36    72.44    77.92    -3.87    +3.39    +7.56  108
mistral_7b       33.18    34.05    36.23    +2.63    +9.19    +6.39  128
qwen_3_0_6b      92.68    89.66    93.76    -3.26    +1.17    +4.57  280
falcon3_7b       35.45    34.67    35.71    -2.22    +0.73    +3.02  112
qwen_3_8b        29.93    29.54    30.38    -1.29    +1.53    +2.85  144
qwen_2_5_0_5b   126.60   128.48   130.79    +1.48    +3.31    +1.80  48
qwen_2_5_7b      27.38    26.08    26.40    -4.75    -3.58    +1.24  56
phi2             19.54    19.81    19.85    +1.35    +1.56    +0.21  0
phi1_5           35.99    36.27    36.02    +0.77    +0.07    -0.69  0
phi1             36.07    36.15    35.36    +0.22    -1.96    -2.17  0

qb2
model                                    DS off   pinned   no cfg  off→pin   off→no   pin→no  DS matmuls
falcon3_7b_tp_qb2                         56.59    56.18    62.04    -0.72    +9.63   +10.43  224
mistral_small_24b_instruct_2501_tp_qb2    29.65    29.42    32.19    -0.78    +8.58    +9.43  240
falcon3_10b_tp_qb2                        41.80    41.35    44.77    -1.07    +7.11    +8.27  320
qwen_2_5_coder_32b_instruct_tp_qb2        17.38    17.64    17.98    +1.51    +3.45    +1.91  384
llama_3_1_8b_instruct_tp_qb2              51.57    50.24    51.11    -2.58    -0.90    +1.73  320
llama_3_1_70b_tp_qb2                      11.90    12.91    13.08    +8.43    +9.88    +1.34  640
gpt_oss_20b_tp_batch_size_1_qb2           21.26    21.38    21.39    +0.58    +0.61    +0.04  96
```

</details>

### Checklist

- [x] New/Existing tests provide coverage for changes. `dram_sharded_matmul_eligible_m32.mlir`
  asserts `CHECK-NOT: compute_config` and fails against a #9247 build; `MatmulDRAMComputeConfig`
  goes with the function it covered; `dram_sharded_matmul_reject_ccl_consumer.mlir`, its control
  `dram_sharded_matmul_eligible_no_ccl_consumer.mlir` and `MatmulFeedingCollectiveDeclined` cover
  the collective decline; `Bfp4NeverFitsWorseThanBfp8` sweeps budgets down to where the floor
  separates the dtypes.
- [x] Perf benchmarks: the nine runs above.
