### PR TITLE
Removed groups protection from conv3d

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Utils/VerificationUtils.h
+++ b/include/ttmlir/Dialect/TTNN/Utils/VerificationUtils.h
@@ -140,7 +140,7 @@ enum OutputDim : unsigned {
 
 // Weight is 2D: [kD*kH*kW*C_in, O]
 enum WeightDim : unsigned {
-  WEIGHT_FLATTENED = 0,  // kD*kH*kW*C_in/groups (patch_size)
+  WEIGHT_FLATTENED = 0,  // kD*kH*kW*C_in_aligned (patch_size)
   WEIGHT_OUT_CHANNEL = 1 // O (output channels)
 };
 
@@ -160,7 +160,7 @@ struct InputTensorDims3d {
 
 struct WeightTensorDims3d {
   int64_t outputChannels;
-  int64_t flattenedKernelChannels; // kD*kH*kW*C_in/groups
+  int64_t flattenedKernelChannels; // kD*kH*kW*C_in
   int64_t kernelDepth;
   int64_t kernelHeight;
   int64_t kernelWidth;

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -2160,11 +2160,6 @@ public:
 
     auto groupsAttr = rewriter.getI32IntegerAttr(adaptor.getGroups());
 
-    if (adaptor.getGroups() != 1) {
-      return rewriter.notifyMatchFailure(
-          op, "ttnn.conv3d only supports groups == 1");
-    }
-
     auto paddingModeAttr = adaptor.getPaddingModeAttr();
 
     constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];

--- a/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
+++ b/lib/Dialect/TTNN/Utils/VerificationUtils.cpp
@@ -4,6 +4,9 @@
 
 #include "ttmlir/Dialect/TTNN/Utils/VerificationUtils.h"
 
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOpsTypes.h"
+#include "ttmlir/Utils.h"
+
 namespace mlir::tt::ttnn::utils::verification_utils::conv2d {
 
 mlir::LogicalResult verifyTensorRanks(mlir::tt::ttnn::Conv2dOp *op) {
@@ -218,12 +221,12 @@ mlir::LogicalResult verifyTensorRanks(mlir::tt::ttnn::Conv3dOp *op) {
   // Conv3dOp accepts weight in two shapes:
   //   - Raw 5D [O, C/G, kD, kH, kW]: present from TTIRToTTNN lowering until
   //     TTNNPrepareConv3dWeights runs.
-  //   - Prepared 2D [kD*kH*kW*C/G_aligned, O]: emitted by
+  //   - Prepared 2D [kD*kH*kW*C_in_aligned, O]: emitted by
   //     PrepareConv3dWeightsOp and consumed by the tt-metal runtime kernel.
   if (weightRank != 5 && weightRank != 2) {
     return op->emitOpError(
         "weight must be either a 5D tensor [O, C/G, kD, kH, kW] (raw) or a "
-        "2D tensor [kD*kH*kW*C/G, O] (prepared)");
+        "2D tensor [kD*kH*kW*C_in, O] (prepared)");
   }
   if (op->getBias() && op->getBias().getType().getRank() != 2) {
     return op->emitOpError("bias must be a 2D tensor [1, O]");
@@ -255,7 +258,7 @@ getConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op) {
                   weightType.getDimSize(2), weightType.getDimSize(3),
                   weightType.getDimSize(4)};
   } else {
-    // Prepared 2D weight: (kD*kH*kW*C/G_aligned, O). Kernel dims come from
+    // Prepared 2D weight: (kD*kH*kW*C_in_aligned, O). Kernel dims come from
     // op attributes since the weight has been flattened.
     weightDims = {op->getOutChannels(), weightType.getDimSize(WEIGHT_FLATTENED),
                   kernelSize[0], kernelSize[1], kernelSize[2]};
@@ -356,32 +359,26 @@ verifyConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op,
                       const std::optional<BiasTensorDims3d> &biasDims,
                       const Conv3dParams &params) {
 
-  if (inputDims.inputChannels % params.groups != 0) {
-    return op->emitOpError()
-           << "in_channels (" << inputDims.inputChannels
-           << ") must be divisible by groups (" << params.groups << ")";
-  }
-
   if (weightDims.outputChannels % params.groups != 0) {
     return op->emitOpError()
            << "out_channels (" << weightDims.outputChannels
            << ") must be divisible by groups (" << params.groups << ")";
   }
 
+  int64_t kernelVolume = params.kernelSize.depth * params.kernelSize.vertical *
+                         params.kernelSize.horizontal;
+
   // The flattened-dim consistency check applies only to the prepared 2D
-  // weight, where the flattened dim is kD*kH*kW*C/G_aligned. For raw 5D
-  // weight, dim 1 is the unaligned C/G — it doesn't match in_channels
-  // (which is already aligned to TILE_WIDTH by TTIRToTTNN).
+  // weight. For raw 5D weight, dim 1 is the unaligned C/G — it doesn't match
+  // in_channels (which is already aligned to TILE_WIDTH by TTIRToTTNN).
   if (op->getWeight().getType().getRank() == 2) {
-    int64_t expectedFlattenedDim =
-        (inputDims.inputChannels / params.groups) * params.kernelSize.depth *
-        params.kernelSize.vertical * params.kernelSize.horizontal;
+    int64_t expectedFlattenedDim = inputDims.inputChannels * kernelVolume;
 
     if (expectedFlattenedDim != weightDims.flattenedKernelChannels) {
-      return op->emitOpError() << "weight flattened dimension ("
-                               << weightDims.flattenedKernelChannels
-                               << ") must equal kD*kH*kW*C_in/groups ("
-                               << expectedFlattenedDim << ")";
+      return op->emitOpError()
+             << "weight flattened dimension ("
+             << weightDims.flattenedKernelChannels
+             << ") must equal kD*kH*kW*C_in (" << expectedFlattenedDim << ")";
     }
   } else {
     // Raw 5D weight: (O, C/G, kD, kH, kW). The flattened-dim check above can't
@@ -396,6 +393,20 @@ verifyConv3dInputDims(mlir::tt::ttnn::Conv3dOp *op,
              << ") must match kernel_size (" << params.kernelSize.depth << ", "
              << params.kernelSize.vertical << ", "
              << params.kernelSize.horizontal << ")";
+    }
+
+    constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
+    int64_t inChannelsPerGroup =
+        weightDims.flattenedKernelChannels / kernelVolume;
+    int64_t expectedInChannels =
+        ttmlir::utils::alignUp(inChannelsPerGroup * params.groups, TILE_WIDTH);
+    if (expectedInChannels != inputDims.inputChannels) {
+      return op->emitOpError()
+             << "in_channels (" << inputDims.inputChannels
+             << ") must equal the weight's input channels per group ("
+             << inChannelsPerGroup << ") * groups (" << params.groups
+             << ") aligned to " << TILE_WIDTH << " (" << expectedInChannels
+             << ")";
     }
   }
 

--- a/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
+++ b/lib/OpModel/TTNN/TTNNOutputTensorInference.cpp
@@ -245,13 +245,13 @@ mlir::RankedTensorType getPreparedConv3dWeightsOutputTensor(Conv3dOp *op) {
 
   constexpr int64_t TILE_WIDTH = ttcore::TileType::getDefaultShape()[1];
   constexpr int64_t ALIGNMENT = TILE_WIDTH;
-  int64_t inChannelsPerGroup = op->getInChannels() / op->getGroups();
   llvm::ArrayRef<int32_t> kernelSize = op->getKernelSize();
   int64_t kernelDepth = kernelSize[0];
   int64_t kernelHeight = kernelSize[1];
   int64_t kernelWidth = kernelSize[2];
   int64_t cInAligned =
-      llvm::divideCeil(inChannelsPerGroup, ALIGNMENT) * ALIGNMENT;
+      llvm::divideCeil(static_cast<int64_t>(op->getInChannels()), ALIGNMENT) *
+      ALIGNMENT;
   int64_t numCInBlocks = cInAligned / TILE_WIDTH;
   llvm::SmallVector<int64_t> preparedShape = {
       numCInBlocks * kernelDepth * kernelHeight * kernelWidth * TILE_WIDTH,

--- a/test/python/golden/ttir_ops/convolution/test_conv3d.py
+++ b/test/python/golden/ttir_ops/convolution/test_conv3d.py
@@ -129,6 +129,36 @@ def clear_program_cache_after_test(device):
             [2, 2, 2],
             1,
         ),
+        # Grouped convolution, tile-aligned C_in
+        (
+            (1, 8, 28, 28, 32),
+            (32, 16, 3, 3, 3),
+            None,
+            [1, 1, 1],
+            [0, 0, 0],
+            1,
+            2,
+        ),
+        # Grouped convolution with bias, C_in not tile-aligned
+        (
+            (1, 8, 28, 28, 12),
+            (24, 6, 3, 3, 3),
+            (1, 1, 1, 1, 24),
+            [1, 1, 1],
+            [0, 0, 0],
+            1,
+            2,
+        ),
+        # Depthwise convolution (groups == C_in)
+        (
+            (1, 8, 16, 16, 32),
+            (32, 1, 3, 3, 3),
+            None,
+            [1, 1, 1],
+            [1, 1, 1],
+            1,
+            32,
+        ),
     ],
     ids=[
         "basic_3x3x3_no_bias",
@@ -140,6 +170,9 @@ def clear_program_cache_after_test(device):
         "pointwise_1x1x1",
         "temporal_downsampling_192ch_s211",
         "dilation2_3x3x3",
+        "grouped_g2_3x3x3",
+        "grouped_g2_with_bias_unaligned_cin",
+        "depthwise_g32_3x3x3",
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16], ids=["f32", "bf16"])

--- a/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_negative.mlir
+++ b/test/ttmlir/Dialect/TTNN/conv/conv3d/conv3d_tests_negative.mlir
@@ -29,7 +29,7 @@ module {
 module {
   func.func @conv3d_invalid_weight_shape(%arg0: tensor<1x8x28x28x4xbf16>, %arg1: tensor<108x3x16xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: error: 'ttnn.conv3d' op weight must be either a 5D tensor [O, C/G, kD, kH, kW] (raw) or a 2D tensor [kD*kH*kW*C/G, O] (prepared)
+    // CHECK: error: 'ttnn.conv3d' op weight must be either a 5D tensor [O, C/G, kD, kH, kW] (raw) or a 2D tensor [kD*kH*kW*C_in, O] (prepared)
     %1 = "ttnn.conv3d"(%arg0, %arg1, %arg2, %0)
             <{
               in_channels = 4: i32,
@@ -270,12 +270,12 @@ module {
 
 // -----
 module {
-  func.func @conv3d_input_channels_not_divisible_by_groups(%arg0: tensor<1x8x28x28x7xbf16>, %arg1: tensor<54x16xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
+  func.func @conv3d_in_channels_mismatch_with_raw_weight(%arg0: tensor<1x8x28x28x32xbf16>, %arg1: tensor<16x2x3x3x3xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: error: 'ttnn.conv3d' op in_channels (7) must be divisible by groups (4)
+    // CHECK: error: 'ttnn.conv3d' op in_channels (64) must equal the weight's input channels per group (2) * groups (4) aligned to 32 (32)
     %1 = "ttnn.conv3d"(%arg0, %arg1, %arg2, %0)
             <{
-              in_channels = 7: i32,
+              in_channels = 64: i32,
               out_channels = 16: i32,
               batch_size = 1: i32,
               input_depth = 8: i32,
@@ -287,7 +287,7 @@ module {
               padding_mode = "zeros",
               groups = 4: i32,
               dtype = #ttcore.supportedDataTypes<bf16>
-            }> : (tensor<1x8x28x28x7xbf16>, tensor<54x16xbf16>, tensor<1x16xbf16>, !ttnn.device) -> tensor<1x6x26x26x16xbf16>
+            }> : (tensor<1x8x28x28x32xbf16>, tensor<16x2x3x3x3xbf16>, tensor<1x16xbf16>, !ttnn.device) -> tensor<1x6x26x26x16xbf16>
     return %1 : tensor<1x6x26x26x16xbf16>
   }
 }
@@ -318,9 +318,9 @@ module {
 
 // -----
 module {
-  func.func @conv3d_weight_flattened_dim_mismatch(%arg0: tensor<1x8x28x28x8xbf16>, %arg1: tensor<216x16xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
+  func.func @conv3d_weight_flattened_dim_mismatch(%arg0: tensor<1x8x28x28x8xbf16>, %arg1: tensor<108x16xbf16>, %arg2: tensor<1x16xbf16>) -> tensor<1x6x26x26x16xbf16> {
     %0 = "ttnn.get_device"() <{mesh_shape = #ttnn<mesh_shape 1x1>}> : () -> !ttnn.device
-    // CHECK: error: 'ttnn.conv3d' op weight flattened dimension (216) must equal kD*kH*kW*C_in/groups (108)
+    // CHECK: error: 'ttnn.conv3d' op weight flattened dimension (108) must equal kD*kH*kW*C_in (216)
     %1 = "ttnn.conv3d"(%arg0, %arg1, %arg2, %0)
             <{
               in_channels = 8: i32,
@@ -335,7 +335,7 @@ module {
               padding_mode = "zeros",
               groups = 2: i32,
               dtype = #ttcore.supportedDataTypes<bf16>
-            }> : (tensor<1x8x28x28x8xbf16>, tensor<216x16xbf16>, tensor<1x16xbf16>, !ttnn.device) -> tensor<1x6x26x26x16xbf16>
+            }> : (tensor<1x8x28x28x8xbf16>, tensor<108x16xbf16>, tensor<1x16xbf16>, !ttnn.device) -> tensor<1x6x26x26x16xbf16>
     return %1 : tensor<1x6x26x26x16xbf16>
   }
 }

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -3384,7 +3384,7 @@ TEST_F(OpModelBase, conv2dInterfaceComputeKernelConfig) {
 
 TEST_F(OpModelBase, Conv3dInterface) {
   llvm::SmallVector<int64_t> inputShape = {1, 5, 10, 10, 32}; // [N, D, H, W, C]
-  // Weight must be 2D: [kD*kH*kW*C_in/groups, C_out]
+  // Weight must be 2D: [kD*kH*kW*C_in, C_out]
   // patch_size = 3*3*3*32 = 864, out_channels = 64 (multiple of 32)
   llvm::SmallVector<int64_t> weightShape = {864, 64};
   // Dilation 2 gives an effective kernel size of 5 in each dimension.

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -10223,17 +10223,15 @@ def chisel_ttnn_conv3d(op, inputs):
     input_width = unpack_mlir_attr(op.attributes["input_width"])
     in_channels = unpack_mlir_attr(op.attributes["in_channels"])
     out_channels = unpack_mlir_attr(op.attributes["out_channels"])
-    groups = unpack_mlir_attr(op.attributes["groups"])
     kernel_size = unpack_mlir_attr(op.attributes["kernel_size"])
     input_ndhwc = inputs["input"].reshape(
         batch_size, input_depth, input_height, input_width, in_channels
     )
-    # TTNN weight is [K_D*K_H*K_W*(C_in/groups), C_out]; reshape to OIDHW for torch conv3d.
+    # TTNN weight is [K_D*K_H*K_W*C_in, C_out]; reshape to OIDHW for torch conv3d.
     kd, kh, kw = kernel_size
-    in_channels_per_group = in_channels // groups
     weight_ncdhw = (
         inputs["weight"]
-        .reshape(kd, kh, kw, in_channels_per_group, out_channels)
+        .reshape(kd, kh, kw, in_channels, out_channels)
         .permute(4, 3, 0, 1, 2)
     )
     result_ndhwc = conv3d_golden(
@@ -10243,7 +10241,7 @@ def chisel_ttnn_conv3d(op, inputs):
         stride=op.attributes["stride"],
         padding=op.attributes["padding"],
         dilation=op.attributes["dilation"],
-        groups=op.attributes["groups"],
+        groups=1,
         batch_dim=0,
         depth_dim=1,
         height_dim=2,


### PR DESCRIPTION
### Ticket
n/a

### Problem description
MLIR was rejecting conv3d op with groups != 1

### What's changed
Since ttnn now supports group param for conv3d, I removed this protection.
Added tests that covers multiple groups.

### Checklist
- [ ] New/Existing tests provide coverage for changes
