### PR TITLE
Notify  TT_FATAL changes in metal train ops

### DIFF
--- a/.github/scripts/tt_fatal_diff.py
+++ b/.github/scripts/tt_fatal_diff.py
@@ -187,14 +187,58 @@ def mrkdwn_escape(s):
     return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def excerpt(call, limit=140):
-    """One-line, escaped, truncated body of a TT_FATAL call for Slack."""
-    s = re.sub(r"^TT_FATAL\s*\(\s*", "", normalize(call))
-    if s.endswith(")"):
-        s = s[:-1].rstrip()
-    s = s.replace("`", "'")
+def top_level_args(call):
+    """Split the body of a TT_FATAL call into its top-level arguments."""
+    body = re.sub(r"^TT_FATAL\s*\(\s*", "", normalize(call))
+    if body.endswith(")"):
+        body = body[:-1].rstrip()
+    parts = []
+    cur = []
+    depth = 0
+    i = 0
+    n = len(body)
+    while i < n:
+        c = body[i]
+        if c == '"' or c == "'":
+            quote = c
+            cur.append(c)
+            i += 1
+            while i < n:
+                cur.append(body[i])
+                if body[i] == "\\":
+                    i += 1
+                    if i < n:
+                        cur.append(body[i])
+                elif body[i] == quote:
+                    break
+                i += 1
+        elif c in "([{":
+            depth += 1
+            cur.append(c)
+        elif c in ")]}":
+            depth -= 1
+            cur.append(c)
+        elif c == "," and depth == 0:
+            parts.append("".join(cur).strip())
+            cur = []
+        else:
+            cur.append(c)
+        i += 1
+    if cur:
+        parts.append("".join(cur).strip())
+    return parts
+
+
+def excerpt(call, limit=90):
+    """Short link label for Slack: the condition (plus message if trivial)."""
+    parts = top_level_args(call)
+    s = parts[0] if parts else normalize(call)
+    if len(s) < 16 and len(parts) > 1:
+        s = f"{s}, {parts[1]}"
     if len(s) > limit:
         s = s[: limit - 1] + "…"
+    # "|" would terminate the Slack link label.
+    s = s.replace("|", "¦")
     return mrkdwn_escape(s)
 
 
@@ -208,16 +252,19 @@ def render_slack(changes, args):
     )
     lines = [header]
     for f, modified, removed, added in changes:
-        lines.append(f"\n*{f}*")
-        for line, call in added:
-            url = f"{gh}/blob/{new_sha}/{f}#L{line}"
-            lines.append(f"• Added <{url}|L{line}>: `{excerpt(call)}`")
-        for (_, _), (new_line, new_call) in modified:
-            url = f"{gh}/blob/{new_sha}/{f}#L{new_line}"
-            lines.append(f"• Modified <{url}|L{new_line}>: `{excerpt(new_call)}`")
-        for line, call in removed:
-            url = f"{gh}/blob/{old_sha}/{f}#L{line}"
-            lines.append(f"• Removed <{url}|was L{line}>: `{excerpt(call)}`")
+        entries = (
+            [(line, "added", call, new_sha) for line, call in added]
+            + [(nl, "modified", nc, new_sha) for _, (nl, nc) in modified]
+            + [(line, "removed", call, old_sha) for line, call in removed]
+        )
+        entries.sort()
+        file_sha = (
+            old_sha if all(kind == "removed" for _, kind, _, _ in entries) else new_sha
+        )
+        name = f.rsplit("/", 1)[-1]
+        lines.append(f"*<{gh}/blob/{file_sha}/{f}|{name}>*")
+        for line, kind, call, sha in entries:
+            lines.append(f"• {kind} <{gh}/blob/{sha}/{f}#L{line}|{excerpt(call)}>")
 
     out = []
     used = 0
@@ -257,7 +304,7 @@ def main():
     parser.add_argument(
         "--max-chars",
         type=int,
-        default=3500,
+        default=12000,
         help="Character budget for the Slack message (default: %(default)s)",
     )
     args = parser.parse_args()

--- a/.github/scripts/tt_fatal_diff.py
+++ b/.github/scripts/tt_fatal_diff.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Report TT_FATAL changes between two tt-metal commits.
+
+Extracts every TT_FATAL(...) call (full, multi-line, balanced-paren) from all
+source files under a given path at two commits and prints the calls that were
+added, removed, or modified. Intended to run on tt-metal uplift to flag
+validation changes in tt-train metal ops.
+
+Usage:
+  tt_fatal_diff.py --repo /path/to/tt-metal OLD_COMMIT NEW_COMMIT \
+      [--path tt-train/sources/ttml/metal/ops] [--slack-out FILE]
+
+The text diff is printed to stdout. With --slack-out, a Slack mrkdwn message
+with GitHub permalinks to the changed lines is also written to FILE, suitable
+for posting via a webhook.
+
+Exit code: 0 if no TT_FATAL changes, 2 if changes were found, 1 on error.
+"""
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+
+SOURCE_EXTENSIONS = (".cpp", ".hpp", ".h", ".cc", ".cxx", ".hxx", ".c")
+MACRO_RE = re.compile(r"\bTT_FATAL\s*\(")
+
+
+def git(repo, *args):
+    result = subprocess.run(
+        ["git", "-C", repo, *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def strip_comments(text):
+    """Replace comment contents with spaces, preserving offsets and newlines."""
+    out = []
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if c == '"' or c == "'":
+            quote = c
+            out.append(c)
+            i += 1
+            while i < n:
+                out.append(text[i])
+                if text[i] == "\\":
+                    i += 1
+                    if i < n:
+                        out.append(text[i])
+                elif text[i] == quote:
+                    i += 1
+                    break
+                i += 1
+                continue
+        elif c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                out.append(" ")
+                i += 1
+        elif c == "/" and i + 1 < n and text[i + 1] == "*":
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                out.append("\n" if text[i] == "\n" else " ")
+                i += 1
+            if i < n:
+                out.append("  ")
+                i += 2
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def extract_calls(text):
+    """Return list of (line_number, call_text) for each TT_FATAL(...) call."""
+    stripped = strip_comments(text)
+    calls = []
+    for match in MACRO_RE.finditer(stripped):
+        start = match.start()
+        i = match.end()  # just past the opening paren
+        depth = 1
+        n = len(stripped)
+        while i < n and depth > 0:
+            c = stripped[i]
+            if c == '"' or c == "'":
+                quote = c
+                i += 1
+                while i < n:
+                    if stripped[i] == "\\":
+                        i += 1
+                    elif stripped[i] == quote:
+                        break
+                    i += 1
+            elif c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+            i += 1
+        line = stripped.count("\n", 0, start) + 1
+        calls.append((line, text[start:i]))
+    return calls
+
+
+def normalize(call):
+    """Whitespace-insensitive form so pure reformatting is not a change."""
+    return " ".join(call.split())
+
+
+def list_files(repo, commit, path):
+    out = git(repo, "ls-tree", "-r", "--name-only", commit, "--", path)
+    return [f for f in out.splitlines() if f.endswith(SOURCE_EXTENSIONS)]
+
+
+def calls_by_file(repo, commit, path):
+    result = {}
+    for f in list_files(repo, commit, path):
+        text = git(repo, "show", f"{commit}:{f}")
+        calls = extract_calls(text)
+        if calls:
+            result[f] = calls
+    return result
+
+
+def indent(text, prefix="    "):
+    return "\n".join(prefix + line for line in text.splitlines())
+
+
+def diff_file(old_calls, new_calls):
+    """Pair up removed/added calls in order; return (modified, removed, added).
+
+    modified is a list of (old, new) pairs matched by SequenceMatcher on the
+    normalized call lists, so an edited condition or message shows up as one
+    modification instead of an unrelated remove + add.
+    """
+    old_norm = [normalize(c) for _, c in old_calls]
+    new_norm = [normalize(c) for _, c in new_calls]
+    matcher = difflib.SequenceMatcher(a=old_norm, b=new_norm, autojunk=False)
+    modified, removed, added = [], [], []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        olds = old_calls[i1:i2]
+        news = new_calls[j1:j2]
+        for old, new in zip(olds, news):
+            modified.append((old, new))
+        removed.extend(olds[len(news) :])
+        added.extend(news[len(olds) :])
+    return modified, removed, added
+
+
+def collect_changes(old, new):
+    """Return [(file, modified, removed, added)] for files with changes."""
+    changes = []
+    for f in sorted(set(old) | set(new)):
+        modified, removed, added = diff_file(old.get(f, []), new.get(f, []))
+        if modified or removed or added:
+            changes.append((f, modified, removed, added))
+    return changes
+
+
+def render_text(changes, args):
+    lines = []
+    for f, modified, removed, added in changes:
+        lines.append(f"\n== {f}")
+        for line, call in added:
+            lines.append(f"  ADDED (line {line}):")
+            lines.append(indent(call))
+        for line, call in removed:
+            lines.append(f"  REMOVED (was line {line}):")
+            lines.append(indent(call))
+        for (old_line, old_call), (new_line, new_call) in modified:
+            lines.append(f"  MODIFIED (line {new_line}):")
+            lines.append(indent(old_call, "    - "))
+            lines.append(indent(new_call, "    + "))
+    lines.append(
+        f"\nTT_FATAL changes found in {args.path} "
+        f"between {args.old_commit} and {args.new_commit}"
+    )
+    return "\n".join(lines)
+
+
+def mrkdwn_escape(s):
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def excerpt(call, limit=140):
+    """One-line, escaped, truncated body of a TT_FATAL call for Slack."""
+    s = re.sub(r"^TT_FATAL\s*\(\s*", "", normalize(call))
+    if s.endswith(")"):
+        s = s[:-1].rstrip()
+    s = s.replace("`", "'")
+    if len(s) > limit:
+        s = s[: limit - 1] + "…"
+    return mrkdwn_escape(s)
+
+
+def render_slack(changes, args, old_sha, new_sha):
+    gh = args.github_url.rstrip("/")
+    header = (
+        f":warning: *TT_FATAL changes in `{args.path}`* "
+        f"(tt-metal uplift <{gh}/compare/{old_sha}...{new_sha}|"
+        f"`{old_sha[:9]}` → `{new_sha[:9]}`>)"
+    )
+    lines = [header]
+    for f, modified, removed, added in changes:
+        lines.append(f"\n*{f}*")
+        for line, call in added:
+            url = f"{gh}/blob/{new_sha}/{f}#L{line}"
+            lines.append(f"• Added <{url}|L{line}>: `{excerpt(call)}`")
+        for (_, _), (new_line, new_call) in modified:
+            url = f"{gh}/blob/{new_sha}/{f}#L{new_line}"
+            lines.append(f"• Modified <{url}|L{new_line}>: `{excerpt(new_call)}`")
+        for line, call in removed:
+            url = f"{gh}/blob/{old_sha}/{f}#L{line}"
+            lines.append(f"• Removed <{url}|was L{line}>: `{excerpt(call)}`")
+
+    out = []
+    used = 0
+    truncated = False
+    for line in lines:
+        if used + len(line) + 1 > args.max_chars:
+            truncated = True
+            break
+        out.append(line)
+        used += len(line) + 1
+    if truncated:
+        out.append("_…output truncated; see the workflow run for the full diff._")
+    return "\n".join(out)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("old_commit", help="Older tt-metal commit (base)")
+    parser.add_argument("new_commit", help="Newer tt-metal commit")
+    parser.add_argument("--repo", required=True, help="Path to a tt-metal checkout")
+    parser.add_argument(
+        "--path",
+        default="tt-train/sources/ttml/metal/ops",
+        help="Repo path to inspect (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--slack-out",
+        metavar="FILE",
+        help="Also write a Slack mrkdwn message with permalinks to FILE",
+    )
+    parser.add_argument(
+        "--github-url",
+        default="https://github.com/tenstorrent/tt-metal",
+        help="Base repo URL for Slack permalinks (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=3500,
+        help="Character budget for the Slack message (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    try:
+        old = calls_by_file(args.repo, args.old_commit, args.path)
+        new = calls_by_file(args.repo, args.new_commit, args.path)
+        changes = collect_changes(old, new)
+        if changes and args.slack_out:
+            old_sha = git(args.repo, "rev-parse", args.old_commit).strip()
+            new_sha = git(args.repo, "rev-parse", args.new_commit).strip()
+    except RuntimeError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if not changes:
+        print(
+            f"No TT_FATAL changes in {args.path} "
+            f"between {args.old_commit} and {args.new_commit}"
+        )
+        return 0
+
+    print(render_text(changes, args))
+    if args.slack_out:
+        with open(args.slack_out, "w") as f:
+            f.write(render_slack(changes, args, old_sha, new_sha) + "\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tt_fatal_diff.py
+++ b/.github/scripts/tt_fatal_diff.py
@@ -2,43 +2,35 @@
 # SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-"""Report TT_FATAL changes between two tt-metal commits.
+"""Report TT_FATAL changes between two tt-metal checkouts.
 
 Extracts every TT_FATAL(...) call (full, multi-line, balanced-paren) from all
-source files under a given path at two commits and prints the calls that were
-added, removed, or modified. Intended to run on tt-metal uplift to flag
-validation changes in tt-train metal ops.
+source files under a given path in two checkout directories and prints the
+calls that were added, removed, or modified. Intended to run on tt-metal
+uplift to flag validation changes in tt-train metal ops; each directory is
+typically a sparse checkout of one commit.
 
 Usage:
-  tt_fatal_diff.py --repo /path/to/tt-metal OLD_COMMIT NEW_COMMIT \
-      [--path tt-train/sources/ttml/metal/ops] [--slack-out FILE]
+  tt_fatal_diff.py OLD_DIR NEW_DIR \
+      [--path tt-train/sources/ttml/metal/ops] \
+      [--old-sha SHA --new-sha SHA] [--slack-out FILE]
 
 The text diff is printed to stdout. With --slack-out, a Slack mrkdwn message
 with GitHub permalinks to the changed lines is also written to FILE, suitable
-for posting via a webhook.
+for posting via a webhook; this requires --old-sha and --new-sha to build the
+links.
 
 Exit code: 0 if no TT_FATAL changes, 2 if changes were found, 1 on error.
 """
 
 import argparse
 import difflib
+import os
 import re
-import subprocess
 import sys
 
 SOURCE_EXTENSIONS = (".cpp", ".hpp", ".h", ".cc", ".cxx", ".hxx", ".c")
 MACRO_RE = re.compile(r"\bTT_FATAL\s*\(")
-
-
-def git(repo, *args):
-    result = subprocess.run(
-        ["git", "-C", repo, *args],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed:\n{result.stderr.strip()}")
-    return result.stdout
 
 
 def strip_comments(text):
@@ -115,18 +107,21 @@ def normalize(call):
     return " ".join(call.split())
 
 
-def list_files(repo, commit, path):
-    out = git(repo, "ls-tree", "-r", "--name-only", commit, "--", path)
-    return [f for f in out.splitlines() if f.endswith(SOURCE_EXTENSIONS)]
-
-
-def calls_by_file(repo, commit, path):
+def calls_by_file(root, path):
+    """Map repo-relative file path -> TT_FATAL calls, for sources under root/path."""
     result = {}
-    for f in list_files(repo, commit, path):
-        text = git(repo, "show", f"{commit}:{f}")
-        calls = extract_calls(text)
-        if calls:
-            result[f] = calls
+    base = os.path.join(root, path)
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = [d for d in dirnames if d != ".git"]
+        for name in sorted(filenames):
+            if not name.endswith(SOURCE_EXTENSIONS):
+                continue
+            full = os.path.join(dirpath, name)
+            with open(full, encoding="utf-8", errors="replace") as f:
+                calls = extract_calls(f.read())
+            if calls:
+                rel = os.path.relpath(full, root).replace(os.sep, "/")
+                result[rel] = calls
     return result
 
 
@@ -167,7 +162,7 @@ def collect_changes(old, new):
     return changes
 
 
-def render_text(changes, args):
+def render_text(changes, args, old_label, new_label):
     lines = []
     for f, modified, removed, added in changes:
         lines.append(f"\n== {f}")
@@ -183,7 +178,7 @@ def render_text(changes, args):
             lines.append(indent(new_call, "    + "))
     lines.append(
         f"\nTT_FATAL changes found in {args.path} "
-        f"between {args.old_commit} and {args.new_commit}"
+        f"between {old_label} and {new_label}"
     )
     return "\n".join(lines)
 
@@ -203,8 +198,9 @@ def excerpt(call, limit=140):
     return mrkdwn_escape(s)
 
 
-def render_slack(changes, args, old_sha, new_sha):
+def render_slack(changes, args):
     gh = args.github_url.rstrip("/")
+    old_sha, new_sha = args.old_sha, args.new_sha
     header = (
         f":warning: *TT_FATAL changes in `{args.path}`* "
         f"(tt-metal uplift <{gh}/compare/{old_sha}...{new_sha}|"
@@ -239,14 +235,15 @@ def render_slack(changes, args, old_sha, new_sha):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    parser.add_argument("old_commit", help="Older tt-metal commit (base)")
-    parser.add_argument("new_commit", help="Newer tt-metal commit")
-    parser.add_argument("--repo", required=True, help="Path to a tt-metal checkout")
+    parser.add_argument("old_dir", help="Checkout of the older tt-metal commit")
+    parser.add_argument("new_dir", help="Checkout of the newer tt-metal commit")
     parser.add_argument(
         "--path",
         default="tt-train/sources/ttml/metal/ops",
-        help="Repo path to inspect (default: %(default)s)",
+        help="Repo-relative path to inspect (default: %(default)s)",
     )
+    parser.add_argument("--old-sha", help="Commit SHA of old_dir, for Slack links")
+    parser.add_argument("--new-sha", help="Commit SHA of new_dir, for Slack links")
     parser.add_argument(
         "--slack-out",
         metavar="FILE",
@@ -265,28 +262,32 @@ def main():
     )
     args = parser.parse_args()
 
-    try:
-        old = calls_by_file(args.repo, args.old_commit, args.path)
-        new = calls_by_file(args.repo, args.new_commit, args.path)
-        changes = collect_changes(old, new)
-        if changes and args.slack_out:
-            old_sha = git(args.repo, "rev-parse", args.old_commit).strip()
-            new_sha = git(args.repo, "rev-parse", args.new_commit).strip()
-    except RuntimeError as e:
-        print(f"error: {e}", file=sys.stderr)
+    if args.slack_out and not (args.old_sha and args.new_sha):
+        print("error: --slack-out requires --old-sha and --new-sha", file=sys.stderr)
+        return 1
+    if not any(
+        os.path.isdir(os.path.join(d, args.path)) for d in (args.old_dir, args.new_dir)
+    ):
+        print(f"error: {args.path} not found in either directory", file=sys.stderr)
         return 1
 
+    old = calls_by_file(args.old_dir, args.path)
+    new = calls_by_file(args.new_dir, args.path)
+    changes = collect_changes(old, new)
+
+    old_label = args.old_sha or args.old_dir
+    new_label = args.new_sha or args.new_dir
     if not changes:
         print(
             f"No TT_FATAL changes in {args.path} "
-            f"between {args.old_commit} and {args.new_commit}"
+            f"between {old_label} and {new_label}"
         )
         return 0
 
-    print(render_text(changes, args))
+    print(render_text(changes, args, old_label, new_label))
     if args.slack_out:
         with open(args.slack_out, "w") as f:
-            f.write(render_slack(changes, args, old_sha, new_sha) + "\n")
+            f.write(render_slack(changes, args) + "\n")
     return 2
 
 

--- a/.github/workflows/call-check-tt-fatal.yml
+++ b/.github/workflows/call-check-tt-fatal.yml
@@ -46,17 +46,17 @@ jobs:
         if: steps.versions.outputs.changed == 'true'
         shell: bash
         run: |
-          OLD=${{ steps.versions.outputs.old }}
-          NEW=${{ steps.versions.outputs.new }}
-          git init tt-metal-src
-          cd tt-metal-src
-          git remote add origin "$TT_METAL_REPO"
-          git sparse-checkout set "$WATCH_PATH"
-          git fetch --depth=1 --filter=blob:none origin "$OLD" "$NEW"
-          # Checking out each commit batch-prefetches the sparse cone's blobs,
-          # so the diff script's git show calls below run fully offline.
-          git checkout -q "$OLD"
-          git checkout -q "$NEW"
+          # Shallow, blobless, sparse clone: only files under WATCH_PATH at
+          # the one commit are downloaded into each folder.
+          clone_at() { # <dir> <sha>
+            git init -q "$1"
+            git -C "$1" remote add origin "$TT_METAL_REPO"
+            git -C "$1" sparse-checkout set "$WATCH_PATH"
+            git -C "$1" fetch -q --depth=1 --filter=blob:none origin "$2"
+            git -C "$1" -c advice.detachedHead=false checkout -q "$2"
+          }
+          clone_at tt-metal-old ${{ steps.versions.outputs.old }}
+          clone_at tt-metal-new ${{ steps.versions.outputs.new }}
 
       - name: Diff TT_FATAL calls
         if: steps.versions.outputs.changed == 'true'
@@ -67,9 +67,10 @@ jobs:
           NEW=${{ steps.versions.outputs.new }}
           echo "notify=false" >> "$GITHUB_OUTPUT"
           rc=0
-          python3 .github/scripts/tt_fatal_diff.py --repo tt-metal-src \
+          python3 .github/scripts/tt_fatal_diff.py tt-metal-old tt-metal-new \
             --path "$WATCH_PATH" --github-url "$TT_METAL_REPO" \
-            --slack-out tt_fatal_slack.txt "$OLD" "$NEW" > tt_fatal_diff.txt || rc=$?
+            --old-sha "$OLD" --new-sha "$NEW" \
+            --slack-out tt_fatal_slack.txt > tt_fatal_diff.txt || rc=$?
           {
             echo "## TT_FATAL diff ($OLD -> $NEW)"
             echo '```'

--- a/.github/workflows/call-check-tt-fatal.yml
+++ b/.github/workflows/call-check-tt-fatal.yml
@@ -1,0 +1,96 @@
+name: Check TT_FATAL
+
+# On tt-metal uplift (TT_METAL_VERSION change in third_party/CMakeLists.txt),
+# report TT_FATAL changes in tt-train metal ops to Slack. Uses a sparse,
+# blobless tt-metal clone so only the watched path is downloaded (~seconds).
+
+on:
+  workflow_call:
+
+env:
+  TT_METAL_REPO: https://github.com/tenstorrent/tt-metal
+  WATCH_PATH: tt-train/sources/ttml/metal/ops
+
+jobs:
+  check-tt-fatal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Detect tt-metal version change
+        id: versions
+        shell: bash
+        run: |
+          extract() { sed -n 's/^set(TT_METAL_VERSION "\([0-9a-fA-F]*\)").*/\1/p'; }
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          BEFORE="${{ github.event.before }}"
+          NEW=$(extract < third_party/CMakeLists.txt)
+          OLD=""
+          case "$BEFORE" in
+            ""|0000000000000000000000000000000000000000) ;;
+            *)
+              git fetch --depth=1 origin "$BEFORE"
+              OLD=$(git show "$BEFORE:third_party/CMakeLists.txt" | extract || true)
+              ;;
+          esac
+          echo "tt-metal version: '$OLD' -> '$NEW'"
+          echo "old=$OLD" >> "$GITHUB_OUTPUT"
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          if [ -n "$OLD" ] && [ -n "$NEW" ] && [ "$OLD" != "$NEW" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tt-metal version unchanged; nothing to check"
+          fi
+
+      - name: Sparse checkout tt-metal at both versions
+        if: steps.versions.outputs.changed == 'true'
+        shell: bash
+        run: |
+          OLD=${{ steps.versions.outputs.old }}
+          NEW=${{ steps.versions.outputs.new }}
+          git init tt-metal-src
+          cd tt-metal-src
+          git remote add origin "$TT_METAL_REPO"
+          git sparse-checkout set "$WATCH_PATH"
+          git fetch --depth=1 --filter=blob:none origin "$OLD" "$NEW"
+          # Checking out each commit batch-prefetches the sparse cone's blobs,
+          # so the diff script's git show calls below run fully offline.
+          git checkout -q "$OLD"
+          git checkout -q "$NEW"
+
+      - name: Diff TT_FATAL calls
+        if: steps.versions.outputs.changed == 'true'
+        id: diff
+        shell: bash
+        run: |
+          OLD=${{ steps.versions.outputs.old }}
+          NEW=${{ steps.versions.outputs.new }}
+          echo "notify=false" >> "$GITHUB_OUTPUT"
+          rc=0
+          python3 .github/scripts/tt_fatal_diff.py --repo tt-metal-src \
+            --path "$WATCH_PATH" --github-url "$TT_METAL_REPO" \
+            --slack-out tt_fatal_slack.txt "$OLD" "$NEW" > tt_fatal_diff.txt || rc=$?
+          {
+            echo "## TT_FATAL diff ($OLD -> $NEW)"
+            echo '```'
+            cat tt_fatal_diff.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$rc" -eq 2 ]; then
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            printf '\nFull diff: <%s|workflow run summary>\n' "$RUN_URL" >> tt_fatal_slack.txt
+            python3 -c 'import json,sys; json.dump({"text": open(sys.argv[1]).read()}, open(sys.argv[2], "w"))' \
+              tt_fatal_slack.txt tt_fatal_slack_payload.json
+            echo "notify=true" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -ne 0 ]; then
+            cat tt_fatal_diff.txt
+            exit "$rc"
+          fi
+
+      - name: Notify Slack
+        if: steps.diff.outputs.notify == 'true'
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          webhook-type: webhook-trigger
+          webhook: ${{ secrets.SLACK_TT_FATAL_WATCH }}
+          payload-file-path: tt_fatal_slack_payload.json

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -16,6 +16,10 @@ jobs:
   pre-commit:
     uses: ./.github/workflows/call-pre-commit.yml
     secrets: inherit
+  check-tt-fatal:
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/call-check-tt-fatal.yml
+    secrets: inherit
   build-image:
     uses: ./.github/workflows/call-build-docker.yml
     secrets: inherit


### PR DESCRIPTION
### Problem description
When tt-metal is uplifted, validation logic (`TT_FATAL` calls) in `tt-train/sources/ttml/metal/ops` can change without anyone noticing, silently changing what inputs the metal ops accept.

### What's changed
On push to `main` that changes `TT_METAL_VERSION` in `third_party/CMakeLists.txt`, a new `check-tt-fatal` job diffs all `TT_FATAL` calls under `tt-train/sources/ttml/metal/ops` between the old and new tt-metal commits and posts the added/removed/modified calls to Slack.