### PR TITLE
[TTIR] decouple head expansion from sdpa core fusing

### DIFF
--- a/include/ttmlir/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.h
+++ b/include/ttmlir/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.h
@@ -40,9 +40,9 @@ namespace mlir::tt::ttir::fusing {
 // on K (either side of the transpose), and on the score tensor (post-matmul).
 // Double-scaling (both pre- and post-) is rejected as ambiguous.
 //
-// GQA: a head-dim ttir.repeat_interleave that expands K/V from Hkv to Hq heads
-// (through an optional typecast) is peeled from both K and V so the un-expanded
-// tensors feed the op, which handles Hkv < Hq natively.
+// GQA expansions on K/V are left in place; SDPAHeadExpansionFusingPattern
+// below fuses them into the op this pattern creates. Recognising the attention
+// math and normalising the op's operands are separate jobs.
 //
 // Attention sink ("softmax padding column"): a sink logit concat'd as an extra
 // score column before softmax and sliced off after is recognised — the trailing
@@ -55,6 +55,24 @@ public:
 
   mlir::LogicalResult
   matchAndRewrite(MatmulOp srcOp,
+                  mlir::PatternRewriter &rewriter) const override;
+};
+
+// Fuses a GQA head-expansion on the K/V operands into an existing
+// ttir.scaled_dot_product_attention. SDPA broadcasts Hkv heads up to Hq
+// natively, so an expansion ahead of the op is not needed.
+//
+// Anchored on the op, so it covers both paths: the decomposed matmul+softmax
+// form that SDPAFusingPattern fuses first, and frontends that emit the atomic
+// op directly with K/V pre-expanded. It matches on a head-dim
+// ttir.repeat_interleave.
+class SDPAHeadExpansionFusingPattern
+    : public mlir::OpRewritePattern<ScaledDotProductAttentionOp> {
+public:
+  using OpRewritePattern<ScaledDotProductAttentionOp>::OpRewritePattern;
+
+  mlir::LogicalResult
+  matchAndRewrite(ScaledDotProductAttentionOp op,
                   mlir::PatternRewriter &rewriter) const override;
 };
 

--- a/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
+++ b/lib/Dialect/TTIR/Transforms/Fusing/SDPAFusingPattern.cpp
@@ -220,6 +220,30 @@ GqaExpansion detectGqaExpansion(Value v) {
   return {repeatOp.getInput(), cast, repeatOp.getRepeats()};
 }
 
+// The type K/V carry once the expansion is fused into the op: the native
+// tensor's shape with the element type the expansion's surrounding cast
+// produced (if any).
+RankedTensorType fusedKvType(GqaExpansion g) {
+  auto nativeType = mlir::cast<RankedTensorType>(g.native.getType());
+  if (!g.cast) {
+    return nativeType;
+  }
+  return RankedTensorType::get(
+      nativeType.getShape(),
+      mlir::cast<RankedTensorType>(g.cast.getType()).getElementType(),
+      nativeType.getEncoding());
+}
+
+// Re-apply the element-type cast (if any) that sat outside the fused GQA
+// expansion onto the smaller native tensor, so K/V keep the element type they
+// had post-expansion.
+Value reapplyGqaCast(PatternRewriter &rewriter, GqaExpansion g) {
+  if (!g.cast) {
+    return g.native;
+  }
+  return rewriter.create<TypecastOp>(g.cast.getLoc(), fusedKvType(g), g.native);
+}
+
 // True if the slice keeps [0 : lastDim-1] of the last dim and is otherwise a
 // full, unit-step slice — i.e. it drops exactly the last column. Used to peel
 // the attention-sink softmax-padding slice.
@@ -560,32 +584,6 @@ SDPAFusingPattern::matchAndRewrite(MatmulOp srcOp,
     c.scale = qPreScale.value_or(1.0f) * kPreScale.value_or(1.0f);
   }
 
-  // GQA: models expand K/V from Hkv to Hq heads with a head-dim
-  // repeat_interleave before the score matmul. SDPA handles Hkv < Hq natively,
-  // so peel a matching expansion from both K and V (only when both match, to
-  // keep their head counts equal) and feed the un-expanded tensors. Any
-  // element-type cast that sat outside the expansion is re-applied on the
-  // smaller native tensor so K/V keep the element type they had post-expansion.
-  GqaExpansion kGqa = detectGqaExpansion(c.key);
-  GqaExpansion vGqa = detectGqaExpansion(c.value);
-  if (kGqa.repeats.has_value() && vGqa.repeats.has_value() &&
-      *kGqa.repeats == *vGqa.repeats) {
-    auto reapplyCast = [&](GqaExpansion g) -> Value {
-      if (!g.cast) {
-        return g.native;
-      }
-      auto nativeType = mlir::cast<RankedTensorType>(g.native.getType());
-      auto castElemType =
-          mlir::cast<RankedTensorType>(g.cast.getType()).getElementType();
-      auto nativeCastType = RankedTensorType::get(
-          nativeType.getShape(), castElemType, nativeType.getEncoding());
-      return rewriter.create<TypecastOp>(g.cast.getLoc(), nativeCastType,
-                                         g.native);
-    };
-    c.key = reapplyCast(kGqa);
-    c.value = reapplyCast(vGqa);
-  }
-
   // Shape validation (strict 4D, no unsqueezing).
   if (!validateShapes(c.query, c.key, c.value)) {
     return failure();
@@ -666,6 +664,34 @@ SDPAFusingPattern::matchAndRewrite(MatmulOp srcOp,
   }
 
   rewriter.replaceOp(c.attentionMatmul, result);
+  return success();
+}
+
+mlir::LogicalResult SDPAHeadExpansionFusingPattern::matchAndRewrite(
+    ScaledDotProductAttentionOp op, mlir::PatternRewriter &rewriter) const {
+  // Both K and V must carry the same head-expansion. SDPA is GQA-native, so
+  // feeding it the un-expanded Hkv-head tensors is equivalent; a mismatch is
+  // not a GQA expansion and is left alone.
+  GqaExpansion kGqa = detectGqaExpansion(op.getKey());
+  GqaExpansion vGqa = detectGqaExpansion(op.getValue());
+  if (!kGqa.repeats.has_value() || !vGqa.repeats.has_value() ||
+      *kGqa.repeats != *vGqa.repeats) {
+    return failure();
+  }
+
+  // The op requires K and V to have the same type.
+  if (fusedKvType(kGqa) != fusedKvType(vGqa)) {
+    return failure();
+  }
+
+  Value fusedKey = reapplyGqaCast(rewriter, kGqa);
+  Value fusedValue = reapplyGqaCast(rewriter, vGqa);
+
+  // Update the K/V operands with the newly fused values.
+  rewriter.modifyOpInPlace(op, [&] {
+    op.getKeyMutable().assign(fusedKey);
+    op.getValueMutable().assign(fusedValue);
+  });
   return success();
 }
 

--- a/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
+++ b/lib/Dialect/TTIR/Transforms/TTIRFusing.cpp
@@ -3689,6 +3689,7 @@ public:
       patterns.add<fusing::RoPEComplexRotationFusingPattern>(&getContext());
       patterns.add<fusing::RoPEInterleavedPairFusingPattern>(&getContext());
       patterns.add<fusing::SDPAFusingPattern>(&getContext());
+      patterns.add<fusing::SDPAHeadExpansionFusingPattern>(&getContext());
       patterns.add<fusing::TopKFusingPattern>(&getContext());
 
       GreedyRewriteConfig config;

--- a/test/python/golden/ttir_ops/fusing/test_sdpa_fusing.py
+++ b/test/python/golden/ttir_ops/fusing/test_sdpa_fusing.py
@@ -17,11 +17,6 @@ from conftest import get_request_kwargs
 
 pytestmark = [
     pytest.mark.frontend("ttir"),
-    pytest.mark.skip_config(
-        ("p150",),
-        ("p300",),
-        reason="Optimizer mock device grid mismatch on Blackhole (https://github.com/tenstorrent/tt-mlir/issues/7809)",
-    ),
 ]
 
 
@@ -155,7 +150,8 @@ REAL_MODEL_SHAPES = [
 ALL_SHAPES = DECODE_SHAPES + PREFILL_SHAPES + REAL_MODEL_SHAPES
 
 # Only GQA shapes (Hq != Hkv) — used by the repeat_interleave test, whose whole
-# point is exercising the native-GQA peel (a no-op when Hq == Hkv).
+# point is exercising the native-GQA head-expansion fusing (a no-op when
+# Hq == Hkv).
 GQA_SHAPES = [p for p in ALL_SHAPES if p.values[0].is_gqa]
 
 # Attention-sink shapes are MHA (Hq == Hkv) so the per-head sink is [1, Hq, 1, 1]
@@ -430,6 +426,34 @@ def assert_sdpa_fused(mlir_path: str, q_seq: int):
         assert check_op(mlir_path, "scaled_dot_product_attention_decode")
     else:
         assert check_op(mlir_path, "scaled_dot_product_attention")
+
+
+def assert_head_expansion_fused(mlir_path: str, sdpa_shapes: SDPAShapes):
+    """The head-expansion feeding SDPA must be fused into the sdpa op itself.
+
+    Verify that the expanding repeat op is not present in the IR.
+    """
+    if not sdpa_shapes.is_gqa:
+        return
+    narrow = "x".join(str(d) for d in sdpa_shapes.key)
+    expanded = "x".join(
+        str(d)
+        for d in (
+            sdpa_shapes.batch,
+            sdpa_shapes.q_heads,
+            sdpa_shapes.kv_seq,
+            sdpa_shapes.head_dim,
+        )
+    )
+    with open(mlir_path) as f:
+        ir = f.read()
+    for line in ir.splitlines():
+        if "ttnn.repeat" in line:
+            assert expanded not in line, (
+                f"tensor<{expanded}x...> repeated: KV was expanded to Hq "
+                f"heads, not fused into the op"
+            )
+    assert narrow in ir, f"no tensor<{narrow}x...> operand: KV is not Hkv-head"
 
 
 def compile_and_run_sdpa(module_fn, target, request):
@@ -812,6 +836,7 @@ def test_sdpa_gqa_repeat_interleave_div_scale(
 
     mlir_path = compile_and_run_sdpa(module, target, request)
     assert_sdpa_fused(mlir_path, sdpa_shapes.q_seq)
+    assert_head_expansion_fused(mlir_path, sdpa_shapes)
 
 
 @pytest.mark.parametrize("sdpa_shapes", SINK_SHAPES)

--- a/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa.mlir
+++ b/test/ttmlir/Dialect/TTIR/Transforms/sdpa_fusing/sdpa.mlir
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// RUN: ttmlir-opt --ttir-fusing %s | FileCheck %s
+// RUN: ttmlir-opt --canonicalize --ttir-fusing %s | FileCheck %s
 
 // Test the canonical mathematical form of SDPA fusing at the TTIR level.
 // Inputs are pre-softmax-fused (use ttir.softmax directly) unless a case
@@ -503,8 +503,9 @@ module {
 // GQA via ttir.repeat_interleave (head-dim expansion)
 //
 // Models expand K/V from Hkv to Hq heads with a head-dim repeat_interleave
-// before the score matmul. SDPA does GQA natively, so the expansion is peeled
-// from both K and V and the un-expanded (Hkv-head) tensors feed the op.
+// before the score matmul. SDPA broadcasts Hkv heads up to Hq natively, so the
+// expansion is fused into the op and the un-expanded (Hkv-head) tensors feed
+// it.
 // ----------------------------------------------------------------------------
 
 // GQA (Hkv=8, Hq=32, G=4): the native 8-head K/V must reach the op.
@@ -529,8 +530,9 @@ module {
 }
 
 // Real-model form: repeat_interleave produces bf16, then a typecast upcasts to
-// f32 before the score matmul. The head-dim repeat is peeled through the
-// typecast, which is re-applied on the native tensor (so K/V stay f32).
+// f32 before the score matmul. The head-dim repeat is fused into the op
+// through the typecast, which is re-applied on the native tensor (so K/V stay
+// f32).
 module {
   func.func @sdpa_gqa_repeat_interleave_typecast(
       %q: tensor<1x32x128x64xf32>,
@@ -662,5 +664,109 @@ module {
     %safe = "ttir.where"(%cond, %zeros, %smx) : (tensor<1x8x128x128xi1>, tensor<1x8x128x128xbf16>, tensor<1x8x128x128xbf16>) -> tensor<1x8x128x128xbf16>
     %o = "ttir.matmul"(%safe, %v) <{transpose_a = false, transpose_b = false}> : (tensor<1x8x128x128xbf16>, tensor<1x8x128x64xbf16>) -> tensor<1x8x128x64xbf16>
     return %o : tensor<1x8x128x64xbf16>
+  }
+}
+
+// ----------------------------------------------------------------------------
+// GQA head-expansion fusing on a ttir.scaled_dot_product_attention
+// ----------------------------------------------------------------------------
+
+// Expansion written as ttir.repeat_interleave.
+module {
+  func.func @sdpa_op_gqa_repeat_interleave(
+      %q: tensor<1x32x1x64xbf16>,
+      %k: tensor<1x8x128x64xbf16>,
+      %v: tensor<1x8x128x64xbf16>,
+      %mask: tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16> {
+    // CHECK-LABEL: @sdpa_op_gqa_repeat_interleave
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>
+    // CHECK-NOT: ttir.repeat_interleave
+    %ke = "ttir.repeat_interleave"(%k) <{dim = 1 : si32, repeats = 4 : ui32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %ve = "ttir.repeat_interleave"(%v) <{dim = 1 : si32, repeats = 4 : ui32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %o = "ttir.scaled_dot_product_attention"(%q, %ke, %ve, %mask) <{is_causal = false, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, scale = 1.250000e-01 : f32}> : (tensor<1x32x1x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16>
+    return %o : tensor<1x32x1x64xbf16>
+  }
+}
+
+// Expansion written as unsqueeze + broadcast + reshape.
+module {
+  func.func @sdpa_op_gqa_unsqueeze_broadcast_reshape(
+      %q: tensor<1x32x1x64xbf16>,
+      %k: tensor<1x8x128x64xbf16>,
+      %v: tensor<1x8x128x64xbf16>,
+      %mask: tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16> {
+    // CHECK-LABEL: @sdpa_op_gqa_unsqueeze_broadcast_reshape
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.repeat_interleave
+    %ku = "ttir.unsqueeze"(%k) <{dim = 2 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %kb = "ttir.broadcast"(%ku) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %ke = "ttir.reshape"(%kb) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %vu = "ttir.unsqueeze"(%v) <{dim = 2 : si32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %vb = "ttir.broadcast"(%vu) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %ve = "ttir.reshape"(%vb) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %o = "ttir.scaled_dot_product_attention"(%q, %ke, %ve, %mask) <{is_causal = false, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, scale = 1.250000e-01 : f32}> : (tensor<1x32x1x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16>
+    return %o : tensor<1x32x1x64xbf16>
+  }
+}
+
+// Expansion written as reshape + broadcast + reshape.
+module {
+  func.func @sdpa_op_gqa_reshape_broadcast_reshape(
+      %q: tensor<1x32x1x64xbf16>,
+      %k: tensor<1x8x128x64xbf16>,
+      %v: tensor<1x8x128x64xbf16>,
+      %mask: tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16> {
+    // CHECK-LABEL: @sdpa_op_gqa_reshape_broadcast_reshape
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>
+    // CHECK-NOT: ttir.broadcast
+    // CHECK-NOT: ttir.repeat_interleave
+    %ku = "ttir.reshape"(%k) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %kb = "ttir.broadcast"(%ku) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %ke = "ttir.reshape"(%kb) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %vu = "ttir.reshape"(%v) <{shape = [1 : i32, 8 : i32, 1 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x128x64xbf16>) -> tensor<1x8x1x128x64xbf16>
+    %vb = "ttir.broadcast"(%vu) <{broadcast_dimensions = array<i64: 1, 1, 4, 1, 1>}> : (tensor<1x8x1x128x64xbf16>) -> tensor<1x8x4x128x64xbf16>
+    %ve = "ttir.reshape"(%vb) <{shape = [1 : i32, 32 : i32, 128 : i32, 64 : i32]}> : (tensor<1x8x4x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %o = "ttir.scaled_dot_product_attention"(%q, %ke, %ve, %mask) <{is_causal = false, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, scale = 1.250000e-01 : f32}> : (tensor<1x32x1x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16>
+    return %o : tensor<1x32x1x64xbf16>
+  }
+}
+
+// Negative: only K is expanded, so fusing K alone would leave K and V with
+// mismatched head counts.
+module {
+  func.func @sdpa_op_gqa_only_k_not_peeled(
+      %q: tensor<1x32x1x64xbf16>,
+      %k: tensor<1x8x128x64xbf16>,
+      %v: tensor<1x32x128x64xbf16>,
+      %mask: tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16> {
+    // CHECK-LABEL: @sdpa_op_gqa_only_k_not_peeled
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>
+    %ke = "ttir.repeat_interleave"(%k) <{dim = 1 : si32, repeats = 4 : ui32}> : (tensor<1x8x128x64xbf16>) -> tensor<1x32x128x64xbf16>
+    %o = "ttir.scaled_dot_product_attention"(%q, %ke, %v, %mask) <{is_causal = false, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, scale = 1.250000e-01 : f32}> : (tensor<1x32x1x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x32x128x64xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x32x1x64xbf16>
+    return %o : tensor<1x32x1x64xbf16>
+  }
+}
+
+// Negative: the expansion is on the seq-len dim, not the heads dim, so it is
+// not a GQA expansion and must not be fused.
+module {
+  func.func @sdpa_op_expansion_on_seq_dim_not_peeled(
+      %q: tensor<1x8x1x64xbf16>,
+      %k: tensor<1x8x32x64xbf16>,
+      %v: tensor<1x8x32x64xbf16>,
+      %mask: tensor<1x1x1x128xbf16>) -> tensor<1x8x1x64xbf16> {
+    // CHECK-LABEL: @sdpa_op_expansion_on_seq_dim_not_peeled
+    // CHECK: ttir.repeat_interleave
+    // CHECK: "ttir.scaled_dot_product_attention"
+    // CHECK-SAME: tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>
+    %ke = "ttir.repeat_interleave"(%k) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x32x64xbf16>) -> tensor<1x8x128x64xbf16>
+    %ve = "ttir.repeat_interleave"(%v) <{dim = 2 : si32, repeats = 4 : ui32}> : (tensor<1x8x32x64xbf16>) -> tensor<1x8x128x64xbf16>
+    %o = "ttir.scaled_dot_product_attention"(%q, %ke, %ve, %mask) <{is_causal = false, operandSegmentSizes = array<i32: 1, 1, 1, 1, 0>, scale = 1.250000e-01 : f32}> : (tensor<1x8x1x64xbf16>, tensor<1x8x128x64xbf16>, tensor<1x8x128x64xbf16>, tensor<1x1x1x128xbf16>) -> tensor<1x8x1x64xbf16>
+    return %o : tensor<1x8x1x64xbf16>
   }
 }


### PR DESCRIPTION
Currently, the `SDPAFusingPattern` is responsible for fusing `ttir.scaled_dot_product_attention` entirely. This means that if we are handed a `TTIR` with `ttir.scaled_dot_product_attention` op in the graph, we will miss out on optimizations that are related to the head expansion - since our `ttir.scaled_dot_product_attention` op can handle those natively, the head expansion can also be fused into the op. However, this won't happen, since the pattern won't match the already existing `ttir.scaled_dot_product_attention` op.

This is resolved by decoupling fusing of the core op and the fusing of redundant/not needed transformations on the inputs, i.e. head expansion. Now, we have a core pattern which is supposed to match the core operations that make the scaled dot product attention and fuse them into a single op; and another fusing pattern
(`SDPAHeadExpansionFusingPattern` - anchored on the `ttir.scaled_dot_product_attention` op), which takes care only of the unneeded head expansion.

Tests are updated with new cases to cover the new behaviour.