### PR TITLE
Uplift third_party/tt-metal to c18bff73f84d 2026-08-27

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -4,7 +4,7 @@ SHELL ["/bin/bash", "-c"]
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG TT_METAL_DEPENDENCIES_COMMIT=58342a6f63d822599484977d61dcd8f3993350f0
+ARG TT_METAL_DEPENDENCIES_COMMIT=c18bff73f84d
 
 # Install dependencies
 RUN <<EOT

--- a/runtime/lib/ttnn/operations/data_movement/copy.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/copy.cpp
@@ -17,6 +17,16 @@ void run(const ::tt::target::ttnn::CopyOp *op, ProgramContext &context) {
   const ::ttnn::Tensor &src = tensorPool.getTTNNTensorAndValidate(op->src());
   ::ttnn::Tensor &dst = tensorPool.getTTNNTensorAndValidate(op->dst());
 
+  // ttnn::copy requires the input and output layouts to match. Since
+  // tt-metal#54212 ported argmax to Metal 2.0, ttnn::argmax can hand back a
+  // ROW_MAJOR tensor while the trace output slot it is copied into is TILE,
+  // which trips the layout assert in CopyDeviceOperation. Reconcile the layouts
+  // the same way updateTensorInPool does. Remove once tt-metal#54212 is fixed.
+  if (src.layout() != dst.layout()) {
+    ::ttnn::copy(::ttnn::to_layout(src, dst.layout()), dst);
+    return;
+  }
+
   ::ttnn::copy(src, dst);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "58342a6f63d822599484977d61dcd8f3993350f0")
+set(TT_METAL_VERSION "c18bff73f84d")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the c18bff73f84d

**Note** Dockerfile.base is modified due to dependency updates

### Checklist
- **Frontend CI passing links**
  - [x] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/33517272570
  - [x] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/33517269733
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): https://github.com/tenstorrent/tt-metal/issues/54987, #9260, #9259, https://github.com/tenstorrent/tt-metal/issues/54639, https://github.com/tenstorrent/tt-metal/issues/54475, https://github.com/tenstorrent/tt-xla/issues/6015
  - [ ] **Frontend fix PRs** ready (if needed by this uplift): tt-xla skip prepared on `akhan/skip-mnist-sigfpe-54639`, onnx xfail drop on `akhan/drop-stale-xfails-mlir-uplift`. Both left unmerged for the frontend owners.

This is a 41 commit metal window on top of #9244. One tt-mlir change was needed to get MLIR CI green, in `runtime/lib/ttnn/operations/data_movement/copy.cpp`.

`llama_3_1_70b_tp_decode_layer` on n300-llmbox aborted with `TT_FATAL: Input tensor layout (Layout::ROW_MAJOR) must equal output tensor layout (Layout::TILE)` out of `CopyDeviceOperation::validate_on_program_cache_miss`, under `ttrt run --enable-program-cache --loops 3`. It was the only failure of 2249 tests, it reproduced twice, and the same job is green on main at `0e5e709c48`, so it came from this window rather than from main. Bisecting the window with tt-mlir held fixed put it at `c18bff73f84d`, the argmax Metal 2.0 port, tt-metal#54212: pinned there it fails, pinned at `06b9188597b` it passes, and the only two commits in between touch `tt_metal/ttsim-version` and a workflow yaml. The copy op's layout check and argmax's `compute_output_specs` are both unchanged across the window, so metal now returns a tensor that disagrees with its own declared spec. Filed as tt-metal#54987.

The tt-mlir side change reconciles the two layouts before the copy, mirroring what `updateTensorInPool` already does in `runtime.cpp`. It is a workaround, not a fix, and it should be deleted when tt-metal#54987 lands. The alternative was pinning at `06b9188597b` and deferring the bad commit, but that commit would then be first in the next chunk's window, so the blocker would just move rather than go away.

tt-xla has four failures, all carried over from #9244. MNIST CNN crashes with SIGFPE on n150 and p150, and `examples/pytorch/compiler_options.py` crashes the same way on n300 because that example sets optimization level 2. All three are the divide by zero in ttnn `create_simple_matmul_program_config` where `per_core_M` is 0 for fc1, tt-metal#54639 and #9260. The skip on `akhan/skip-mnist-sigfpe-54639` covers both the runner test and the example. `test_batch_norm_decomposition_conv2d` is #9259, it fails on main too and was bisected to #9242.

On forge onnx all 31 unique failures across the four shards are `XPASS(strict)`, so nothing regressed, tests got better. 19 of them, `test_reduce_sum` x12, `test_reduce_mean` x6 and `test_divide[shape1]`, are the stale xfails from #9244 that `akhan/drop-stale-xfails-mlir-uplift` already drops. The remaining 12 are `test_reduce_max` and they were already XPASS before either uplift, so that branch needs extending before onnx goes green. Baseline is tt-forge-onnx#3407 https://github.com/tenstorrent/tt-forge-onnx/actions/runs/33168526352, which pins tt-mlir `4d8ef78e` and shows the same 12.

`@tenstorrent/forge-developers-mlir-runtime` for the `copy.cpp` change above.

