### PR TITLE
[D2M] Add dataflow planning framework

### DIFF
--- a/docs/design/d2m-dataflow-planning.md
+++ b/docs/design/d2m-dataflow-planning.md
@@ -1,0 +1,65 @@
+# D2M Dataflow Planning
+
+The D2M dataflow planner owns compiler decisions that cross individual
+`d2m.generic` operations. It runs after TTIR-to-D2M conversion and constant
+scalarization, while generic operations still have tensor semantics, and
+before grid selection fixes layout and placement decisions.
+
+## Pipeline boundary
+
+```text
+TTIR decomposition
+  -> TTIRToD2M
+  -> candidate graph construction
+  -> kernel variant enumeration
+  -> feasibility filtering
+  -> cost evaluation and plan selection
+  -> selected-plan materialization
+  -> grid/layout/buffer selection
+  -> internal D2M scheduling and DMA lowering
+  -> TTKernel / TTMetal
+```
+
+The generic operations produced by TTIR-to-D2M are kernel candidates, not
+necessarily final physical kernels. A selected variant can eventually fuse
+multiple candidates, while staged variants can split one candidate after their
+interface and coverage rules are modeled explicitly.
+
+Internal planning happens in two phases. Before external planning it enumerates
+variants and records estimates without lowering the payload IR. After external
+planning selects kernel boundaries, placement, and communication, downstream
+D2M passes materialize tile loops, circular buffers, compute and data-movement
+threads, synchronization, and DMA.
+
+## Framework objects
+
+- `DataflowCandidateGraph` is an immutable function-block scope containing
+  top-level `d2m.generic` candidates and producer-consumer dependencies.
+- `DataflowKernelVariant` describes a candidate implementation, including its
+  member computations, grid, block factors, resource estimate, and optional
+  cycle estimate.
+- `DataflowMappingPlan` records the selected temporal, fused, or spatial
+  kernels and their connections. Search constructs plans out of band.
+- `DataflowFeasibilityModel` rejects invalid plans before ranking. The initial
+  structural model checks graph coverage, variants, and connections; hardware
+  models will add L1, CB, DST, core-range, and communication constraints.
+- `DataflowCostModel` evaluates feasible plans. The analytical baseline does
+  not invent missing cycle data: temporal latency and spatial initiation
+  interval remain unknown until all participating kernels have estimates.
+- `DataflowPlanMaterializer` applies only the selected plan. The temporal
+  fallback is already represented by the input IR and is therefore a no-op.
+
+Feasibility and cost are separate by design. An impossible plan is rejected
+with a structured reason rather than assigned a large penalty. Feasible plans
+retain multiple metrics, including latency, initiation interval, DRAM and NoC
+traffic, L1 pressure, occupied cores, spills, and program count, so later
+search policies can preserve a Pareto frontier instead of depending on one
+fragile weighted score.
+
+## Initial policy
+
+The first policy creates one kernel variant per candidate, preserves program
+order and materialized producer-consumer edges, and leaves existing D2M IR
+unchanged. This provides a behavior-preserving baseline for adding variant
+enumeration, hardware resource checks, fused plans, and `d2m.spatial`
+materialization incrementally.

--- a/include/ttmlir/Dialect/D2M/Analysis/DataflowPlanning.h
+++ b/include/ttmlir/Dialect/D2M/Analysis/DataflowPlanning.h
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TTMLIR_DIALECT_D2M_ANALYSIS_DATAFLOWPLANNING_H
+#define TTMLIR_DIALECT_D2M_ANALYSIS_DATAFLOWPLANNING_H
+
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace mlir::tt::d2m {
+
+using DataflowCandidateId = unsigned;
+
+struct DataflowCandidateEdge {
+  DataflowCandidateId producer;
+  DataflowCandidateId consumer;
+};
+
+/// A stable, read-only view of the top-level d2m.generic operations in one
+/// function block. Candidate IDs are indices into operations.
+class DataflowCandidateGraph {
+public:
+  DataflowCandidateGraph(func::FuncOp function, Block *block,
+                         unsigned scopeOrdinal,
+                         llvm::SmallVector<GenericOp> operations,
+                         llvm::SmallVector<DataflowCandidateEdge> edges);
+
+  func::FuncOp getFunction() const { return function; }
+  Block *getBlock() const { return block; }
+  unsigned getScopeOrdinal() const { return scopeOrdinal; }
+  llvm::ArrayRef<GenericOp> getOperations() const { return operations; }
+  llvm::ArrayRef<DataflowCandidateEdge> getEdges() const { return edges; }
+
+private:
+  func::FuncOp function;
+  Block *block;
+  unsigned scopeOrdinal;
+  llvm::SmallVector<GenericOp> operations;
+  llvm::SmallVector<DataflowCandidateEdge> edges;
+};
+
+llvm::SmallVector<DataflowCandidateGraph>
+buildDataflowCandidateGraphs(ModuleOp module);
+
+struct KernelResourceEstimate {
+  uint64_t l1BytesPerCore = 0;
+  uint64_t dramBytes = 0;
+  uint64_t nocBytes = 0;
+  uint32_t cbCount = 0;
+  uint32_t dstTiles = 0;
+};
+
+struct KernelCostEstimate {
+  std::optional<uint64_t> computeCycles;
+  std::optional<uint64_t> dataMovementCycles;
+  std::optional<uint64_t> initiationIntervalCycles;
+  float confidence = 0.0F;
+};
+
+/// One possible implementation of one or more candidate computations. A
+/// multi-member variant represents fusion. Future staged variants may appear
+/// more than once in a plan after the feasibility model learns their contract.
+class DataflowKernelVariant {
+public:
+  DataflowKernelVariant(unsigned variantId,
+                        llvm::SmallVector<DataflowCandidateId> members,
+                        llvm::SmallVector<int64_t> gridShape,
+                        llvm::SmallVector<int64_t> blockFactors,
+                        KernelResourceEstimate resources = {},
+                        KernelCostEstimate cost = {});
+
+  unsigned getVariantId() const { return variantId; }
+  llvm::ArrayRef<DataflowCandidateId> getMembers() const { return members; }
+  llvm::ArrayRef<int64_t> getGridShape() const { return gridShape; }
+  llvm::ArrayRef<int64_t> getBlockFactors() const { return blockFactors; }
+  const KernelResourceEstimate &getResources() const { return resources; }
+  const KernelCostEstimate &getCost() const { return cost; }
+
+private:
+  unsigned variantId;
+  llvm::SmallVector<DataflowCandidateId> members;
+  llvm::SmallVector<int64_t> gridShape;
+  llvm::SmallVector<int64_t> blockFactors;
+  KernelResourceEstimate resources;
+  KernelCostEstimate cost;
+};
+
+struct DataflowPlannedKernel {
+  DataflowKernelVariant variant;
+  llvm::SmallVector<int64_t> coreOffset;
+};
+
+enum class DataflowConnectionKind {
+  Materialized,
+  L1Stream,
+  NocStream,
+  Dram,
+};
+
+llvm::StringRef stringifyDataflowConnectionKind(DataflowConnectionKind kind);
+
+struct DataflowPlannedConnection {
+  unsigned producerKernel;
+  unsigned consumerKernel;
+  DataflowConnectionKind kind = DataflowConnectionKind::Materialized;
+  uint32_t bufferDepth = 1;
+};
+
+enum class DataflowPlanStrategy {
+  Temporal,
+  Fused,
+  Spatial,
+};
+
+llvm::StringRef stringifyDataflowPlanStrategy(DataflowPlanStrategy strategy);
+
+/// An immutable external-dataflow decision. Search implementations construct
+/// plans out of band and materialize only the selected plan.
+class DataflowMappingPlan {
+public:
+  DataflowMappingPlan(func::FuncOp function, Block *block,
+                      unsigned scopeOrdinal, DataflowPlanStrategy strategy,
+                      llvm::SmallVector<DataflowPlannedKernel, 0> kernels,
+                      llvm::SmallVector<DataflowPlannedConnection> connections);
+
+  func::FuncOp getFunction() const { return function; }
+  Block *getBlock() const { return block; }
+  unsigned getScopeOrdinal() const { return scopeOrdinal; }
+  DataflowPlanStrategy getStrategy() const { return strategy; }
+  llvm::ArrayRef<DataflowPlannedKernel> getKernels() const { return kernels; }
+  llvm::ArrayRef<DataflowPlannedConnection> getConnections() const {
+    return connections;
+  }
+
+private:
+  func::FuncOp function;
+  Block *block;
+  unsigned scopeOrdinal;
+  DataflowPlanStrategy strategy;
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  llvm::SmallVector<DataflowPlannedConnection> connections;
+};
+
+enum class DataflowRejectionKind {
+  None,
+  InvalidGraph,
+  InvalidVariant,
+  ResourceLimit,
+  Unsupported,
+};
+
+llvm::StringRef stringifyDataflowRejectionKind(DataflowRejectionKind kind);
+
+struct DataflowFeasibilityResult {
+  bool feasible;
+  DataflowRejectionKind rejectionKind;
+  std::string message;
+
+  static DataflowFeasibilityResult success();
+  static DataflowFeasibilityResult reject(DataflowRejectionKind kind,
+                                          llvm::StringRef message);
+};
+
+class DataflowFeasibilityModel {
+public:
+  virtual ~DataflowFeasibilityModel() = default;
+
+  virtual DataflowFeasibilityResult
+  evaluate(const DataflowCandidateGraph &graph,
+           const DataflowMappingPlan &plan) const = 0;
+};
+
+/// Enforces graph coverage, variant shape, and connection integrity. Hardware
+/// resource models can compose stricter checks on top of this baseline.
+class StructuralDataflowFeasibilityModel final
+    : public DataflowFeasibilityModel {
+public:
+  DataflowFeasibilityResult
+  evaluate(const DataflowCandidateGraph &graph,
+           const DataflowMappingPlan &plan) const override;
+};
+
+struct DataflowPlanCost {
+  std::optional<uint64_t> latencyCycles;
+  std::optional<uint64_t> initiationIntervalCycles;
+  uint64_t dramBytes = 0;
+  uint64_t nocBytes = 0;
+  uint64_t peakL1BytesPerCore = 0;
+  uint32_t occupiedCores = 0;
+  uint32_t spillCount = 0;
+  uint32_t programCount = 0;
+  float confidence = 0.0F;
+};
+
+class DataflowCostModel {
+public:
+  virtual ~DataflowCostModel() = default;
+
+  virtual DataflowPlanCost evaluate(const DataflowCandidateGraph &graph,
+                                    const DataflowMappingPlan &plan) const = 0;
+};
+
+/// Aggregates optional per-kernel estimates without inventing unavailable
+/// cycle data. Temporal latency and spatial initiation interval are reported
+/// only when every participating kernel has a cycle estimate.
+class AnalyticalDataflowCostModel final : public DataflowCostModel {
+public:
+  DataflowPlanCost evaluate(const DataflowCandidateGraph &graph,
+                            const DataflowMappingPlan &plan) const override;
+};
+
+DataflowMappingPlan
+buildTemporalFallbackPlan(const DataflowCandidateGraph &graph);
+
+void printDataflowPlan(llvm::raw_ostream &os,
+                       const DataflowCandidateGraph &graph,
+                       const DataflowMappingPlan &plan,
+                       const DataflowPlanCost &cost);
+
+class DataflowPlanMaterializer {
+public:
+  virtual ~DataflowPlanMaterializer() = default;
+
+  virtual LogicalResult materialize(const DataflowCandidateGraph &graph,
+                                    const DataflowMappingPlan &plan) const = 0;
+};
+
+/// The temporal fallback already matches the input IR, so its materializer is
+/// intentionally a no-op. Fused and spatial strategies provide their own
+/// implementations without changing the planning pass boundary.
+class TemporalDataflowPlanMaterializer final : public DataflowPlanMaterializer {
+public:
+  LogicalResult materialize(const DataflowCandidateGraph &graph,
+                            const DataflowMappingPlan &plan) const override;
+};
+
+} // namespace mlir::tt::d2m
+
+#endif // TTMLIR_DIALECT_D2M_ANALYSIS_DATAFLOWPLANNING_H

--- a/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
+++ b/include/ttmlir/Dialect/D2M/Pipelines/D2MPipelines.h
@@ -71,6 +71,12 @@ struct D2MPipelineOptions : public PassPipelineOptions<D2MPipelineOptions> {
           "reduction d2m.generic consumer (single reduction dim)."),
       llvm::cl::init(false)};
 
+  Option<bool> enableDataflowPlanning{
+      *this, "enable-dataflow-planning",
+      llvm::cl::desc(
+          "Enable TTMetal D2M dataflow planning before grid selection."),
+      llvm::cl::init(false)};
+
   ListOption<int64_t> matmulInterchange{
       *this, "matmul-interchange",
       llvm::cl::desc(

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -1053,6 +1053,27 @@ def D2MScalarizeConstTensors : Pass<"d2m-scalarize-const-tensors", "::mlir::Modu
   let dependentDialects = ["::mlir::tt::d2m::D2MDialect", "::mlir::arith::ArithDialect"];
 }
 
+def D2MDataflowPlanning : Pass<"d2m-dataflow-planning", "::mlir::ModuleOp"> {
+  let summary = "Plan TTMetal dataflow mappings before D2M grid selection";
+  let description = [{
+    Establishes the analysis and materialization boundary for graph-level D2M
+    dataflow planning. The pass runs after TTIRToD2M and
+    D2MScalarizeConstTensors, while d2m.generic operations still use tensor
+    semantics, and before D2MGridSelection fixes grid and layout decisions.
+
+    The initial implementation builds an immutable temporal fallback plan and
+    deliberately leaves the IR unchanged. Future planning policies can add wrap
+    partitioning, internal variants, spatial placement, and explicit
+    communication without changing the pipeline boundary. This initial pass is
+    enabled only for the TTMetal path.
+  }];
+  let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
+  let options = [
+    Option<"dumpPlan", "dump-plan", "bool", /*default=*/"false",
+        "Print the selected mapping plan in a deterministic text form.">,
+  ];
+}
+
 def D2MGenerateOuterLoops : Pass<"d2m-generate-outer-loops", "::mlir::ModuleOp"> {
   let summary = "Generate outer loops.";
   let description = [{

--- a/include/ttmlir/Dialect/D2M/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/D2M/Transforms/Passes.td
@@ -1061,11 +1061,13 @@ def D2MDataflowPlanning : Pass<"d2m-dataflow-planning", "::mlir::ModuleOp"> {
     D2MScalarizeConstTensors, while d2m.generic operations still use tensor
     semantics, and before D2MGridSelection fixes grid and layout decisions.
 
-    The initial implementation builds an immutable temporal fallback plan and
-    deliberately leaves the IR unchanged. Future planning policies can add wrap
-    partitioning, internal variants, spatial placement, and explicit
-    communication without changing the pipeline boundary. This initial pass is
-    enabled only for the TTMetal path.
+    The framework builds a candidate graph, selects immutable kernel variants,
+    rejects structurally infeasible plans, evaluates available cost estimates,
+    and materializes only the selected plan. The initial policy selects an
+    always-legal temporal fallback and deliberately leaves the IR unchanged.
+    Future policies can add wrap partitioning, internal variants, spatial
+    placement, resource models, and explicit communication without changing
+    the pipeline boundary. This pass is enabled only for the TTMetal path.
   }];
   let dependentDialects = ["::mlir::tt::d2m::D2MDialect"];
   let options = [

--- a/lib/Dialect/D2M/Analysis/CMakeLists.txt
+++ b/lib/Dialect/D2M/Analysis/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(Allocation)
 
 add_mlir_dialect_library(MLIRD2MAnalysis
   BlockFactorAnalysis.cpp
+  DataflowPlanning.cpp
   GenericOpBufferAnalysis.cpp
   CBProducerConsumer.cpp
   GenericInterchangeAnalysis.cpp

--- a/lib/Dialect/D2M/Analysis/DataflowPlanning.cpp
+++ b/lib/Dialect/D2M/Analysis/DataflowPlanning.cpp
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Analysis/DataflowPlanning.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <limits>
+#include <tuple>
+#include <utility>
+
+namespace mlir::tt::d2m {
+
+DataflowCandidateGraph::DataflowCandidateGraph(
+    func::FuncOp function, Block *block, unsigned scopeOrdinal,
+    llvm::SmallVector<GenericOp> operations,
+    llvm::SmallVector<DataflowCandidateEdge> edges)
+    : function(function), block(block), scopeOrdinal(scopeOrdinal),
+      operations(std::move(operations)), edges(std::move(edges)) {}
+
+static void collectDefiningCandidates(
+    Value value, const llvm::DenseMap<Operation *, DataflowCandidateId> &ids,
+    llvm::DenseSet<Value> &visited,
+    llvm::DenseSet<DataflowCandidateId> &producers) {
+  if (!visited.insert(value).second) {
+    return;
+  }
+
+  Operation *definingOp = value.getDefiningOp();
+  if (!definingOp) {
+    return;
+  }
+
+  auto candidate = ids.find(definingOp);
+  if (candidate != ids.end()) {
+    producers.insert(candidate->second);
+    return;
+  }
+
+  // Do not infer dependencies through the body of another kernel candidate.
+  if (definingOp->getParentOfType<GenericOp>()) {
+    return;
+  }
+
+  for (Value operand : definingOp->getOperands()) {
+    collectDefiningCandidates(operand, ids, visited, producers);
+  }
+}
+
+static llvm::SmallVector<DataflowCandidateEdge>
+buildCandidateEdges(llvm::ArrayRef<GenericOp> operations) {
+  llvm::DenseMap<Operation *, DataflowCandidateId> ids;
+  for (auto item : llvm::enumerate(operations)) {
+    GenericOp operation = item.value();
+    ids.try_emplace(operation.getOperation(),
+                    static_cast<DataflowCandidateId>(item.index()));
+  }
+
+  llvm::SmallVector<DataflowCandidateEdge> edges;
+  for (auto item : llvm::enumerate(operations)) {
+    DataflowCandidateId consumerId =
+        static_cast<DataflowCandidateId>(item.index());
+    GenericOp consumer = item.value();
+    llvm::DenseSet<DataflowCandidateId> producers;
+    for (Value input : consumer.getInputs()) {
+      llvm::DenseSet<Value> visited;
+      collectDefiningCandidates(input, ids, visited, producers);
+    }
+    for (DataflowCandidateId producerId : producers) {
+      if (producerId != consumerId) {
+        edges.push_back({producerId, consumerId});
+      }
+    }
+  }
+
+  llvm::sort(edges, [](const DataflowCandidateEdge &lhs,
+                       const DataflowCandidateEdge &rhs) {
+    return std::tie(lhs.producer, lhs.consumer) <
+           std::tie(rhs.producer, rhs.consumer);
+  });
+  edges.erase(std::unique(edges.begin(), edges.end(),
+                          [](const DataflowCandidateEdge &lhs,
+                             const DataflowCandidateEdge &rhs) {
+                            return lhs.producer == rhs.producer &&
+                                   lhs.consumer == rhs.consumer;
+                          }),
+              edges.end());
+  return edges;
+}
+
+llvm::SmallVector<DataflowCandidateGraph>
+buildDataflowCandidateGraphs(ModuleOp module) {
+  llvm::SmallVector<DataflowCandidateGraph> graphs;
+
+  for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+    llvm::DenseMap<Block *, unsigned> blockToScope;
+    llvm::SmallVector<Block *> blocks;
+    llvm::SmallVector<llvm::SmallVector<GenericOp>> operationsByBlock;
+
+    function.walk([&](GenericOp genericOp) {
+      if (genericOp->getParentOfType<SpatialOp>() ||
+          genericOp->getParentOfType<GenericOp>()) {
+        return;
+      }
+
+      Block *block = genericOp->getBlock();
+      auto [it, inserted] = blockToScope.try_emplace(
+          block, static_cast<unsigned>(operationsByBlock.size()));
+      if (inserted) {
+        blocks.push_back(block);
+        operationsByBlock.emplace_back();
+      }
+      operationsByBlock[it->second].push_back(genericOp);
+    });
+
+    for (size_t scope = 0; scope < operationsByBlock.size(); ++scope) {
+      llvm::SmallVector<GenericOp> operations =
+          std::move(operationsByBlock[scope]);
+      llvm::SmallVector<DataflowCandidateEdge> edges =
+          buildCandidateEdges(operations);
+      graphs.emplace_back(function, blocks[scope], static_cast<unsigned>(scope),
+                          std::move(operations), std::move(edges));
+    }
+  }
+
+  return graphs;
+}
+
+DataflowKernelVariant::DataflowKernelVariant(
+    unsigned variantId, llvm::SmallVector<DataflowCandidateId> members,
+    llvm::SmallVector<int64_t> gridShape,
+    llvm::SmallVector<int64_t> blockFactors, KernelResourceEstimate resources,
+    KernelCostEstimate cost)
+    : variantId(variantId), members(std::move(members)),
+      gridShape(std::move(gridShape)), blockFactors(std::move(blockFactors)),
+      resources(resources), cost(cost) {}
+
+llvm::StringRef stringifyDataflowConnectionKind(DataflowConnectionKind kind) {
+  switch (kind) {
+  case DataflowConnectionKind::Materialized:
+    return "materialized";
+  case DataflowConnectionKind::L1Stream:
+    return "l1-stream";
+  case DataflowConnectionKind::NocStream:
+    return "noc-stream";
+  case DataflowConnectionKind::Dram:
+    return "dram";
+  }
+  llvm_unreachable("unknown dataflow connection kind");
+}
+
+llvm::StringRef stringifyDataflowPlanStrategy(DataflowPlanStrategy strategy) {
+  switch (strategy) {
+  case DataflowPlanStrategy::Temporal:
+    return "temporal-fallback";
+  case DataflowPlanStrategy::Fused:
+    return "fused";
+  case DataflowPlanStrategy::Spatial:
+    return "spatial";
+  }
+  llvm_unreachable("unknown dataflow plan strategy");
+}
+
+DataflowMappingPlan::DataflowMappingPlan(
+    func::FuncOp function, Block *block, unsigned scopeOrdinal,
+    DataflowPlanStrategy strategy,
+    llvm::SmallVector<DataflowPlannedKernel, 0> kernels,
+    llvm::SmallVector<DataflowPlannedConnection> connections)
+    : function(function), block(block), scopeOrdinal(scopeOrdinal),
+      strategy(strategy), kernels(std::move(kernels)),
+      connections(std::move(connections)) {}
+
+llvm::StringRef stringifyDataflowRejectionKind(DataflowRejectionKind kind) {
+  switch (kind) {
+  case DataflowRejectionKind::None:
+    return "none";
+  case DataflowRejectionKind::InvalidGraph:
+    return "invalid-graph";
+  case DataflowRejectionKind::InvalidVariant:
+    return "invalid-variant";
+  case DataflowRejectionKind::ResourceLimit:
+    return "resource-limit";
+  case DataflowRejectionKind::Unsupported:
+    return "unsupported";
+  }
+  llvm_unreachable("unknown dataflow rejection kind");
+}
+
+DataflowFeasibilityResult DataflowFeasibilityResult::success() {
+  return {true, DataflowRejectionKind::None, {}};
+}
+
+DataflowFeasibilityResult
+DataflowFeasibilityResult::reject(DataflowRejectionKind kind,
+                                  llvm::StringRef message) {
+  return {false, kind, message.str()};
+}
+
+DataflowFeasibilityResult StructuralDataflowFeasibilityModel::evaluate(
+    const DataflowCandidateGraph &graph,
+    const DataflowMappingPlan &plan) const {
+  if (plan.getFunction() != graph.getFunction() ||
+      plan.getBlock() != graph.getBlock() ||
+      plan.getScopeOrdinal() != graph.getScopeOrdinal()) {
+    return DataflowFeasibilityResult::reject(
+        DataflowRejectionKind::InvalidGraph,
+        "plan identity does not match its candidate graph");
+  }
+
+  llvm::SmallVector<std::optional<unsigned>> candidateToKernel(
+      graph.getOperations().size());
+  for (auto [kernelIndex, kernel] : llvm::enumerate(plan.getKernels())) {
+    const DataflowKernelVariant &variant = kernel.variant;
+    if (variant.getMembers().empty() || variant.getGridShape().empty() ||
+        llvm::any_of(variant.getGridShape(),
+                     [](int64_t dim) { return dim <= 0; })) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidVariant,
+          "kernel variant must have members and a positive grid shape");
+    }
+
+    for (DataflowCandidateId member : variant.getMembers()) {
+      if (member >= candidateToKernel.size()) {
+        return DataflowFeasibilityResult::reject(
+            DataflowRejectionKind::InvalidVariant,
+            "kernel variant references an unknown candidate");
+      }
+      if (candidateToKernel[member]) {
+        return DataflowFeasibilityResult::reject(
+            DataflowRejectionKind::InvalidVariant,
+            "candidate is covered by more than one kernel variant");
+      }
+      candidateToKernel[member] = static_cast<unsigned>(kernelIndex);
+    }
+  }
+
+  if (llvm::any_of(candidateToKernel,
+                   [](const std::optional<unsigned> &kernel) {
+                     return !kernel.has_value();
+                   })) {
+    return DataflowFeasibilityResult::reject(
+        DataflowRejectionKind::InvalidGraph,
+        "mapping plan does not cover every graph candidate");
+  }
+
+  llvm::DenseSet<std::pair<unsigned, unsigned>> connections;
+  for (const DataflowPlannedConnection &connection : plan.getConnections()) {
+    if (connection.producerKernel >= plan.getKernels().size() ||
+        connection.consumerKernel >= plan.getKernels().size() ||
+        connection.producerKernel == connection.consumerKernel ||
+        connection.bufferDepth == 0) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidGraph,
+          "plan contains an invalid kernel connection");
+    }
+    if (!connections
+             .insert({connection.producerKernel, connection.consumerKernel})
+             .second) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidGraph,
+          "plan contains a duplicate kernel connection");
+    }
+  }
+
+  for (const DataflowCandidateEdge &edge : graph.getEdges()) {
+    if (edge.producer >= candidateToKernel.size() ||
+        edge.consumer >= candidateToKernel.size()) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidGraph,
+          "candidate graph contains an invalid dependency");
+    }
+    unsigned producerKernel = *candidateToKernel[edge.producer];
+    unsigned consumerKernel = *candidateToKernel[edge.consumer];
+    if (producerKernel == consumerKernel) {
+      continue;
+    }
+    if (!connections.contains({producerKernel, consumerKernel})) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidGraph,
+          "plan does not preserve a producer-consumer dependency");
+    }
+    if (plan.getStrategy() == DataflowPlanStrategy::Temporal &&
+        producerKernel >= consumerKernel) {
+      return DataflowFeasibilityResult::reject(
+          DataflowRejectionKind::InvalidGraph,
+          "temporal plan does not preserve dependency order");
+    }
+  }
+
+  return DataflowFeasibilityResult::success();
+}
+
+static std::optional<uint64_t>
+getKernelInitiationInterval(const DataflowKernelVariant &variant) {
+  const KernelCostEstimate &cost = variant.getCost();
+  if (cost.initiationIntervalCycles) {
+    return cost.initiationIntervalCycles;
+  }
+  if (!cost.computeCycles || !cost.dataMovementCycles) {
+    return std::nullopt;
+  }
+  return std::max(*cost.computeCycles, *cost.dataMovementCycles);
+}
+
+static uint32_t getCoreCount(llvm::ArrayRef<int64_t> gridShape) {
+  uint64_t count = 1;
+  for (int64_t dim : gridShape) {
+    count *= static_cast<uint64_t>(dim);
+  }
+  return static_cast<uint32_t>(
+      std::min<uint64_t>(count, std::numeric_limits<uint32_t>::max()));
+}
+
+DataflowPlanCost
+AnalyticalDataflowCostModel::evaluate(const DataflowCandidateGraph &,
+                                      const DataflowMappingPlan &plan) const {
+  DataflowPlanCost result;
+  result.programCount = static_cast<uint32_t>(plan.getKernels().size());
+  result.confidence = 1.0F;
+
+  bool allCyclesKnown = true;
+  uint64_t cycleSum = 0;
+  uint64_t maxInitiationInterval = 0;
+  for (const DataflowPlannedKernel &kernel : plan.getKernels()) {
+    const DataflowKernelVariant &variant = kernel.variant;
+    const KernelResourceEstimate &resources = variant.getResources();
+    result.dramBytes += resources.dramBytes;
+    result.nocBytes += resources.nocBytes;
+    result.peakL1BytesPerCore =
+        std::max(result.peakL1BytesPerCore, resources.l1BytesPerCore);
+
+    uint32_t coreCount = getCoreCount(variant.getGridShape());
+    if (plan.getStrategy() == DataflowPlanStrategy::Spatial) {
+      result.occupiedCores += coreCount;
+    } else {
+      result.occupiedCores = std::max(result.occupiedCores, coreCount);
+    }
+
+    std::optional<uint64_t> initiationInterval =
+        getKernelInitiationInterval(variant);
+    if (!initiationInterval) {
+      allCyclesKnown = false;
+      result.confidence = 0.0F;
+      continue;
+    }
+    cycleSum += *initiationInterval;
+    maxInitiationInterval =
+        std::max(maxInitiationInterval, *initiationInterval);
+    result.confidence =
+        std::min(result.confidence, variant.getCost().confidence);
+  }
+
+  if (allCyclesKnown) {
+    if (plan.getStrategy() == DataflowPlanStrategy::Spatial) {
+      result.initiationIntervalCycles = maxInitiationInterval;
+    } else {
+      result.latencyCycles = cycleSum;
+    }
+  }
+
+  return result;
+}
+
+DataflowMappingPlan
+buildTemporalFallbackPlan(const DataflowCandidateGraph &graph) {
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.reserve(graph.getOperations().size());
+  for (auto item : llvm::enumerate(graph.getOperations())) {
+    DataflowCandidateId candidateId =
+        static_cast<DataflowCandidateId>(item.index());
+    GenericOp operation = item.value();
+    kernels.push_back({DataflowKernelVariant(
+                           /*variantId=*/0, {candidateId},
+                           llvm::to_vector(operation.getGrid().getShape()),
+                           operation.getBlockFactorsValue()),
+                       /*coreOffset=*/{}});
+  }
+
+  llvm::SmallVector<DataflowPlannedConnection> connections;
+  connections.reserve(graph.getEdges().size());
+  for (const DataflowCandidateEdge &edge : graph.getEdges()) {
+    connections.push_back({edge.producer, edge.consumer,
+                           DataflowConnectionKind::Materialized,
+                           /*bufferDepth=*/1});
+  }
+
+  return DataflowMappingPlan(graph.getFunction(), graph.getBlock(),
+                             graph.getScopeOrdinal(),
+                             DataflowPlanStrategy::Temporal, std::move(kernels),
+                             std::move(connections));
+}
+
+static void printOptionalCycles(llvm::raw_ostream &os,
+                                std::optional<uint64_t> cycles) {
+  if (cycles) {
+    os << *cycles;
+  } else {
+    os << "unknown";
+  }
+}
+
+void printDataflowPlan(llvm::raw_ostream &os,
+                       const DataflowCandidateGraph &graph,
+                       const DataflowMappingPlan &plan,
+                       const DataflowPlanCost &cost) {
+  os << "d2m-dataflow-plan function=@" << plan.getFunction().getSymName()
+     << " scope=" << plan.getScopeOrdinal()
+     << " strategy=" << stringifyDataflowPlanStrategy(plan.getStrategy())
+     << " candidates=" << graph.getOperations().size()
+     << " dependencies=" << graph.getEdges().size()
+     << " kernels=" << plan.getKernels().size()
+     << " connections=" << plan.getConnections().size() << " latency=";
+  printOptionalCycles(os, cost.latencyCycles);
+  os << " ii=";
+  printOptionalCycles(os, cost.initiationIntervalCycles);
+  os << "\n";
+}
+
+LogicalResult TemporalDataflowPlanMaterializer::materialize(
+    const DataflowCandidateGraph &, const DataflowMappingPlan &plan) const {
+  return success(plan.getStrategy() == DataflowPlanStrategy::Temporal);
+}
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
+++ b/lib/Dialect/D2M/Pipelines/D2MPipelines.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
+#include "llvm/Support/ErrorHandling.h"
 
 namespace mlir::tt::ttmetal {
 //===----------------------------------------------------------------------===//
@@ -111,6 +112,13 @@ void createD2MFrontendPipeline(OpPassManager &pm,
   }
   pm.addPass(tt::createTTIRToD2MPass(toD2MOptions));
   pm.addPass(d2m::createD2MScalarizeConstTensors());
+  if (options.enableDataflowPlanning) {
+    if (options.ttnnMode) {
+      llvm::report_fatal_error(
+          "D2M dataflow planning currently supports only the TTMetal path");
+    }
+    pm.addPass(d2m::createD2MDataflowPlanning());
+  }
   d2m::D2MGridSelectionOptions gridOptOptions;
   {
     gridOptOptions.overrideDeviceShape =

--- a/lib/Dialect/D2M/Transforms/CMakeLists.txt
+++ b/lib/Dialect/D2M/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRD2MTransforms
         Allocate.cpp
         BuildTopkChain.cpp
+        DataflowPlanning.cpp
         DMAOptimizations.cpp
         DecomposeArange.cpp
         DecomposeMasking.cpp

--- a/lib/Dialect/D2M/Transforms/DataflowPlanning.cpp
+++ b/lib/Dialect/D2M/Transforms/DataflowPlanning.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h"
+
+#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstddef>
+#include <utility>
+
+namespace mlir::tt::d2m {
+#define GEN_PASS_DEF_D2MDATAFLOWPLANNING
+#include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
+
+namespace {
+
+// This is the stable input boundary for future dependency and legality
+// analyses. Keeping collection separate from planning prevents search from
+// repeatedly cloning or mutating the payload IR.
+class CandidateGraph {
+public:
+  CandidateGraph(func::FuncOp function, Block *block, unsigned scopeOrdinal,
+                 llvm::SmallVector<GenericOp> operations)
+      : function(function), block(block), scopeOrdinal(scopeOrdinal),
+        operations(std::move(operations)) {}
+
+  func::FuncOp getFunction() const { return function; }
+
+  Block *getBlock() const { return block; }
+
+  unsigned getScopeOrdinal() const { return scopeOrdinal; }
+
+  llvm::ArrayRef<GenericOp> getOperations() const { return operations; }
+
+private:
+  func::FuncOp function;
+  Block *block;
+  unsigned scopeOrdinal;
+  llvm::SmallVector<GenericOp> operations;
+};
+
+// MappingPlan intentionally exposes no mutation API. Search implementations
+// should build candidate plans out of band and materialize only the selected
+// plan.
+class MappingPlan {
+public:
+  MappingPlan(func::FuncOp function, Block *block, unsigned scopeOrdinal,
+              llvm::SmallVector<GenericOp> temporalOrder)
+      : function(function), block(block), scopeOrdinal(scopeOrdinal),
+        temporalOrder(std::move(temporalOrder)) {}
+
+  func::FuncOp getFunction() const { return function; }
+
+  Block *getBlock() const { return block; }
+
+  unsigned getScopeOrdinal() const { return scopeOrdinal; }
+
+  llvm::ArrayRef<GenericOp> getTemporalOrder() const { return temporalOrder; }
+
+private:
+  func::FuncOp function;
+  Block *block;
+  unsigned scopeOrdinal;
+  llvm::SmallVector<GenericOp> temporalOrder;
+};
+
+static llvm::SmallVector<CandidateGraph> buildCandidateGraphs(ModuleOp module) {
+  llvm::SmallVector<CandidateGraph> graphs;
+
+  for (func::FuncOp function : module.getOps<func::FuncOp>()) {
+    llvm::DenseMap<Block *, unsigned> blockToScope;
+    llvm::SmallVector<Block *> blocks;
+    llvm::SmallVector<llvm::SmallVector<GenericOp>> operationsByBlock;
+
+    function.walk([&](GenericOp genericOp) {
+      if (genericOp->getParentOfType<SpatialOp>() ||
+          genericOp->getParentOfType<GenericOp>()) {
+        return;
+      }
+
+      Block *block = genericOp->getBlock();
+      auto [it, inserted] = blockToScope.try_emplace(
+          block, static_cast<unsigned>(operationsByBlock.size()));
+      if (inserted) {
+        blocks.push_back(block);
+        operationsByBlock.emplace_back();
+      }
+      operationsByBlock[it->second].push_back(genericOp);
+    });
+
+    for (std::size_t scope = 0; scope < operationsByBlock.size(); ++scope) {
+      graphs.emplace_back(function, blocks[scope], static_cast<unsigned>(scope),
+                          std::move(operationsByBlock[scope]));
+    }
+  }
+
+  return graphs;
+}
+
+// The first policy is the always-legal temporal fallback: retain the existing
+// d2m.generic order and let downstream passes make their current decisions.
+static MappingPlan buildTemporalFallbackPlan(const CandidateGraph &graph) {
+  return MappingPlan(graph.getFunction(), graph.getBlock(),
+                     graph.getScopeOrdinal(),
+                     llvm::SmallVector<GenericOp>(graph.getOperations()));
+}
+
+static LogicalResult verifyMappingPlan(const MappingPlan &plan) {
+  llvm::DenseSet<Operation *> seen;
+  Operation *previous = nullptr;
+  for (GenericOp genericOp : plan.getTemporalOrder()) {
+    if (!genericOp || genericOp->getBlock() != plan.getBlock() ||
+        genericOp->getParentOfType<func::FuncOp>() != plan.getFunction() ||
+        genericOp->getParentOfType<SpatialOp>() ||
+        genericOp->getParentOfType<GenericOp>() ||
+        !seen.insert(genericOp.getOperation()).second ||
+        (previous && !previous->isBeforeInBlock(genericOp))) {
+      return failure();
+    }
+    previous = genericOp;
+  }
+  return success();
+}
+
+static void dumpMappingPlan(const MappingPlan &plan) {
+  llvm::errs() << "d2m-dataflow-plan function=@"
+               << plan.getFunction().getSymName()
+               << " scope=" << plan.getScopeOrdinal()
+               << " strategy=temporal-fallback generics="
+               << plan.getTemporalOrder().size() << "\n";
+}
+
+static LogicalResult materializeMappingPlan(const MappingPlan &) {
+  // The fallback is already represented by the current IR, so materialization
+  // is intentionally a no-op. Spatial and fused plans will be emitted here.
+  return success();
+}
+
+class D2MDataflowPlanningPass final
+    : public impl::D2MDataflowPlanningBase<D2MDataflowPlanningPass> {
+public:
+  using impl::D2MDataflowPlanningBase<
+      D2MDataflowPlanningPass>::D2MDataflowPlanningBase;
+
+  void runOnOperation() override {
+    llvm::SmallVector<CandidateGraph> graphs =
+        buildCandidateGraphs(getOperation());
+    for (const CandidateGraph &graph : graphs) {
+      MappingPlan plan = buildTemporalFallbackPlan(graph);
+
+      if (failed(verifyMappingPlan(plan))) {
+        getOperation().emitError(
+            "dataflow planner produced an invalid mapping plan");
+        signalPassFailure();
+        return;
+      }
+
+      if (this->dumpPlan) {
+        dumpMappingPlan(plan);
+      }
+
+      if (failed(materializeMappingPlan(plan))) {
+        getOperation().emitError("failed to materialize the selected dataflow "
+                                 "mapping plan");
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+} // namespace
+
+} // namespace mlir::tt::d2m

--- a/lib/Dialect/D2M/Transforms/DataflowPlanning.cpp
+++ b/lib/Dialect/D2M/Transforms/DataflowPlanning.cpp
@@ -4,147 +4,15 @@
 
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h"
 
-#include "ttmlir/Dialect/D2M/IR/D2MOps.h"
+#include "ttmlir/Dialect/D2M/Analysis/DataflowPlanning.h"
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Support/LogicalResult.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include <cstddef>
-#include <utility>
 
 namespace mlir::tt::d2m {
 #define GEN_PASS_DEF_D2MDATAFLOWPLANNING
 #include "ttmlir/Dialect/D2M/Transforms/Passes.h.inc"
 
 namespace {
-
-// This is the stable input boundary for future dependency and legality
-// analyses. Keeping collection separate from planning prevents search from
-// repeatedly cloning or mutating the payload IR.
-class CandidateGraph {
-public:
-  CandidateGraph(func::FuncOp function, Block *block, unsigned scopeOrdinal,
-                 llvm::SmallVector<GenericOp> operations)
-      : function(function), block(block), scopeOrdinal(scopeOrdinal),
-        operations(std::move(operations)) {}
-
-  func::FuncOp getFunction() const { return function; }
-
-  Block *getBlock() const { return block; }
-
-  unsigned getScopeOrdinal() const { return scopeOrdinal; }
-
-  llvm::ArrayRef<GenericOp> getOperations() const { return operations; }
-
-private:
-  func::FuncOp function;
-  Block *block;
-  unsigned scopeOrdinal;
-  llvm::SmallVector<GenericOp> operations;
-};
-
-// MappingPlan intentionally exposes no mutation API. Search implementations
-// should build candidate plans out of band and materialize only the selected
-// plan.
-class MappingPlan {
-public:
-  MappingPlan(func::FuncOp function, Block *block, unsigned scopeOrdinal,
-              llvm::SmallVector<GenericOp> temporalOrder)
-      : function(function), block(block), scopeOrdinal(scopeOrdinal),
-        temporalOrder(std::move(temporalOrder)) {}
-
-  func::FuncOp getFunction() const { return function; }
-
-  Block *getBlock() const { return block; }
-
-  unsigned getScopeOrdinal() const { return scopeOrdinal; }
-
-  llvm::ArrayRef<GenericOp> getTemporalOrder() const { return temporalOrder; }
-
-private:
-  func::FuncOp function;
-  Block *block;
-  unsigned scopeOrdinal;
-  llvm::SmallVector<GenericOp> temporalOrder;
-};
-
-static llvm::SmallVector<CandidateGraph> buildCandidateGraphs(ModuleOp module) {
-  llvm::SmallVector<CandidateGraph> graphs;
-
-  for (func::FuncOp function : module.getOps<func::FuncOp>()) {
-    llvm::DenseMap<Block *, unsigned> blockToScope;
-    llvm::SmallVector<Block *> blocks;
-    llvm::SmallVector<llvm::SmallVector<GenericOp>> operationsByBlock;
-
-    function.walk([&](GenericOp genericOp) {
-      if (genericOp->getParentOfType<SpatialOp>() ||
-          genericOp->getParentOfType<GenericOp>()) {
-        return;
-      }
-
-      Block *block = genericOp->getBlock();
-      auto [it, inserted] = blockToScope.try_emplace(
-          block, static_cast<unsigned>(operationsByBlock.size()));
-      if (inserted) {
-        blocks.push_back(block);
-        operationsByBlock.emplace_back();
-      }
-      operationsByBlock[it->second].push_back(genericOp);
-    });
-
-    for (std::size_t scope = 0; scope < operationsByBlock.size(); ++scope) {
-      graphs.emplace_back(function, blocks[scope], static_cast<unsigned>(scope),
-                          std::move(operationsByBlock[scope]));
-    }
-  }
-
-  return graphs;
-}
-
-// The first policy is the always-legal temporal fallback: retain the existing
-// d2m.generic order and let downstream passes make their current decisions.
-static MappingPlan buildTemporalFallbackPlan(const CandidateGraph &graph) {
-  return MappingPlan(graph.getFunction(), graph.getBlock(),
-                     graph.getScopeOrdinal(),
-                     llvm::SmallVector<GenericOp>(graph.getOperations()));
-}
-
-static LogicalResult verifyMappingPlan(const MappingPlan &plan) {
-  llvm::DenseSet<Operation *> seen;
-  Operation *previous = nullptr;
-  for (GenericOp genericOp : plan.getTemporalOrder()) {
-    if (!genericOp || genericOp->getBlock() != plan.getBlock() ||
-        genericOp->getParentOfType<func::FuncOp>() != plan.getFunction() ||
-        genericOp->getParentOfType<SpatialOp>() ||
-        genericOp->getParentOfType<GenericOp>() ||
-        !seen.insert(genericOp.getOperation()).second ||
-        (previous && !previous->isBeforeInBlock(genericOp))) {
-      return failure();
-    }
-    previous = genericOp;
-  }
-  return success();
-}
-
-static void dumpMappingPlan(const MappingPlan &plan) {
-  llvm::errs() << "d2m-dataflow-plan function=@"
-               << plan.getFunction().getSymName()
-               << " scope=" << plan.getScopeOrdinal()
-               << " strategy=temporal-fallback generics="
-               << plan.getTemporalOrder().size() << "\n";
-}
-
-static LogicalResult materializeMappingPlan(const MappingPlan &) {
-  // The fallback is already represented by the current IR, so materialization
-  // is intentionally a no-op. Spatial and fused plans will be emitted here.
-  return success();
-}
-
 class D2MDataflowPlanningPass final
     : public impl::D2MDataflowPlanningBase<D2MDataflowPlanningPass> {
 public:
@@ -152,23 +20,30 @@ public:
       D2MDataflowPlanningPass>::D2MDataflowPlanningBase;
 
   void runOnOperation() override {
-    llvm::SmallVector<CandidateGraph> graphs =
-        buildCandidateGraphs(getOperation());
-    for (const CandidateGraph &graph : graphs) {
-      MappingPlan plan = buildTemporalFallbackPlan(graph);
+    StructuralDataflowFeasibilityModel feasibilityModel;
+    AnalyticalDataflowCostModel costModel;
+    TemporalDataflowPlanMaterializer materializer;
 
-      if (failed(verifyMappingPlan(plan))) {
-        getOperation().emitError(
-            "dataflow planner produced an invalid mapping plan");
+    for (const DataflowCandidateGraph &graph :
+         buildDataflowCandidateGraphs(getOperation())) {
+      DataflowMappingPlan plan = buildTemporalFallbackPlan(graph);
+      DataflowFeasibilityResult feasibility =
+          feasibilityModel.evaluate(graph, plan);
+      if (!feasibility.feasible) {
+        getOperation().emitError()
+            << "dataflow planner rejected the selected mapping plan ("
+            << stringifyDataflowRejectionKind(feasibility.rejectionKind)
+            << "): " << feasibility.message;
         signalPassFailure();
         return;
       }
 
+      DataflowPlanCost cost = costModel.evaluate(graph, plan);
       if (this->dumpPlan) {
-        dumpMappingPlan(plan);
+        printDataflowPlan(llvm::errs(), graph, plan, cost);
       }
 
-      if (failed(materializeMappingPlan(plan))) {
+      if (failed(materializer.materialize(graph, plan))) {
         getOperation().emitError("failed to materialize the selected dataflow "
                                  "mapping plan");
         signalPassFailure();

--- a/test/ttmlir/Dialect/D2M/Transforms/dataflow_planning.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/dataflow_planning.mlir
@@ -1,0 +1,25 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttir-to-d2m --d2m-scalarize-const-tensors "--d2m-dataflow-planning=dump-plan=true" %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=PLAN
+// RUN: ttmlir-opt "--d2m-fe-pipeline=enable-dataflow-planning=true" --mlir-print-ir-after=d2m-dataflow-planning %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=PIPELINE
+// RUN: not --crash ttmlir-opt "--d2m-fe-pipeline=enable-dataflow-planning=true ttnn-mode=true" %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=TTNN-REJECTED
+// RUN: ttmlir-opt --split-input-file "--d2m-dataflow-planning=dump-plan=true" %S/../../../Conversion/D2MToTTMetal/spatial_fabric_config_scope.mlir -o /dev/null 2>&1 | FileCheck %s --allow-empty --check-prefix=SPATIAL
+
+#any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
+
+module attributes {ttcore.device = #any_device} {
+  // PLAN: d2m-dataflow-plan function=@planner_skeleton scope=0 strategy=temporal-fallback generics=1
+  // PLAN-NEXT: d2m-dataflow-plan function=@planner_second_function scope=0 strategy=temporal-fallback generics=1
+  // PIPELINE: IR Dump After D2MDataflowPlanning (d2m-dataflow-planning)
+  // PIPELINE: func.func @planner_skeleton
+  // PIPELINE: d2m.generic {{.*}}grid = #ttcore.grid<1x1>
+  // TTNN-REJECTED: LLVM ERROR: D2M dataflow planning currently supports only the TTMetal path
+  // SPATIAL-NOT: d2m-dataflow-plan
+  func.func @planner_skeleton(%arg0: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    %0 = "ttir.relu"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
+  }
+
+  func.func @planner_second_function(%arg0: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    %0 = "ttir.exp"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %0 : tensor<64x64xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/D2M/Transforms/dataflow_planning.mlir
+++ b/test/ttmlir/Dialect/D2M/Transforms/dataflow_planning.mlir
@@ -6,8 +6,9 @@
 #any_device = #ttcore.device<workerGrid = #ttcore.grid<8x8, virt_to_physical_map = (d0, d1) -> (0, d0, d1), physical_to_virt_map = (d0, d1) -> (0, d0, d1)>, dramGrid = #ttcore.grid<1x12>, l1Map = (d0, d1, d2)[s0] -> (0, d0, d1, d2 + s0), dramMap = (d0, d1, d2)[s0, s1] -> (0, 0, 0, d0 * s1 + d1 * s1 + d2 + s0), meshShape = , chipIds = [0]>
 
 module attributes {ttcore.device = #any_device} {
-  // PLAN: d2m-dataflow-plan function=@planner_skeleton scope=0 strategy=temporal-fallback generics=1
-  // PLAN-NEXT: d2m-dataflow-plan function=@planner_second_function scope=0 strategy=temporal-fallback generics=1
+  // PLAN: d2m-dataflow-plan function=@planner_skeleton scope=0 strategy=temporal-fallback candidates=1 dependencies=0 kernels=1 connections=0 latency=unknown ii=unknown
+  // PLAN-NEXT: d2m-dataflow-plan function=@planner_second_function scope=0 strategy=temporal-fallback candidates=1 dependencies=0 kernels=1 connections=0 latency=unknown ii=unknown
+  // PLAN-NEXT: d2m-dataflow-plan function=@planner_chain scope=0 strategy=temporal-fallback candidates=2 dependencies=1 kernels=2 connections=1 latency=unknown ii=unknown
   // PIPELINE: IR Dump After D2MDataflowPlanning (d2m-dataflow-planning)
   // PIPELINE: func.func @planner_skeleton
   // PIPELINE: d2m.generic {{.*}}grid = #ttcore.grid<1x1>
@@ -21,5 +22,11 @@ module attributes {ttcore.device = #any_device} {
   func.func @planner_second_function(%arg0: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
     %0 = "ttir.exp"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
     return %0 : tensor<64x64xbf16>
+  }
+
+  func.func @planner_chain(%arg0: tensor<64x64xbf16>) -> tensor<64x64xbf16> {
+    %0 = "ttir.relu"(%arg0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    %1 = "ttir.exp"(%0) : (tensor<64x64xbf16>) -> tensor<64x64xbf16>
+    return %1 : tensor<64x64xbf16>
   }
 }

--- a/test/unittests/D2MGenericAnalysis/CMakeLists.txt
+++ b/test/unittests/D2MGenericAnalysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TESTSUITE D2MGenericAnalysisTests)
 
 add_mlir_unittest(${TESTSUITE}
+    TestDataflowPlanning.cpp
     TestD2MGenericAnalysis.cpp
 )
 

--- a/test/unittests/D2MGenericAnalysis/TestDataflowPlanning.cpp
+++ b/test/unittests/D2MGenericAnalysis/TestDataflowPlanning.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttmlir/Dialect/D2M/Analysis/DataflowPlanning.h"
+
+#include <gtest/gtest.h>
+
+namespace mlir::tt::d2m {
+namespace {
+
+DataflowKernelVariant
+makeVariant(DataflowCandidateId member, llvm::SmallVector<int64_t> grid,
+            KernelResourceEstimate resources, uint64_t computeCycles,
+            uint64_t dataMovementCycles, float confidence) {
+  KernelCostEstimate cost;
+  cost.computeCycles = computeCycles;
+  cost.dataMovementCycles = dataMovementCycles;
+  cost.confidence = confidence;
+  return DataflowKernelVariant(/*variantId=*/0, {member}, std::move(grid), {},
+                               resources, cost);
+}
+
+TEST(DataflowPlanningTest, AggregatesTemporalPlanCost) {
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0, {}, {});
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.push_back(
+      {makeVariant(/*member=*/0, {1, 2},
+                   {/*l1BytesPerCore=*/100, /*dramBytes=*/10,
+                    /*nocBytes=*/20, /*cbCount=*/2, /*dstTiles=*/1},
+                   /*computeCycles=*/100, /*dataMovementCycles=*/50,
+                   /*confidence=*/0.8F),
+       {}});
+  kernels.push_back(
+      {makeVariant(/*member=*/1, {2, 2},
+                   {/*l1BytesPerCore=*/200, /*dramBytes=*/30,
+                    /*nocBytes=*/40, /*cbCount=*/3, /*dstTiles=*/2},
+                   /*computeCycles=*/60, /*dataMovementCycles=*/80,
+                   /*confidence=*/0.6F),
+       {}});
+  DataflowMappingPlan plan({}, nullptr, /*scopeOrdinal=*/0,
+                           DataflowPlanStrategy::Temporal, std::move(kernels),
+                           {});
+
+  DataflowPlanCost cost = AnalyticalDataflowCostModel().evaluate(graph, plan);
+
+  EXPECT_EQ(cost.latencyCycles, 180u);
+  EXPECT_FALSE(cost.initiationIntervalCycles.has_value());
+  EXPECT_EQ(cost.dramBytes, 40u);
+  EXPECT_EQ(cost.nocBytes, 60u);
+  EXPECT_EQ(cost.peakL1BytesPerCore, 200u);
+  EXPECT_EQ(cost.occupiedCores, 4u);
+  EXPECT_EQ(cost.programCount, 2u);
+  EXPECT_FLOAT_EQ(cost.confidence, 0.6F);
+}
+
+TEST(DataflowPlanningTest, AggregatesSpatialPlanInitiationInterval) {
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0, {}, {});
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.push_back(
+      {makeVariant(/*member=*/0, {1, 2}, {}, /*computeCycles=*/100,
+                   /*dataMovementCycles=*/50, /*confidence=*/0.8F),
+       {0, 0}});
+  kernels.push_back(
+      {makeVariant(/*member=*/1, {2, 2}, {}, /*computeCycles=*/60,
+                   /*dataMovementCycles=*/80, /*confidence=*/0.6F),
+       {1, 0}});
+  DataflowMappingPlan plan({}, nullptr, /*scopeOrdinal=*/0,
+                           DataflowPlanStrategy::Spatial, std::move(kernels),
+                           {});
+
+  DataflowPlanCost cost = AnalyticalDataflowCostModel().evaluate(graph, plan);
+
+  EXPECT_FALSE(cost.latencyCycles.has_value());
+  EXPECT_EQ(cost.initiationIntervalCycles, 100u);
+  EXPECT_EQ(cost.occupiedCores, 6u);
+  EXPECT_FLOAT_EQ(cost.confidence, 0.6F);
+}
+
+TEST(DataflowPlanningTest, LeavesCyclesUnknownWithoutKernelEstimate) {
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0, {}, {});
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.push_back(
+      {DataflowKernelVariant(/*variantId=*/0, {/*members=*/0}, {1, 1}, {}),
+       {}});
+  DataflowMappingPlan plan({}, nullptr, /*scopeOrdinal=*/0,
+                           DataflowPlanStrategy::Temporal, std::move(kernels),
+                           {});
+
+  DataflowPlanCost cost = AnalyticalDataflowCostModel().evaluate(graph, plan);
+
+  EXPECT_FALSE(cost.latencyCycles.has_value());
+  EXPECT_FALSE(cost.initiationIntervalCycles.has_value());
+  EXPECT_FLOAT_EQ(cost.confidence, 0.0F);
+}
+
+TEST(DataflowPlanningTest, RejectsUnknownCandidateReference) {
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0, {}, {});
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.push_back(
+      {DataflowKernelVariant(/*variantId=*/0, {/*members=*/0}, {1, 1}, {}),
+       {}});
+  DataflowMappingPlan plan({}, nullptr, /*scopeOrdinal=*/0,
+                           DataflowPlanStrategy::Temporal, std::move(kernels),
+                           {});
+
+  DataflowFeasibilityResult result =
+      StructuralDataflowFeasibilityModel().evaluate(graph, plan);
+
+  EXPECT_FALSE(result.feasible);
+  EXPECT_EQ(result.rejectionKind, DataflowRejectionKind::InvalidVariant);
+}
+
+TEST(DataflowPlanningTest, RejectsInvalidCandidateDependency) {
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0, {}, {{0, 1}});
+  DataflowMappingPlan plan({}, nullptr, /*scopeOrdinal=*/0,
+                           DataflowPlanStrategy::Temporal, {}, {});
+
+  DataflowFeasibilityResult result =
+      StructuralDataflowFeasibilityModel().evaluate(graph, plan);
+
+  EXPECT_FALSE(result.feasible);
+  EXPECT_EQ(result.rejectionKind, DataflowRejectionKind::InvalidGraph);
+}
+
+TEST(DataflowPlanningTest, RejectsReorderedTemporalDependency) {
+  llvm::SmallVector<GenericOp> operations(2);
+  DataflowCandidateGraph graph({}, nullptr, /*scopeOrdinal=*/0,
+                               std::move(operations), {{0, 1}});
+  llvm::SmallVector<DataflowPlannedKernel, 0> kernels;
+  kernels.push_back(
+      {DataflowKernelVariant(/*variantId=*/0, {/*members=*/1}, {1, 1}, {}),
+       {}});
+  kernels.push_back(
+      {DataflowKernelVariant(/*variantId=*/0, {/*members=*/0}, {1, 1}, {}),
+       {}});
+  DataflowMappingPlan plan(
+      {}, nullptr, /*scopeOrdinal=*/0, DataflowPlanStrategy::Temporal,
+      std::move(kernels),
+      {{/*producerKernel=*/1, /*consumerKernel=*/0,
+        DataflowConnectionKind::Materialized, /*bufferDepth=*/1}});
+
+  DataflowFeasibilityResult result =
+      StructuralDataflowFeasibilityModel().evaluate(graph, plan);
+
+  EXPECT_FALSE(result.feasible);
+  EXPECT_EQ(result.rejectionKind, DataflowRejectionKind::InvalidGraph);
+}
+
+} // namespace
+} // namespace mlir::tt::d2m


### PR DESCRIPTION
## Summary

- add an opt-in, TTMetal-only D2M dataflow planning pass after TTIR-to-D2M conversion and constant scalarization, before grid selection
- introduce a public D2M planning framework for candidate graphs, kernel variants, immutable mapping plans, typed connections, feasibility models, cost models, and selected-plan materializers
- discover producer-consumer dependencies between top-level `d2m.generic` candidates, including dependencies routed through intermediate layout operations
- provide a behavior-preserving temporal fallback, structural validation, and an analytical multi-metric cost baseline that keeps unavailable cycle estimates explicitly unknown
- document the intended boundary between graph-level external dataflow planning and downstream internal D2M scheduling/DMA lowering

## Current policy

The initial policy creates one kernel per candidate and materialized connections for graph dependencies. It validates and scores the plan but deliberately leaves the input IR unchanged. Future changes can add fused/spatial variants, hardware resource limits, search, and non-temporal materializers without changing the pass boundary.

## Testing

- `pre-commit run --all-files`
- `cmake --build build --target ttmlir-opt D2MGenericAnalysisTests -j8`
- `build/test/unittests/D2MGenericAnalysis/D2MGenericAnalysisTests`: 22/22 passed
- `llvm-lit -sv test/ttmlir/Dialect/D2M/Transforms`: 85/85 passed
- `cmake --build build --target check-ttmlir -j8`: 1608 passed, 673 unsupported, 0 failed

No hardware execution was required; this PR changes compiler planning infrastructure only.