### PR TITLE
StableHLO: fix dynamic_slice local shape attributes

### DIFF
--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -208,6 +208,34 @@ static FailureOr<mlir::OperationState> createNewOperationState(
 
             return mlir::success();
           })
+          .Case<mlir::stablehlo::DynamicSliceOp>(
+              [&](auto dynamicSliceOp) {
+                // stablehlo.dynamic_slice stores its result shape in the
+                // slice_sizes attribute. Keep it consistent with the localized
+                // result type.
+                if (newTypes.empty()) {
+                  dynamicSliceOp->emitError(
+                      "DynamicSlice operation does not have a result type.");
+                  return mlir::failure();
+                }
+
+                llvm::SmallVector<int64_t> newSliceSizes(
+                    newTypes[0].getShape().begin(),
+                    newTypes[0].getShape().end());
+
+                llvm::StringRef sliceSizesAttrName = "slice_sizes";
+                assert(attrDict.contains(sliceSizesAttrName) &&
+                       "DynamicSlice operation does not have slice sizes "
+                       "attribute. Ill-formed operation");
+                auto namedAttrSliceSizesIt = llvm::find_if(
+                    namedAttrs, [&](const mlir::NamedAttribute &attr) {
+                      return attr.getName() == sliceSizesAttrName;
+                    });
+                namedAttrSliceSizesIt->setValue(
+                    mlir::DenseI64ArrayAttr::get(context, newSliceSizes));
+
+                return mlir::success();
+              })
           .Case<mlir::stablehlo::GatherOp>([&](auto gatherOp) {
             // 1. Get the sharding for each operand dimension.
             llvm::ArrayRef<mlir::sdy::DimensionShardingAttr>

--- a/test/ttmlir/Dialect/StableHLO/global_to_local_shape/dynamic_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/global_to_local_shape/dynamic_slice.mlir
@@ -1,0 +1,19 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --split-input-file --update-global-to-local-shapes -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @DynamicSliceLocalShape attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  sdy.mesh @mesh = <["b"=2]>
+  func.func @main(%arg0: tensor<4x64x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"b"}, {}]>, ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<4x32x64xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x64x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"b"}, {}]>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x64xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {"b"}, {}]>] out_shardings=[<@mesh, [{}, {"b"}, {}]>] manual_axes={} (%arg1: tensor<4x64x64xf32>) {
+      %c0 = stablehlo.constant dense<0> : tensor<i32>
+      // CHECK: stablehlo.dynamic_slice
+      // CHECK-SAME: sizes = [1, 32, 64]
+      // CHECK-SAME: (tensor<4x32x64xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<1x32x64xf32>
+      %1 = stablehlo.dynamic_slice %arg1, %c0, %c0, %c0, sizes = [1, 64, 64] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"b"}, {}]>]>} : (tensor<4x64x64xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<1x64x64xf32>
+      sdy.return %1 : tensor<1x64x64xf32>
+    } : (tensor<4x64x64xf32>) -> tensor<1x64x64xf32>
+    return %0 : tensor<1x64x64xf32>
+  }
+}


### PR DESCRIPTION
## Summary
- Bugfix: update StableHLO dynamic_slice sizes when global tensor shapes are localized under sharding.
- Add lit coverage for a dynamic_slice result whose sharded local shape differs from the original global slice size.

Without this, UpdateGlobalToLocalShapes can rewrite the result type to a local shape while leaving the dynamic_slice sizes attribute at the original global shape.

## Testing
- `cmake --build build-dynamic-slice --target ttmlir-opt -j \"64\"`
- `llvm-lit -q test/ttmlir/Dialect/StableHLO/global_to_local_shape`
- `llvm-lit -q test/ttmlir/Dialect/StableHLO`