### PR TITLE
[TTML] Add layer_norm_bw op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/TransformerRules.h
@@ -79,6 +79,17 @@ struct TTMLLayerNormForwardRuleBook : OpRuleBook {
                  const std::vector<OpConfig> &legalConfigs) const override;
 };
 
+/// TTML layer norm backward:
+/// All operands must be tiled and DRAM-interleaved. The backend derives the
+/// output and optional statistics layouts from the input.
+struct TTMLLayerNormBackwardRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
 /// ScaledDotProductAttentionDecodeOp / PagedScaledDotProductAttentionDecodeOp:
 /// Per-operand input layout filtering.
 /// - Q (operand 0): DRAM (any) or L1-sharded -- L1-interleaved rejected

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2928,6 +2928,40 @@ def TTNN_LayerNormForwardOp : TTNN_Op<"layernorm_fw",
     let hasVerifier = 1;
 }
 
+def TTNN_LayerNormBackwardOp : TTNN_Op<"layernorm_bw"> {
+    let summary = "Layer normalization backward (ttml).";
+    let description = [{
+      Training-oriented fused layer normalization backward pass, backed by
+      `ttml::metal::layernorm_bw`. Given the original input, affine scale,
+      forward mean and reciprocal standard deviation, and upstream gradient,
+      it returns the input, gamma, and beta gradients.
+
+      The backing kernel requires rank-4 tensors: `input` and `dL_dout` are
+      `(B, N, S, C)`, `gamma` is `(1, 1, 1, C)`, and `mean`/`rstd` are
+      `(B, N, S, 1)`. All inputs and outputs must be bfloat16, tiled, and
+      interleaved in DRAM; the workarounds pass enforces these requirements.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$gamma,
+                         AnyRankedTensor:$mean,
+                         AnyRankedTensor:$rstd,
+                         AnyRankedTensor:$dL_dout);
+
+    let results = (outs AnyRankedTensor:$dx,
+                        AnyRankedTensor:$dgamma,
+                        AnyRankedTensor:$dbeta);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createLayerNormBackwardOpOperandsWorkarounds(this->getOperation());
+      }
+    }];
+
+    let hasVerifier = 1;
+}
+
 def TTNN_DitRMSNormUnaryFusedOp : TTNN_Op<"dit_rms_norm_unary_fused",
     [AttrSizedOperandSegments, TTNN_MemoryConfigOpInterface, TTNN_ComputeKernelConfigOpInterface]> {
     let summary = "Fused RMSNorm + unary activation op.";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -401,6 +401,11 @@ public:
   static TTNNOperandsWorkarounds
   createLayerNormForwardOpOperandsWorkarounds(Operation *op);
 
+  // Create workarounds for the ttml layernorm_bw op: force bf16, tile layout
+  // and DRAM interleaved memory for every operand and result.
+  static TTNNOperandsWorkarounds
+  createLayerNormBackwardOpOperandsWorkarounds(Operation *op);
+
   // Create workarounds for sparse_matmul op operands.
   // Sparsity tensor must be in ROW_MAJOR layout.
   // Issue page: https://github.com/tenstorrent/tt-metal/issues/39126

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -33,6 +33,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 } // namespace ttnn::graph::detail
 
 #include "metal/ops/cross_entropy_fw/cross_entropy_fw.hpp"
+#include "metal/ops/layernorm_bw/layernorm_bw.hpp"
 #include "metal/ops/layernorm_fw/layernorm_fw.hpp"
 #include "metal/ops/sdpa_bw/sdpa_bw.hpp"
 #include "metal/ops/sdpa_fw/sdpa_fw.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2434,6 +2434,25 @@ struct OpModel<SDPABackwardOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// CrossEntropyForwardOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<CrossEntropyForwardOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout,
+                   llvm::ArrayRef<int64_t> targetShape,
+                   TTNNLayoutAttr targetLayout, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               llvm::ArrayRef<int64_t> targetShape, TTNNLayoutAttr targetLayout,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp
 //===----------------------------------------------------------------------===//
 
@@ -2455,22 +2474,27 @@ struct OpModel<LayerNormForwardOp> {
 };
 
 //===----------------------------------------------------------------------===//
-// CrossEntropyForwardOp
+// LayerNormBackwardOp
 //===----------------------------------------------------------------------===//
 
 template <>
-struct OpModel<CrossEntropyForwardOp> {
-  static llvm::Expected<OpConstraints>
-  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
-                   TTNNLayoutAttr inputLayout,
-                   llvm::ArrayRef<int64_t> targetShape,
-                   TTNNLayoutAttr targetLayout, TTNNLayoutAttr outputLayout,
-                   const MockAllocatorState *initialState = nullptr);
+struct OpModel<LayerNormBackwardOp> {
+  static llvm::Expected<OpConstraints> getOpConstraints(
+      llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+      llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+      llvm::ArrayRef<int64_t> meanShape, TTNNLayoutAttr meanLayout,
+      llvm::ArrayRef<int64_t> rstdShape, TTNNLayoutAttr rstdLayout,
+      llvm::ArrayRef<int64_t> dL_doutShape, TTNNLayoutAttr dL_doutLayout,
+      TTNNLayoutAttr outputLayout,
+      const MockAllocatorState *initialState = nullptr);
 
   static llvm::Expected<size_t>
   getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
-               llvm::ArrayRef<int64_t> targetShape, TTNNLayoutAttr targetLayout,
-               TTNNLayoutAttr outputLayout);
+               llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+               llvm::ArrayRef<int64_t> meanShape, TTNNLayoutAttr meanLayout,
+               llvm::ArrayRef<int64_t> rstdShape, TTNNLayoutAttr rstdLayout,
+               llvm::ArrayRef<int64_t> dL_doutShape,
+               TTNNLayoutAttr dL_doutLayout, TTNNLayoutAttr outputLayout);
 };
 
 } // namespace mlir::tt::ttnn::op_model

--- a/include/ttmlir/Target/TTNN/operations/ttml.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ttml.fbs
@@ -42,6 +42,17 @@ table LayerNormForwardOp {
   rstd: tt.target.ttnn.TensorRef;
 }
 
+table LayerNormBackwardOp {
+  input: tt.target.ttnn.TensorRef;
+  gamma: tt.target.ttnn.TensorRef;
+  mean: tt.target.ttnn.TensorRef;
+  rstd: tt.target.ttnn.TensorRef;
+  dl_dout: tt.target.ttnn.TensorRef;
+  dx: tt.target.ttnn.TensorRef;
+  dgamma: tt.target.ttnn.TensorRef;
+  dbeta: tt.target.ttnn.TensorRef;
+}
+
 table SDPABackwardOp {
   grad_output: tt.target.ttnn.TensorRef;
   attn_output: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -92,6 +92,7 @@ union OpType {
   GlobalAvgPool2dOp,
   GroupNormOp,
   IndexerScoreDsaOp,
+  LayerNormBackwardOp,
   LayerNormForwardOp,
   LayerNormOp,
   LayerNormPreAllGatherOp,

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -2273,6 +2273,37 @@ public:
   }
 };
 
+class TenstorrentLayerNormBackwardConversionPattern
+    : public OpConversionPattern<mlir::stablehlo::CompositeOp> {
+public:
+  using OpConversionPattern<mlir::stablehlo::CompositeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::stablehlo::CompositeOp srcOp,
+                  mlir::stablehlo::CompositeOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (srcOp.getName() != "tenstorrent.layernorm_bw") {
+      return failure();
+    }
+    if (adaptor.getOperands().size() != 5 || srcOp.getNumResults() != 3) {
+      return rewriter.notifyMatchFailure(srcOp,
+                                         "tenstorrent.layernorm_bw must have "
+                                         "exactly 5 operands and 3 results");
+    }
+    if (srcOp.getCompositeAttributes() &&
+        !srcOp.getCompositeAttributes().empty()) {
+      return rewriter.notifyMatchFailure(
+          srcOp, "tenstorrent.layernorm_bw does not accept attributes");
+    }
+
+    rewriter.replaceOpWithNewOp<ttcore::CompositeOp>(
+        srcOp, srcOp.getResultTypes(), adaptor.getOperands(),
+        rewriter.getStringAttr("layernorm_bw"), srcOp.getDecomposition(),
+        rewriter.getDictionaryAttr({}));
+    return success();
+  }
+};
+
 struct LegalizeStableHLOCompositeToTTIR
     : public ttir::impl::LegalizeStableHLOCompositeToTTIRBase<
           LegalizeStableHLOCompositeToTTIR> {
@@ -2312,6 +2343,7 @@ void populateStableHLOCompositeLegalizationPatterns(
   patterns.add<TenstorrentSDPAForwardConversionPattern>(context);
   patterns.add<TenstorrentSDPABackwardConversionPattern>(context);
   patterns.add<TenstorrentLayerNormForwardConversionPattern>(context);
+  patterns.add<TenstorrentLayerNormBackwardConversionPattern>(context);
   patterns.add<
       StableHLOToTTIRCompositeOpConversionPattern<ttir::CrossEntropyForwardOp>>(
       context, "tenstorrent.cross_entropy_fw");

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1285,21 +1285,21 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// LayerNorm forward decomposition pattern
+// LayerNorm decomposition pattern
 //===----------------------------------------------------------------------===//
 
-// ttml::metal::layernorm_fw only accepts rank-4 tensors. Normalize the
+// The TTML layernorm kernels only accept rank-4 tensors. Normalize the
 // composite signature while preserving a valid decomposition fallback.
 namespace {
-struct LayerNormForwardPattern
-    : public OpConversionPattern<ttcore::CompositeOp> {
+struct LayerNormPattern : public OpConversionPattern<ttcore::CompositeOp> {
 public:
   using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (op.getCompositeName() != "layernorm_fw") {
+    if (op.getCompositeName() != "layernorm_fw" &&
+        op.getCompositeName() != "layernorm_bw") {
       return failure();
     }
 
@@ -2447,8 +2447,8 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<AdamWPattern>(typeConverter, ctx);
   patterns.add<SDPAForwardPattern>(typeConverter, ctx);
   patterns.add<SDPABackwardPattern>(typeConverter, ctx);
-  patterns.add<LayerNormForwardPattern>(typeConverter, ctx);
   patterns.add<CrossEntropyForwardPattern>(typeConverter, ctx);
+  patterns.add<LayerNormPattern>(typeConverter, ctx);
   patterns.add<QuantizeOpPattern>(typeConverter, ctx);
   patterns.add<DequantizeOpPattern>(typeConverter, ctx);
   patterns.add<RequantizeOpPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -120,13 +120,16 @@ struct TTIRToTTIRDecompositionPass
       return op.getParam().getType().getRank() == 4;
     });
 
-    // The ttml::metal SDPA and layernorm_fw ops only accept rank-4 tensors.
+
+
+
+    // The ttml::metal SDPA and layernorm ops only accept rank-4 tensors.
     // Other composites are unaffected by this decomposition.
     target.addDynamicallyLegalOp<ttcore::CompositeOp>(
         [&](ttcore::CompositeOp op) {
           StringRef compositeName = op.getCompositeName();
           if (compositeName != "sdpa_fw" && compositeName != "sdpa_bw" &&
-              compositeName != "layernorm_fw") {
+              compositeName != "layernorm_fw" && compositeName != "layernorm_bw") {
             return true;
           }
           bool operandsRank4 = llvm::all_of(op.getInputs(), [&](Value input) {

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3762,6 +3762,69 @@ public:
 } // namespace
 
 //
+// LayerNormBackwardOp conversion pattern (emits ::ttml::metal::layernorm_bw)
+//
+namespace {
+class LayerNormBackwardOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormBackwardOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.layernorm_bw";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttml::metal::layernorm_bw";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormBackwardOp>::TTNNToEmitCBaseOpConversionPattern;
+  using Adaptor = mlir::tt::ttnn::LayerNormBackwardOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormBackwardOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::LayerNormBackwardOp>
+        emitter(srcOp, adaptor, rewriter);
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()), emitter.emit(srcOp.getGamma()),
+        emitter.emit(srcOp.getMean()), emitter.emit(srcOp.getRstd()),
+        emitter.emit(srcOp.getDLDout())};
+
+    using ReturnTy = std::vector<std::optional<::ttnn::Tensor>>;
+    auto call = rewriter.create<emitc::CallOpaqueOp>(
+        srcOp.getLoc(),
+        rewriter.getType<emitc::OpaqueType>(ttnn_to_emitc::TypeNameV<ReturnTy>),
+        convertOpName(srcOp), rewriter.getArrayAttr(args),
+        /*template_args=*/nullptr, adaptor.getOperands());
+
+    auto optionalType = emitc::OpaqueType::get(
+        rewriter.getContext(), ttnn_to_emitc::TypeNameV<ReturnTy::value_type>);
+    auto optionalLValueType = emitc::LValueType::get(optionalType);
+    auto tensorType = rewriter.getType<emitc::OpaqueType>(
+        ttnn_to_emitc::TypeNameV<::ttnn::Tensor>);
+    llvm::SmallVector<mlir::Value, 3> results;
+    for (unsigned i = 0; i < 3; ++i) {
+      auto index = rewriter.create<emitc::LiteralOp>(
+          srcOp.getLoc(), rewriter.getIndexType(), std::to_string(i));
+      auto subscript = rewriter.create<emitc::SubscriptOp>(
+          srcOp.getLoc(), optionalLValueType, call.getResult(0),
+          index.getResult());
+      auto load = rewriter.create<emitc::LoadOp>(srcOp.getLoc(), optionalType,
+                                                 subscript.getResult());
+      auto value = rewriter.create<emitc::CallOpaqueOp>(
+          srcOp.getLoc(), tensorType,
+          ttnn_to_emitc::kGetOptionalValueFunctionName, /*args=*/nullptr,
+          /*template_args=*/nullptr, load.getResult());
+      results.push_back(value.getResult(0));
+    }
+    rewriter.replaceOp(srcOp, results);
+    return success();
+  }
+};
+} // namespace
+
+//
 // SDPABackwardOp conversion pattern (emits ::ttml::metal::sdpa_bw)
 //
 namespace {
@@ -6320,6 +6383,7 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
            BatchNormInferenceOpConversionPattern, AdamWOpConversionPattern,
            SDPAForwardOpConversionPattern, SDPABackwardOpConversionPattern,
            LayerNormForwardOpConversionPattern,
+           LayerNormBackwardOpConversionPattern,
            CrossEntropyForwardOpConversionPattern,
            BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
            DitRMSNormUnaryFusedOpConversionPattern,

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -5618,6 +5618,24 @@ public:
         "bindings.");
   }
 };
+
+class LayerNormBackwardOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::LayerNormBackwardOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::LayerNormBackwardOp>::TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::LayerNormBackwardOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return rewriter.notifyMatchFailure(
+        srcOp,
+        "EmitPy lowering for ttnn.layernorm_bw is not supported: ttml does not "
+        "expose the metal::layernorm_bw primitive through its Python "
+        "bindings.");
+  }
+};
 } // namespace
 
 namespace mlir::tt {
@@ -5931,18 +5949,14 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
   patterns.add<PagedFlashMultiLatentAttentionDecodeOpConversionPattern>(
       typeConverter, ctx);
 
-  // AdamW: deliberately declines conversion (see TODO(pglusac) above).
+  // TTML ops: deliberately decline conversion (see issue above).
   patterns.add<AdamWOpConversionPattern>(typeConverter, ctx);
-
-  // SDPAForward: deliberately declines conversion (see comment above).
   patterns.add<SDPAForwardOpConversionPattern>(typeConverter, ctx);
-
-  // SDPABackward: deliberately declines conversion (see comment above).
   patterns.add<SDPABackwardOpConversionPattern>(typeConverter, ctx);
   patterns.add<LayerNormForwardOpConversionPattern>(typeConverter, ctx);
-
-  // CrossEntropyForward: deliberately declines conversion, same reason.
+  patterns.add<LayerNormBackwardOpConversionPattern>(typeConverter, ctx);
   patterns.add<CrossEntropyForwardOpConversionPattern>(typeConverter, ctx);
+  
 }
 
 } // namespace mlir::tt

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -81,6 +81,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static TTMLSDPAForwardRuleBook ttmlSdpaForward;
   static TTMLSDPABackwardRuleBook ttmlSdpaBackward;
   static TTMLLayerNormForwardRuleBook ttmlLayerNormForward;
+  static TTMLLayerNormBackwardRuleBook ttmlLayerNormBackward;
   static SDPADecodeRuleBook sdpaDecode;
   static EmbeddingRuleBook embedding;
   static TypecastRuleBook typecast;
@@ -123,6 +124,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(SDPAForwardOp::getOperationName(), &ttmlSdpaForward);
     reg(SDPABackwardOp::getOperationName(), &ttmlSdpaBackward);
     reg(LayerNormForwardOp::getOperationName(), &ttmlLayerNormForward);
+    reg(LayerNormBackwardOp::getOperationName(), &ttmlLayerNormBackward);
     reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
     reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(),
         &sdpaDecode);

--- a/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/TransformerRules.cpp
@@ -97,6 +97,27 @@ OutputHints TTMLLayerNormForwardRuleBook::getOutputHints(
 }
 
 //===----------------------------------------------------------------------===//
+// TTMLLayerNormBackwardRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn TTMLLayerNormBackwardRuleBook::getInputLayoutFilter(
+    unsigned /*operandIdx*/) const {
+  return [](TTNNLayoutAttr layout) {
+    return layout_filter_utils::requireTiled(layout) &&
+           layout_filter_utils::requireDRAMInterleaved(layout);
+  };
+}
+
+bool TTMLLayerNormBackwardRuleBook::shouldExploreReshards() const {
+  return false;
+}
+
+OutputHints TTMLLayerNormBackwardRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> & /*legalConfigs*/) const {
+  return layout_filter_utils::nullHintOnly();
+}
+
+//===----------------------------------------------------------------------===//
 // SDPADecodeRuleBook
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4060,6 +4060,65 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormBackwardOp
+//===----------------------------------------------------------------------===//
+::mlir::LogicalResult mlir::tt::ttnn::LayerNormBackwardOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType gammaType = getGamma().getType();
+  RankedTensorType meanType = getMean().getType();
+  RankedTensorType rstdType = getRstd().getType();
+  RankedTensorType gradType = getDLDout().getType();
+
+  if (inputType.getRank() != 4 || gammaType.getRank() != 4 ||
+      meanType.getRank() != 4 || rstdType.getRank() != 4 ||
+      gradType.getRank() != 4) {
+    return emitOpError("all inputs must be rank 4");
+  }
+
+  int64_t normalizedSize = inputType.getDimSize(3);
+  llvm::SmallVector<int64_t, 4> expectedGammaShape{1, 1, 1, normalizedSize};
+  if (gammaType.getShape() != llvm::ArrayRef<int64_t>(expectedGammaShape)) {
+    return emitOpError("gamma must have shape (1, 1, 1, ")
+           << normalizedSize << ")";
+  }
+
+  llvm::SmallVector<int64_t, 4> expectedStatsShape(inputType.getShape());
+  expectedStatsShape.back() = 1;
+  if (meanType.getShape() != llvm::ArrayRef<int64_t>(expectedStatsShape) ||
+      rstdType.getShape() != llvm::ArrayRef<int64_t>(expectedStatsShape)) {
+    return emitOpError("mean and rstd must have shape (B, N, S, 1)");
+  }
+  if (gradType.getShape() != inputType.getShape()) {
+    return emitOpError("dL_dout must have the same shape as input");
+  }
+
+  Type elementType = inputType.getElementType();
+  if (gammaType.getElementType() != elementType ||
+      meanType.getElementType() != elementType ||
+      rstdType.getElementType() != elementType ||
+      gradType.getElementType() != elementType) {
+    return emitOpError("all inputs must have the same element type");
+  }
+
+  RankedTensorType dxType = getDx().getType();
+  RankedTensorType dgammaType = getDgamma().getType();
+  RankedTensorType dbetaType = getDbeta().getType();
+  if (dxType.getShape() != inputType.getShape()) {
+    return emitOpError("dx must have the same shape as input");
+  }
+  if (dgammaType.getShape() != gammaType.getShape() ||
+      dbetaType.getShape() != gammaType.getShape()) {
+    return emitOpError("dgamma and dbeta must have the same shape as gamma");
+  }
+  if (dxType.getElementType() != elementType ||
+      dgammaType.getElementType() != elementType ||
+      dbetaType.getElementType() != elementType) {
+    return emitOpError("all outputs must have the same element type as input");
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // DitRMSNormUnaryFusedOp
 //===----------------------------------------------------------------------===//
 ::mlir::LogicalResult mlir::tt::ttnn::DitRMSNormUnaryFusedOp::verify() {

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1270,6 +1270,29 @@ TTNNOperandsWorkaroundsFactory::createLayerNormForwardOpOperandsWorkarounds(
   return operandsWorkaround;
 }
 
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createLayerNormBackwardOpOperandsWorkarounds(
+    Operation *op) {
+  TTNNOperandWorkarounds tileDramBf16;
+  tileDramBf16.tensorLayoutWorkaround = Layout::Tile;
+  tileDramBf16.tensorBufferTypeWorkaround = BufferType::DRAM;
+  tileDramBf16.tensorMemoryLayoutWorkaround = TensorMemoryLayoutAttr::get(
+      op->getContext(), TensorMemoryLayout::Interleaved);
+  tileDramBf16.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+
+  TTNNOperandsWorkarounds operandsWorkaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds();
+  for (unsigned i = 0; i < 5; ++i) {
+    operandsWorkaround =
+        operandsWorkaround.addInputOperandWorkaround(tileDramBf16);
+  }
+  for (unsigned i = 0; i < 3; ++i) {
+    operandsWorkaround =
+        operandsWorkaround.addOutputOperandWorkaround(tileDramBf16);
+  }
+  return operandsWorkaround;
+}
+
 // Create workarounds for SDPA decode op: cast f32 inputs to bf16.
 // tt-metal SDPA only supports bf16/bfp8_b/bfp4_b.
 // Issue page: https://github.com/tenstorrent/tt-metal/issues/36717

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4720,6 +4720,36 @@ LayerNormForwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormBackwardOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> LayerNormBackwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 5 && "LayerNormBackwardOp must have 5 inputs");
+  return detail::constraintsDispatch(
+      *this, liveRecords, getInput().getType().getShape(), inputs[0],
+      getGamma().getType().getShape(), inputs[1],
+      getMean().getType().getShape(), inputs[2], getRstd().getType().getShape(),
+      inputs[3], getDLDout().getType().getShape(), inputs[4],
+      opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+LayerNormBackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                                  const OpConfig &opConfig) {
+  assert(inputs.size() == 5 && "LayerNormBackwardOp must have 5 inputs");
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<LayerNormBackwardOp>::getOpRuntime, *this,
+      getInput().getType().getShape(), inputs[0],
+      getGamma().getType().getShape(), inputs[1],
+      getMean().getType().getShape(), inputs[2], getRstd().getType().getShape(),
+      inputs[3], getDLDout().getType().getShape(), inputs[4],
+      opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // CrossEntropyForwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -149,6 +149,33 @@ static void registerBuiltinComposites() {
       },
       /*promotionGuard=*/nullptr};
 
+  registry["layernorm_bw"] = CompositeEntry{
+      // Validate
+      [](ttcore::CompositeOp compositeOp,
+         OpBuilder &builder) -> OpValidationResult {
+        TT_assert(compositeOp.getInputs().size() == 5u);
+        TT_assert(compositeOp.getNumResults() == 3u);
+        auto attrs = compositeOp.getCompositeAttributes();
+        TT_assert((!attrs || attrs->empty()));
+
+        SmallVector<Type> resultTypes(compositeOp.getResultTypes());
+        IsolatedIRValidationWrapper validator(compositeOp.getContext());
+        return validator.validateOp<LayerNormBackwardOp>(
+            compositeOp.getOperation(), compositeOp.getLoc(), resultTypes,
+            compositeOp.getInputs()[0], compositeOp.getInputs()[1],
+            compositeOp.getInputs()[2], compositeOp.getInputs()[3],
+            compositeOp.getInputs()[4]);
+      },
+      // Build
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        return builder.create<LayerNormBackwardOp>(
+            compositeOp.getLoc(), compositeOp.getResultTypes(),
+            compositeOp.getInputs()[0], compositeOp.getInputs()[1],
+            compositeOp.getInputs()[2], compositeOp.getInputs()[3],
+            compositeOp.getInputs()[4]);
+      },
+      /*promotionGuard=*/nullptr};
+
   registry["topk_router_gpt"] = CompositeEntry{
       // Validate
       [](ttcore::CompositeOp compositeOp,

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9766,6 +9766,88 @@ llvm::Expected<size_t> OpModel<LayerNormForwardOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// LayerNormBackwardOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<LayerNormBackwardOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+    llvm::ArrayRef<int64_t> meanShape, TTNNLayoutAttr meanLayout,
+    llvm::ArrayRef<int64_t> rstdShape, TTNNLayoutAttr rstdLayout,
+    llvm::ArrayRef<int64_t> dL_doutShape, TTNNLayoutAttr dL_doutLayout,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gammaSpec,
+      detail::convertToTensorSpec(device, gammaShape, gammaLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec meanSpec,
+                   detail::convertToTensorSpec(device, meanShape, meanLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec rstdSpec,
+                   detail::convertToTensorSpec(device, rstdShape, rstdLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec dL_doutSpec,
+      detail::convertToTensorSpec(device, dL_doutShape, dL_doutLayout));
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto layerNormBackwardOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttml::metal::layernorm_bw, device, initialStateOpt, inputSpec,
+        gammaSpec, meanSpec, rstdSpec, dL_doutSpec);
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              layerNormBackwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<LayerNormBackwardOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+    llvm::ArrayRef<int64_t> meanShape, TTNNLayoutAttr meanLayout,
+    llvm::ArrayRef<int64_t> rstdShape, TTNNLayoutAttr rstdLayout,
+    llvm::ArrayRef<int64_t> dL_doutShape, TTNNLayoutAttr dL_doutLayout,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gammaSpec,
+      detail::convertToTensorSpec(device, gammaShape, gammaLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec meanSpec,
+                   detail::convertToTensorSpec(device, meanShape, meanLayout));
+  ASSIGN_OR_RETURN(::tt::tt_metal::TensorSpec rstdSpec,
+                   detail::convertToTensorSpec(device, rstdShape, rstdLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec dL_doutSpec,
+      detail::convertToTensorSpec(device, dL_doutShape, dL_doutLayout));
+
+  auto layerNormBackwardOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttml::metal::layernorm_bw, device, inputSpec,
+                            gammaSpec, meanSpec, rstdSpec, dL_doutSpec);
+  };
+
+  return operation::getOpRuntime(layerNormBackwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // CrossEntropyForwardOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1710,6 +1710,23 @@ createOp(FlatbufferObjectCache &cache, LayerNormForwardOp op) {
       op.getReturnMeanRstd(), output, mean, rstd);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::LayerNormBackwardOp>
+createOp(FlatbufferObjectCache &cache, LayerNormBackwardOp op) {
+  auto getInput = [&](Value value) {
+    return cache.at<::tt::target::ttnn::TensorRef>(
+        getOperandThroughDPSOps(value));
+  };
+  auto getOutput = [&](Value value) {
+    return cache.getOrCreateNoSharding(value, tensorValueToFlatbuffer,
+                                       /*local_shape*/ std::nullopt);
+  };
+  return ::tt::target::ttnn::CreateLayerNormBackwardOp(
+      *cache.fbb, getInput(op.getInput()), getInput(op.getGamma()),
+      getInput(op.getMean()), getInput(op.getRstd()), getInput(op.getDLDout()),
+      getOutput(op.getDx()), getOutput(op.getDgamma()),
+      getOutput(op.getDbeta()));
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::SDPABackwardOp>
 createOp(FlatbufferObjectCache &cache, SDPABackwardOp op) {
   auto gradOutput = cache.at<::tt::target::ttnn::TensorRef>(
@@ -5150,6 +5167,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto crossEntropyFwOp = dyn_cast<CrossEntropyForwardOp>(op);
       crossEntropyFwOp) {
     return createOperation(cache, createOp(cache, crossEntropyFwOp),
+                           debugString, locInfo);
+  }
+  if (auto layerNormBackwardOp = dyn_cast<LayerNormBackwardOp>(op);
+      layerNormBackwardOp) {
+    return createOperation(cache, createOp(cache, layerNormBackwardOp),
                            debugString, locInfo);
   }
   if (auto rmsNormOp = dyn_cast<RMSNormOp>(op); rmsNormOp) {

--- a/runtime/lib/ttnn/operations/ttml/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/ttml/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 add_library(TTRuntimeTTMLOps STATIC
   adamw.cpp
+  layernorm_bw.cpp
   layernorm_fw.cpp
   sdpa_fw.cpp
   sdpa_bw.cpp

--- a/runtime/lib/ttnn/operations/ttml/layernorm_bw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/layernorm_bw.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/ttml/layernorm_bw.h"
+#include "metal/ops/layernorm_bw/layernorm_bw.hpp"
+
+namespace tt::runtime::ttnn::operations::ttml {
+
+void run(const ::tt::target::ttnn::LayerNormBackwardOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &gamma =
+      tensorPool.getTTNNTensorAndValidate(op->gamma());
+  const ::ttnn::Tensor &mean = tensorPool.getTTNNTensorAndValidate(op->mean());
+  const ::ttnn::Tensor &rstd = tensorPool.getTTNNTensorAndValidate(op->rstd());
+  const ::ttnn::Tensor &dL_dout =
+      tensorPool.getTTNNTensorAndValidate(op->dl_dout());
+
+  std::vector<std::optional<::ttnn::Tensor>> result =
+      ::ttml::metal::layernorm_bw(input, gamma, mean, rstd, dL_dout);
+  LOG_ASSERT(result.size() == 3, "layernorm_bw expected 3 results, got {}",
+             result.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    LOG_ASSERT(result[i].has_value(), "layernorm_bw result {} was not returned",
+               i);
+  }
+
+  tensorPool.insertTTNNTensorAndValidate(op->dx(), result[0].value());
+  tensorPool.insertTTNNTensorAndValidate(op->dgamma(), result[1].value());
+  tensorPool.insertTTNNTensorAndValidate(op->dbeta(), result[2].value());
+}
+
+} // namespace tt::runtime::ttnn::operations::ttml

--- a/runtime/lib/ttnn/operations/ttml/layernorm_bw.h
+++ b/runtime/lib/ttnn/operations/ttml/layernorm_bw.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_TTML_LAYERNORM_BW_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_TTML_LAYERNORM_BW_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::ttml {
+void run(const ::tt::target::ttnn::LayerNormBackwardOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::ttml
+
+#endif

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -128,6 +128,7 @@
 #include "operations/transformer/split_query_key_value_and_split_heads.h"
 #include "operations/ttml/adamw.h"
 #include "operations/ttml/cross_entropy_fw.h"
+#include "operations/ttml/layernorm_bw.h"
 #include "operations/ttml/layernorm_fw.h"
 #include "operations/ttml/sdpa_bw.h"
 #include "operations/ttml/sdpa_fw.h"
@@ -662,6 +663,10 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::CrossEntropyForwardOp: {
     return operations::ttml::run(op->type_as_CrossEntropyForwardOp(),
+                                 getContext());
+  }
+  case ::tt::target::ttnn::OpType::LayerNormBackwardOp: {
+    return operations::ttml::run(op->type_as_LayerNormBackwardOp(),
                                  getContext());
   }
   case ::tt::target::ttnn::OpType::DumpTensorOp: {

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1625,6 +1625,11 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     tensorRefs = {opContext.type_as_CrossEntropyForwardOp()->out()};
     break;
   }
+  case ::tt::target::ttnn::OpType::LayerNormBackwardOp: {
+    auto *op = opContext.type_as_LayerNormBackwardOp();
+    tensorRefs = {op->dx(), op->dgamma(), op->dbeta()};
+    break;
+  }
   case ::tt::target::ttnn::OpType::AdamWOp:
   case ::tt::target::ttnn::OpType::FillCacheOp:
   case ::tt::target::ttnn::OpType::PagedFillCacheOp:
@@ -2025,6 +2030,12 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
   case ::tt::target::ttnn::OpType::CrossEntropyForwardOp: {
     tensorRefs = {opContext.type_as_CrossEntropyForwardOp()->input(),
                   opContext.type_as_CrossEntropyForwardOp()->target()};
+    break;
+  }
+  case ::tt::target::ttnn::OpType::LayerNormBackwardOp: {
+    auto *op = opContext.type_as_LayerNormBackwardOp();
+    tensorRefs = {op->input(), op->gamma(), op->mean(), op->rstd(),
+                  op->dl_dout()};
     break;
   }
   case ::tt::target::ttnn::OpType::RMSNormOp: {

--- a/test/python/golden/test_stablehlo_ops.py
+++ b/test/python/golden/test_stablehlo_ops.py
@@ -281,6 +281,53 @@ def module_layernorm_fw_composite(builder: StableHLOBuilder):
         )
 
 
+def module_layernorm_bw_composite(builder: StableHLOBuilder):
+    shape = (1, 1, 128, 256)
+    param_shape = (1, 1, 1, 256)
+    stats_shape = (1, 1, 128, 1)
+
+    @builder.func(
+        [shape, param_shape, stats_shape, stats_shape, shape],
+        [torch.bfloat16] * 5,
+    )
+    def layernorm_bw_impl(
+        input: Operand,
+        gamma: Operand,
+        mean: Operand,
+        rstd: Operand,
+        dL_dout: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        # The promoted TTML op supplies the implementation. Keep a valid
+        # shape-compatible decomposition for fallback.
+        return dL_dout, gamma, gamma
+
+    layernorm_bw_impl.sym_visibility = StringAttr.get("private")
+    builder._nested_funcs.append(layernorm_bw_impl.name.value)
+
+    @builder.func(
+        [shape, param_shape, stats_shape, stats_shape, shape],
+        [torch.bfloat16] * 5,
+    )
+    def layernorm_bw(
+        input: Operand,
+        gamma: Operand,
+        mean: Operand,
+        rstd: Operand,
+        dL_dout: Operand,
+        builder: StableHLOBuilder,
+        unit_attrs: Optional[List[str]] = None,
+    ):
+        builder.set_graph_level_check(True)
+        return builder.composite(
+            "tenstorrent.layernorm_bw",
+            [input, gamma, mean, rstd, dL_dout],
+            decomposition=layernorm_bw_impl,
+            unit_attrs=unit_attrs,
+        )
+
+
 def module_sdpa_fw_composite(builder: StableHLOBuilder):
     shape = (1, 8, 64, 64)
 
@@ -2387,6 +2434,16 @@ def test_composite_op(target: str, request, device):
 def test_layernorm_fw_composite(target: str, request, device):
     compile_and_execute_shlo(
         module_layernorm_fw_composite,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        ttir_pipeline_options=["composite-resolution=force-promote"],
+    )
+
+@pytest.mark.parametrize("target", ["ttnn" | SkipIf("sim")])
+def test_layernorm_bw_composite(target: str, request, device):
+    compile_and_execute_shlo(
+        module_layernorm_bw_composite,
         **get_request_kwargs(request),
         target=target,
         device=device,

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_layernorm_bw.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_layernorm_bw.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --legalize-stablehlo-composite-to-ttir %s | FileCheck %s
+
+module {
+  func.func @layernorm_bw(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    // CHECK: "ttcore.composite"
+    // CHECK-SAME: composite_attributes = {}
+    // CHECK-SAME: composite_name = "layernorm_bw"
+    // CHECK-SAME: decomposition = @tenstorrent.layernorm_bw.impl
+    // CHECK-NOT: stablehlo.composite
+    %0:3 = stablehlo.composite "tenstorrent.layernorm_bw" %input, %gamma, %mean, %rstd, %grad {
+      decomposition = @tenstorrent.layernorm_bw.impl
+    } : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+
+  func.func private @tenstorrent.layernorm_bw.impl(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    return %grad, %gamma, %gamma : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTIR/layernorm_bw/layernorm_bw_reshape_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/layernorm_bw/layernorm_bw_reshape_test.mlir
@@ -1,0 +1,33 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s | FileCheck %s
+
+module {
+  // CHECK-LABEL: func.func @layernorm_bw_rank2
+  func.func @layernorm_bw_rank2(
+      %input: tensor<128x256xbf16>, %gamma: tensor<256xbf16>,
+      %mean: tensor<128x1xbf16>, %rstd: tensor<128x1xbf16>,
+      %grad: tensor<128x256xbf16>)
+      -> (tensor<128x256xbf16>, tensor<256xbf16>, tensor<256xbf16>) {
+    // CHECK-DAG: "ttir.reshape"(%arg0) {{.*}} -> tensor<1x1x128x256xbf16>
+    // CHECK-DAG: "ttir.reshape"(%arg1) {{.*}} -> tensor<1x1x1x256xbf16>
+    // CHECK-DAG: "ttir.reshape"(%arg2) {{.*}} -> tensor<1x1x128x1xbf16>
+    // CHECK: "ttcore.composite"
+    // CHECK-SAME: composite_name = "layernorm_bw"
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>)
+    // CHECK: "ttir.reshape"({{.*}}) {{.*}} -> tensor<128x256xbf16>
+    // CHECK-COUNT-2: "ttir.reshape"({{.*}}) {{.*}} -> tensor<256xbf16>
+    %0:3 = "ttcore.composite"(%input, %gamma, %mean, %rstd, %grad) <{
+      composite_name = "layernorm_bw",
+      decomposition = @layernorm_bw_decomp,
+      composite_attributes = {}
+    }> : (tensor<128x256xbf16>, tensor<256xbf16>, tensor<128x1xbf16>, tensor<128x1xbf16>, tensor<128x256xbf16>) -> (tensor<128x256xbf16>, tensor<256xbf16>, tensor<256xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<128x256xbf16>, tensor<256xbf16>, tensor<256xbf16>
+  }
+
+  func.func private @layernorm_bw_decomp(
+      %input: tensor<128x256xbf16>, %gamma: tensor<256xbf16>,
+      %mean: tensor<128x1xbf16>, %rstd: tensor<128x1xbf16>,
+      %grad: tensor<128x256xbf16>)
+      -> (tensor<128x256xbf16>, tensor<256xbf16>, tensor<256xbf16>) {
+    return %grad, %gamma, %gamma : tensor<128x256xbf16>, tensor<256xbf16>, tensor<256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/layernorm_bw_f32_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/layernorm_bw_f32_workaround.mlir
@@ -1,0 +1,19 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --canonicalize %s | FileCheck %s
+
+module {
+  func.func public @layernorm_bw_f32(
+      %input: tensor<1x1x128x256xf32>, %gamma: tensor<1x1x1x256xf32>,
+      %mean: tensor<1x1x128x1xf32>, %rstd: tensor<1x1x128x1xf32>,
+      %grad: tensor<1x1x128x256xf32>)
+      -> (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>, tensor<1x1x1x256xf32>) {
+    // CHECK-LABEL: func.func public @layernorm_bw_f32
+    // CHECK-COUNT-5: "ttnn.to_tensor_spec"
+    // CHECK: %[[DX:.*]], %[[DGAMMA:.*]], %[[DBETA:.*]] = "ttnn.layernorm_bw"
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16{{.*}}, tensor<1x1x1x256xbf16{{.*}}, tensor<1x1x1x256xbf16
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%[[DX]])
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%[[DGAMMA]])
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%[[DBETA]])
+    %0:3 = "ttnn.layernorm_bw"(%input, %gamma, %mean, %rstd, %grad) : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>, tensor<1x1x128x1xf32>, tensor<1x1x128x1xf32>, tensor<1x1x128x256xf32>) -> (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>, tensor<1x1x1x256xf32>)
+    return %0#0, %0#1, %0#2 : tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>, tensor<1x1x1x256xf32>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/layernorm_bw/simple_layernorm_bw.mlir
+++ b/test/ttmlir/Dialect/TTNN/layernorm_bw/simple_layernorm_bw.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline="composite-resolution=force-promote" %s | FileCheck %s
+
+module {
+  func.func @layernorm_bw(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    // CHECK: "ttnn.layernorm_bw"
+    %0:3 = "ttcore.composite"(%input, %gamma, %mean, %rstd, %grad) <{
+      composite_name = "layernorm_bw",
+      decomposition = @layernorm_bw_decomp,
+      composite_attributes = {}
+    }> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+
+  func.func private @layernorm_bw_decomp(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    return %grad, %gamma, %gamma : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/layernorm_bw/layernorm_bw.mlir
+++ b/test/ttmlir/EmitC/TTNN/layernorm_bw/layernorm_bw.mlir
@@ -1,0 +1,29 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path% composite-resolution=force-promote" -o %t.mlir %s
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir | FileCheck %s
+
+module {
+  // CHECK-LABEL: layernorm_bw
+  // CHECK: ttml::metal::layernorm_bw(
+  // CHECK-COUNT-3: util_get_optional_value(
+  func.func @layernorm_bw(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    %0:3 = "ttcore.composite"(%input, %gamma, %mean, %rstd, %grad) <{
+      composite_name = "layernorm_bw",
+      decomposition = @layernorm_bw_decomp,
+      composite_attributes = {}
+    }> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+
+  func.func private @layernorm_bw_decomp(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    return %grad, %gamma, %gamma : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+}

--- a/test/ttmlir/EmitPy/layernorm_bw/layernorm_bw_unsupported.mlir
+++ b/test/ttmlir/EmitPy/layernorm_bw/layernorm_bw_unsupported.mlir
@@ -1,0 +1,25 @@
+// RUN: not ttmlir-opt --ttir-to-emitpy-pipeline="system-desc-path=%system_desc_path% composite-resolution=force-promote" %s 2>&1 | FileCheck %s
+
+module {
+  func.func @layernorm_bw(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    // CHECK: failed to legalize operation 'ttnn.layernorm_bw'
+    %0:3 = "ttcore.composite"(%input, %gamma, %mean, %rstd, %grad) <{
+      composite_name = "layernorm_bw",
+      decomposition = @layernorm_bw_decomp,
+      composite_attributes = {}
+    }> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x1xbf16>, tensor<1x1x128x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>)
+    return %0#0, %0#1, %0#2 : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+
+  func.func private @layernorm_bw_decomp(
+      %input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>,
+      %mean: tensor<1x1x128x1xbf16>, %rstd: tensor<1x1x128x1xbf16>,
+      %grad: tensor<1x1x128x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>) {
+    return %grad, %gamma, %gamma : tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>, tensor<1x1x1x256xbf16>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6098,6 +6098,33 @@ TEST_F(OpModelTest, LayerNormForwardOp) {
   EXPECT_EQ(outputOnlyConstraintsExp.get().outputLayouts.size(), 1u);
 }
 
+TEST_F(OpModelTest, LayerNormBackwardOp) {
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
+  const llvm::SmallVector<int64_t> parameterShape = {1, 1, 1, 256};
+  const llvm::SmallVector<int64_t> statisticsShape = {1, 1, 128, 1};
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr parameterLayout = CreateTiledLayout(
+      parameterShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr statisticsLayout = CreateTiledLayout(
+      statisticsShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<LayerNormBackwardOp>::getOpConstraints(
+      inputShape, inputLayout, parameterShape, parameterLayout, statisticsShape,
+      statisticsLayout, statisticsShape, statisticsLayout, inputShape,
+      inputLayout, /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputLayouts.size(), 3u);
+
+  auto runtimeExp = OpModel<LayerNormBackwardOp>::getOpRuntime(
+      inputShape, inputLayout, parameterShape, parameterLayout, statisticsShape,
+      statisticsLayout, statisticsShape, statisticsLayout, inputShape,
+      inputLayout, /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_GT(runtimeExp.get(), 0);
+}
+
 //===----------------------------------------------------------------------===//
 // QuantizeOp Tests
 //===----------------------------------------------------------------------===//

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6478,6 +6478,50 @@ TEST_F(OpModelBase, LayerNormForwardOpInterface) {
   }
 }
 
+TEST_F(OpModelBase, LayerNormBackwardOpInterface) {
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
+  llvm::SmallVector<int64_t> parameterShape = {1, 1, 1, 256};
+  llvm::SmallVector<int64_t> statisticsShape = {1, 1, 128, 1};
+  auto inputLayout = CreateTiledLayout(inputShape, BufferType::DRAM,
+                                       TensorMemoryLayout::Interleaved);
+  auto parameterLayout = CreateTiledLayout(parameterShape, BufferType::DRAM,
+                                           TensorMemoryLayout::Interleaved);
+  auto statisticsLayout = CreateTiledLayout(statisticsShape, BufferType::DRAM,
+                                            TensorMemoryLayout::Interleaved);
+
+  auto input =
+      createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout);
+  auto gamma =
+      createEmptyTensor(parameterShape, builder.getBF16Type(), parameterLayout);
+  auto mean = createEmptyTensor(statisticsShape, builder.getBF16Type(),
+                                statisticsLayout);
+  auto rstd = createEmptyTensor(statisticsShape, builder.getBF16Type(),
+                                statisticsLayout);
+  auto grad = createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout);
+  auto outputType =
+      createRankedTensorType(inputShape, builder.getBF16Type(), inputLayout);
+  auto parameterOutputType = createRankedTensorType(
+      parameterShape, builder.getBF16Type(), parameterLayout);
+
+  auto op = builder.create<LayerNormBackwardOp>(
+      builder.getUnknownLoc(),
+      TypeRange{outputType, parameterOutputType, parameterOutputType}, input,
+      gamma, mean, rstd, grad);
+  auto backend = dyn_cast<OpModel>(op.getOperation());
+  ASSERT_TRUE(backend);
+  auto inputLayouts = getInputLayouts(op.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 5u);
+
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputLayouts.size(), 3u);
+
+  auto runtimeExp = backend.getOpRuntime(inputLayouts, OpConfig());
+  ASSERT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_GT(runtimeExp.get(), 0);
+}
+
 TEST_F(OpModelBase, QuantizeOpInterface) {
   llvm::SmallVector<int64_t> inputShape = {32, 64};
   llvm::SmallVector<int64_t> scaleShape = {64};

--- a/third_party/ttml/CMakeLists.txt
+++ b/third_party/ttml/CMakeLists.txt
@@ -13,12 +13,16 @@ if (NOT ((TTMLIR_ENABLE_RUNTIME AND TT_RUNTIME_ENABLE_TTNN) OR TTMLIR_ENABLE_OPM
 endif()
 
 set(TTML_METAL_OP_SRCS
+  ${TTML_SOURCE_DIR}/core/compute_kernel_config.cpp
   ${TTML_SOURCE_DIR}/metal/optimizers/adamw/adamw.cpp
   ${TTML_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_device_operation.cpp
   ${TTML_SOURCE_DIR}/metal/optimizers/adamw/device/adamw_program_factory.cpp
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/layernorm_fw.cpp
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/layernorm_bw/layernorm_bw.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_device_operation.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/layernorm_bw/device/layernorm_bw_program_factory.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/sdpa_fw.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
@@ -35,6 +39,7 @@ set_source_files_properties(${TTML_METAL_OP_SRCS} PROPERTIES GENERATED TRUE)
 
 add_library(ttml_metal_ops STATIC ${TTML_METAL_OP_SRCS})
 set_property(TARGET ttml_metal_ops PROPERTY CXX_STANDARD 20)
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|x86|i386|i686)$")
   target_compile_options(ttml_metal_ops PRIVATE -march=x86-64-v3)
 endif()

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6639,6 +6639,13 @@ def stablehlo_composite_golden(
             dropout_probability=dropout_probability,
         )
 
+    if composite_name == "tenstorrent.layernorm_bw":
+        result_types = list(decomposition_fn.type.results)
+        return layernorm_bw_golden(
+            *operand_tensors,
+            output_type_mlir=RankedTensorType(result_types[0]).element_type,
+        )
+
     if len(decomposition_fn.body.blocks) != 1:
         raise NotImplementedError(
             "stablehlo_composite_golden: multi-block decompositions are not supported."
@@ -8773,6 +8780,36 @@ def layernorm_fw_golden(
     if return_mean_rstd:
         return output, mean.to(output_dtype), rstd.to(output_dtype)
     return (output,)
+
+
+def layernorm_bw_golden(
+    input: GoldenMapTensor,
+    gamma: GoldenMapTensor,
+    mean: GoldenMapTensor,
+    rstd: GoldenMapTensor,
+    dL_dout: GoldenMapTensor,
+    output_type_mlir: Type = None,
+    **kwargs,
+) -> Tuple[GoldenMapTensor, GoldenMapTensor, GoldenMapTensor]:
+    x_hat = torch.mul(torch.sub(input.float(), mean.float()), rstd.float())
+    grad = dL_dout.float()
+    dx_hat = torch.mul(grad, gamma.float())
+    centered_dx_hat = torch.sub(dx_hat, torch.mean(dx_hat, dim=-1, keepdim=True))
+    projected_dx_hat = torch.sub(
+        centered_dx_hat,
+        torch.mul(x_hat, torch.mean(torch.mul(dx_hat, x_hat), dim=-1, keepdim=True)),
+    )
+    dx = torch.mul(rstd.float(), projected_dx_hat)
+    reduction_dims = tuple(range(grad.ndim - 1))
+    dgamma = torch.sum(torch.mul(grad, x_hat), dim=reduction_dims, keepdim=True)
+    dbeta = torch.sum(grad, dim=reduction_dims, keepdim=True)
+
+    output_dtype = (
+        mlir_type_to_torch_dtype(output_type_mlir)
+        if output_type_mlir is not None
+        else input.dtype
+    )
+    return tuple(tensor.to(output_dtype) for tensor in (dx, dgamma, dbeta))
 
 
 def flash_mla_prefill_golden(


### PR DESCRIPTION
### Ticket
Part of https://github.com/tenstorrent/tt-mlir/issues/9097
closes https://github.com/tenstorrent/tt-mlir/issues/9101

### Problem description
Unimplemendted TTML op in compiler.

### What's changed
Added composite ops and relevant conversions for layer_norm_fw op.

### Checklist
- [x] New/Existing tests provide coverage for changes

Blocked until https://github.com/tenstorrent/tt-metal/pull/55178 is merged.
