### PR TITLE
[TTNN] Fix ttnn-memory-management non-convergence and multi-use permutes

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
+++ b/include/ttmlir/Dialect/TTNN/Transforms/Passes.td
@@ -854,6 +854,19 @@ def TTNNMemoryManagement : Pass<"ttnn-memory-management", "::mlir::ModuleOp"> {
            "aggressive-memory-saving",
            "bool", /*default=*/"true",
            "Opt-out: disable aggressive memory saving patterns to reduce DRAM usage.">,
+    Option<"maxIterations",
+           "max-iterations",
+           "int64_t", /*default=*/"10",
+           "Maximum greedy rewrite iterations, exposed so non-convergence can "
+           "be characterised without a rebuild.">,
+    Option<"aggressivePatternMask",
+           "aggressive-pattern-mask",
+           "int64_t", /*default=*/"15",
+           "Bitmask selecting which aggressive memory saving pattern kinds are "
+           "enabled: 0x1 PropagateSliceThroughEltwise, 0x2 "
+           "ReshapeElementwiseAdjusting, 0x4 PermuteRowMajorAdjusting, 0x8 "
+           "ReshapeRowMajorAdjusting. Diagnostic aid for bisecting a "
+           "non-converging graph down to a single pattern kind.">,
   ];
 }
 

--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -796,7 +796,20 @@ public:
       return failure();
     }
 
-    SmallVector<Value> newOperands;
+    // Validate every operand and compute its target shape before creating any
+    // IR. The greedy rewrite driver does not roll back ops created by a
+    // pattern that subsequently returns failure, so bailing out after a
+    // rewriter.create() leaks dead ops. Those get erased as trivially dead and
+    // then recreated identically on the next sweep, which registers as
+    // activity without net change and stops the driver ever converging.
+    struct OperandPlan {
+      Value input;
+      SmallVector<int64_t> targetShape;
+      bool needsReshape;
+    };
+    SmallVector<OperandPlan> plans;
+    plans.reserve(eltwiseOp->getNumOperands());
+
     for (uint32_t i = 0; i < eltwiseOp->getNumOperands(); ++i) {
       Value operand = eltwiseOp->getOperand(i);
       auto operandType = dyn_cast<RankedTensorType>(operand.getType());
@@ -851,19 +864,32 @@ public:
       // Check if a reshape is actually needed.
       if (reshapeInputType.getShape() ==
           llvm::ArrayRef<int64_t>(operandTargetShape)) {
-        newOperands.push_back(reshapeInput);
+        plans.push_back({reshapeInput, std::move(operandTargetShape),
+                         /*needsReshape=*/false});
         continue;
       }
       if (ttmlir::utils::volume(reshapeInputType.getShape()) !=
           ttmlir::utils::volume(llvm::ArrayRef(operandTargetShape))) {
         return failure();
       }
-      SmallVector<int32_t> targetShape32(operandTargetShape.begin(),
-                                         operandTargetShape.end());
+      plans.push_back({reshapeInput, std::move(operandTargetShape),
+                       /*needsReshape=*/true});
+    }
+
+    // Every operand is known good, so it is now safe to mutate the IR.
+    SmallVector<Value> newOperands;
+    newOperands.reserve(plans.size());
+    for (OperandPlan &plan : plans) {
+      if (!plan.needsReshape) {
+        newOperands.push_back(plan.input);
+        continue;
+      }
+      SmallVector<int32_t> targetShape32(plan.targetShape.begin(),
+                                         plan.targetShape.end());
       auto newOperandType = utils::RankedTensorTypeFactory::create(
-          reshapeInputType, operandTargetShape);
+          cast<RankedTensorType>(plan.input.getType()), plan.targetShape);
       auto newReshape = rewriter.create<ttnn::ReshapeOp>(
-          op.getLoc(), newOperandType, reshapeInput,
+          op.getLoc(), newOperandType, plan.input,
           rewriter.getI32ArrayAttr(targetShape32));
       newOperands.push_back(newReshape.getResult());
     }
@@ -888,21 +914,45 @@ public:
 
   LogicalResult matchAndRewrite(ttnn::PermuteOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!op->hasOneUse()) {
+    if (op->use_empty()) {
       return failure();
     }
 
-    Operation *user = *op->user_begin();
-    ttnn::RepeatOp repeatUser = mlir::dyn_cast<ttnn::RepeatOp>(user);
-    ttnn::ReshapeOp reshapeUser = mlir::dyn_cast<ttnn::ReshapeOp>(user);
-    if (!reshapeUser) {
-      if (!repeatUser || !repeatUser->hasOneUse()) {
+    // Collect the reshape users. A permute can feed more than one reshape --
+    // the pixel shuffle lowering produces two that differ only by a leading
+    // unit dim -- and moving the permute to row major is just as valid there,
+    // so long as every user is a reshape that can be rewritten alongside it.
+    SmallVector<ttnn::ReshapeOp> reshapeUsers;
+    ttnn::RepeatOp repeatUser;
+    if (op->hasOneUse()) {
+      Operation *user = *op->user_begin();
+      if (auto reshape = mlir::dyn_cast<ttnn::ReshapeOp>(user)) {
+        reshapeUsers.push_back(reshape);
+      } else if (auto repeat = mlir::dyn_cast<ttnn::RepeatOp>(user)) {
+        if (!repeat->hasOneUse()) {
+          return failure();
+        }
+        auto reshape = mlir::dyn_cast<ttnn::ReshapeOp>(*repeat->user_begin());
+        if (!reshape) {
+          return failure();
+        }
+        repeatUser = repeat;
+        reshapeUsers.push_back(reshape);
+      } else {
         return failure();
       }
-      reshapeUser = mlir::dyn_cast<ttnn::ReshapeOp>(*repeatUser->user_begin());
-    }
-    if (!reshapeUser) {
-      return failure();
+    } else {
+      // With several users an interposed repeat would have to be cloned per
+      // user, which is not worth the complexity, so require plain reshapes.
+      for (Operation *user : op->getUsers()) {
+        auto reshape = mlir::dyn_cast<ttnn::ReshapeOp>(user);
+        if (!reshape) {
+          return failure();
+        }
+        if (!llvm::is_contained(reshapeUsers, reshape)) {
+          reshapeUsers.push_back(reshape);
+        }
+      }
     }
 
     auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
@@ -966,21 +1016,20 @@ public:
           repeatResultType.cloneWithEncoding(rowMajorRepeatLayout);
     }
 
-    auto reshapeResultType =
-        mlir::cast<RankedTensorType>(reshapeUser.getResult().getType());
-    auto reshapeResultLayout =
-        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(reshapeResultType.getEncoding());
-    if (!reshapeResultLayout || !reshapeResultLayout.isTiled()) {
-      return failure();
+    // Validate every reshape user before touching the IR: the greedy driver
+    // does not roll back ops created by a pattern that subsequently fails.
+    SmallVector<ttnn::TTNNLayoutAttr> reshapeResultLayouts;
+    reshapeResultLayouts.reserve(reshapeUsers.size());
+    for (ttnn::ReshapeOp reshapeUser : reshapeUsers) {
+      auto reshapeResultType =
+          mlir::cast<RankedTensorType>(reshapeUser.getResult().getType());
+      auto reshapeResultLayout =
+          mlir::dyn_cast<ttnn::TTNNLayoutAttr>(reshapeResultType.getEncoding());
+      if (!reshapeResultLayout || !reshapeResultLayout.isTiled()) {
+        return failure();
+      }
+      reshapeResultLayouts.push_back(reshapeResultLayout);
     }
-
-    auto rowMajorReshapeLayout =
-        TTNNLayoutAttr::Builder(reshapeResultLayout,
-                                reshapeResultType.getShape())
-            .setLayout(ttnn::Layout::RowMajor)
-            .build();
-    RankedTensorType rowMajorReshapeResultType =
-        reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
 
     Value permuteInput = op.getInput();
     if (!permuteInput.getDefiningOp<ttnn::ToLayoutOp>()) {
@@ -1010,19 +1059,34 @@ public:
       reshapeInput = newRepeatOp.getResult();
     }
 
-    auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
-        reshapeUser.getLoc(), rowMajorReshapeResultType, reshapeInput,
-        reshapeUser.getShapeAttr());
+    for (auto [reshapeUser, reshapeResultLayout] :
+         llvm::zip_equal(reshapeUsers, reshapeResultLayouts)) {
+      auto reshapeResultType =
+          mlir::cast<RankedTensorType>(reshapeUser.getResult().getType());
+      auto rowMajorReshapeLayout =
+          TTNNLayoutAttr::Builder(reshapeResultLayout,
+                                  reshapeResultType.getShape())
+              .setLayout(ttnn::Layout::RowMajor)
+              .build();
+      RankedTensorType rowMajorReshapeResultType =
+          reshapeResultType.cloneWithEncoding(rowMajorReshapeLayout);
 
-    auto restoredLayout = utils::createToTensorSpecOp(
-        reshapeUser,
-        mlir::cast<mlir::TypedValue<RankedTensorType>>(
-            newReshapeOp.getResult()),
-        rewriter, reshapeResultLayout.getLayout(),
-        reshapeResultLayout.getBufferType(), reshapeResultLayout.getMemLayout(),
-        reshapeResultLayout.getDataType(), "_restore_layout");
+      auto newReshapeOp = rewriter.create<ttnn::ReshapeOp>(
+          reshapeUser.getLoc(), rowMajorReshapeResultType, reshapeInput,
+          reshapeUser.getShapeAttr());
 
-    rewriter.replaceOp(reshapeUser, restoredLayout.getResult());
+      auto restoredLayout = utils::createToTensorSpecOp(
+          reshapeUser,
+          mlir::cast<mlir::TypedValue<RankedTensorType>>(
+              newReshapeOp.getResult()),
+          rewriter, reshapeResultLayout.getLayout(),
+          reshapeResultLayout.getBufferType(),
+          reshapeResultLayout.getMemLayout(), reshapeResultLayout.getDataType(),
+          "_restore_layout");
+
+      rewriter.replaceOp(reshapeUser, restoredLayout.getResult());
+    }
+
     if (repeatUser) {
       rewriter.eraseOp(repeatUser);
     }
@@ -1151,16 +1215,29 @@ public:
   void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     if (aggressiveMemorySaving) {
-      patterns.add<PropagateSliceThroughEltwise<ttnn::AddOp>,
-                   PropagateSliceThroughEltwise<ttnn::MultiplyOp>,
-                   PropagateSliceThroughEltwise<ttnn::SubtractOp>,
-                   PropagateSliceThroughEltwise<ttnn::DivideOp>,
-                   ReshapeElementwiseAdjusting<ttnn::AddOp>,
-                   ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
-                   ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
-                   ReshapeElementwiseAdjusting<ttnn::DivideOp>,
-                   PermuteRowMajorAdjusting, ReshapeRowMajorAdjusting>(
-          &getContext());
+      // aggressivePatternMask selects which aggressive pattern kinds are
+      // enabled, so a non-converging graph can be bisected down to a single
+      // pattern kind without a rebuild. All kinds are enabled by default.
+      if (aggressivePatternMask & 0x1) {
+        patterns.add<PropagateSliceThroughEltwise<ttnn::AddOp>,
+                     PropagateSliceThroughEltwise<ttnn::MultiplyOp>,
+                     PropagateSliceThroughEltwise<ttnn::SubtractOp>,
+                     PropagateSliceThroughEltwise<ttnn::DivideOp>>(
+            &getContext());
+      }
+      if (aggressivePatternMask & 0x2) {
+        patterns.add<ReshapeElementwiseAdjusting<ttnn::AddOp>,
+                     ReshapeElementwiseAdjusting<ttnn::MultiplyOp>,
+                     ReshapeElementwiseAdjusting<ttnn::SubtractOp>,
+                     ReshapeElementwiseAdjusting<ttnn::DivideOp>>(
+            &getContext());
+      }
+      if (aggressivePatternMask & 0x4) {
+        patterns.add<PermuteRowMajorAdjusting>(&getContext());
+      }
+      if (aggressivePatternMask & 0x8) {
+        patterns.add<ReshapeRowMajorAdjusting>(&getContext());
+      }
     }
     patterns.add<PropagateSliceThroughPermute, PropagateSliceThroughReshape,
                  HoistCommonReshapeAboveSlices, PropagateSliceThroughRepeat,
@@ -1168,9 +1245,21 @@ public:
 
     GreedyRewriteConfig config;
     config.setUseTopDownTraversal(true);
+    // The slice propagation patterns move a slice above a single producer at a
+    // time. Under top-down traversal the relocated slice sits behind the
+    // traversal point, so it is only reconsidered on the next sweep. Graphs
+    // with long producer chains therefore need considerably more sweeps than
+    // the greedy driver's default of 10 to reach a fixpoint.
+    config.setMaxIterations(maxIterations);
 
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns),
                                      config))) {
+      emitError(getOperation()->getLoc())
+          << "ttnn-memory-management: pattern application did not converge "
+             "within "
+          << maxIterations.getValue()
+          << " iterations; raise the pass' max-iterations option if the graph "
+             "is still making progress";
       signalPassFailure();
       return;
     }

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -27,6 +27,7 @@
 #layout_8192x16384_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x512x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_1x1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 * 8192 + d2, d3), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_4d_8192x8192x1x1_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3) -> (d0 * 8192 + d1 + d2, d3), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_3d_1x8192x8192_tile = #ttnn.ttnn_layout<(d0, d1, d2) -> (d0 * 8192 + d1, d2), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 
 module {
   // sliceReshape
@@ -163,5 +164,50 @@ module {
     %0 = "ttnn.reshape"(%arg0) <{shape = [8192 : i32, 8192 : i32, 1 : i32, 1 : i32]}> : (tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>) -> tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>
     %1 = "ttnn.permute"(%0) <{permutation = array<i64: 2, 3, 0, 1>}> : (tensor<8192x8192x1x1xf32, #layout_4d_8192x8192x1x1_tile>) -> tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
     return %1 : tensor<1x1x8192x8192xf32, #layout_4d_1x1x8192x8192_tile>
+  }
+
+  // permute feeding two reshapes row-major adjust:
+  // The pixel shuffle lowering gives the permute two reshape users that differ
+  // only by a leading unit dim. Both are rewritten alongside the permute, so
+  // the permute consumes the row-major input rather than %arg0 directly.
+  // CHECK-LABEL: func.func @permute_multi_reshape_row_major_adjusting
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
+  // CHECK-SAME: permutation = array<i64: 1, 0>
+  // CHECK-SAME: -> tensor<67108864x1xf32
+  // CHECK-DAG: "ttnn.reshape"(%[[PERM]]) <{shape = [8192 : i32, 8192 : i32]}>
+  // CHECK-DAG: "ttnn.reshape"(%[[PERM]]) <{shape = [1 : i32, 8192 : i32, 8192 : i32]}>
+  // CHECK: "ttnn.to_tensor_spec"
+  func.func @permute_multi_reshape_row_major_adjusting(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> (tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<1x8192x8192xf32, #layout_3d_1x8192x8192_tile>) {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile>
+    %2 = "ttnn.reshape"(%0) <{shape = [1 : i32, 8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<1x8192x8192xf32, #layout_3d_1x8192x8192_tile>
+    return %1, %2 : tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<1x8192x8192xf32, #layout_3d_1x8192x8192_tile>
+  }
+
+  // A multi-use permute is only rewritten when every user is a plain reshape.
+  // Here the permute result is also returned directly, so the pattern declines
+  // and the permute still consumes %arg0 with no layout ops inserted.
+  // CHECK-LABEL: func.func @permute_multi_use_non_reshape_declines
+  // CHECK: "ttnn.permute"(%arg0)
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  func.func @permute_multi_use_non_reshape_declines(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> (tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<67108864x1xf32, #layout_67Mx1_tile>) {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile>
+    return %1, %0 : tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<67108864x1xf32, #layout_67Mx1_tile>
+  }
+
+  // An interposed repeat is handled only on the single-use path (see
+  // @permute_repeat_reshape_row_major_adjusting); alongside a second user it
+  // would have to be cloned per user, so the pattern declines instead.
+  // CHECK-LABEL: func.func @permute_multi_use_repeat_declines
+  // CHECK: "ttnn.permute"(%arg0)
+  // CHECK-NOT: "ttnn.to_tensor_spec"
+  func.func @permute_multi_use_repeat_declines(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> (tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<8192x16384xf32, #layout_8192x16384_tile>) {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile>
+    %2 = "ttnn.repeat"(%0) <{repeat_dims = #ttnn.shape<1x2>}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<67108864x2xf32, #layout_67Mx2_tile>
+    %3 = "ttnn.reshape"(%2) <{shape = [8192 : i32, 16384 : i32]}> : (tensor<67108864x2xf32, #layout_67Mx2_tile>) -> tensor<8192x16384xf32, #layout_8192x16384_tile>
+    return %1, %3 : tensor<8192x8192xf32, #layout_8192x8192_tile>, tensor<8192x16384xf32, #layout_8192x16384_tile>
   }
 }

--- a/test/ttmlir/Transforms/memory_management_options.mlir
+++ b/test/ttmlir/Transforms/memory_management_options.mlir
@@ -1,0 +1,42 @@
+// Diagnostic options on --ttnn-memory-management. Both default to current
+// behaviour; they exist so a non-converging graph can be characterised and
+// bisected without a rebuild.
+
+// Default: every aggressive pattern kind is registered, so PermuteRowMajorAdjusting fires.
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-memory-management -o %t.default %s
+// RUN: FileCheck %s --input-file=%t.default --check-prefix=DEFAULT
+
+// aggressive-pattern-mask=11 clears 0x4, leaving PermuteRowMajorAdjusting out
+// of the pattern set while the other three kinds stay enabled.
+// RUN: ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-memory-management="aggressive-pattern-mask=11" -o %t.masked %s
+// RUN: FileCheck %s --input-file=%t.masked --check-prefix=MASKED
+
+// max-iterations=1 lets the driver run a single sweep. That sweep rewrites the
+// permute, so it ends with changes still pending and the pass reports
+// non-convergence instead of failing mute.
+// RUN: not ttmlir-opt --ttcore-register-device="system-desc-path=%system_desc_path%" --ttnn-memory-management="max-iterations=1" -o %t.noconv %s 2>&1 | FileCheck %s --check-prefix=NOCONV
+
+// NOCONV: ttnn-memory-management: pattern application did not converge within 1 iterations
+// NOCONV-SAME: max-iterations
+
+#dram = #ttnn.buffer_type<dram>
+#layout_1x67M_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<1x2097152x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_67Mx1_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<2097152x1x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+#layout_8192x8192_tile = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<256x256x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
+
+module {
+  // DEFAULT-LABEL: func.func @permute_reshape_row_major_gated
+  // DEFAULT: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // DEFAULT: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
+  // DEFAULT-SAME: -> tensor<67108864x1xf32
+  // DEFAULT: "ttnn.reshape"(%[[PERM]]) <{shape = [8192 : i32, 8192 : i32]}>
+
+  // MASKED-LABEL: func.func @permute_reshape_row_major_gated
+  // MASKED: "ttnn.permute"(%arg0)
+  // MASKED-NOT: "ttnn.to_tensor_spec"
+  func.func @permute_reshape_row_major_gated(%arg0: tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile> {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 1, 0>}> : (tensor<1x67108864xf32, #layout_1x67M_tile>) -> tensor<67108864x1xf32, #layout_67Mx1_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [8192 : i32, 8192 : i32]}> : (tensor<67108864x1xf32, #layout_67Mx1_tile>) -> tensor<8192x8192xf32, #layout_8192x8192_tile>
+    return %1 : tensor<8192x8192xf32, #layout_8192x8192_tile>
+  }
+}


### PR DESCRIPTION
### Ticket
Fixes [#5935](https://github.com/tenstorrent/tt-xla/issues/5935)

### Problem description

- The Mochi VAE decoder component test is xfailed with DRAM OOM during sharded decoder pixel-shuffle intermediate (tt-xla#4252) despite running with experimental-enable-dram-space-saving-optimization set, which reaches ttnn-memory-management as aggressiveMemorySaving via dramSpaceSavingOptimizationEnabled in TTNNPipelines.cpp. The pass that is supposed to relieve that intermediate never does, for two independent reasons.

- PermuteRowMajorAdjusting is the pattern that moves a permute feeding a reshape into row-major layout, which is what keeps TILE layout from padding the decoder's unpatchify permute's size-2 dim out to 32. It opened with if (!op->hasOneUse()) return failure();. The pixel shuffle lowering emits a permute feeding two reshapes that differ only by a leading unit dim, so the pattern matched nothing and the permute stayed tiled — the rewrite that the compile option was enabled for simply did not fire, silently.

- ReshapeElementwiseAdjusting walked the eltwise operands and called rewriter.create<ttnn::ReshapeOp>() inside that loop, but could still return failure() on a later operand's volume-mismatch check. The greedy rewrite driver does not roll back ops created by a pattern that subsequently returns failure, so those reshapes were left behind, erased as trivially dead, and then recreated identically on the next sweep. That registers as activity without net change, so applyPatternsGreedily never reaches a fixpoint, exhausts its iteration budget and returns failure — which runOnOperation turned into a bare signalPassFailure() with no diagnostic explaining why. Separately, the slice-propagation patterns move a slice above one producer per application, and under top-down traversal the relocated slice sits behind the traversal point, so a long producer chain needs one sweep per link.

### What's changed

- In TTNNMemoryManagement.cpp, ReshapeElementwiseAdjusting::matchAndRewrite is split into a plan phase and an apply phase. A new local OperandPlan { Value input; SmallVector<int64_t> targetShape; bool needsReshape; } records each operand's validated target shape, and the loop that creates ttnn::ReshapeOp runs only after every operand is known good, so a bail-out can no longer leave dead IR for the driver to churn on. The new-operand type is now built from plan.input.getType() rather than the loop-local reshapeInputType, which is no longer in scope in the apply phase.

- PermuteRowMajorAdjusting now gates on op->use_empty() and collects a SmallVector<ttnn::ReshapeOp> reshapeUsers. The single-use path keeps both existing shapes — permute→reshape and permute→repeat→reshape, the latter still requiring the repeat to have one use. The multi-use path requires every user to be a plain reshape, deduped via llvm::is_contained; an interposed repeat is rejected there because it would have to be cloned per user. All reshape-user layouts are validated into reshapeResultLayouts before any IR is touched, for the same no-rollback reason as above, and each user is then rewritten to a row-major reshape plus a createToTensorSpecOp restore and replaced, with the repeat erased once at the end.

- Two options are added to TTNNMemoryManagement in Passes.td. max-iterations (default 10) is wired to config.setMaxIterations() so the sweep budget can be raised for a graph with long producer chains without a rebuild. aggressive-pattern-mask (default 15) is a bitmask over the aggressive pattern kinds — 0x1 PropagateSliceThroughEltwise, 0x2 ReshapeElementwiseAdjusting, 0x4 PermuteRowMajorAdjusting, 0x8 ReshapeRowMajorAdjusting — so a non-converging graph can be bisected down to a single kind. Both default to current behaviour. Non-convergence now emits an error naming the iteration count and pointing at max-iterations before signalPassFailure(), instead of failing mute.

### Logs
[memory_management_options.log](https://github.com/user-attachments/files/32001520/memory_management_options.log)
[memory_management.log](https://github.com/user-attachments/files/32001525/memory_management.log)
