### PR TITLE
Uplift third_party/tt-metal to d04395ed862b4c65eb6877000c40200f456cb74e 2026-09-01

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(TT_METAL_VERSION "0af4133eb16c12d4c78e57af7151e85d986469a5")
+set(TT_METAL_VERSION "d04395ed862b4c65eb6877000c40200f456cb74e")
 
 set(TTMLIR_TTMETAL_SOURCE_DIR "" CACHE PATH
     "Path to a user-managed tt-metal checkout. If empty, ExternalProject clones tt-metal at TT_METAL_VERSION.")


### PR DESCRIPTION
This PR uplifts the third_party/tt-metal to the d04395ed862



### Checklist
- **Frontend CI passing links**
  - [ ] [tt-forge-onnx](https://github.com/tenstorrent/tt-forge-onnx/actions/workflows/on-pr.yml): https://github.com/tenstorrent/tt-forge-onnx/actions/runs/33642508335
  - [ ] [tt-xla (full-mlir-uplift-qualification.json)](https://github.com/tenstorrent/tt-xla/actions/workflows/manual-test.yml): https://github.com/tenstorrent/tt-xla/actions/runs/33642504800
- **Follow-up Actions**
  - [x] **Issues filed** to follow up on incomplete changes (if any): #9272, tt-metal#54987 (both from #9265, carried here)
  - [ ] **Frontend fix PRs** ready (if needed by this uplift):


This is a 79 commit metal window on top of #9265, `0af4133eb16c..d04395ed862`, roughly double chunk three because metal main is currently over 150 commits ahead and a 40 commit cadence no longer keeps pace with it. It was stacked on `uplift_0831` while #9265 was open; now that #9265 has merged this is rebased onto main and is a single uplift commit.

`.github/Dockerfile.base` is deliberately not bumped. `install_dependencies.sh`, `tt_metal/sfpi-info.sh`, `tt_metal/sfpi-version` and `tools/triage/requirements.txt` are all unchanged across this window, which is the condition the uplift job uses, so the dependency pin stays where chunk three left it and the base image stays cached.

Cut point `d04395ed862` is a `[skip ci]` CODEOWNERS-only commit, chosen so the window ends on something inert. SFPI stays at 7.72.0 throughout.

No new frontend failures. On tt-xla the four failures are the ones carried from #9261 and #9265: MNIST CNN SIGFPE on n150 and p150 plus `examples/pytorch/compiler_options.py` on n300, all tt-metal#54639 and #9260, and `test_batch_norm_decomposition_conv2d` which is #9259 and fails on main too. On forge onnx three of the four push shards are pure `XPASS(strict)` with the same 31 unique params as the previous two uplifts; the fourth shard died at `Setup Forge Models repo` with a git checkout error and ran no tests, so that shard has no signal.

The frontend results above describe an earlier run against `85bf67c663`. That run predates the rebase onto current main, which pulled in 57 files of unrelated main side work including `cross_entropy_fw`, SDPA fw/bw and runtime changes, so it is not valid evidence for this head. Both workflows have been re-fired against `0a9999778d` and the links point at those.

The strict xfail on `test_ttir_rmsnorm_sharding` (#9272) and the `copy.cpp` layout workaround (tt-metal#54987) both come from earlier chunks and are now inherited from main rather than carried here.

