### PR TITLE
StableHLO: unroll static while ops for scan lowering

### DIFF
--- a/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/StableHLO/Transforms/Passes.td
@@ -209,6 +209,52 @@ def StableHLOFusingPass : Pass<"stablehlo-fusing", "::mlir::ModuleOp">
   ];
 }
 
+def StableHLOUnrollStaticWhilePass : Pass<"stablehlo-unroll-static-while", "::mlir::ModuleOp">
+{
+  let summary = "Unroll StableHLO while ops with statically provable trip counts.";
+  let description = [{
+    This pass unrolls the common JAX scan lowering pattern:
+
+      - scalar integer induction variable initialized by a constant,
+      - condition `induction < constant_limit`,
+      - body returns `induction + 1`.
+
+    Other while ops are left unchanged, so dynamic control flow remains explicit
+    and is rejected by later lowering if unsupported.
+  }];
+
+  let dependentDialects = [
+    "::mlir::stablehlo::StablehloDialect"
+  ];
+
+  let options = [
+    Option<"maxTripCount", "max-trip-count", "int64_t",
+           /*default=*/"128", "Maximum trip count to unroll">,
+  ];
+}
+
+def RewriteStaticDynamicUpdateSlicePass : Pass<"rewrite-static-dynamic-update-slice", "::mlir::ModuleOp">
+{
+  let summary = "Rewrite static StableHLO dynamic slice/update ops.";
+  let description = [{
+    This pass rewrites the narrow static case produced by unrolled JAX scans:
+    stablehlo.dynamic_slice or stablehlo.dynamic_update_slice with constant
+    start indices. It also recognizes simple scalar integer constant
+    expressions in start indices, such as those produced by reverse scans.
+
+    Static dynamic_update_slice updates are rewritten when the update differs
+    from the base shape in at most one dimension and is full-size in all other
+    dimensions.
+
+    Non-matching dynamic slice/update ops are left unchanged for the existing
+    fallback paths.
+  }];
+
+  let dependentDialects = [
+    "::mlir::stablehlo::StablehloDialect"
+  ];
+}
+
 def PartiallyConvertSdyToStableHLOPass : Pass<"partially-convert-sdy-to-stablehlo", "::mlir::ModuleOp">
 {
   let summary = "Partially convert Shardy operations to StableHLO operations.";

--- a/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
+++ b/lib/Dialect/StableHLO/Pipelines/StableHLOPipelines.cpp
@@ -34,6 +34,10 @@ void createStableHLOPipeline(OpPassManager &pm,
   // Apply StableHLO fusing pass.
   pm.addPass(mlir::tt::stablehlo::createStableHLOFusingPass());
 
+  // Lower statically bounded scan-style while ops to straight-line StableHLO so
+  // sharding propagation and TTIR conversion can reason about the body.
+  pm.addPass(mlir::tt::stablehlo::createStableHLOUnrollStaticWhilePass());
+
   // Partially convert sdy ops to stablehlo.
   pm.addPass(createPartiallyConvertSdyToStableHLOPass());
 
@@ -128,6 +132,9 @@ void createStableHLOPipeline(OpPassManager &pm,
 
   // Split tensor dimensions according to tensor sharding annotations.
   pm.addPass(createUpdateGlobalToLocalShapesPass());
+
+  // Replace static scan-output updates with device-lowerable slice/concat ops.
+  pm.addPass(createRewriteStaticDynamicUpdateSlicePass());
 
   // Re-outline composite ops from flattened groups.
   pm.addPass(createReoutlineCompositePass());

--- a/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
+++ b/lib/Dialect/StableHLO/Transforms/CMakeLists.txt
@@ -15,10 +15,12 @@ add_mlir_dialect_library(MLIRStableHLOTransforms
   RegisterUserShardingRule.cpp
   ReoutlineComposite.cpp
   ReplicateNonSplittableValues.cpp
+  RewriteStaticDynamicUpdateSlice.cpp
   ShardyCCLCanonicalization.cpp
   ShardyCCLToStableHLOCCLPatterns.cpp
   StableHLOFusing.cpp
   UnsolvedGraphPasses.cpp
+  UnrollStaticWhile.cpp
   UpdateGlobalToLocalShapes.cpp
   WrapUnderManualComputation.cpp
 

--- a/lib/Dialect/StableHLO/Transforms/RewriteStaticDynamicUpdateSlice.cpp
+++ b/lib/Dialect/StableHLO/Transforms/RewriteStaticDynamicUpdateSlice.cpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include <algorithm>
+#include <optional>
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_REWRITESTATICDYNAMICUPDATESLICEPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+namespace {
+
+static std::optional<int64_t> getScalarIntExpression(Value value,
+                                                     int depth = 0) {
+  if (depth > 16) {
+    return std::nullopt;
+  }
+
+  auto constantOp = value.getDefiningOp<mlir::stablehlo::ConstantOp>();
+  if (constantOp) {
+    auto denseAttr = dyn_cast<DenseIntElementsAttr>(constantOp.getValue());
+    if (!denseAttr || denseAttr.getNumElements() != 1) {
+      return std::nullopt;
+    }
+
+    return denseAttr.getSplatValue<APInt>().getSExtValue();
+  }
+
+  if (auto addOp = value.getDefiningOp<mlir::stablehlo::AddOp>()) {
+    std::optional<int64_t> lhs =
+        getScalarIntExpression(addOp.getLhs(), depth + 1);
+    std::optional<int64_t> rhs =
+        getScalarIntExpression(addOp.getRhs(), depth + 1);
+    if (!lhs || !rhs) {
+      return std::nullopt;
+    }
+    return *lhs + *rhs;
+  }
+
+  if (auto subtractOp = value.getDefiningOp<mlir::stablehlo::SubtractOp>()) {
+    std::optional<int64_t> lhs =
+        getScalarIntExpression(subtractOp.getLhs(), depth + 1);
+    std::optional<int64_t> rhs =
+        getScalarIntExpression(subtractOp.getRhs(), depth + 1);
+    if (!lhs || !rhs) {
+      return std::nullopt;
+    }
+    return *lhs - *rhs;
+  }
+
+  return std::nullopt;
+}
+
+static std::optional<int64_t>
+getClampedStart(int64_t start, int64_t operandSize, int64_t updateSize) {
+  if (ShapedType::isDynamic(operandSize) || ShapedType::isDynamic(updateSize) ||
+      updateSize > operandSize) {
+    return std::nullopt;
+  }
+
+  return std::clamp(start, int64_t(0), operandSize - updateSize);
+}
+
+static Value createSlice(Location loc, Value input,
+                         llvm::ArrayRef<int64_t> start,
+                         llvm::ArrayRef<int64_t> limit, IRRewriter &rewriter) {
+  auto inputType = cast<RankedTensorType>(input.getType());
+  SmallVector<int64_t> shape;
+  shape.reserve(inputType.getRank());
+  for (auto [startDim, limitDim] : llvm::zip_equal(start, limit)) {
+    shape.push_back(limitDim - startDim);
+  }
+
+  auto resultType = RankedTensorType::get(shape, inputType.getElementType(),
+                                          inputType.getEncoding());
+  SmallVector<int64_t> strides(inputType.getRank(), 1);
+
+  return rewriter
+      .create<mlir::stablehlo::SliceOp>(loc, resultType, input,
+                                        rewriter.getDenseI64ArrayAttr(start),
+                                        rewriter.getDenseI64ArrayAttr(limit),
+                                        rewriter.getDenseI64ArrayAttr(strides))
+      .getResult();
+}
+
+static LogicalResult rewriteIfStaticSlice(mlir::stablehlo::DynamicSliceOp op,
+                                          IRRewriter &rewriter) {
+  auto operandType = dyn_cast<RankedTensorType>(op.getOperand().getType());
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
+  if (!operandType || !resultType ||
+      operandType.getRank() != resultType.getRank()) {
+    return failure();
+  }
+
+  llvm::ArrayRef<int64_t> sliceSizes = op.getSliceSizes();
+  if (static_cast<int64_t>(sliceSizes.size()) != operandType.getRank() ||
+      resultType.getShape() != sliceSizes) {
+    return failure();
+  }
+
+  SmallVector<int64_t> starts;
+  starts.reserve(operandType.getRank());
+  for (auto [dim, startIndex] : llvm::enumerate(op.getStartIndices())) {
+    std::optional<int64_t> start = getScalarIntExpression(startIndex);
+    if (!start) {
+      return failure();
+    }
+
+    std::optional<int64_t> clampedStart =
+        getClampedStart(*start, operandType.getDimSize(dim), sliceSizes[dim]);
+    if (!clampedStart) {
+      return failure();
+    }
+    starts.push_back(*clampedStart);
+  }
+
+  if (static_cast<int64_t>(starts.size()) != operandType.getRank()) {
+    return failure();
+  }
+
+  SmallVector<int64_t> limits;
+  limits.reserve(operandType.getRank());
+  for (auto [start, size] : llvm::zip_equal(starts, sliceSizes)) {
+    limits.push_back(start + size);
+  }
+
+  SmallVector<int64_t> strides(operandType.getRank(), 1);
+  rewriter.setInsertionPoint(op);
+  auto slice = rewriter.create<mlir::stablehlo::SliceOp>(
+      op.getLoc(), resultType, op.getOperand(),
+      rewriter.getDenseI64ArrayAttr(starts),
+      rewriter.getDenseI64ArrayAttr(limits),
+      rewriter.getDenseI64ArrayAttr(strides));
+  rewriter.replaceOp(op, slice.getResult());
+  return success();
+}
+
+static LogicalResult
+rewriteIfSingleAxisStaticUpdate(mlir::stablehlo::DynamicUpdateSliceOp op,
+                                IRRewriter &rewriter) {
+  auto operandType = dyn_cast<RankedTensorType>(op.getOperand().getType());
+  auto updateType = dyn_cast<RankedTensorType>(op.getUpdate().getType());
+  auto resultType = dyn_cast<RankedTensorType>(op.getResult().getType());
+  if (!operandType || !updateType || !resultType) {
+    return failure();
+  }
+
+  if (operandType.getRank() != updateType.getRank() ||
+      operandType.getRank() != resultType.getRank()) {
+    return failure();
+  }
+
+  if (operandType.getShape() != resultType.getShape()) {
+    return failure();
+  }
+
+  SmallVector<int64_t> starts;
+  starts.reserve(operandType.getRank());
+  for (Value startIndex : op.getStartIndices()) {
+    std::optional<int64_t> start = getScalarIntExpression(startIndex);
+    if (!start) {
+      return failure();
+    }
+    starts.push_back(*start);
+  }
+
+  if (static_cast<int64_t>(starts.size()) != operandType.getRank()) {
+    return failure();
+  }
+
+  int64_t updateDim = -1;
+  for (int64_t dim = 0; dim < operandType.getRank(); ++dim) {
+    int64_t operandSize = operandType.getDimSize(dim);
+    int64_t updateSize = updateType.getDimSize(dim);
+    int64_t start = starts[dim];
+
+    std::optional<int64_t> clampedStart =
+        getClampedStart(start, operandSize, updateSize);
+    if (!clampedStart) {
+      return failure();
+    }
+    starts[dim] = *clampedStart;
+
+    if (updateSize == operandSize) {
+      continue;
+    }
+
+    if (updateDim != -1) {
+      return failure();
+    }
+    updateDim = dim;
+  }
+
+  rewriter.setInsertionPoint(op);
+  if (updateDim == -1) {
+    rewriter.replaceOp(op, op.getUpdate());
+    return success();
+  }
+
+  Location loc = op.getLoc();
+  SmallVector<Value> pieces;
+  SmallVector<int64_t> zeroStart(operandType.getRank(), 0);
+  SmallVector<int64_t> operandLimit(operandType.getShape().begin(),
+                                    operandType.getShape().end());
+
+  int64_t start = starts[updateDim];
+  int64_t updateSize = updateType.getDimSize(updateDim);
+  if (start > 0) {
+    SmallVector<int64_t> beforeLimit = operandLimit;
+    beforeLimit[updateDim] = start;
+    pieces.push_back(
+        createSlice(loc, op.getOperand(), zeroStart, beforeLimit, rewriter));
+  }
+
+  pieces.push_back(op.getUpdate());
+
+  int64_t afterStartValue = start + updateSize;
+  if (afterStartValue < operandType.getDimSize(updateDim)) {
+    SmallVector<int64_t> afterStart = zeroStart;
+    afterStart[updateDim] = afterStartValue;
+    pieces.push_back(
+        createSlice(loc, op.getOperand(), afterStart, operandLimit, rewriter));
+  }
+
+  if (pieces.size() == 1) {
+    rewriter.replaceOp(op, pieces.front());
+    return success();
+  }
+
+  auto concat = rewriter.create<mlir::stablehlo::ConcatenateOp>(
+      loc, resultType, pieces, updateDim);
+  rewriter.replaceOp(op, concat.getResult());
+  return success();
+}
+
+class RewriteStaticDynamicUpdateSlicePass
+    : public impl::RewriteStaticDynamicUpdateSlicePassBase<
+          RewriteStaticDynamicUpdateSlicePass> {
+public:
+  using impl::RewriteStaticDynamicUpdateSlicePassBase<
+      RewriteStaticDynamicUpdateSlicePass>::
+      RewriteStaticDynamicUpdateSlicePassBase;
+
+  void runOnOperation() final {
+    ModuleOp module = getOperation();
+    IRRewriter rewriter(module.getContext());
+
+    SmallVector<mlir::stablehlo::DynamicSliceOp> dynamicSliceWorklist;
+    module.walk([&](mlir::stablehlo::DynamicSliceOp op) {
+      dynamicSliceWorklist.push_back(op);
+    });
+
+    for (mlir::stablehlo::DynamicSliceOp op : dynamicSliceWorklist) {
+      (void)rewriteIfStaticSlice(op, rewriter);
+    }
+
+    SmallVector<mlir::stablehlo::DynamicUpdateSliceOp> worklist;
+    module.walk([&](mlir::stablehlo::DynamicUpdateSliceOp op) {
+      worklist.push_back(op);
+    });
+
+    for (mlir::stablehlo::DynamicUpdateSliceOp op : worklist) {
+      (void)rewriteIfSingleAxisStaticUpdate(op, rewriter);
+    }
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::stablehlo

--- a/lib/Dialect/StableHLO/Transforms/UnrollStaticWhile.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UnrollStaticWhile.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h"
+
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/PatternMatch.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include <algorithm>
+#include <optional>
+
+namespace mlir::tt::stablehlo {
+#define GEN_PASS_DEF_STABLEHLOUNROLLSTATICWHILEPASS
+#include "ttmlir/Dialect/StableHLO/Transforms/Passes.h.inc"
+
+namespace {
+
+static std::optional<int64_t> getScalarIntConstant(Value value) {
+  auto constantOp = value.getDefiningOp<mlir::stablehlo::ConstantOp>();
+  if (!constantOp) {
+    return std::nullopt;
+  }
+
+  auto denseAttr = dyn_cast<DenseIntElementsAttr>(constantOp.getValue());
+  if (!denseAttr || denseAttr.getNumElements() != 1) {
+    return std::nullopt;
+  }
+
+  return denseAttr.getSplatValue<APInt>().getSExtValue();
+}
+
+static Value createScalarIntConstant(Location loc, Type type, int64_t value,
+                                     IRRewriter &rewriter) {
+  auto tensorType = cast<RankedTensorType>(type);
+  auto intType = cast<IntegerType>(tensorType.getElementType());
+  APInt intValue(intType.getWidth(), value, /*isSigned=*/true);
+  auto attr = DenseIntElementsAttr::get(tensorType, intValue);
+  return rewriter.create<mlir::stablehlo::ConstantOp>(loc, attr);
+}
+
+static bool isOneStepInductionReturn(Value value, BlockArgument inductionArg) {
+  auto addOp = value.getDefiningOp<mlir::stablehlo::AddOp>();
+  if (!addOp) {
+    return false;
+  }
+
+  Value maybeStep;
+  if (addOp.getLhs() == inductionArg) {
+    maybeStep = addOp.getRhs();
+  } else if (addOp.getRhs() == inductionArg) {
+    maybeStep = addOp.getLhs();
+  } else {
+    return false;
+  }
+
+  std::optional<int64_t> step = getScalarIntConstant(maybeStep);
+  return step && *step == 1;
+}
+
+static LogicalResult getStaticTripCount(mlir::stablehlo::WhileOp whileOp,
+                                        int64_t maxTripCount,
+                                        unsigned &inductionIndex,
+                                        int64_t &startValue,
+                                        int64_t &tripCount) {
+  Block &condBlock = whileOp.getCond().front();
+  Block &bodyBlock = whileOp.getBody().front();
+
+  auto condReturn = dyn_cast<mlir::stablehlo::ReturnOp>(
+      condBlock.getTerminator());
+  auto bodyReturn = dyn_cast<mlir::stablehlo::ReturnOp>(
+      bodyBlock.getTerminator());
+  if (!condReturn || !bodyReturn || condReturn.getNumOperands() != 1 ||
+      bodyReturn.getNumOperands() != whileOp.getNumOperands()) {
+    return failure();
+  }
+
+  auto compareOp =
+      condReturn.getOperand(0).getDefiningOp<mlir::stablehlo::CompareOp>();
+  if (!compareOp ||
+      compareOp.getComparisonDirection() !=
+          mlir::stablehlo::ComparisonDirection::LT) {
+    return failure();
+  }
+
+  auto condInductionArg = dyn_cast<BlockArgument>(compareOp.getLhs());
+  if (!condInductionArg || condInductionArg.getOwner() != &condBlock) {
+    return failure();
+  }
+
+  std::optional<int64_t> limit = getScalarIntConstant(compareOp.getRhs());
+  if (!limit) {
+    return failure();
+  }
+
+  inductionIndex = condInductionArg.getArgNumber();
+  std::optional<int64_t> start =
+      getScalarIntConstant(whileOp->getOperand(inductionIndex));
+  if (!start) {
+    return failure();
+  }
+
+  BlockArgument bodyInductionArg = bodyBlock.getArgument(inductionIndex);
+  if (!isOneStepInductionReturn(bodyReturn.getOperand(inductionIndex),
+                                bodyInductionArg)) {
+    return failure();
+  }
+
+  int64_t computedTripCount = std::max<int64_t>(0, *limit - *start);
+  if (computedTripCount > maxTripCount) {
+    return failure();
+  }
+
+  startValue = *start;
+  tripCount = computedTripCount;
+  return success();
+}
+
+static void unrollWhile(mlir::stablehlo::WhileOp whileOp,
+                        unsigned inductionIndex, int64_t startValue,
+                        int64_t tripCount, IRRewriter &rewriter) {
+  Block &bodyBlock = whileOp.getBody().front();
+  auto bodyReturn =
+      cast<mlir::stablehlo::ReturnOp>(bodyBlock.getTerminator());
+
+  SmallVector<Value> carried(whileOp.getOperands());
+  rewriter.setInsertionPoint(whileOp);
+
+  for (int64_t i = 0; i < tripCount; ++i) {
+    IRMapping mapping;
+    for (auto [index, arg] : llvm::enumerate(bodyBlock.getArguments())) {
+      if (index == inductionIndex) {
+        Value indexConstant = createScalarIntConstant(
+            whileOp.getLoc(), arg.getType(), startValue + i, rewriter);
+        mapping.map(arg, indexConstant);
+        continue;
+      }
+      mapping.map(arg, carried[index]);
+    }
+
+    for (Operation &op : bodyBlock.without_terminator()) {
+      rewriter.clone(op, mapping);
+    }
+
+    for (auto [index, returned] : llvm::enumerate(bodyReturn.getOperands())) {
+      if (index == inductionIndex) {
+        carried[index] = createScalarIntConstant(
+            whileOp.getLoc(), returned.getType(), startValue + i + 1, rewriter);
+        continue;
+      }
+      carried[index] = mapping.lookupOrDefault(returned);
+    }
+  }
+
+  rewriter.replaceOp(whileOp, carried);
+}
+
+class StableHLOUnrollStaticWhilePass
+    : public impl::StableHLOUnrollStaticWhilePassBase<
+          StableHLOUnrollStaticWhilePass> {
+public:
+  using impl::StableHLOUnrollStaticWhilePassBase<
+      StableHLOUnrollStaticWhilePass>::StableHLOUnrollStaticWhilePassBase;
+
+  void runOnOperation() final {
+    ModuleOp module = getOperation();
+    MLIRContext *context = module.getContext();
+    IRRewriter rewriter(context);
+
+    bool changed = false;
+    do {
+      changed = false;
+      module.walk([&](mlir::stablehlo::WhileOp whileOp) {
+        unsigned inductionIndex = 0;
+        int64_t startValue = 0;
+        int64_t tripCount = 0;
+        if (failed(getStaticTripCount(whileOp, maxTripCount, inductionIndex,
+                                      startValue, tripCount))) {
+          return WalkResult::advance();
+        }
+        unrollWhile(whileOp, inductionIndex, startValue, tripCount, rewriter);
+        changed = true;
+        return WalkResult::interrupt();
+      });
+    } while (changed);
+  }
+};
+
+} // namespace
+} // namespace mlir::tt::stablehlo

--- a/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
+++ b/lib/Dialect/StableHLO/Transforms/UpdateGlobalToLocalShapes.cpp
@@ -208,6 +208,34 @@ static FailureOr<mlir::OperationState> createNewOperationState(
 
             return mlir::success();
           })
+          .Case<mlir::stablehlo::DynamicSliceOp>(
+              [&](auto dynamicSliceOp) {
+                // stablehlo.dynamic_slice stores its result shape in the
+                // slice_sizes attribute. Keep it consistent with the localized
+                // result type.
+                if (newTypes.empty()) {
+                  dynamicSliceOp->emitError(
+                      "DynamicSlice operation does not have a result type.");
+                  return mlir::failure();
+                }
+
+                llvm::SmallVector<int64_t> newSliceSizes(
+                    newTypes[0].getShape().begin(),
+                    newTypes[0].getShape().end());
+
+                llvm::StringRef sliceSizesAttrName = "slice_sizes";
+                assert(attrDict.contains(sliceSizesAttrName) &&
+                       "DynamicSlice operation does not have slice sizes "
+                       "attribute. Ill-formed operation");
+                auto namedAttrSliceSizesIt = llvm::find_if(
+                    namedAttrs, [&](const mlir::NamedAttribute &attr) {
+                      return attr.getName() == sliceSizesAttrName;
+                    });
+                namedAttrSliceSizesIt->setValue(
+                    mlir::DenseI64ArrayAttr::get(context, newSliceSizes));
+
+                return mlir::success();
+              })
           .Case<mlir::stablehlo::GatherOp>([&](auto gatherOp) {
             // 1. Get the sharding for each operand dimension.
             llvm::ArrayRef<mlir::sdy::DimensionShardingAttr>

--- a/test/ttmlir/Dialect/StableHLO/global_to_local_shape/dynamic_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/global_to_local_shape/dynamic_slice.mlir
@@ -1,0 +1,19 @@
+// REQUIRES: stablehlo
+// RUN: rm -rf %t.mlir
+// RUN: ttmlir-opt --split-input-file --update-global-to-local-shapes -o %t.mlir %s
+// RUN: FileCheck %s --input-file=%t.mlir
+
+module @DynamicSliceLocalShape attributes {mhlo.num_partitions = 2 : i32, mhlo.num_replicas = 1 : i32} {
+  sdy.mesh @mesh = <["b"=2]>
+  func.func @main(%arg0: tensor<4x64x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"b"}, {}]>, ttcore.argument_type = #ttcore.argument_type<input>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<4x32x64xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) -> (tensor<1x64x64xf32> {sdy.sharding = #sdy.sharding<@mesh, [{}, {"b"}, {}]>, ttcore.local_shape = #ttcore<local_shape local_shape = tensor<1x32x64xf32>>, ttcore.shard_status = #ttcore.shard_status<presharded>}) {
+    %0 = sdy.manual_computation(%arg0) in_shardings=[<@mesh, [{}, {"b"}, {}]>] out_shardings=[<@mesh, [{}, {"b"}, {}]>] manual_axes={} (%arg1: tensor<4x64x64xf32>) {
+      %c0 = stablehlo.constant dense<0> : tensor<i32>
+      // CHECK: stablehlo.dynamic_slice
+      // CHECK-SAME: sizes = [1, 32, 64]
+      // CHECK-SAME: (tensor<4x32x64xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<1x32x64xf32>
+      %1 = stablehlo.dynamic_slice %arg1, %c0, %c0, %c0, sizes = [1, 64, 64] {sdy.sharding = #sdy.sharding_per_value<[<@mesh, [{}, {"b"}, {}]>]>} : (tensor<4x64x64xf32>, tensor<i32>, tensor<i32>, tensor<i32>) -> tensor<1x64x64xf32>
+      sdy.return %1 : tensor<1x64x64xf32>
+    } : (tensor<4x64x64xf32>) -> tensor<1x64x64xf32>
+    return %0 : tensor<1x64x64xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/rewrite_static_dynamic_update_slice.mlir
+++ b/test/ttmlir/Dialect/StableHLO/rewrite_static_dynamic_update_slice.mlir
@@ -1,0 +1,78 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --rewrite-static-dynamic-update-slice %s | FileCheck %s
+
+module {
+  func.func @static_dynamic_slice_expr(%arg0: tensor<4x32xf32>) -> tensor<1x32xf32> {
+    %c4 = stablehlo.constant dense<4> : tensor<i32>
+    %c1 = stablehlo.constant dense<1> : tensor<i32>
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    %start = stablehlo.subtract %c4, %c1 : tensor<i32>
+    // CHECK-LABEL: func.func @static_dynamic_slice_expr
+    // CHECK-NOT: stablehlo.dynamic_slice
+    // CHECK: stablehlo.slice %arg0 [3:4, 0:32]
+    // CHECK-NOT: stablehlo.dynamic_slice
+    // CHECK: return
+    %0 = stablehlo.dynamic_slice %arg0, %start, %c0, sizes = [1, 32] : (tensor<4x32xf32>, tensor<i32>, tensor<i32>) -> tensor<1x32xf32>
+    return %0 : tensor<1x32xf32>
+  }
+
+  func.func @static_dynamic_slice_clamped(%arg0: tensor<4x32xf32>) -> tensor<2x16xf32> {
+    %c_neg1 = stablehlo.constant dense<-1> : tensor<i32>
+    %c99 = stablehlo.constant dense<99> : tensor<i32>
+    // CHECK-LABEL: func.func @static_dynamic_slice_clamped
+    // CHECK-NOT: stablehlo.dynamic_slice
+    // CHECK: stablehlo.slice %arg0 [0:2, 16:32]
+    // CHECK-NOT: stablehlo.dynamic_slice
+    // CHECK: return
+    %0 = stablehlo.dynamic_slice %arg0, %c_neg1, %c99, sizes = [2, 16] : (tensor<4x32xf32>, tensor<i32>, tensor<i32>) -> tensor<2x16xf32>
+    return %0 : tensor<2x16xf32>
+  }
+
+  func.func @single_axis(%arg0: tensor<4x32xf32>, %arg1: tensor<1x32xf32>) -> tensor<4x32xf32> {
+    %c1 = stablehlo.constant dense<1> : tensor<i32>
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    // CHECK-LABEL: func.func @single_axis
+    // CHECK-NOT: stablehlo.dynamic_update_slice
+    // CHECK: stablehlo.slice %arg0 [0:1, 0:32]
+    // CHECK: stablehlo.slice %arg0 [2:4, 0:32]
+    // CHECK: stablehlo.concatenate {{.*}} dim = 0
+    %0 = stablehlo.dynamic_update_slice %arg0, %arg1, %c1, %c0 : (tensor<4x32xf32>, tensor<1x32xf32>, tensor<i32>, tensor<i32>) -> tensor<4x32xf32>
+    return %0 : tensor<4x32xf32>
+  }
+
+  func.func @single_axis_expr(%arg0: tensor<4x32xf32>, %arg1: tensor<1x32xf32>) -> tensor<4x32xf32> {
+    %c4 = stablehlo.constant dense<4> : tensor<i32>
+    %c1 = stablehlo.constant dense<1> : tensor<i32>
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    %start = stablehlo.subtract %c4, %c1 : tensor<i32>
+    // CHECK-LABEL: func.func @single_axis_expr
+    // CHECK-NOT: stablehlo.dynamic_update_slice
+    // CHECK: stablehlo.slice %arg0 [0:3, 0:32]
+    // CHECK: stablehlo.concatenate {{.*}} dim = 0
+    // CHECK-NOT: stablehlo.dynamic_update_slice
+    // CHECK: return
+    %0 = stablehlo.dynamic_update_slice %arg0, %arg1, %start, %c0 : (tensor<4x32xf32>, tensor<1x32xf32>, tensor<i32>, tensor<i32>) -> tensor<4x32xf32>
+    return %0 : tensor<4x32xf32>
+  }
+
+  func.func @single_axis_clamped(%arg0: tensor<4x32xf32>, %arg1: tensor<1x32xf32>) -> tensor<4x32xf32> {
+    %c99 = stablehlo.constant dense<99> : tensor<i32>
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    // CHECK-LABEL: func.func @single_axis_clamped
+    // CHECK-NOT: stablehlo.dynamic_update_slice
+    // CHECK: stablehlo.slice %arg0 [0:3, 0:32]
+    // CHECK: stablehlo.concatenate {{.*}} dim = 0
+    // CHECK-NOT: stablehlo.dynamic_update_slice
+    // CHECK: return
+    %0 = stablehlo.dynamic_update_slice %arg0, %arg1, %c99, %c0 : (tensor<4x32xf32>, tensor<1x32xf32>, tensor<i32>, tensor<i32>) -> tensor<4x32xf32>
+    return %0 : tensor<4x32xf32>
+  }
+
+  func.func @dynamic_start_kept(%arg0: tensor<4x32xf32>, %arg1: tensor<1x32xf32>, %arg2: tensor<i32>) -> tensor<4x32xf32> {
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    // CHECK-LABEL: func.func @dynamic_start_kept
+    // CHECK: stablehlo.dynamic_update_slice
+    %0 = stablehlo.dynamic_update_slice %arg0, %arg1, %arg2, %c0 : (tensor<4x32xf32>, tensor<1x32xf32>, tensor<i32>, tensor<i32>) -> tensor<4x32xf32>
+    return %0 : tensor<4x32xf32>
+  }
+}

--- a/test/ttmlir/Dialect/StableHLO/unroll_static_while.mlir
+++ b/test/ttmlir/Dialect/StableHLO/unroll_static_while.mlir
@@ -1,0 +1,28 @@
+// REQUIRES: stablehlo
+// RUN: ttmlir-opt --stablehlo-unroll-static-while %s | FileCheck %s
+
+module @static_while {
+  func.func @main(%arg0: tensor<2x2xf32>) -> tensor<2x2xf32> {
+    %c0 = stablehlo.constant dense<0> : tensor<i32>
+    %c1 = stablehlo.constant dense<1> : tensor<i32>
+    %c2 = stablehlo.constant dense<2> : tensor<i32>
+    %0:2 = stablehlo.while(%iterArg = %c0, %iterArg_0 = %arg0) : tensor<i32>, tensor<2x2xf32>
+    cond {
+      %1 = stablehlo.compare  LT, %iterArg, %c2,  SIGNED : (tensor<i32>, tensor<i32>) -> tensor<i1>
+      stablehlo.return %1 : tensor<i1>
+    } do {
+      %1 = stablehlo.add %iterArg_0, %iterArg_0 : tensor<2x2xf32>
+      %2 = stablehlo.add %iterArg, %c1 : tensor<i32>
+      stablehlo.return %2, %1 : tensor<i32>, tensor<2x2xf32>
+    }
+    return %0#1 : tensor<2x2xf32>
+  }
+}
+
+// CHECK-LABEL: func.func @main
+// CHECK-NOT: stablehlo.while
+// CHECK: stablehlo.constant dense<0> : tensor<i32>
+// CHECK: stablehlo.add
+// CHECK: stablehlo.constant dense<1> : tensor<i32>
+// CHECK: stablehlo.add
+// CHECK: return


### PR DESCRIPTION
Stacked on #9274. Please review the scan commit after the DynamicSlice local-shape fix lands or after this branch is rebased.

This adds narrow StableHLO handling for the JAX `lax.scan` lowering pattern:
- unroll `stablehlo.while` ops with statically provable trip counts
- rewrite constant-index `dynamic_slice` / `dynamic_update_slice` cases to static slice/concat forms after local-shape conversion

Validation:
- `cmake --build build-scan-only --target ttmlir-opt -j 30`
- `llvm-lit -q test/ttmlir/Dialect/StableHLO/unroll_static_while.mlir test/ttmlir/Dialect/StableHLO/rewrite_static_dynamic_update_slice.mlir test/ttmlir/Dialect/StableHLO/global_to_local_shape/dynamic_slice.mlir`
- `llvm-lit -q test/ttmlir/Dialect/StableHLO`
- N300: `pytest -q tests/jax/multi_chip/n300/graphs/data_parallel/batch_sharded/test_lax_scan.py` against a tt-xla PJRT build using this stack: 7 passed
