### PR TITLE
[TTIR] canonicalize `(un)squeeze` to `reshape`

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -4989,6 +4989,7 @@ def TTIR_SqueezeOp : TTIR_NamedOp<"squeeze"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+    let hasCanonicalizeMethod = 1;
 }
 
 def TTIR_UnsqueezeOp : TTIR_NamedOp<"unsqueeze"> {
@@ -5036,6 +5037,7 @@ def TTIR_UnsqueezeOp : TTIR_NamedOp<"unsqueeze"> {
     let results = (outs AnyRankedTensor:$result);
 
     let hasVerifier = 1;
+    let hasCanonicalizeMethod = 1;
 }
 
 def TTIR_ClampScalarOp : TTIR_NamedOp<"clamp_scalar", [TTIR_ElementwiseUnary]> {

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3838,6 +3838,7 @@ template <typename OpTy>
 mlir::tt::ttir::SqueezeOp::canonicalize(mlir::tt::ttir::SqueezeOp op,
                                         ::mlir::PatternRewriter &rewriter) {
   // Rewrite `ttir.squeeze` as `ttir.reshape`.
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   return normalizeToReshape(op, rewriter);
 }
 
@@ -4184,6 +4185,7 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 mlir::tt::ttir::UnsqueezeOp::canonicalize(mlir::tt::ttir::UnsqueezeOp op,
                                           ::mlir::PatternRewriter &rewriter) {
   // Rewrite `ttir.unsqueeze` as `ttir.reshape`.
+  // NOLINTNEXTLINE(clang-analyzer-core.StackAddressEscape)
   return normalizeToReshape(op, rewriter);
 }
 

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3814,6 +3814,35 @@ mlir::OpFoldResult mlir::tt::ttir::SliceStaticOp::fold(FoldAdaptor adaptor) {
   return success();
 }
 
+namespace {
+// Rewrite a rank-changing, size-1-dim-only shape change into the equivalent
+// `ttir.reshape`. TTNN dialect doesn't have `squeeze`/`unsqueeze` op, so we
+// canonicalize both ops to `ttir.reshape`.
+::llvm::LogicalResult normalizeToReshape(::mlir::Operation *op,
+                                         ::mlir::Value input,
+                                         ::mlir::PatternRewriter &rewriter) {
+  assert(
+      (::mlir::isa<::mlir::tt::ttir::SqueezeOp, ::mlir::tt::ttir::UnsqueezeOp>(
+          op)) &&
+      "normalizeToReshape expects a squeeze or unsqueeze op");
+
+  auto resultType =
+      ::mlir::cast<::mlir::RankedTensorType>(op->getResult(0).getType());
+
+  ::llvm::SmallVector<int32_t> shape(resultType.getShape());
+  rewriter.replaceOpWithNewOp<::mlir::tt::ttir::ReshapeOp>(
+      op, resultType, input, rewriter.getI32ArrayAttr(shape));
+  return ::mlir::success();
+}
+} // namespace
+
+::llvm::LogicalResult
+mlir::tt::ttir::SqueezeOp::canonicalize(mlir::tt::ttir::SqueezeOp op,
+                                        ::mlir::PatternRewriter &rewriter) {
+  // Rewrite `ttir.squeeze` as `ttir.reshape`.
+  return normalizeToReshape(op, op.getInput(), rewriter);
+}
+
 //===----------------------------------------------------------------------===//
 // TransposeOp
 //===----------------------------------------------------------------------===//
@@ -4150,6 +4179,14 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
   }
 
   return success();
+}
+
+// UnsqueezeOp canonicalization method
+::llvm::LogicalResult
+mlir::tt::ttir::UnsqueezeOp::canonicalize(mlir::tt::ttir::UnsqueezeOp op,
+                                          ::mlir::PatternRewriter &rewriter) {
+  // Rewrite `ttir.unsqueeze` as `ttir.reshape`.
+  return normalizeToReshape(op, op.getInput(), rewriter);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -3818,20 +3818,18 @@ namespace {
 // Rewrite a rank-changing, size-1-dim-only shape change into the equivalent
 // `ttir.reshape`. TTNN dialect doesn't have `squeeze`/`unsqueeze` op, so we
 // canonicalize both ops to `ttir.reshape`.
-::llvm::LogicalResult normalizeToReshape(::mlir::Operation *op,
-                                         ::mlir::Value input,
+template <typename OpTy>
+::llvm::LogicalResult normalizeToReshape(OpTy op,
                                          ::mlir::PatternRewriter &rewriter) {
-  assert(
-      (::mlir::isa<::mlir::tt::ttir::SqueezeOp, ::mlir::tt::ttir::UnsqueezeOp>(
-          op)) &&
-      "normalizeToReshape expects a squeeze or unsqueeze op");
+  static_assert(std::is_same_v<OpTy, ::mlir::tt::ttir::SqueezeOp> ||
+                    std::is_same_v<OpTy, ::mlir::tt::ttir::UnsqueezeOp>,
+                "normalizeToReshape expects a squeeze or unsqueeze op");
 
-  auto resultType =
-      ::mlir::cast<::mlir::RankedTensorType>(op->getResult(0).getType());
+  ::mlir::RankedTensorType resultType = op.getType();
 
   ::llvm::SmallVector<int32_t> shape(resultType.getShape());
   rewriter.replaceOpWithNewOp<::mlir::tt::ttir::ReshapeOp>(
-      op, resultType, input, rewriter.getI32ArrayAttr(shape));
+      op, resultType, op.getInput(), rewriter.getI32ArrayAttr(shape));
   return ::mlir::success();
 }
 } // namespace
@@ -3840,7 +3838,7 @@ namespace {
 mlir::tt::ttir::SqueezeOp::canonicalize(mlir::tt::ttir::SqueezeOp op,
                                         ::mlir::PatternRewriter &rewriter) {
   // Rewrite `ttir.squeeze` as `ttir.reshape`.
-  return normalizeToReshape(op, op.getInput(), rewriter);
+  return normalizeToReshape(op, rewriter);
 }
 
 //===----------------------------------------------------------------------===//
@@ -4186,7 +4184,7 @@ mlir::tt::ttir::TypecastOp::canonicalize(mlir::tt::ttir::TypecastOp op,
 mlir::tt::ttir::UnsqueezeOp::canonicalize(mlir::tt::ttir::UnsqueezeOp op,
                                           ::mlir::PatternRewriter &rewriter) {
   // Rewrite `ttir.unsqueeze` as `ttir.reshape`.
-  return normalizeToReshape(op, op.getInput(), rewriter);
+  return normalizeToReshape(op, rewriter);
 }
 
 //===----------------------------------------------------------------------===//

--- a/test/ttmlir/Dialect/TTIR/Transforms/DecomposeComplexReshape/decompose_complex_reshape_unsqueeze.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/DecomposeComplexReshape/decompose_complex_reshape_unsqueeze.mlir
@@ -1,0 +1,14 @@
+// RUN: ttmlir-opt --canonicalize --ttir-decompose-complex-reshape %s | FileCheck %s
+
+// The unsqueeze version of @singleton_transpose_append_trailing_one from decompose_complex_reshape.mlir.
+// Separate file because --canonicalize folds away the identity reshape that file's @no_transform_identity needs.
+// CHECK-LABEL: @singleton_transpose_from_unsqueeze
+// CHECK: %[[RESHAPE:.*]] = "ttir.reshape"(%arg0)
+// CHECK-SAME: (tensor<128xf32>) -> tensor<1x128xf32>
+// CHECK: "ttir.permute"(%[[RESHAPE]])
+// CHECK-SAME: permutation = array<i64: 1, 0>
+// CHECK-NOT: ttir.unsqueeze
+func.func @singleton_transpose_from_unsqueeze(%arg0: tensor<128xf32>) -> tensor<128x1xf32> {
+  %0 = "ttir.unsqueeze"(%arg0) <{dim = 1 : si32}> : (tensor<128xf32>) -> tensor<128x1xf32>
+  return %0 : tensor<128x1xf32>
+}

--- a/test/ttmlir/Dialect/TTIR/Transforms/DecomposeComplexReshape/decompose_complex_reshape_unsqueeze.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/DecomposeComplexReshape/decompose_complex_reshape_unsqueeze.mlir
@@ -1,7 +1,6 @@
 // RUN: ttmlir-opt --canonicalize --ttir-decompose-complex-reshape %s | FileCheck %s
 
-// The unsqueeze version of @singleton_transpose_append_trailing_one from decompose_complex_reshape.mlir.
-// Separate file because --canonicalize folds away the identity reshape that file's @no_transform_identity needs.
+// The unsqueeze version of @singleton_transpose_add_trailing_1_rank_increase from decompose_complex_reshape.mlir.
 // CHECK-LABEL: @singleton_transpose_from_unsqueeze
 // CHECK: %[[RESHAPE:.*]] = "ttir.reshape"(%arg0)
 // CHECK-SAME: (tensor<128xf32>) -> tensor<1x128xf32>

--- a/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/basic_eltwise_unary_commute.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/EraseInverseOps/CommuteUpwards/basic_eltwise_unary_commute.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-erase-inverse-ops="force=true enable-commute-downwards=false" -o %t %s
+// RUN: ttmlir-opt --canonicalize --ttir-erase-inverse-ops="force=true enable-commute-downwards=false" -o %t %s
 // RUN: FileCheck %s --input-file=%t
 module {
     func.func @test_commute_identical_users(%arg0: tensor<32x64xbf16>) -> (tensor<64x32xbf16>, tensor<64x32xbf16>) {
@@ -44,5 +44,43 @@ module {
         %1 = "ttir.exp"(%arg0) : (tensor<1x3x224x224xbf16>) -> tensor<1x3x224x224xbf16>
         %3 = "ttir.permute"(%1) <{permutation = array<i64: 0, 2, 3, 1>}> : (tensor<1x3x224x224xbf16>) -> tensor<1x224x224x3xbf16>
         return %3: tensor<1x224x224x3xbf16>
+    }
+}
+
+// The squeeze version of @test_commute_identical_users, with the permutes replaced by squeezes.
+module {
+    func.func @commute_identical_squeeze_users(%arg0: tensor<1x32x64xbf16>) -> (tensor<32x64xbf16>, tensor<32x64xbf16>) {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0)
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[RESHAPE]]
+        // CHECK: return %[[EXP]], %[[EXP]]
+        %1 = "ttir.exp"(%arg0) : (tensor<1x32x64xbf16>) -> tensor<1x32x64xbf16>
+        %3 = "ttir.squeeze"(%1) <{dim = 0 : si32}> : (tensor<1x32x64xbf16>) -> tensor<32x64xbf16>
+        %5 = "ttir.squeeze"(%1) <{dim = 0 : si32}> : (tensor<1x32x64xbf16>) -> tensor<32x64xbf16>
+        return %3, %5 : tensor<32x64xbf16>, tensor<32x64xbf16>
+    }
+}
+
+// The unsqueeze version of @test_commute_reshape.
+module {
+    func.func @commute_unsqueeze_through_unary(%arg0: tensor<32x64xbf16>) -> tensor<1x32x64xbf16> {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0)
+        // CHECK: %[[EXP:[0-9]+]] = "ttir.exp"(%[[RESHAPE]]
+        // CHECK: return %[[EXP]]
+        %1 = "ttir.exp"(%arg0) : (tensor<32x64xbf16>) -> tensor<32x64xbf16>
+        %3 = "ttir.unsqueeze"(%1) <{dim = 0 : si32}> : (tensor<32x64xbf16>) -> tensor<1x32x64xbf16>
+        return %3 : tensor<1x32x64xbf16>
+    }
+}
+
+// A squeeze on one user and the reshape spelling on the other: both must be seen as the same TM.
+module {
+    func.func @commute_mixed_squeeze_and_reshape_users(%arg0: tensor<1x32x64xbf16>) -> (tensor<32x64xbf16>, tensor<32x64xbf16>) {
+        // CHECK: %[[RESHAPE:[0-9]+]] = "ttir.reshape"(%arg0)
+        // CHECK: %[[SQRT:[0-9]+]] = "ttir.sqrt"(%[[RESHAPE]]
+        // CHECK: return %[[SQRT]], %[[SQRT]]
+        %1 = "ttir.sqrt"(%arg0) : (tensor<1x32x64xbf16>) -> tensor<1x32x64xbf16>
+        %3 = "ttir.squeeze"(%1) <{dim = 0 : si32}> : (tensor<1x32x64xbf16>) -> tensor<32x64xbf16>
+        %5 = "ttir.reshape"(%1) <{shape = [32 : i32, 64 : i32]}> : (tensor<1x32x64xbf16>) -> tensor<32x64xbf16>
+        return %3, %5 : tensor<32x64xbf16>, tensor<32x64xbf16>
     }
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/matmul_squeeze_unsqueeze_canonicalize.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/matmul_squeeze_unsqueeze_canonicalize.mlir
@@ -142,4 +142,34 @@ module {
     %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 7 : i32, 5 : i32, 64 : i32, 64 : i32]}> : (tensor<7x5x64x64xbf16>) -> tensor<1x7x5x64x64xbf16>
     return %2 : tensor<1x7x5x64x64xbf16>
   }
+
+  // The literal ttir.squeeze/ttir.unsqueeze version of the first case above.
+  func.func @matmul_both_inputs_squeeze_op(%arg0: tensor<1x5x64x32xbf16>, %arg1: tensor<1x5x32x64xbf16>) -> tensor<1x5x64x64xbf16> {
+    // CHECK-LABEL: @matmul_both_inputs_squeeze_op
+    // CHECK-NOT: "ttir.squeeze"
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: -> tensor<1x5x64x64xbf16>
+    // CHECK-NOT: "ttir.unsqueeze"
+    // CHECK-NOT: "ttir.reshape"
+    %0 = "ttir.squeeze"(%arg0) <{dim = 0 : si32}> : (tensor<1x5x64x32xbf16>) -> tensor<5x64x32xbf16>
+    %1 = "ttir.squeeze"(%arg1) <{dim = 0 : si32}> : (tensor<1x5x32x64xbf16>) -> tensor<5x32x64xbf16>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<5x64x32xbf16>, tensor<5x32x64xbf16>) -> tensor<5x64x64xbf16>
+    %3 = "ttir.unsqueeze"(%2) <{dim = 0 : si32}> : (tensor<5x64x64xbf16>) -> tensor<1x5x64x64xbf16>
+    return %3 : tensor<1x5x64x64xbf16>
+  }
+
+  // Squeeze on the inputs, reshape on the output.
+  func.func @matmul_squeeze_inputs_reshape_output(%arg0: tensor<1x5x64x32xbf16>, %arg1: tensor<1x5x32x64xbf16>) -> tensor<1x5x64x64xbf16> {
+    // CHECK-LABEL: @matmul_squeeze_inputs_reshape_output
+    // CHECK-NOT: "ttir.squeeze"
+    // CHECK: "ttir.matmul"(%arg0, %arg1)
+    // CHECK-SAME: -> tensor<1x5x64x64xbf16>
+    // CHECK-NOT: "ttir.reshape"
+    %0 = "ttir.squeeze"(%arg0) <{dim = 0 : si32}> : (tensor<1x5x64x32xbf16>) -> tensor<5x64x32xbf16>
+    %1 = "ttir.squeeze"(%arg1) <{dim = 0 : si32}> : (tensor<1x5x32x64xbf16>) -> tensor<5x32x64xbf16>
+    %2 = "ttir.matmul"(%0, %1) : (tensor<5x64x32xbf16>, tensor<5x32x64xbf16>) -> tensor<5x64x64xbf16>
+    %3 = "ttir.reshape"(%2) <{shape = [1 : i32, 5 : i32, 64 : i32, 64 : i32]}> : (tensor<5x64x64xbf16>) -> tensor<1x5x64x64xbf16>
+    return %3 : tensor<1x5x64x64xbf16>
+  }
 }

--- a/test/ttmlir/Dialect/TTIR/canonicalize/squeeze_unsqueeze_to_reshape.mlir
+++ b/test/ttmlir/Dialect/TTIR/canonicalize/squeeze_unsqueeze_to_reshape.mlir
@@ -1,0 +1,40 @@
+// RUN: ttmlir-opt -canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// ttir.squeeze and ttir.unsqueeze are normalized into ttir.reshape.
+
+// The reshape's shape comes from the result type rather than being recomputed
+// from `dim`, so a negative dim needs no special handling.
+module {
+  func.func @unsqueeze_negative_dim(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64x1xbf16> {
+    // CHECK-LABEL: @unsqueeze_negative_dim
+    // CHECK: "ttir.reshape"(%arg0)
+    // CHECK-SAME: shape = [1 : i32, 8 : i32, 128 : i32, 64 : i32, 1 : i32]
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = -1 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64x1xbf16>
+    return %0 : tensor<1x8x128x64x1xbf16>
+  }
+}
+
+module {
+  func.func @squeeze_negative_dim(%arg0: tensor<8x128x64x1xbf16>) -> tensor<8x128x64xbf16> {
+    // CHECK-LABEL: @squeeze_negative_dim
+    // CHECK: "ttir.reshape"(%arg0)
+    // CHECK-SAME: shape = [8 : i32, 128 : i32, 64 : i32]
+    %0 = "ttir.squeeze"(%arg0) <{dim = -1 : si32}> : (tensor<8x128x64x1xbf16>) -> tensor<8x128x64xbf16>
+    return %0 : tensor<8x128x64xbf16>
+  }
+}
+
+// Normalizing also puts the shape change within reach of the existing reshape
+// folds: an unsqueeze/squeeze round trip collapses entirely, which it could not
+// do while the two ops were opaque to each other.
+module {
+  func.func @unsqueeze_squeeze_round_trip(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64xbf16> {
+    // CHECK-LABEL: @unsqueeze_squeeze_round_trip
+    // CHECK-NOT: ttir.reshape
+    // CHECK: return %arg0
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 2 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %1 = "ttir.squeeze"(%0) <{dim = 2 : si32}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x128x64xbf16>
+    return %1 : tensor<1x8x128x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/matmul_with_bias_positive.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt -ttir-to-ttir-decomposition -ttir-implicit-broadcast-fold -ttir-fusing -o %t %s
+// RUN: ttmlir-opt -ttir-to-ttir-decomposition --canonicalize -ttir-implicit-broadcast-fold -ttir-fusing -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // ===----------------------------------------------------------------------===
@@ -202,5 +202,25 @@ module {
     %0 = "ttir.matmul"(%arg0, %arg1) <{transpose_a = false, transpose_b = false}> : (tensor<1x1x68x2048xbf16>, tensor<2048x51200xbf16>) -> tensor<1x1x68x51200xbf16>
     %1 = "ttir.add"(%0, %bias) : (tensor<1x1x68x51200xbf16>, tensor<1x68x51200xbf16>) -> tensor<1x1x68x51200xbf16>
     return %1 : tensor<1x1x68x51200xbf16>
+  }
+}
+
+// The unsqueeze version of @dot_general_with_bias_4, with the bias reshape replaced by unsqueezes.
+module {
+  func.func @dot_general_with_unsqueezed_bias(%arg0: tensor<68x1024xf32>, %arg1: tensor<1024x1024xf32>, %bias: tensor<1024xf32>) -> tensor<2x34x1024xf32> {
+    // CHECK-LABEL: func.func @dot_general_with_unsqueezed_bias
+    // CHECK: "ttir.linear"(%arg0, %arg1, %arg2)
+    // CHECK-SAME: (tensor<68x1024xf32>, tensor<1024x1024xf32>, tensor<1024xf32>) -> tensor<68x1024xf32>
+    // CHECK: "ttir.reshape"
+    // CHECK-SAME: (tensor<68x1024xf32>) -> tensor<2x34x1024xf32>
+    // CHECK-NOT: "ttir.dot_general"
+    // CHECK-NOT: "ttir.add"
+    %1 = "ttir.dot_general"(%arg0, %arg1) <{batch_dims_lhs = array<i64>, batch_dims_rhs = array<i64>, contract_dims_lhs = array<i64: 1>, contract_dims_rhs = array<i64: 0>}> : (tensor<68x1024xf32>, tensor<1024x1024xf32>) -> tensor<68x1024xf32>
+    %3 = "ttir.reshape"(%1) <{shape = [2 : i32, 34 : i32, 1024 : i32]}> : (tensor<68x1024xf32>) -> tensor<2x34x1024xf32>
+    %4 = "ttir.unsqueeze"(%bias) <{dim = 0 : si32}> : (tensor<1024xf32>) -> tensor<1x1024xf32>
+    %5 = "ttir.unsqueeze"(%4) <{dim = 0 : si32}> : (tensor<1x1024xf32>) -> tensor<1x1x1024xf32>
+    %7 = "ttir.broadcast"(%5) <{broadcast_dimensions = array<i64: 2, 34, 1>}> : (tensor<1x1x1024xf32>) -> tensor<2x34x1024xf32>
+    %9 = "ttir.add"(%3, %7) : (tensor<2x34x1024xf32>, tensor<2x34x1024xf32>) -> tensor<2x34x1024xf32>
+    return %9 : tensor<2x34x1024xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/reduction_fusing.mlir
@@ -1,4 +1,4 @@
-// RUN: ttmlir-opt --ttir-fusing -o %t %s
+// RUN: ttmlir-opt --canonicalize --ttir-fusing -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
 // Test basic reduction + reshape fusion (sum operation).
@@ -135,5 +135,56 @@ module {
     %3 = "ttir.reshape"(%1) {shape = [1 : i32, 32 : i32, 128 : i32]} : (tensor<32x128xf32>) -> tensor<1x32x128xf32>
 
     return %3 : tensor<1x32x128xf32>
+  }
+}
+
+// The unsqueeze version of @sum_reshape_fusion.
+module {
+  // CHECK-LABEL: func.func @sum_unsqueeze_fusion
+  func.func @sum_unsqueeze_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x1x128xf32> {
+    // CHECK: %[[RESULT:.*]] = "ttir.sum"(%arg0) <{dim_arg = [1 : i32], keep_dim = true}> : (tensor<32x64x128xf32>) -> tensor<32x1x128xf32>
+    // CHECK-NOT: ttir.unsqueeze
+    // CHECK-NOT: ttir.reshape
+    // CHECK: return %[[RESULT]]
+
+    %1 = "ttir.sum"(%arg0) {dim_arg = [1 : i32], keep_dim = false} : (tensor<32x64x128xf32>) -> tensor<32x128xf32>
+
+    %3 = "ttir.unsqueeze"(%1) <{dim = 1 : si32}> : (tensor<32x128xf32>) -> tensor<32x1x128xf32>
+
+    return %3 : tensor<32x1x128xf32>
+  }
+}
+
+// The unsqueeze version of @mean_reshape_fusion.
+module {
+  // CHECK-LABEL: func.func @mean_unsqueeze_fusion
+  func.func @mean_unsqueeze_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<32x64x1xf32> {
+    // CHECK: %[[RESULT:.*]] = "ttir.mean"(%arg0) <{dim_arg = [2 : i32], keep_dim = true}> : (tensor<32x64x128xf32>) -> tensor<32x64x1xf32>
+    // CHECK-NOT: ttir.unsqueeze
+    // CHECK-NOT: ttir.reshape
+    // CHECK: return %[[RESULT]]
+
+    %1 = "ttir.mean"(%arg0) {dim_arg = [2 : i32], keep_dim = false} : (tensor<32x64x128xf32>) -> tensor<32x64xf32>
+
+    %3 = "ttir.unsqueeze"(%1) <{dim = 2 : si32}> : (tensor<32x64xf32>) -> tensor<32x64x1xf32>
+
+    return %3 : tensor<32x64x1xf32>
+  }
+}
+
+// The unsqueeze version of @max_reshape_fusion.
+module {
+  // CHECK-LABEL: func.func @max_unsqueeze_fusion
+  func.func @max_unsqueeze_fusion(%arg0: tensor<32x64x128xf32>) -> tensor<1x64x128xf32> {
+    // CHECK: %[[RESULT:.*]] = "ttir.max"(%arg0) <{dim_arg = [0 : i32], keep_dim = true}> : (tensor<32x64x128xf32>) -> tensor<1x64x128xf32>
+    // CHECK-NOT: ttir.unsqueeze
+    // CHECK-NOT: ttir.reshape
+    // CHECK: return %[[RESULT]]
+
+    %1 = "ttir.max"(%arg0) {dim_arg = [0 : i32], keep_dim = false} : (tensor<32x64x128xf32>) -> tensor<64x128xf32>
+
+    %3 = "ttir.unsqueeze"(%1) <{dim = 0 : si32}> : (tensor<64x128xf32>) -> tensor<1x64x128xf32>
+
+    return %3 : tensor<1x64x128xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/fusing/reshape_broadcast_reshape_to_repeat.mlir
+++ b/test/ttmlir/Dialect/TTIR/fusing/reshape_broadcast_reshape_to_repeat.mlir
@@ -1,0 +1,121 @@
+// RUN: ttmlir-opt --canonicalize --ttir-fusing %s | FileCheck %s
+
+// ReshapeBroadcastReshapeToRepeatPattern normalizes an
+// insert-size-1-dim -> broadcast -> reshape chain into a repeat or a
+// repeat_interleave.
+
+// Unsqueeze right of the expanded dim, final reshape merges left -> repeat_interleave.
+module {
+  func.func @unsqueeze_broadcast_reshape_to_repeat_interleave(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @unsqueeze_broadcast_reshape_to_repeat_interleave
+    // CHECK: "ttir.repeat_interleave"(%arg0)
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: repeats = 4 : ui32
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 2 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+// Unsqueeze left of the expanded dim, final reshape merges right -> repeat.
+module {
+  func.func @unsqueeze_broadcast_reshape_to_repeat(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @unsqueeze_broadcast_reshape_to_repeat
+    // CHECK: "ttir.repeat"(%arg0)
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 4, 1, 1>
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 1 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x1x8x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 4, 1, 1, 1>}> : (tensor<1x1x8x128x64xbf16>) -> tensor<1x4x8x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x4x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+// The reshape spelling of the same two shape changes.
+module {
+  func.func @reshape_broadcast_reshape_to_repeat_interleave(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @reshape_broadcast_reshape_to_repeat_interleave
+    // CHECK: "ttir.repeat_interleave"(%arg0)
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: repeats = 4 : ui32
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+module {
+  func.func @reshape_broadcast_reshape_to_repeat(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @reshape_broadcast_reshape_to_repeat
+    // CHECK: "ttir.repeat"(%arg0)
+    // CHECK-SAME: repeat_dimensions = array<i64: 1, 4, 1, 1>
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 8 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x128x64xbf16>) -> tensor<1x1x8x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 4, 1, 1, 1>}> : (tensor<1x1x8x128x64xbf16>) -> tensor<1x4x8x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x4x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+// The expanded dim has size 1.
+module {
+  func.func @unsqueeze_broadcast_reshape_size_one_dim(%arg0: tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @unsqueeze_broadcast_reshape_size_one_dim
+    // CHECK: "ttir.repeat_interleave"(%arg0)
+    // CHECK-SAME: dim = 1 : si32
+    // CHECK-SAME: repeats = 32 : ui32
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 2 : si32}> : (tensor<1x1x128x64xbf16>) -> tensor<1x1x1x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 1, 32, 1, 1>}> : (tensor<1x1x1x128x64xbf16>) -> tensor<1x1x32x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x1x32x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+// Negative: the inserted dim feeds a second consumer, so the broadcast would
+// survive anyway and the rewrite is not a saving.
+module {
+  func.func @unsqueeze_broadcast_reshape_multiple_uses(%arg0: tensor<1x8x128x64xbf16>) -> (tensor<1x32x128x64xbf16>, tensor<1x8x1x128x64xbf16>) {
+    // CHECK-LABEL: @unsqueeze_broadcast_reshape_multiple_uses
+    // CHECK: ttir.broadcast
+    // CHECK-NOT: ttir.repeat_interleave
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 2 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2, %0 : tensor<1x32x128x64xbf16>, tensor<1x8x1x128x64xbf16>
+  }
+}
+
+// Negative: the broadcast expands two dims at once. Only a single expanded
+// dim is modelled, so the chain is left alone rather than split into a
+// repeat_interleave plus a repeat.
+module {
+  func.func @broadcast_of_two_dims_not_fused(%arg0: tensor<1x1x128x64xbf16>) -> tensor<1x32x128x64xbf16> {
+    // CHECK-LABEL: @broadcast_of_two_dims_not_fused
+    // CHECK: ttir.broadcast
+    // CHECK-NOT: ttir.repeat_interleave
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 2 : si32}> : (tensor<1x1x128x64xbf16>) -> tensor<1x1x1x128x64xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 4, 8, 1, 1>}> : (tensor<1x1x1x128x64xbf16>) -> tensor<1x4x8x128x64xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x4x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    return %2 : tensor<1x32x128x64xbf16>
+  }
+}
+
+// An expansion merged into the last dim normalizes the same way.
+module {
+  func.func @unsqueeze_broadcast_reshape_on_last_dim(%arg0: tensor<1x8x128x64xbf16>) -> tensor<1x8x128x256xbf16> {
+    // CHECK-LABEL: @unsqueeze_broadcast_reshape_on_last_dim
+    // CHECK: "ttir.repeat_interleave"(%arg0)
+    // CHECK-SAME: dim = 3 : si32
+    // CHECK-SAME: repeats = 4 : ui32
+    // CHECK-NOT: ttir.broadcast
+    %0 = "ttir.unsqueeze"(%arg0) <{dim = 4 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64x1xbf16>
+    %1 = "ttir.broadcast"(%0) <{broadcast_dimensions = array<i64: 1, 1, 1, 1, 4>}> : (tensor<1x8x128x64x1xbf16>) -> tensor<1x8x128x64x4xbf16>
+    %2 = "ttir.reshape"(%1) <{shape = [1 : i32, 8 : i32, 128 : i32, 256 : i32]}> : (tensor<1x8x128x64x4xbf16>) -> tensor<1x8x128x256xbf16>
+    return %2 : tensor<1x8x128x256xbf16>
+  }
+}


### PR DESCRIPTION
There are currently no `(un)sqeeze` ops in the TTNN dialect. Some of the existing fusions in TTIR, e.g. `ReshapeBroadcastReshapeToRepeatPattern` work only on `reshape` - and the semantically equivalent `(un)squeeze` will cause patterns to miss.

Instead of extending patterns to cover `(un)squeeze` ops, we will canonicalize them to `reshape`.

Tests are added to cover cases of existing patterns which match `ttir.reshape` to verify that they work for the
`ttir.unsqueeze`/`ttir.squeeze` equivalent IRs.

Also, added lit tests for covering `ReshapeBroadcastReshapeToRepeatPattern`.