### PR TITLE
[TTML] Take AdamW lr / beta_pow as tensor operands

### DIFF
--- a/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
+++ b/include/ttmlir/Dialect/TTIR/IR/TTIROps.td
@@ -2379,13 +2379,14 @@ def TTIR_AdamWOp : TTIR_NamedOp<"adamw"> {
     - `grad` (Tensor): gradient of the parameter.
     - `exp_avg` (Tensor): first moment estimate.
     - `exp_avg_sq` (Tensor): second moment estimate.
+    - `lr`, `beta1_pow`, `beta2_pow` (single-element f32 Tensors): learning rate
+      and the beta1^t / beta2^t bias-correction terms. They change every step,
+      so they are tensors rather than attributes to keep the compiled graph stable.
     - `max_exp_avg_sq` (Optional Tensor): max second moment for AMSGrad. Its
       presence implies amsgrad, and requires the matching result.
 
     Attributes:
-    - `lr`: learning rate.
     - `beta1`, `beta2`: exponential decay rates for the moment estimates.
-    - `beta1_pow`, `beta2_pow`: beta1^t and beta2^t bias-correction terms.
     - `epsilon`: numerical-stability constant.
     - `weight_decay`: decoupled weight-decay coefficient.
     - `stochastic_rounding`: enable stochastic rounding (default false).
@@ -2398,12 +2399,12 @@ def TTIR_AdamWOp : TTIR_NamedOp<"adamw"> {
                        AnyRankedTensor:$grad,
                        AnyRankedTensor:$exp_avg,
                        AnyRankedTensor:$exp_avg_sq,
+                       AnyRankedTensor:$lr,
+                       AnyRankedTensor:$beta1_pow,
+                       AnyRankedTensor:$beta2_pow,
                        Optional<AnyRankedTensor>:$max_exp_avg_sq,
-                       F32Attr:$lr,
                        F32Attr:$beta1,
                        F32Attr:$beta2,
-                       F32Attr:$beta1_pow,
-                       F32Attr:$beta2_pow,
                        F32Attr:$epsilon,
                        F32Attr:$weight_decay,
                        DefaultValuedAttr<BoolAttr, "false">:$stochastic_rounding);

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2782,18 +2782,22 @@ def TTNN_AdamWOp : TTNN_InplaceOp<"adamw"> {
       `param`, `exp_avg`, `exp_avg_sq` and the optional `max_exp_avg_sq` (used for
       AMSGrad) are all mutated in place, so the op has no results. `amsgrad` is
       implied by the presence of `max_exp_avg_sq`.
+
+      `lr`, `beta1_pow` and `beta2_pow` are single-element f32 tensors. The
+      backing kernel takes them as host floats, so they are read back from the
+      device at execution time; the op is therefore excluded from trace capture.
     }];
 
     let arguments = (ins Arg<AnyRankedTensor, "parameter tensor (updated in place)", [MemWrite]>:$param,
                          AnyRankedTensor:$grad,
                          Arg<AnyRankedTensor, "first moment estimate", [MemWrite]>:$exp_avg,
                          Arg<AnyRankedTensor, "second moment estimate", [MemWrite]>:$exp_avg_sq,
+                         AnyRankedTensor:$lr,
+                         AnyRankedTensor:$beta1_pow,
+                         AnyRankedTensor:$beta2_pow,
                          Arg<Optional<AnyRankedTensor>, "max second moment estimate (amsgrad)", [MemWrite]>:$max_exp_avg_sq,
-                         F32Attr:$lr,
                          F32Attr:$beta1,
                          F32Attr:$beta2,
-                         F32Attr:$beta1_pow,
-                         F32Attr:$beta2_pow,
                          F32Attr:$epsilon,
                          F32Attr:$weight_decay,
                          DefaultValuedAttr<BoolAttr, "false">:$stochastic_rounding);
@@ -2801,14 +2805,13 @@ def TTNN_AdamWOp : TTNN_InplaceOp<"adamw"> {
     let builders = [
       OpBuilder<(ins "Value":$param, "Value":$grad,
                      "Value":$exp_avg, "Value":$exp_avg_sq,
-                     "llvm::APFloat":$lr, "llvm::APFloat":$beta1,
-                     "llvm::APFloat":$beta2, "llvm::APFloat":$beta1_pow,
-                     "llvm::APFloat":$beta2_pow, "llvm::APFloat":$epsilon,
-                     "llvm::APFloat":$weight_decay),
+                     "Value":$lr, "Value":$beta1_pow, "Value":$beta2_pow,
+                     "llvm::APFloat":$beta1, "llvm::APFloat":$beta2,
+                     "llvm::APFloat":$epsilon, "llvm::APFloat":$weight_decay),
       [{
-        build($_builder, $_state, param, grad, exp_avg, exp_avg_sq,
-              /*max_exp_avg_sq=*/nullptr, lr, beta1, beta2, beta1_pow, beta2_pow,
-              epsilon, weight_decay, /*stochastic_rounding=*/false);
+        build($_builder, $_state, param, grad, exp_avg, exp_avg_sq, lr, beta1_pow,
+              beta2_pow, /*max_exp_avg_sq=*/nullptr, beta1, beta2, epsilon,
+              weight_decay, /*stochastic_rounding=*/false);
       }]>
     ];
 

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2354,9 +2354,8 @@ struct OpModel<AdamWOp> {
       llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
       llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
       std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
-      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
-      llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
-      llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat beta1,
+      llvm::APFloat beta2, llvm::APFloat epsilon, llvm::APFloat weightDecay,
       bool stochasticRounding, TTNNLayoutAttr outputLayout,
       const MockAllocatorState *initialState = nullptr);
 
@@ -2366,9 +2365,8 @@ struct OpModel<AdamWOp> {
       llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
       llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
       std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
-      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
-      llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
-      llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+      std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat beta1,
+      llvm::APFloat beta2, llvm::APFloat epsilon, llvm::APFloat weightDecay,
       bool stochasticRounding, TTNNLayoutAttr outputLayout);
 };
 

--- a/include/ttmlir/Target/TTNN/operations/ttml.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ttml.fbs
@@ -9,11 +9,11 @@ table AdamWOp {
   exp_avg: tt.target.ttnn.TensorRef;
   exp_avg_sq: tt.target.ttnn.TensorRef;
   max_exp_avg_sq: tt.target.ttnn.TensorRef;
-  lr: float;
+  lr: tt.target.ttnn.TensorRef;
+  beta1_pow: tt.target.ttnn.TensorRef;
+  beta2_pow: tt.target.ttnn.TensorRef;
   beta1: float;
   beta2: float;
-  beta1_pow: float;
-  beta2_pow: float;
   epsilon: float;
   weight_decay: float;
   stochastic_rounding: bool = false;

--- a/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
+++ b/lib/Conversion/StableHLOToTTIR/StableHLOLegalizeCompositePass.cpp
@@ -2012,13 +2012,14 @@ public:
       return failure();
     }
     size_t numOperands = adaptor.getOperands().size();
-    if (numOperands != 4 && numOperands != 5) {
+    if (numOperands != 7 && numOperands != 8) {
       return rewriter.notifyMatchFailure(
-          srcOp, "tenstorrent.adamw must have 4 or 5 operands (param, grad, "
-                 "exp_avg, exp_avg_sq, [max_exp_avg_sq]).");
+          srcOp, "tenstorrent.adamw must have 7 or 8 operands (param, grad, "
+                 "exp_avg, exp_avg_sq, lr, beta1_pow, beta2_pow, "
+                 "[max_exp_avg_sq]).");
     }
 
-    if (srcOp.getNumResults() != numOperands - 1) {
+    if (srcOp.getNumResults() != numOperands - 4) {
       return rewriter.notifyMatchFailure(
           srcOp, "tenstorrent.adamw must have one result per updated operand "
                  "(param, exp_avg, exp_avg_sq, [max_exp_avg_sq]).");
@@ -2032,9 +2033,8 @@ public:
 
     // Copy the required F32 hyperparameters through, normalizing to F32 so the
     // ttir.adamw verifier accepts them regardless of the source float width.
-    static constexpr StringRef kFloatAttrs[] = {
-        "lr",        "beta1",   "beta2",       "beta1_pow",
-        "beta2_pow", "epsilon", "weight_decay"};
+    static constexpr StringRef kFloatAttrs[] = {"beta1", "beta2", "epsilon",
+                                                "weight_decay"};
 
     SmallVector<NamedAttribute> namedAttrs;
     for (StringRef name : kFloatAttrs) {

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1130,9 +1130,10 @@ public:
         reshapeToRank4IfNeeded(rewriter, loc, adaptor.getGrad()),
         reshapeToRank4IfNeeded(rewriter, loc, adaptor.getExpAvg()),
         reshapeToRank4IfNeeded(rewriter, loc, adaptor.getExpAvgSq()),
-        maxExpAvgSq4D, adaptor.getLr(), adaptor.getBeta1(), adaptor.getBeta2(),
-        adaptor.getBeta1Pow(), adaptor.getBeta2Pow(), adaptor.getEpsilon(),
-        adaptor.getWeightDecay(), adaptor.getStochasticRounding());
+        adaptor.getLr(), adaptor.getBeta1Pow(), adaptor.getBeta2Pow(),
+        maxExpAvgSq4D, adaptor.getBeta1(), adaptor.getBeta2(),
+        adaptor.getEpsilon(), adaptor.getWeightDecay(),
+        adaptor.getStochasticRounding());
 
     llvm::SmallVector<mlir::Value> restored;
     for (auto [result4D, originalType] :

--- a/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
+++ b/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp
@@ -1249,9 +1249,9 @@ public:
 
     rewriter.create<ttnn::AdamWOp>(
         op.getLoc(), adaptor.getParam(), adaptor.getGrad(), adaptor.getExpAvg(),
-        adaptor.getExpAvgSq(), adaptor.getMaxExpAvgSq(), adaptor.getLr(),
-        adaptor.getBeta1(), adaptor.getBeta2(), adaptor.getBeta1Pow(),
-        adaptor.getBeta2Pow(), adaptor.getEpsilon(), adaptor.getWeightDecay(),
+        adaptor.getExpAvgSq(), adaptor.getLr(), adaptor.getBeta1Pow(),
+        adaptor.getBeta2Pow(), adaptor.getMaxExpAvgSq(), adaptor.getBeta1(),
+        adaptor.getBeta2(), adaptor.getEpsilon(), adaptor.getWeightDecay(),
         adaptor.getStochasticRounding());
 
     SmallVector<Value> replacements{adaptor.getParam(), adaptor.getExpAvg(),

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3576,20 +3576,30 @@ public:
     ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::AdamWOp> emitter(
         srcOp, adaptor, rewriter);
 
-    // Arg order matches ttml::metal::adamw(param, grad, exp_avg, exp_avg_sq,
-    // max_exp_avg_sq, lr, beta1, beta2, beta1_pow, beta2_pow, epsilon,
-    // weight_decay, stochastic_rounding).
+    auto scalar = [&](mlir::Value v, uint32_t index) {
+      return emitter.emit(
+          rewriter
+              .create<emitc::CallOpaqueOp>(
+                  srcOp.getLoc(), rewriter.getF32Type(),
+                  ttnn_to_emitc::kGetScalarFromTensorFunctionName,
+                  /*args=*/nullptr,
+                  rewriter.getArrayAttr({TypeAttr::get(rewriter.getF32Type())}),
+                  v)
+              .getResult(0),
+          index);
+    };
+    uint32_t hasMax = adaptor.getMaxExpAvgSq() ? 1 : 0;
     llvm::SmallVector<mlir::Attribute> args{
         emitter.emit(srcOp.getParam()),
         emitter.emit(srcOp.getGrad()),
         emitter.emit(srcOp.getExpAvg()),
         emitter.emit(srcOp.getExpAvgSq()),
-        emitter.emit(srcOp.getMaxExpAvgSq()),
-        emitter.emit(srcOp.getLr()),
+        emitter.emit(adaptor.getMaxExpAvgSq(), 4),
+        scalar(adaptor.getLr(), 4 + hasMax),
         emitter.emit(srcOp.getBeta1()),
         emitter.emit(srcOp.getBeta2()),
-        emitter.emit(srcOp.getBeta1Pow()),
-        emitter.emit(srcOp.getBeta2Pow()),
+        scalar(adaptor.getBeta1Pow(), 5 + hasMax),
+        scalar(adaptor.getBeta2Pow(), 6 + hasMax),
         emitter.emit(srcOp.getEpsilon()),
         emitter.emit(srcOp.getWeightDecay()),
         rewriter.getAttr<emitc::OpaqueAttr>(

--- a/lib/Dialect/TTIR/IR/TTIROps.cpp
+++ b/lib/Dialect/TTIR/IR/TTIROps.cpp
@@ -7308,6 +7308,14 @@ mlir::tt::ttir::SplitQueryKeyValueAndSplitHeadsOp::verify() {
   if (getMaxExpAvgSq() && !sameShape(getMaxExpAvgSq().getType())) {
     return emitOpError("max_exp_avg_sq must have the same shape as param");
   }
+  for (auto [name, v] :
+       {std::pair{"lr", getLr()}, std::pair{"beta1_pow", getBeta1Pow()},
+        std::pair{"beta2_pow", getBeta2Pow()}}) {
+    RankedTensorType t = v.getType();
+    if (t.getNumElements() != 1 || !t.getElementType().isF32()) {
+      return emitOpError() << name << " must be a single-element f32 tensor";
+    }
+  }
 
   // Each result stands for the updated value of the operand it is paired with,
   // and TTIRToTTNN forwards it to that operand, so the types must match.

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -3931,6 +3931,14 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
   if (getMaxExpAvgSq() && !sameShape(getMaxExpAvgSq().getType())) {
     return emitOpError("max_exp_avg_sq must have the same shape as param");
   }
+  for (auto [name, v] :
+       {std::pair{"lr", getLr()}, std::pair{"beta1_pow", getBeta1Pow()},
+        std::pair{"beta2_pow", getBeta2Pow()}}) {
+    RankedTensorType t = v.getType();
+    if (t.getNumElements() != 1 || !t.getElementType().isF32()) {
+      return emitOpError() << name << " must be a single-element f32 tensor";
+    }
+  }
   return success();
 }
 

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4527,8 +4527,8 @@ llvm::Expected<op_model::OpConstraints> AdamWOp::getOpConstraints(
     const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
     std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
         liveRecords) {
-  assert(inputs.size() >= 4 && inputs.size() <= 5 &&
-         "AdamWOp must have 4 or 5 inputs");
+  assert(inputs.size() >= 7 && inputs.size() <= 8 &&
+         "AdamWOp must have 7 or 8 inputs");
 
   auto paramShape = getParam().getType().getShape();
   auto gradShape = getGrad().getType().getShape();
@@ -4538,22 +4538,21 @@ llvm::Expected<op_model::OpConstraints> AdamWOp::getOpConstraints(
   std::optional<TTNNLayoutAttr> maxExpAvgSqLayout;
   if (getMaxExpAvgSq()) {
     maxExpAvgSqShape = getMaxExpAvgSq().getType().getShape();
-    maxExpAvgSqLayout = inputs[4];
+    maxExpAvgSqLayout = inputs[7];
   }
 
   return detail::constraintsDispatch(
       *this, liveRecords, paramShape, inputs[0], gradShape, inputs[1],
       expAvgShape, inputs[2], expAvgSqShape, inputs[3], maxExpAvgSqShape,
-      maxExpAvgSqLayout, getLr(), getBeta1(), getBeta2(), getBeta1Pow(),
-      getBeta2Pow(), getEpsilon(), getWeightDecay(), getStochasticRounding(),
-      opConfig.outputLayout);
+      maxExpAvgSqLayout, getBeta1(), getBeta2(), getEpsilon(), getWeightDecay(),
+      getStochasticRounding(), opConfig.outputLayout);
 }
 
 llvm::Expected<size_t>
 AdamWOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
                       const OpConfig &opConfig) {
-  assert(inputs.size() >= 4 && inputs.size() <= 5 &&
-         "AdamWOp must have 4 or 5 inputs");
+  assert(inputs.size() >= 7 && inputs.size() <= 8 &&
+         "AdamWOp must have 7 or 8 inputs");
 
   auto paramShape = getParam().getType().getShape();
   auto gradShape = getGrad().getType().getShape();
@@ -4563,15 +4562,14 @@ AdamWOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
   std::optional<TTNNLayoutAttr> maxExpAvgSqLayout;
   if (getMaxExpAvgSq()) {
     maxExpAvgSqShape = getMaxExpAvgSq().getType().getShape();
-    maxExpAvgSqLayout = inputs[4];
+    maxExpAvgSqLayout = inputs[7];
   }
 
   return opRuntimeCache().getOrCompute(
       op_model::OpModel<AdamWOp>::getOpRuntime, *this, paramShape, inputs[0],
       gradShape, inputs[1], expAvgShape, inputs[2], expAvgSqShape, inputs[3],
-      maxExpAvgSqShape, maxExpAvgSqLayout, getLr(), getBeta1(), getBeta2(),
-      getBeta1Pow(), getBeta2Pow(), getEpsilon(), getWeightDecay(),
-      getStochasticRounding(), opConfig.outputLayout);
+      maxExpAvgSqShape, maxExpAvgSqLayout, getBeta1(), getBeta2(), getEpsilon(),
+      getWeightDecay(), getStochasticRounding(), opConfig.outputLayout);
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -61,6 +61,7 @@ private:
     shouldHoist &= !::mlir::isa<mlir::tt::ttcore::LoadCachedOp>(op);
     shouldHoist &= !::mlir::isa<mlir::tt::ttnn::CaptureOrExecuteTraceOp>(op);
     shouldHoist &= !::mlir::isa<mlir::tt::ttnn::GetDeviceOp>(op);
+    shouldHoist &= !::mlir::isa<mlir::tt::ttnn::AdamWOp>(op);
     shouldHoist &=
         !(op->hasTrait<mlir::tt::ttcore::Trait::TTCoreCreationOpTrait>());
     return shouldHoist;

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -966,6 +966,48 @@ private:
     return mlir::success();
   }
 
+  // ttnn.adamw is not hoistable (host readback of lr / beta*_pow), so an
+  // adamw followed by hoistable compute would split the trace region and fail
+  // below. adamw has no results and mutates its param / moment operands in
+  // place, so it can be moved to the end of the block as long as no later
+  // non-adamw op touches any of its operands. Relative order of adamw ops is
+  // preserved. Anything that cannot be moved is left in place and reported by
+  // the "non-hoistable op in the middle" check.
+  void sinkAdamWOpsToEnd(mlir::Block &block) {
+    llvm::SmallVector<Operation *> adamWOps;
+    for (mlir::Operation &op : block.getOperations()) {
+      if (::mlir::isa<mlir::tt::ttnn::AdamWOp>(op)) {
+        adamWOps.push_back(&op);
+      }
+    }
+    if (adamWOps.empty()) {
+      return;
+    }
+
+    Operation *terminator = block.getTerminator();
+    for (Operation *adamW : adamWOps) {
+      llvm::SmallPtrSet<mlir::Value, 8> operands(adamW->operand_begin(),
+                                                 adamW->operand_end());
+      bool canSink = true;
+      for (Operation *later = adamW->getNextNode();
+           later && later != terminator && canSink;
+           later = later->getNextNode()) {
+        if (::mlir::isa<mlir::tt::ttnn::AdamWOp>(later)) {
+          continue;
+        }
+        for (mlir::Value v : later->getOperands()) {
+          if (operands.contains(v)) {
+            canSink = false;
+            break;
+          }
+        }
+      }
+      if (canSink) {
+        adamW->moveBefore(terminator);
+      }
+    }
+  }
+
   mlir::LogicalResult processFuncOp(func::FuncOp funcOp) {
     // Skip non-forward functions.
     if (!ttmlir::utils::isForwardDeviceFunc(funcOp)) {
@@ -979,6 +1021,8 @@ private:
     llvm::SmallVector<Operation *> opsToHoist;
 
     mlir::Block &block = funcOp.getBlocks().front();
+
+    sinkAdamWOpsToEnd(block);
 
     // Collect all hoistable ops, but skip the first non-hoistable ops and the
     // last non-hoistable ops. Non-hoistable ops at the boundaries should remain

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9394,9 +9394,8 @@ llvm::Expected<OpConstraints> OpModel<AdamWOp>::getOpConstraints(
     llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
     llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
     std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
-    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
-    llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
-    llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat beta1,
+    llvm::APFloat beta2, llvm::APFloat epsilon, llvm::APFloat weightDecay,
     bool stochasticRounding, TTNNLayoutAttr outputLayout,
     const MockAllocatorState *initialState) {
 
@@ -9430,11 +9429,10 @@ llvm::Expected<OpConstraints> OpModel<AdamWOp>::getOpConstraints(
   auto adamWOpQuery = [=]() {
     return QUERY_OP_CONSTRAINTS_WITH_STATE(
         ::ttml::metal::adamw, device, initialStateOpt, paramSpec, gradSpec,
-        expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec, lr.convertToFloat(),
-        beta1.convertToFloat(), beta2.convertToFloat(),
-        beta1Pow.convertToFloat(), beta2Pow.convertToFloat(),
-        epsilon.convertToFloat(), weightDecay.convertToFloat(),
-        stochasticRoundingValue);
+        expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec, /*lr=*/0.0F,
+        beta1.convertToFloat(), beta2.convertToFloat(), /*beta1_pow=*/0.0F,
+        /*beta2_pow=*/0.0F, epsilon.convertToFloat(),
+        weightDecay.convertToFloat(), stochasticRoundingValue);
   };
 
   return operation::getOpConstraintsWithState(paramLayout.getContext(),
@@ -9450,9 +9448,8 @@ llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
     llvm::ArrayRef<int64_t> expAvgShape, TTNNLayoutAttr expAvgLayout,
     llvm::ArrayRef<int64_t> expAvgSqShape, TTNNLayoutAttr expAvgSqLayout,
     std::optional<llvm::ArrayRef<int64_t>> maxExpAvgSqShape,
-    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat lr,
-    llvm::APFloat beta1, llvm::APFloat beta2, llvm::APFloat beta1Pow,
-    llvm::APFloat beta2Pow, llvm::APFloat epsilon, llvm::APFloat weightDecay,
+    std::optional<TTNNLayoutAttr> maxExpAvgSqLayout, llvm::APFloat beta1,
+    llvm::APFloat beta2, llvm::APFloat epsilon, llvm::APFloat weightDecay,
     bool stochasticRounding, TTNNLayoutAttr outputLayout) {
 
 #ifdef TTMLIR_ENABLE_OPMODEL
@@ -9481,9 +9478,9 @@ llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
   auto adamWOpQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttml::metal::adamw, device, paramSpec, gradSpec,
                             expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec,
-                            lr.convertToFloat(), beta1.convertToFloat(),
-                            beta2.convertToFloat(), beta1Pow.convertToFloat(),
-                            beta2Pow.convertToFloat(), epsilon.convertToFloat(),
+                            /*lr=*/0.0F, beta1.convertToFloat(),
+                            beta2.convertToFloat(), /*beta1_pow=*/0.0F,
+                            /*beta2_pow=*/0.0F, epsilon.convertToFloat(),
                             weightDecay.convertToFloat(),
                             stochasticRoundingValue);
   };

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1641,11 +1641,14 @@ createOp(FlatbufferObjectCache &cache, AdamWOp op) {
         getOperandThroughDPSOps(op.getMaxExpAvgSq()));
   }
 
+  auto tensorRef = [&](Value v) {
+    return cache.at<::tt::target::ttnn::TensorRef>(getOperandThroughDPSOps(v));
+  };
   return ::tt::target::ttnn::CreateAdamWOp(
       *cache.fbb, param, grad, expAvg, expAvgSq, maxExpAvgSq,
-      op.getLr().convertToFloat(), op.getBeta1().convertToFloat(),
-      op.getBeta2().convertToFloat(), op.getBeta1Pow().convertToFloat(),
-      op.getBeta2Pow().convertToFloat(), op.getEpsilon().convertToFloat(),
+      tensorRef(op.getLr()), tensorRef(op.getBeta1Pow()),
+      tensorRef(op.getBeta2Pow()), op.getBeta1().convertToFloat(),
+      op.getBeta2().convertToFloat(), op.getEpsilon().convertToFloat(),
       op.getWeightDecay().convertToFloat(), op.getStochasticRounding());
 }
 

--- a/runtime/include/tt/runtime/detail/ttnn/types/types.h
+++ b/runtime/include/tt/runtime/detail/ttnn/types/types.h
@@ -313,8 +313,27 @@ public:
   //
   size_t getProgramIndex() const { return programIndex; }
 
+  //
+  // Host scalar cache
+  //
+  // Ops that need a device scalar as a host value (e.g. AdamW lr / beta*_pow)
+  // read it back once per program run and reuse it here, keyed by the tensor's
+  // global id. Only valid for tensors that are not mutated within the program.
+  float getHostScalar(std::uint32_t globalId,
+                      const std::function<float()> &read) {
+    auto it = hostScalarCache.find(globalId);
+    if (it != hostScalarCache.end()) {
+      return it->second;
+    }
+    float value = read();
+    hostScalarCache.emplace(globalId, value);
+    return value;
+  }
+
 private:
   ProgramTensorPool tensorPool;
+
+  std::unordered_map<std::uint32_t, float> hostScalarCache;
 
   ProgramGlobalSemaphorePool globalSemaphorePool;
 

--- a/runtime/lib/ttnn/operations/ttml/adamw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/adamw.cpp
@@ -5,8 +5,16 @@
 #include "operations/ttml/adamw.h"
 #include "metal/common/const_utils.hpp"     // ttml::metal::StochasticRounding
 #include "metal/optimizers/adamw/adamw.hpp" // ttml::metal::adamw
+#include "ttnn/distributed/api.hpp"
 
 namespace tt::runtime::ttnn::operations::ttml {
+
+static float readScalar(const ::ttnn::Tensor &tensor) {
+  return ::ttnn::distributed::get_device_tensors(tensor)
+      .front()
+      .to_vector<float>()
+      .front();
+}
 
 void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -30,10 +38,13 @@ void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
                                 : ::ttml::metal::StochasticRounding::Disabled;
 
   // param, exp_avg, exp_avg_sq (and max_exp_avg_sq) are all updated in place.
-  ::ttml::metal::adamw(param, grad, expAvg, expAvgSq, maxExpAvgSq, op->lr(),
-                       op->beta1(), op->beta2(), op->beta1_pow(),
-                       op->beta2_pow(), op->epsilon(), op->weight_decay(),
-                       stochasticRounding);
+  ::ttml::metal::adamw(
+      param, grad, expAvg, expAvgSq, maxExpAvgSq,
+      readScalar(tensorPool.getTTNNTensorAndValidate(op->lr())), op->beta1(),
+      op->beta2(),
+      readScalar(tensorPool.getTTNNTensorAndValidate(op->beta1_pow())),
+      readScalar(tensorPool.getTTNNTensorAndValidate(op->beta2_pow())),
+      op->epsilon(), op->weight_decay(), stochasticRounding);
 }
 
 } // namespace tt::runtime::ttnn::operations::ttml

--- a/runtime/lib/ttnn/operations/ttml/adamw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/adamw.cpp
@@ -25,8 +25,8 @@ static float readScalar(ProgramContext &context,
         ::ttnn::distributed::get_device_tensors(tensor);
     LOG_ASSERT(!shards.empty(), "AdamW scalar operand has no device shards");
     const std::vector<float> values = shards.front().to_vector<float>();
-    LOG_ASSERT(values.size() == 1,
-               "AdamW scalar readback returned ", values.size(), " elements");
+    LOG_ASSERT(values.size() == 1, "AdamW scalar readback returned ",
+               values.size(), " elements");
     return values.front();
   });
 }

--- a/runtime/lib/ttnn/operations/ttml/adamw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/adamw.cpp
@@ -14,11 +14,20 @@ namespace tt::runtime::ttnn::operations::ttml {
 static float readScalar(ProgramContext &context,
                         const ::tt::target::ttnn::TensorRef *ref) {
   return context.getHostScalar(ref->global_id(), [&]() {
-    return ::ttnn::distributed::get_device_tensors(
-               context.getTensorPool().getTTNNTensorAndValidate(ref))
-        .front()
-        .to_vector<float>()
-        .front();
+    const ::ttnn::Tensor &tensor =
+        context.getTensorPool().getTTNNTensorAndValidate(ref);
+    LOG_ASSERT(tensor.logical_volume() == 1,
+               "AdamW scalar operand must have exactly one element, got ",
+               tensor.logical_volume());
+    LOG_ASSERT(tensor.dtype() == ::ttnn::DataType::FLOAT32,
+               "AdamW scalar operand must be float32");
+    const std::vector<::ttnn::Tensor> shards =
+        ::ttnn::distributed::get_device_tensors(tensor);
+    LOG_ASSERT(!shards.empty(), "AdamW scalar operand has no device shards");
+    const std::vector<float> values = shards.front().to_vector<float>();
+    LOG_ASSERT(values.size() == 1,
+               "AdamW scalar readback returned ", values.size(), " elements");
+    return values.front();
   });
 }
 

--- a/runtime/lib/ttnn/operations/ttml/adamw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/adamw.cpp
@@ -9,11 +9,17 @@
 
 namespace tt::runtime::ttnn::operations::ttml {
 
-static float readScalar(const ::ttnn::Tensor &tensor) {
-  return ::ttnn::distributed::get_device_tensors(tensor)
-      .front()
-      .to_vector<float>()
-      .front();
+// Device -> host readback of a single-element tensor. Cached per program run
+// in ProgramContext so N AdamW ops sharing one lr tensor cost one sync.
+static float readScalar(ProgramContext &context,
+                        const ::tt::target::ttnn::TensorRef *ref) {
+  return context.getHostScalar(ref->global_id(), [&]() {
+    return ::ttnn::distributed::get_device_tensors(
+               context.getTensorPool().getTTNNTensorAndValidate(ref))
+        .front()
+        .to_vector<float>()
+        .front();
+  });
 }
 
 void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
@@ -38,13 +44,11 @@ void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
                                 : ::ttml::metal::StochasticRounding::Disabled;
 
   // param, exp_avg, exp_avg_sq (and max_exp_avg_sq) are all updated in place.
-  ::ttml::metal::adamw(
-      param, grad, expAvg, expAvgSq, maxExpAvgSq,
-      readScalar(tensorPool.getTTNNTensorAndValidate(op->lr())), op->beta1(),
-      op->beta2(),
-      readScalar(tensorPool.getTTNNTensorAndValidate(op->beta1_pow())),
-      readScalar(tensorPool.getTTNNTensorAndValidate(op->beta2_pow())),
-      op->epsilon(), op->weight_decay(), stochasticRounding);
+  ::ttml::metal::adamw(param, grad, expAvg, expAvgSq, maxExpAvgSq,
+                       readScalar(context, op->lr()), op->beta1(), op->beta2(),
+                       readScalar(context, op->beta1_pow()),
+                       readScalar(context, op->beta2_pow()), op->epsilon(),
+                       op->weight_decay(), stochasticRounding);
 }
 
 } // namespace tt::runtime::ttnn::operations::ttml

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1993,7 +1993,10 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
     tensorRefs = {opContext.type_as_AdamWOp()->param(),
                   opContext.type_as_AdamWOp()->grad(),
                   opContext.type_as_AdamWOp()->exp_avg(),
-                  opContext.type_as_AdamWOp()->exp_avg_sq()};
+                  opContext.type_as_AdamWOp()->exp_avg_sq(),
+                  opContext.type_as_AdamWOp()->lr(),
+                  opContext.type_as_AdamWOp()->beta1_pow(),
+                  opContext.type_as_AdamWOp()->beta2_pow()};
     if (opContext.type_as_AdamWOp()->max_exp_avg_sq()) {
       tensorRefs.push_back(opContext.type_as_AdamWOp()->max_exp_avg_sq());
     }

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -177,31 +177,45 @@ def test_div(shape: Shape, dtype: torch.dtype, target: str, request, device):
 def test_adamw(shape: Shape, target: str, request, device):
     def module(builder: TTIRBuilder):
         @builder.func(
-            [shape, shape, shape, shape],
-            [torch.float32, torch.bfloat16, torch.float32, torch.float32],
+            [shape, shape, shape, shape, (1,), (1,), (1,)],
+            [torch.float32, torch.bfloat16, torch.float32, torch.float32]
+            + [torch.float32] * 3,
         )
         def adamw(
             param: Operand,
             grad: Operand,
             exp_avg: Operand,
             exp_avg_sq: Operand,
+            lr: Operand,
+            beta1_pow: Operand,
+            beta2_pow: Operand,
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            exp_avg_sq_t = builder._get_golden_tensor(exp_avg_sq).apply_shardwise(
-                lambda s: s.abs()
+            fill = lambda op, v: builder._get_golden_tensor(op).apply_shardwise(
+                lambda s: torch.full_like(s, v)
             )
-            builder.set_goldens_from_builder_tensor({exp_avg_sq: exp_avg_sq_t}, {})
+            builder.set_goldens_from_builder_tensor(
+                {
+                    exp_avg_sq: builder._get_golden_tensor(exp_avg_sq).apply_shardwise(
+                        lambda s: s.abs()
+                    ),
+                    lr: fill(lr, 1e-3),
+                    beta1_pow: fill(beta1_pow, 0.9),
+                    beta2_pow: fill(beta2_pow, 0.999),
+                },
+                {},
+            )
             return builder.adamw(
                 param,
                 grad,
                 exp_avg,
                 exp_avg_sq,
-                lr=1e-3,
+                lr,
+                beta1_pow,
+                beta2_pow,
                 beta1=0.9,
                 beta2=0.999,
-                beta1_pow=0.9,
-                beta2_pow=0.999,
                 epsilon=1e-8,
                 weight_decay=1e-2,
             )
@@ -219,28 +233,44 @@ def test_adamw(shape: Shape, target: str, request, device):
 def test_adamw_fused_forward(shape: Shape, target: str, request, device):
     def module(builder: TTIRBuilder):
         @builder.func(
-            [shape, shape, shape, shape],
-            [torch.float32, torch.bfloat16, torch.float32, torch.float32],
+            [shape, shape, shape, shape, (1,), (1,), (1,)],
+            [torch.float32, torch.bfloat16, torch.float32, torch.float32]
+            + [torch.float32] * 3,
         )
         def adamw_fused_forward(
             param: Operand,
             grad: Operand,
             exp_avg: Operand,
             exp_avg_sq: Operand,
+            lr: Operand,
+            beta1_pow: Operand,
+            beta2_pow: Operand,
             builder: TTIRBuilder,
             unit_attrs: Optional[List[str]] = None,
         ):
-            exp_avg_sq_t = builder._get_golden_tensor(exp_avg_sq).apply_shardwise(
-                lambda s: s.abs()
+            fill = lambda op, v: builder._get_golden_tensor(op).apply_shardwise(
+                lambda s: torch.full_like(s, v)
             )
-            builder.set_goldens_from_builder_tensor({exp_avg_sq: exp_avg_sq_t}, {})
+            builder.set_goldens_from_builder_tensor(
+                {
+                    exp_avg_sq: builder._get_golden_tensor(exp_avg_sq).apply_shardwise(
+                        lambda s: s.abs()
+                    ),
+                    lr: fill(lr, 1.0),
+                    beta1_pow: fill(beta1_pow, 0.9),
+                    beta2_pow: fill(beta2_pow, 0.999),
+                },
+                {},
+            )
             act = builder.abs(param)
             param_out, _, _ = builder.adamw(
                 param,
                 grad,
                 exp_avg,
                 exp_avg_sq,
-                lr=1.0,
+                lr,
+                beta1_pow,
+                beta2_pow,
                 weight_decay=1e-2,
             )
             return builder.add(param_out, act)

--- a/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_adamw.mlir
+++ b/test/ttmlir/Conversion/StableHLOToTTIR/composite/test_adamw.mlir
@@ -2,64 +2,57 @@
 // RUN: ttmlir-opt -split-input-file --legalize-stablehlo-composite-to-ttir -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// AdamW composite without max_exp_avg_sq (4 operands).
+// AdamW composite without max_exp_avg_sq (7 operands).
 module {
   func.func @adamw(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>,
-                   %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>)
+                   %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<64x64xf32> {
     // CHECK: "ttir.adamw"
     // CHECK-SAME: beta1 = 0.899999976 : f32
-    // CHECK-SAME: lr = 1.000000e-03 : f32
     // CHECK-SAME: stochastic_rounding = false
     // CHECK-SAME: weight_decay = 0.00999999977 : f32
-    // CHECK-SAME: (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
+    // CHECK-SAME: (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
     // CHECK-NOT: stablehlo.composite
-    %0:3 = stablehlo.composite "tenstorrent.adamw" %param, %grad, %exp_avg, %exp_avg_sq {
+    %0:3 = stablehlo.composite "tenstorrent.adamw" %param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow {
       composite_attributes = {
-        lr = 1.000000e-03 : f32,
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32
       },
       decomposition = @tenstorrent.adamw.impl
-    } : (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
+    } : (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
     return %0#0 : tensor<64x64xf32>
   }
-  func.func private @tenstorrent.adamw.impl(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>, %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) {
+  func.func private @tenstorrent.adamw.impl(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>, %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) {
     return %param, %exp_avg, %exp_avg_sq : tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>
   }
 }
 
 // -----
 
-// AdamW composite with max_exp_avg_sq (5 operands, amsgrad) and stochastic_rounding.
+// AdamW composite with max_exp_avg_sq (8 operands, amsgrad) and stochastic_rounding.
 module {
   func.func @adamw_amsgrad(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>,
-                           %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>,
+                           %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>,
                            %max_exp_avg_sq: tensor<64x64xf32>) -> tensor<64x64xf32> {
     // CHECK: "ttir.adamw"
     // CHECK-SAME: stochastic_rounding = true
-    // CHECK-SAME: (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
+    // CHECK-SAME: (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
     // CHECK-NOT: stablehlo.composite
-    %0:4 = stablehlo.composite "tenstorrent.adamw" %param, %grad, %exp_avg, %exp_avg_sq, %max_exp_avg_sq {
+    %0:4 = stablehlo.composite "tenstorrent.adamw" %param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow, %max_exp_avg_sq {
       composite_attributes = {
-        lr = 1.000000e-03 : f32,
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32,
         stochastic_rounding = true
       },
       decomposition = @tenstorrent.adamw.impl
-    } : (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
+    } : (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
     return %0#0 : tensor<64x64xf32>
   }
-  func.func private @tenstorrent.adamw.impl(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>, %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %max_exp_avg_sq: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) {
+  func.func private @tenstorrent.adamw.impl(%param: tensor<64x64xf32>, %grad: tensor<64x64xf32>, %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>, %max_exp_avg_sq: tensor<64x64xf32>) -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) {
     return %param, %exp_avg, %exp_avg_sq, %max_exp_avg_sq : tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>
   }
 }

--- a/test/ttmlir/Dialect/TTIR/adamw/adamw_reshape_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/adamw/adamw_reshape_test.mlir
@@ -5,19 +5,19 @@
 module {
   // CHECK-LABEL: func.func @adamw_rank2
   func.func @adamw_rank2(%param: tensor<64x64xf32>, %grad: tensor<64x64xbf16>,
-                         %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>)
+                         %exp_avg: tensor<64x64xf32>, %exp_avg_sq: tensor<64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>) {
     // CHECK-DAG: "ttir.reshape"(%arg0) <{shape = [1 : i32, 1 : i32, 64 : i32, 64 : i32]}>
     // CHECK-DAG: "ttir.reshape"(%arg1) <{shape = [1 : i32, 1 : i32, 64 : i32, 64 : i32]}>
     // CHECK-DAG: "ttir.reshape"(%arg2) <{shape = [1 : i32, 1 : i32, 64 : i32, 64 : i32]}>
     // CHECK-DAG: "ttir.reshape"(%arg3) <{shape = [1 : i32, 1 : i32, 64 : i32, 64 : i32]}>
-    // CHECK: "ttir.adamw"
+    // The scalar operands are passed through untouched.
+    // CHECK: "ttir.adamw"({{.*}}, %arg4, %arg5, %arg6)
     // CHECK-SAME: -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32, beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32, beta2_pow = 0.999000012 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32, weight_decay = 1.000000e-02 : f32}>
-        : (tensor<64x64xf32>, tensor<64x64xbf16>, tensor<64x64xf32>, tensor<64x64xf32>)
+        : (tensor<64x64xf32>, tensor<64x64xbf16>, tensor<64x64xf32>, tensor<64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<64x64xf32>, tensor<64x64xf32>, tensor<64x64xf32>)
     // Every result is reshaped back, so the updated moments reach the caller.
     // CHECK-COUNT-3: "ttir.reshape"({{.*}}) <{shape = [64 : i32, 64 : i32]}>
@@ -27,15 +27,14 @@ module {
   // A rank-4 op is already legal and must be left alone.
   // CHECK-LABEL: func.func @adamw_rank4
   func.func @adamw_rank4(%param: tensor<1x1x64x64xf32>, %grad: tensor<1x1x64x64xbf16>,
-                         %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>)
+                         %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xf32> {
     // CHECK-NOT: "ttir.reshape"
     // CHECK: "ttir.adamw"
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32, beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32, beta2_pow = 0.999000012 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32, weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
     return %0#0 : tensor<1x1x64x64xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/adamw/adamw_fused_forward.mlir
+++ b/test/ttmlir/Dialect/TTNN/adamw/adamw_fused_forward.mlir
@@ -6,21 +6,18 @@
 // survive to the return.
 module {
   func.func @fwd_then_step(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
-                           %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>)
+                           %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) {
     // CHECK: %[[ACT:[0-9a-z_]+]] = "ttnn.abs"(%[[PARAM:[0-9a-z_]+]])
     %act = "ttir.abs"(%param) : (tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
     // CHECK: "ttnn.adamw"(%[[PARAM]],
     // CHECK-SAME: -> ()
-    %new:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %new:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
     // CHECK-NOT: "ttnn.deallocate"(%[[PARAM]])
     // CHECK: return %[[PARAM]], %[[ACT]]
@@ -29,20 +26,17 @@ module {
 
   // CHECK-LABEL: func.func @fwd_add_then_step
   func.func @fwd_add_then_step(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
-                               %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>)
+                               %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xbf16> {
     // CHECK: %[[ACT:[0-9a-z_]+]] = "ttnn.abs"(%[[PARAM:[0-9a-z_]+]])
     %act = "ttir.abs"(%param) : (tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
     // CHECK: "ttnn.adamw"(%[[PARAM]],
-    %new:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %new:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
     // CHECK: "ttnn.add"(%[[PARAM]], %[[ACT]])
     // CHECK-SAME: input_tensor_b_activations = []

--- a/test/ttmlir/Dialect/TTNN/adamw/simple_adamw.mlir
+++ b/test/ttmlir/Dialect/TTNN/adamw/simple_adamw.mlir
@@ -4,19 +4,16 @@
 module {
   // AdamW without AMSGrad (no max_exp_avg_sq).
   func.func @adamw(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
-                   %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>)
+                   %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xbf16> {
     // CHECK: "ttnn.adamw"(%[[PARAM:[0-9a-z_]+]],
     // CHECK-SAME: -> ()
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
     // CHECK-NOT: "ttnn.deallocate"(%[[PARAM]])
     // CHECK: return %[[PARAM]]

--- a/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/adamw_validation.mlir
@@ -3,22 +3,19 @@
 // RUN: FileCheck %s --input-file=%t
 
 module {
-  // AdamW without AMSGrad (4 operands).
+  // AdamW without AMSGrad (7 operands).
   func.func @adamw_optimizer(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
-                             %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>)
+                             %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xbf16> {
     // CHECK-LABEL: func.func @adamw_optimizer
     // CHECK: "ttnn.adamw"
     // CHECK-SAME: -> ()
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
     return %0#0 : tensor<1x1x64x64xbf16>
   }
@@ -27,45 +24,39 @@ module {
   // the input workaround. The optimizer must also select the tiled,
   // DRAM-interleaved layouts required by the backing kernel.
   func.func @adamw_optimizer_f32(%param: tensor<1x1x64x64xf32>, %grad: tensor<1x1x64x64xf32>,
-                                 %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>)
+                                 %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xf32> {
     // CHECK-LABEL: func.func @adamw_optimizer_f32
     // CHECK: %[[GRAD_BF16:.*]] = "ttnn.typecast"(%{{.*}}) : {{.*}} -> tensor<1x1x64x64xbf16
-    // CHECK: "ttnn.adamw"(%{{[^,]+}}, %[[GRAD_BF16]], %{{[^,]+}}, %{{[^)]+}})
-    // CHECK-SAME: : (tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xbf16, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>)
+    // CHECK: "ttnn.adamw"(%{{[^,]+}}, %[[GRAD_BF16]], %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %{{[^,]+}}, %{{[^)]+}})
+    // CHECK-SAME: : (tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xbf16, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1x1x64x64xf32, #ttnn_layout{{[^>]*}}>, tensor<1xf32, #ttnn_layout{{[^>]*}}>, tensor<1xf32, #ttnn_layout{{[^>]*}}>, tensor<1xf32, #ttnn_layout{{[^>]*}}>)
     // CHECK-SAME: -> ()
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
     return %0#0 : tensor<1x1x64x64xf32>
   }
 
-  // AdamW with AMSGrad (5 operands). The presence of max_exp_avg_sq is what
-  // enables amsgrad in ttml, and it exercises the 5-input path through the
+  // AdamW with AMSGrad (8 operands). The presence of max_exp_avg_sq is what
+  // enables amsgrad in ttml, and it exercises the 8-input path through the
   // op model interface.
   func.func @adamw_amsgrad_optimizer(%param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
-                                     %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>,
+                                     %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>,
                                      %max_exp_avg_sq: tensor<1x1x64x64xbf16>)
       -> tensor<1x1x64x64xbf16> {
     // CHECK-LABEL: func.func @adamw_amsgrad_optimizer
     // CHECK: "ttnn.adamw"
     // CHECK-SAME: -> ()
-    %0:4 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %max_exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:4 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow, %max_exp_avg_sq) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1x1x64x64xbf16>)
           -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
     return %0#0 : tensor<1x1x64x64xbf16>
   }
@@ -81,7 +72,7 @@ module {
                                          %g0: tensor<1x1x256x256xbf16>,
                                          %g1: tensor<1x1x256x256xbf16>,
                                          %exp_avg: tensor<1x1x256x256xbf16>,
-                                         %exp_avg_sq: tensor<1x1x256x256xbf16>)
+                                         %exp_avg_sq: tensor<1x1x256x256xbf16>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x256x256xbf16> {
     // CHECK-LABEL: func.func @adamw_grad_from_l1_producer
     // CHECK: %[[MUL:[0-9a-z_]+]] = "ttnn.multiply"
@@ -89,15 +80,12 @@ module {
     // CHECK: "ttnn.adamw"(%{{[0-9a-z_]+}}, %[[RESHARD]],
     // CHECK-SAME: -> ()
     %grad = "ttir.multiply"(%g0, %g1) : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>) -> tensor<1x1x256x256xbf16>
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>)
+        : (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>, tensor<1x1x256x256xbf16>)
     return %0#0 : tensor<1x1x256x256xbf16>
   }

--- a/test/ttmlir/Dialect/TTNN/trace/adamw_not_hoisted.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/adamw_not_hoisted.mlir
@@ -1,0 +1,28 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline="enable-trace=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// ttnn.adamw reads lr / beta*_pow back to the host, a sync a captured trace
+// would not replay, so it must stay outside the trace region while the compute
+// feeding it (the gradient multiply) is traced.
+module {
+  // CHECK-LABEL: func.func private @trace_0_step
+  // CHECK: "ttnn.multiply"
+  // CHECK-NOT: "ttnn.adamw"
+
+  // CHECK-LABEL: func.func @step(
+  // CHECK: "ttnn.capture_or_execute_trace"
+  // CHECK: "ttnn.adamw"
+  func.func @step(%param: tensor<1x1x64x64xbf16>, %g0: tensor<1x1x64x64xbf16>,
+                  %g1: tensor<1x1x64x64xbf16>, %exp_avg: tensor<1x1x64x64xbf16>,
+                  %exp_avg_sq: tensor<1x1x64x64xbf16>, %lr: tensor<1xf32>,
+                  %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
+      -> tensor<1x1x64x64xbf16> {
+    %grad = "ttir.multiply"(%g0, %g1) : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32, weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    return %0#0 : tensor<1x1x64x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/trace/adamw_sunk_to_end.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/adamw_sunk_to_end.mlir
@@ -1,0 +1,41 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline="enable-trace=true" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// ttnn.adamw is not hoistable. When hoistable compute that does not touch its
+// operands follows it, the adamw is sunk below that compute so the trace
+// region stays contiguous instead of failing on a non-hoistable op in the
+// middle.
+module {
+  // CHECK-LABEL: func.func private @trace_0_step
+  // CHECK: "ttnn.multiply"
+  // CHECK: "ttnn.add"
+  // CHECK-NOT: "ttnn.adamw"
+
+  // CHECK-LABEL: func.func @step(
+  // CHECK: "ttnn.capture_or_execute_trace"
+  // CHECK: "ttnn.adamw"
+  // CHECK: "ttnn.adamw"
+  // CHECK: return
+  func.func @step(%p0: tensor<1x1x64x64xbf16>, %p1: tensor<1x1x64x64xbf16>,
+                  %g0: tensor<1x1x64x64xbf16>, %g1: tensor<1x1x64x64xbf16>,
+                  %m0: tensor<1x1x64x64xbf16>, %v0: tensor<1x1x64x64xbf16>,
+                  %m1: tensor<1x1x64x64xbf16>, %v1: tensor<1x1x64x64xbf16>,
+                  %a: tensor<1x1x64x64xbf16>, %b: tensor<1x1x64x64xbf16>,
+                  %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
+      -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) {
+    %grad0 = "ttir.multiply"(%g0, %g1) : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
+    %0:3 = "ttir.adamw"(%p0, %grad0, %m0, %v0, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32, weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    // Unrelated hoistable compute after the first adamw.
+    %out = "ttir.add"(%a, %b) : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>) -> tensor<1x1x64x64xbf16>
+    %1:3 = "ttir.adamw"(%p1, %g1, %m1, %v1, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32, beta2 = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32, weight_decay = 1.000000e-02 : f32}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    return %0#0, %out, %1#0 : tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/adamw/adamw.mlir
+++ b/test/ttmlir/EmitC/TTNN/adamw/adamw.mlir
@@ -4,20 +4,19 @@
 
 module {
   func.func @adamw(%param: tensor<1x1x64x64xf32>, %grad: tensor<1x1x64x64xbf16>,
-                   %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>)
+                   %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xf32> {
+    // lr / beta*_pow are read back from their device tensors.
+    // CHECK-COUNT-3: ::ttnn::getScalarFromTensor<float>(
     // CHECK: {{^ *}}ttml::metal::adamw(
     // CHECK-SAME: ::std::nullopt
     // CHECK-SAME: ::ttml::metal::StochasticRounding::Disabled
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
     return %0#0 : tensor<1x1x64x64xf32>
   }

--- a/test/ttmlir/EmitPy/adamw/adamw_unsupported.mlir
+++ b/test/ttmlir/EmitPy/adamw/adamw_unsupported.mlir
@@ -5,18 +5,15 @@
 
 module {
   func.func @adamw(%param: tensor<1x1x64x64xf32>, %grad: tensor<1x1x64x64xbf16>,
-                   %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>)
+                   %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xf32> {
     // CHECK: failed to legalize operation 'ttnn.adamw'
-    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq) <{
-        lr = 1.000000e-03 : f32,
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
-        beta1_pow = 0.899999976 : f32,
-        beta2_pow = 0.999000012 : f32,
         epsilon = 1.000000e-08 : f32,
         weight_decay = 1.000000e-02 : f32}>
-        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
+        : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
     return %0#0 : tensor<1x1x64x64xf32>
   }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5893,7 +5893,6 @@ TEST_F(OpModelTest, PagedFillCacheOp) {
 
 class OpModelAdamWTest : public OpModelTest {
 protected:
-  static constexpr float kLr = 1e-3f;
   static constexpr float kBeta1 = 0.9f;
   static constexpr float kBeta2 = 0.999f;
   static constexpr float kEpsilon = 1e-8f;
@@ -5911,9 +5910,8 @@ protected:
     }
     return OpModel<AdamWOp>::getOpConstraints(
         shape, paramLayout, shape, gradLayout, shape, momentLayout, shape,
-        momentLayout, maxExpAvgSqShape, maxExpAvgSqLayout, llvm::APFloat(kLr),
-        llvm::APFloat(kBeta1), llvm::APFloat(kBeta2), llvm::APFloat(kBeta1),
-        llvm::APFloat(kBeta2), llvm::APFloat(kEpsilon),
+        momentLayout, maxExpAvgSqShape, maxExpAvgSqLayout,
+        llvm::APFloat(kBeta1), llvm::APFloat(kBeta2), llvm::APFloat(kEpsilon),
         llvm::APFloat(kWeightDecay), stochasticRounding,
         /*outputLayout=*/paramLayout);
   }
@@ -5960,7 +5958,6 @@ TEST_F(OpModelAdamWTest, AdamWOpFloat32) {
   auto runtimeExp = OpModel<AdamWOp>::getOpRuntime(
       shape, f32Layout, shape, bf16Layout, shape, f32Layout, shape, f32Layout,
       /*maxExpAvgSqShape=*/std::nullopt, /*maxExpAvgSqLayout=*/std::nullopt,
-      llvm::APFloat(kLr), llvm::APFloat(kBeta1), llvm::APFloat(kBeta2),
       llvm::APFloat(kBeta1), llvm::APFloat(kBeta2), llvm::APFloat(kEpsilon),
       llvm::APFloat(kWeightDecay), /*stochasticRounding=*/false, f32Layout);
   EXPECT_TRUE(static_cast<bool>(runtimeExp));

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6257,19 +6257,27 @@ TEST_F(OpModelBase, AdamWOpInterface) {
   auto grad = createEmptyTensor(shape, builder.getBF16Type(), bf16Layout);
   auto expAvg = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
   auto expAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  llvm::SmallVector<int64_t> scalarShape = {1};
+  auto scalarLayout = CreateTiledLayout(
+      scalarShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  auto lr = createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
+  auto beta1Pow =
+      createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
+  auto beta2Pow =
+      createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
 
   auto adamW = builder.create<AdamWOp>(
-      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq,
-      /*lr=*/llvm::APFloat(1e-3f), /*beta1=*/llvm::APFloat(0.9f),
-      /*beta2=*/llvm::APFloat(0.999f), /*beta1_pow=*/llvm::APFloat(0.9f),
-      /*beta2_pow=*/llvm::APFloat(0.999f), /*epsilon=*/llvm::APFloat(1e-8f),
-      /*weight_decay=*/llvm::APFloat(0.01f));
+      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq, lr, beta1Pow,
+      beta2Pow, /*beta1=*/llvm::APFloat(0.9f), /*beta2=*/llvm::APFloat(0.999f),
+      /*epsilon=*/llvm::APFloat(1e-8f), /*weight_decay=*/llvm::APFloat(0.01f));
 
   auto backend = dyn_cast<OpModel>(adamW.getOperation());
   ASSERT_TRUE(backend);
 
   auto inputLayouts = getInputLayouts(adamW.getOperation());
-  ASSERT_EQ(inputLayouts.size(), 4u);
+  ASSERT_EQ(inputLayouts.size(), 7u);
 
   // OpConfig() carries a null output layout, which is what the optimizer passes
   // for an op with no results.
@@ -6297,7 +6305,7 @@ TEST_F(OpModelBase, AdamWOpInterface) {
 }
 
 // Same op with the optional max_exp_avg_sq operand present, which is what
-// enables AMSGrad in ttml. Exercises the 5-input path through the interface.
+// enables AMSGrad in ttml. Exercises the 8-input path through the interface.
 TEST_F(OpModelBase, AdamWOpInterfaceAmsgrad) {
   llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
 
@@ -6313,14 +6321,22 @@ TEST_F(OpModelBase, AdamWOpInterfaceAmsgrad) {
   auto expAvg = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
   auto expAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
   auto maxExpAvgSq = createEmptyTensor(shape, builder.getF32Type(), f32Layout);
+  llvm::SmallVector<int64_t> scalarShape = {1};
+  auto scalarLayout = CreateTiledLayout(
+      scalarShape, BufferType::DRAM, TensorMemoryLayout::Interleaved,
+      /*virtualGrid=*/std::nullopt, GetPhysicalGridSize(),
+      builder.getF32Type());
+  auto lr = createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
+  auto beta1Pow =
+      createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
+  auto beta2Pow =
+      createEmptyTensor(scalarShape, builder.getF32Type(), scalarLayout);
 
   auto adamW = builder.create<AdamWOp>(
-      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq, maxExpAvgSq,
-      /*lr=*/builder.getF32FloatAttr(1e-3f),
+      builder.getUnknownLoc(), param, grad, expAvg, expAvgSq, lr, beta1Pow,
+      beta2Pow, maxExpAvgSq,
       /*beta1=*/builder.getF32FloatAttr(0.9f),
       /*beta2=*/builder.getF32FloatAttr(0.999f),
-      /*beta1_pow=*/builder.getF32FloatAttr(0.9f),
-      /*beta2_pow=*/builder.getF32FloatAttr(0.999f),
       /*epsilon=*/builder.getF32FloatAttr(1e-8f),
       /*weight_decay=*/builder.getF32FloatAttr(0.01f),
       /*stochastic_rounding=*/builder.getBoolAttr(false));
@@ -6329,7 +6345,7 @@ TEST_F(OpModelBase, AdamWOpInterfaceAmsgrad) {
   ASSERT_TRUE(backend);
 
   auto inputLayouts = getInputLayouts(adamW.getOperation());
-  ASSERT_EQ(inputLayouts.size(), 5u);
+  ASSERT_EQ(inputLayouts.size(), 8u);
 
   auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
   if (constraintsExp) {

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -7591,12 +7591,12 @@ class TTIRBuilder(Builder):
         grad: Operand,
         exp_avg: Operand,
         exp_avg_sq: Operand,
+        lr: Operand,
+        beta1_pow: Operand,
+        beta2_pow: Operand,
         max_exp_avg_sq: Optional[Operand] = None,
-        lr: float = 1e-3,
         beta1: float = 0.9,
         beta2: float = 0.999,
-        beta1_pow: float = 0.9,
-        beta2_pow: float = 0.999,
         epsilon: float = 1e-8,
         weight_decay: float = 0.0,
         stochastic_rounding: bool = False,
@@ -7605,11 +7605,8 @@ class TTIRBuilder(Builder):
         unit_attrs: Optional[List[str]] = None,
     ) -> OpResult:
         ttir_op = self.get_opview_from_method(TTIRBuilder.adamw)
-        lr_attr = FloatAttr.get_f32(lr)
         beta1_attr = FloatAttr.get_f32(beta1)
         beta2_attr = FloatAttr.get_f32(beta2)
-        beta1_pow_attr = FloatAttr.get_f32(beta1_pow)
-        beta2_pow_attr = FloatAttr.get_f32(beta2_pow)
         epsilon_attr = FloatAttr.get_f32(epsilon)
         weight_decay_attr = FloatAttr.get_f32(weight_decay)
 
@@ -7634,12 +7631,12 @@ class TTIRBuilder(Builder):
             grad0,
             exp_avg0,
             exp_avg_sq0,
+            self._get_golden_tensor(lr),
+            self._get_golden_tensor(beta1_pow),
+            self._get_golden_tensor(beta2_pow),
             max_exp_avg_sq0,
-            lr_attr,
             beta1_attr,
             beta2_attr,
-            beta1_pow_attr,
-            beta2_pow_attr,
             epsilon_attr,
             weight_decay_attr,
             stochastic_rounding,
@@ -7669,11 +7666,11 @@ class TTIRBuilder(Builder):
             grad,
             exp_avg,
             exp_avg_sq,
-            lr_attr,
+            lr,
+            beta1_pow,
+            beta2_pow,
             beta1_attr,
             beta2_attr,
-            beta1_pow_attr,
-            beta2_pow_attr,
             epsilon_attr,
             weight_decay_attr,
             max_exp_avg_sq=max_exp_avg_sq,
@@ -8077,7 +8074,11 @@ class TTIRBuilder(Builder):
         running_mean0 = self._get_golden_tensor(running_mean)
         running_variance0 = self._get_golden_tensor(running_variance)
         op_golden_function = get_golden_function(ttir_op)
-        (golden_output, golden_batch_mean, golden_batch_variance,) = op_golden_function(
+        (
+            golden_output,
+            golden_batch_mean,
+            golden_batch_variance,
+        ) = op_golden_function(
             input0,
             scale0,
             offset0,
@@ -17049,7 +17050,11 @@ class TTIRBuilder(Builder):
         in2 = self._get_golden_tensor(expert_scores)
         in3 = self._get_golden_tensor(expert_mapping)
         op_golden_function = get_golden_function(ttir_op)
-        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
+        (
+            golden_dispatched,
+            golden_indices,
+            golden_scores,
+        ) = op_golden_function(
             in0,
             in1,
             in2,
@@ -17125,7 +17130,11 @@ class TTIRBuilder(Builder):
         input2 = self._get_golden_tensor(expert_scores)
         input3 = self._get_golden_tensor(expert_mapping)
         op_golden_function = get_golden_function(ttir_op)
-        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
+        (
+            golden_dispatched,
+            golden_indices,
+            golden_scores,
+        ) = op_golden_function(
             input0,
             input1,
             input2,

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -8074,11 +8074,7 @@ class TTIRBuilder(Builder):
         running_mean0 = self._get_golden_tensor(running_mean)
         running_variance0 = self._get_golden_tensor(running_variance)
         op_golden_function = get_golden_function(ttir_op)
-        (
-            golden_output,
-            golden_batch_mean,
-            golden_batch_variance,
-        ) = op_golden_function(
+        (golden_output, golden_batch_mean, golden_batch_variance,) = op_golden_function(
             input0,
             scale0,
             offset0,
@@ -17050,11 +17046,7 @@ class TTIRBuilder(Builder):
         in2 = self._get_golden_tensor(expert_scores)
         in3 = self._get_golden_tensor(expert_mapping)
         op_golden_function = get_golden_function(ttir_op)
-        (
-            golden_dispatched,
-            golden_indices,
-            golden_scores,
-        ) = op_golden_function(
+        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
             in0,
             in1,
             in2,
@@ -17130,11 +17122,7 @@ class TTIRBuilder(Builder):
         input2 = self._get_golden_tensor(expert_scores)
         input3 = self._get_golden_tensor(expert_mapping)
         op_golden_function = get_golden_function(ttir_op)
-        (
-            golden_dispatched,
-            golden_indices,
-            golden_scores,
-        ) = op_golden_function(
+        (golden_dispatched, golden_indices, golden_scores,) = op_golden_function(
             input0,
             input1,
             input2,

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1157,12 +1157,12 @@ def adamw_golden(
     grad: GoldenMapTensor,
     exp_avg: GoldenMapTensor,
     exp_avg_sq: GoldenMapTensor,
+    lr: GoldenMapTensor,
+    beta1_pow: GoldenMapTensor,
+    beta2_pow: GoldenMapTensor,
     max_exp_avg_sq: Optional[GoldenMapTensor] = None,
-    lr=1e-3,
     beta1=0.9,
     beta2=0.999,
-    beta1_pow=0.9,
-    beta2_pow=0.999,
     epsilon=1e-8,
     weight_decay=0.0,
     stochastic_rounding=False,
@@ -1178,11 +1178,10 @@ def adamw_golden(
     Uses torch.* ops only (GoldenMapTensor does not support python operators).
     Returns the updated parameter and moments, one per op result.
     """
-    lr = unpack_mlir_attr(lr)
+    scalar = lambda t: float(t.shard_at(0).flatten()[0].item())
+    lr, beta1_pow, beta2_pow = scalar(lr), scalar(beta1_pow), scalar(beta2_pow)
     beta1 = unpack_mlir_attr(beta1)
     beta2 = unpack_mlir_attr(beta2)
-    beta1_pow = unpack_mlir_attr(beta1_pow)
-    beta2_pow = unpack_mlir_attr(beta2_pow)
     epsilon = unpack_mlir_attr(epsilon)
     weight_decay = unpack_mlir_attr(weight_decay)
 

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -99,6 +99,7 @@
 #include <limits>
 #include <optional>
 #include <tuple>
+#include <type_traits>
 #include <vector>
 
 template <typename... T>
@@ -231,10 +232,25 @@ void constEvalFuncWrapperZeroArg(
   }
 }
 
+template <typename T>
+constexpr ::ttnn::DataType scalarDataTypeFor() {
+  static_assert(std::is_same_v<T, uint32_t> || std::is_same_v<T, float>,
+                "getScalarFromTensor supports uint32_t and float only");
+  if constexpr (std::is_same_v<T, uint32_t>) {
+    return ::ttnn::DataType::UINT32;
+  } else {
+    return ::ttnn::DataType::FLOAT32;
+  }
+}
+
 template <typename T = uint32_t>
 T getScalarFromTensor(const ttnn::Tensor &tensor) {
   assert(tensor.logical_volume() == 1 && "expected scalar tensor");
-  return ::ttnn::from_device(tensor).to_vector<T>().front();
+  assert(tensor.dtype() == scalarDataTypeFor<T>() &&
+         "scalar tensor dtype does not match requested type");
+  const std::vector<T> values = ::ttnn::from_device(tensor).to_vector<T>();
+  assert(values.size() == 1 && "expected exactly one element");
+  return values[0];
 }
 
 ::ttnn::Tensor loadTensor(const std::string &filePath, ttnn::Layout layout,

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -231,15 +231,10 @@ void constEvalFuncWrapperZeroArg(
   }
 }
 
-uint32_t getScalarFromTensor(const ttnn::Tensor &tensor) {
+template <typename T = uint32_t>
+T getScalarFromTensor(const ttnn::Tensor &tensor) {
   assert(tensor.logical_volume() == 1 && "expected scalar tensor");
-  assert(tensor.dtype() == ttnn::DataType::UINT32 && "expected uint32 tensor");
-
-  const ::ttnn::Tensor tensorOnHost = ::ttnn::from_device(tensor);
-  const ::tt::tt_metal::HostBuffer buffer =
-      ::tt::tt_metal::host_buffer::get_host_buffer(tensorOnHost);
-  const auto &buf = buffer.view_as<uint32_t>();
-  return *buf.begin();
+  return ::ttnn::from_device(tensor).to_vector<T>().front();
 }
 
 ::ttnn::Tensor loadTensor(const std::string &filePath, ttnn::Layout layout,


### PR DESCRIPTION
### Problem description
`ttir.adamw` / `ttnn.adamw` carried `lr`, `beta1_pow`, `beta2_pow` as attributes. They change every step, so multi-step training recompiled on each step.

### What's changed
- `lr`, `beta1_pow`, `beta2_pow` are single-element f32 tensor operands (TTIR, TTNN, composite, flatbuffer). `max_exp_avg_sq` is now the last operand.
- Runtime and EmitC read the scalars back to host for `ttml::metal::adamw`. The runtime caches each readback per program run in `ProgramContext` (keyed by tensor global id), so N `adamw` ops sharing one `lr` tensor cost one device→host sync per step.
- `ttnn.adamw` is excluded from trace capture since that sync is not replayed. `TTNNTraceHoistTransform` sinks `adamw` ops to the end of the block when no later op touches their operands, so hoistable compute after an optimizer step keeps the trace region contiguous instead of failing with "non-hoistable op in the middle". Relative order of `adamw` ops is preserved; an `adamw` whose operands are used later stays put.
- OpModel, builder, golden and tests updated; new trace lit tests (`adamw_not_hoisted`, `adamw_sunk_to_end`).

### Checklist
- [x] New/Existing tests provide coverage for changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
