### PR TITLE
[TTML] Generate seed for AdamW per step in runtime

### DIFF
--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3607,6 +3607,16 @@ public:
                 : "::ttml::metal::StochasticRounding::Disabled"),
     };
 
+    // Generate a seed for stochastic rounding iff stochastic rounding is
+    // enabled. The seed needs to be drawn for every call to maintain
+    // stochastic rounding randomness.
+    if (srcOp.getStochasticRounding()) {
+      args.push_back(rewriter.getAttr<emitc::OpaqueAttr>(
+          "[]() {static thread_local ::std::mt19937 "
+          "generator(::std::random_device{}());return "
+          "::std::optional<uint32_t>{static_cast<uint32_t>(generator())};}()"));
+    }
+
     emitter.replaceOp(*this, args);
     return success();
   }

--- a/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNTraceHoistTransform.cpp
@@ -966,13 +966,13 @@ private:
     return mlir::success();
   }
 
-  // ttnn.adamw is not hoistable (host readback of lr / beta*_pow), so an
-  // adamw followed by hoistable compute would split the trace region and fail
-  // below. adamw has no results and mutates its param / moment operands in
-  // place, so it can be moved to the end of the block as long as no later
-  // non-adamw op touches any of its operands. Relative order of adamw ops is
-  // preserved. Anything that cannot be moved is left in place and reported by
-  // the "non-hoistable op in the middle" check.
+  // ttnn.adamw is not hoistable (host readback of lr / beta*_pow and per-step
+  // seed generation), so an adamw followed by hoistable compute would split the
+  // trace region and fail below. adamw has no results and mutates its param /
+  // moment operands in place, so it can be moved to the end of the block as
+  // long as no later non-adamw op touches any of its operands. Relative order
+  // of adamw ops is preserved. Anything that cannot be moved is left in place
+  // and reported by the "non-hoistable op in the middle" check.
   void sinkAdamWOpsToEnd(mlir::Block &block) {
     llvm::SmallVector<Operation *> adamWOps;
     for (mlir::Operation &op : block.getOperations()) {

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9425,6 +9425,14 @@ llvm::Expected<OpConstraints> OpModel<AdamWOp>::getOpConstraints(
       stochasticRounding ? ::ttml::metal::StochasticRounding::Enabled
                          : ::ttml::metal::StochasticRounding::Disabled;
 
+  // ttml requires a seed iff stochastic rounding is enabled. The seed only
+  // affects the rounding of the parameter update, so a fixed one keeps the
+  // constraints stable.
+  constexpr uint32_t kStochasticRoundingQuerySeed = 0;
+  const std::optional<uint32_t> stochasticRoundingSeed =
+      stochasticRounding ? std::optional<uint32_t>(kStochasticRoundingQuerySeed)
+                         : std::nullopt;
+
   std::optional<MockAllocatorState> initialStateOpt =
       initialState ? std::optional<MockAllocatorState>(*initialState)
                    : std::nullopt;
@@ -9435,7 +9443,8 @@ llvm::Expected<OpConstraints> OpModel<AdamWOp>::getOpConstraints(
         expAvgSpec, expAvgSqSpec, maxExpAvgSqSpec, /*lr=*/0.0F,
         beta1.convertToFloat(), beta2.convertToFloat(), /*beta1_pow=*/0.0F,
         /*beta2_pow=*/0.0F, epsilon.convertToFloat(),
-        weightDecay.convertToFloat(), stochasticRoundingValue);
+        weightDecay.convertToFloat(), stochasticRoundingValue,
+        stochasticRoundingSeed);
   };
 
   return operation::getOpConstraintsWithState(paramLayout.getContext(),
@@ -9477,6 +9486,12 @@ llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
   const ::ttml::metal::StochasticRounding stochasticRoundingValue =
       stochasticRounding ? ::ttml::metal::StochasticRounding::Enabled
                          : ::ttml::metal::StochasticRounding::Disabled;
+  // The seed is required by ttml iff stochastic rounding is enabled, but does
+  // not affect the reported cost.
+  constexpr uint32_t kStochasticRoundingQuerySeed = 0;
+  const std::optional<uint32_t> stochasticRoundingSeed =
+      stochasticRounding ? std::optional<uint32_t>(kStochasticRoundingQuerySeed)
+                         : std::nullopt;
 
   auto adamWOpQuery = [=]() {
     return QUERY_OP_RUNTIME(::ttml::metal::adamw, device, paramSpec, gradSpec,
@@ -9485,7 +9500,7 @@ llvm::Expected<size_t> OpModel<AdamWOp>::getOpRuntime(
                             beta2.convertToFloat(), /*beta1_pow=*/0.0F,
                             /*beta2_pow=*/0.0F, epsilon.convertToFloat(),
                             weightDecay.convertToFloat(),
-                            stochasticRoundingValue);
+                            stochasticRoundingValue, stochasticRoundingSeed);
   };
 
   return operation::getOpRuntime(adamWOpQuery);

--- a/runtime/lib/ttnn/operations/ttml/adamw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/adamw.cpp
@@ -7,6 +7,8 @@
 #include "metal/optimizers/adamw/adamw.hpp" // ttml::metal::adamw
 #include "ttnn/distributed/api.hpp"
 
+#include <random>
+
 namespace tt::runtime::ttnn::operations::ttml {
 
 // Device -> host readback of a single-element tensor. Cached per program run
@@ -31,6 +33,14 @@ static float readScalar(ProgramContext &context,
   });
 }
 
+// Generate a seed for stochastic rounding. `ttml::metal::adamw` requires it iff
+// stochastic rounding is enabled. A constant seed would defeat the purpose of
+// stochastic rounding by reusing the same rounding sequence in every step.
+static uint32_t drawStochasticRoundingSeed() {
+  static thread_local std::mt19937 generator(std::random_device{}());
+  return static_cast<uint32_t>(generator());
+}
+
 void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
 
@@ -51,13 +61,17 @@ void run(const ::tt::target::ttnn::AdamWOp *op, ProgramContext &context) {
   const ::ttml::metal::StochasticRounding stochasticRounding =
       op->stochastic_rounding() ? ::ttml::metal::StochasticRounding::Enabled
                                 : ::ttml::metal::StochasticRounding::Disabled;
+  const std::optional<uint32_t> stochasticRoundingSeed =
+      op->stochastic_rounding()
+          ? std::optional<uint32_t>(drawStochasticRoundingSeed())
+          : std::nullopt;
 
   // param, exp_avg, exp_avg_sq (and max_exp_avg_sq) are all updated in place.
-  ::ttml::metal::adamw(param, grad, expAvg, expAvgSq, maxExpAvgSq,
-                       readScalar(context, op->lr()), op->beta1(), op->beta2(),
-                       readScalar(context, op->beta1_pow()),
-                       readScalar(context, op->beta2_pow()), op->epsilon(),
-                       op->weight_decay(), stochasticRounding);
+  ::ttml::metal::adamw(
+      param, grad, expAvg, expAvgSq, maxExpAvgSq, readScalar(context, op->lr()),
+      op->beta1(), op->beta2(), readScalar(context, op->beta1_pow()),
+      readScalar(context, op->beta2_pow()), op->epsilon(), op->weight_decay(),
+      stochasticRounding, stochasticRoundingSeed);
 }
 
 } // namespace tt::runtime::ttnn::operations::ttml

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -172,14 +172,26 @@ def test_div(shape: Shape, dtype: torch.dtype, target: str, request, device):
     )
 
 
+@pytest.mark.parametrize(
+    "tensor_types,stochastic_rounding",
+    [
+        (
+            [torch.float32, torch.bfloat16, torch.float32, torch.float32],
+            False,
+        ),
+        ([torch.bfloat16] * 4, True),
+    ],
+    ids=["default", "stochastic-rounding"],
+)
 @pytest.mark.parametrize("shape", [(1, 1, 64, 64)], ids=shape_str)
 @pytest.mark.parametrize("target", ["ttnn" | SkipIf("sim")])
-def test_adamw(shape: Shape, target: str, request, device):
+def test_adamw(
+    tensor_types, stochastic_rounding: bool, shape: Shape, target: str, request, device
+):
     def module(builder: TTIRBuilder):
         @builder.func(
             [shape, shape, shape, shape, (1,), (1,), (1,)],
-            [torch.float32, torch.bfloat16, torch.float32, torch.float32]
-            + [torch.float32] * 3,
+            tensor_types + [torch.float32] * 3,
         )
         def adamw(
             param: Operand,
@@ -218,6 +230,7 @@ def test_adamw(shape: Shape, target: str, request, device):
                 beta2=0.999,
                 epsilon=1e-8,
                 weight_decay=1e-2,
+                stochastic_rounding=stochastic_rounding,
             )
 
     compile_and_execute_ttir(

--- a/test/ttmlir/Dialect/TTNN/trace/adamw_not_hoisted.mlir
+++ b/test/ttmlir/Dialect/TTNN/trace/adamw_not_hoisted.mlir
@@ -2,8 +2,9 @@
 // RUN: FileCheck %s --input-file=%t
 
 // ttnn.adamw reads lr / beta*_pow back to the host, a sync a captured trace
-// would not replay, so it must stay outside the trace region while the compute
-// feeding it (the gradient multiply) is traced.
+// would not replay. Also, the seed for stochastic rounding (if enabled) is
+// generated on host in every step. So it must stay outside the trace region
+// while the compute feeding it (the gradient multiply) is traced.
 module {
   // CHECK-LABEL: func.func private @trace_0_step
   // CHECK: "ttnn.multiply"

--- a/test/ttmlir/EmitC/TTNN/adamw/adamw.mlir
+++ b/test/ttmlir/EmitC/TTNN/adamw/adamw.mlir
@@ -7,10 +7,12 @@ module {
                    %exp_avg: tensor<1x1x64x64xf32>, %exp_avg_sq: tensor<1x1x64x64xf32>, %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
       -> tensor<1x1x64x64xf32> {
     // lr / beta*_pow are read back from their device tensors.
+    // CHECK-LABEL: adamw
     // CHECK-COUNT-3: ::ttnn::getScalarFromTensor<float>(
     // CHECK: {{^ *}}ttml::metal::adamw(
     // CHECK-SAME: ::std::nullopt
     // CHECK-SAME: ::ttml::metal::StochasticRounding::Disabled
+    // CHECK-NOT: ::std::mt19937
     %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
         beta1 = 0.899999976 : f32,
         beta2 = 0.999000012 : f32,
@@ -19,5 +21,28 @@ module {
         : (tensor<1x1x64x64xf32>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
           -> (tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>, tensor<1x1x64x64xf32>)
     return %0#0 : tensor<1x1x64x64xf32>
+  }
+
+  // TTML requires a stochastic rounding seed iff stochastic rounding is
+  // enabled, so the trailing argument is emitted only in this variant.
+  func.func @adamw_stochastic_rounding(
+      %param: tensor<1x1x64x64xbf16>, %grad: tensor<1x1x64x64xbf16>,
+      %exp_avg: tensor<1x1x64x64xbf16>, %exp_avg_sq: tensor<1x1x64x64xbf16>,
+      %lr: tensor<1xf32>, %beta1_pow: tensor<1xf32>, %beta2_pow: tensor<1xf32>)
+      -> tensor<1x1x64x64xbf16> {
+    // CHECK-LABEL: adamw_stochastic_rounding
+    // CHECK: {{^ *}}ttml::metal::adamw(
+    // CHECK-SAME: ::ttml::metal::StochasticRounding::Enabled
+    // CHECK-SAME: static thread_local ::std::mt19937
+    // CHECK-SAME: static_cast<uint32_t>(generator())
+    %0:3 = "ttir.adamw"(%param, %grad, %exp_avg, %exp_avg_sq, %lr, %beta1_pow, %beta2_pow) <{
+        beta1 = 0.899999976 : f32,
+        beta2 = 0.999000012 : f32,
+        epsilon = 1.000000e-08 : f32,
+        weight_decay = 1.000000e-02 : f32,
+        stochastic_rounding = true}>
+        : (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1xf32>, tensor<1xf32>, tensor<1xf32>)
+          -> (tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>, tensor<1x1x64x64xbf16>)
+    return %0#0 : tensor<1x1x64x64xbf16>
   }
 }

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -5986,6 +5986,26 @@ TEST_F(OpModelAdamWTest, AdamWOpFloat32) {
   }
 }
 
+TEST_F(OpModelAdamWTest, AdamWOpBFloat16) {
+  const llvm::SmallVector<int64_t> shape = {1, 1, 128, 128};
+
+  const TTNNLayoutAttr bf16Layout = CreateTiledLayout(
+      shape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = queryConstraints(shape, bf16Layout, bf16Layout,
+                                         bf16Layout, /*amsgrad=*/false,
+                                         /*stochasticRounding=*/true);
+  EXPECT_TRUE(static_cast<bool>(constraintsExp));
+  if (!constraintsExp) {
+    llvm::consumeError(constraintsExp.takeError());
+  } else {
+    OpConstraints &opCstr = constraintsExp.get();
+    EXPECT_GT(opCstr.cbL1PeakSize, 0);
+    EXPECT_EQ(opCstr.tensorL1PeakSize, 0);
+    EXPECT_EQ(opCstr.outputL1BufferSize, 0);
+  }
+}
+
 TEST_F(OpModelAdamWTest, AdamWOpRejectsL1Param) {
   // The ttml device operation TT_FATALs unless every operand is in DRAM. The
   // query must surface that as an error rather than a bogus cost, otherwise the

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -1216,7 +1216,10 @@ def adamw_golden(
     if output_type_mlir is not None:
         result = result.to(mlir_type_to_torch_dtype(output_type_mlir))
 
+    new_exp_avg = new_exp_avg.to(exp_avg.dtype)
+    new_exp_avg_sq = new_exp_avg_sq.to(exp_avg_sq.dtype)
     if max_exp_avg_sq is not None:
+        new_max = new_max.to(max_exp_avg_sq.dtype)
         return result, new_exp_avg, new_exp_avg_sq, new_max
     return result, new_exp_avg, new_exp_avg_sq
 

--- a/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/local/ttnn-precompiled.hpp
@@ -67,6 +67,7 @@
 #include <iostream>
 #include <limits>
 #include <optional>
+#include <random>
 #include <vector>
 
 template <typename... T>

--- a/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
+++ b/tools/tt-alchemist/templates/cpp/standalone/ttnn-precompiled.hpp
@@ -67,6 +67,7 @@
 #include <iostream>
 #include <limits>
 #include <optional>
+#include <random>
 #include <vector>
 
 template <typename... T>

--- a/tools/ttnn-standalone/ttnn-precompiled.hpp
+++ b/tools/ttnn-standalone/ttnn-precompiled.hpp
@@ -98,6 +98,7 @@
 #include <iostream>
 #include <limits>
 #include <optional>
+#include <random>
 #include <tuple>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
### Ticket
Closes #9237 

### Problem description
After changes in tt-metal, adamw has an additional parameter (`stochastic_rounding_seed`) which is required iff `stochastic_rounding` is enabled, so the op fails in our runtime when it is enabled.

### What's changed
Changed the implementations of `adamw` in the runtime and EmitC backend so that a new seed is generated every time `ttml::metal::adamw` is executed and passed as its argument.

The seed is expected to have a different value in each iteration, so it can't be modeled as an attribute. It can be generated by the host at runtime because the op is not traced.

### Checklist
- [x] New/Existing tests provide coverage for changes
