### PR TITLE
[TTNN] Avoid DRAM page padding for thin-last-dim permutes in memory management

### DIFF
--- a/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNMemoryManagement.cpp
@@ -9,6 +9,8 @@
 
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include <cstdint>
+#include <optional>
+#include <utility>
 
 namespace mlir::tt::ttnn {
 #define GEN_PASS_DEF_TTNNMEMORYMANAGEMENT
@@ -882,6 +884,164 @@ public:
   }
 };
 
+// Row-major rows narrower than this pay DRAM page padding.
+constexpr int64_t kMinWideRowElems = ttcore::TileType::getDefaultShape()[1];
+
+// Per `dst` dim, the [begin, end) range of adjacent `src` dims it merges;
+// nullopt if `dst` is not a pure merge of `src`.
+static std::optional<llvm::SmallVector<std::pair<int64_t, int64_t>>>
+computeCollapseGroups(llvm::ArrayRef<int64_t> src,
+                      llvm::ArrayRef<int64_t> dst) {
+  const int64_t srcRank = static_cast<int64_t>(src.size());
+  const int64_t dstRank = static_cast<int64_t>(dst.size());
+  llvm::SmallVector<std::pair<int64_t, int64_t>> groups;
+  int64_t s = 0;
+  for (int64_t d = 0; d < dstRank; ++d) {
+    const int64_t begin = s;
+    int64_t prod = 1;
+    while (s < srcRank && (s == begin || prod < dst[d])) {
+      prod *= src[s++];
+    }
+    if (prod != dst[d] || s == begin) {
+      return std::nullopt;
+    }
+    // Absorb trailing unit dims while enough src dims remain for the rest.
+    while (s < srcRank && src[s] == 1 && (srcRank - s) > (dstRank - d - 1)) {
+      ++s;
+    }
+    groups.emplace_back(begin, s);
+  }
+  if (s != srcRank) {
+    return std::nullopt;
+  }
+  return groups;
+}
+
+// Widest dim of the permute result (at least kMinWideRowElems) that the
+// reshape passes through unchanged, as (dim in permute result, dim in reshape
+// result); nullopt if there is none.
+static std::optional<std::pair<int64_t, int64_t>>
+findWidestPassThroughDim(llvm::ArrayRef<int64_t> permuteShape,
+                         llvm::ArrayRef<std::pair<int64_t, int64_t>> groups) {
+  std::optional<std::pair<int64_t, int64_t>> best;
+  for (auto [reshapeDim, group] : llvm::enumerate(groups)) {
+    if (group.second - group.first != 1) {
+      continue;
+    }
+    int64_t permuteDim = group.first;
+    if (permuteShape[permuteDim] < kMinWideRowElems) {
+      continue;
+    }
+    if (!best || permuteShape[permuteDim] > permuteShape[best->first]) {
+      best = {permuteDim, static_cast<int64_t>(reshapeDim)};
+    }
+  }
+  return best;
+}
+
+// permute(P) -> reshape, where the permute result has a thin last dim, becomes
+//   permute(P, dim k last) -> reshape -> to_layout(tile) -> permute(dim k back)
+// with k the widest dim the reshape passes through unchanged.
+static LogicalResult rewriteThinLastDimPermute(ttnn::PermuteOp op,
+                                               ttnn::ReshapeOp reshapeUser,
+                                               PatternRewriter &rewriter) {
+  auto inputType = mlir::cast<RankedTensorType>(op.getInput().getType());
+  auto resultType = mlir::cast<RankedTensorType>(op.getResult().getType());
+  auto reshapeType =
+      mlir::cast<RankedTensorType>(reshapeUser.getResult().getType());
+  llvm::ArrayRef<int64_t> inShape = inputType.getShape();
+  llvm::ArrayRef<int64_t> yShape = resultType.getShape();
+  llvm::ArrayRef<int64_t> zShape = reshapeType.getShape();
+
+  if (yShape.size() < 2 || yShape.back() >= kMinWideRowElems ||
+      inShape.back() < kMinWideRowElems) {
+    return failure();
+  }
+
+  auto groups = computeCollapseGroups(yShape, zShape);
+  if (!groups) {
+    return failure();
+  }
+
+  auto wideDim = findWidestPassThroughDim(yShape, *groups);
+  if (!wideDim) {
+    return failure();
+  }
+  const auto [permuteDim, reshapeDim] = *wideDim;
+
+  llvm::SmallVector<int64_t> perm(op.getPermutation());
+  const int64_t movedSrcDim = perm[permuteDim];
+  perm.erase(perm.begin() + permuteDim);
+  perm.push_back(movedSrcDim);
+
+  llvm::SmallVector<int64_t> yPrimeShape(yShape);
+  yPrimeShape.erase(yPrimeShape.begin() + permuteDim);
+  yPrimeShape.push_back(yShape[permuteDim]);
+
+  llvm::SmallVector<int64_t> zPrimeShape(zShape);
+  zPrimeShape.erase(zPrimeShape.begin() + reshapeDim);
+  zPrimeShape.push_back(zShape[reshapeDim]);
+
+  // Moves the last dim of Z' back to position reshapeDim.
+  const int64_t zRank = static_cast<int64_t>(zShape.size());
+  llvm::SmallVector<int64_t> backPerm;
+  for (int64_t i = 0; i < reshapeDim; ++i) {
+    backPerm.push_back(i);
+  }
+  backPerm.push_back(zRank - 1);
+  for (int64_t i = reshapeDim; i < zRank - 1; ++i) {
+    backPerm.push_back(i);
+  }
+
+  Value permuteInput = op.getInput();
+  if (!permuteInput.getDefiningOp<ttnn::ToLayoutOp>()) {
+    auto inputLayout =
+        mlir::dyn_cast<ttnn::TTNNLayoutAttr>(inputType.getEncoding());
+    if (inputLayout && inputLayout.isTiled()) {
+      permuteInput =
+          utils::createToTensorSpecOp(
+              op, mlir::cast<mlir::TypedValue<RankedTensorType>>(permuteInput),
+              rewriter, Layout::RowMajor, inputLayout.getBufferType(),
+              inputLayout.getMemLayout(), inputLayout.getDataType(),
+              "_input_row_major")
+              .getResult();
+    }
+  }
+
+  RankedTensorType yPrimeType = utils::RankedTensorTypeFactory::create(
+      utils::RankedTensorTypeFactory::create(resultType, yPrimeShape),
+      Layout::RowMajor);
+  auto newPermute = rewriter.create<ttnn::PermuteOp>(
+      op.getLoc(), yPrimeType, permuteInput, llvm::ArrayRef<int64_t>(perm),
+      op.getPadValue());
+
+  RankedTensorType zPrimeType = utils::RankedTensorTypeFactory::create(
+      utils::RankedTensorTypeFactory::create(reshapeType, zPrimeShape),
+      Layout::RowMajor);
+  llvm::SmallVector<int32_t> zPrimeShape32(zPrimeShape.begin(),
+                                           zPrimeShape.end());
+  auto newReshape = rewriter.create<ttnn::ReshapeOp>(
+      reshapeUser.getLoc(), zPrimeType, newPermute.getResult(),
+      rewriter.getI32ArrayAttr(zPrimeShape32));
+
+  auto reshapeLayout =
+      mlir::cast<ttnn::TTNNLayoutAttr>(reshapeType.getEncoding());
+  auto restoredLayout = utils::createToTensorSpecOp(
+      reshapeUser,
+      mlir::cast<mlir::TypedValue<RankedTensorType>>(newReshape.getResult()),
+      rewriter, reshapeLayout.getLayout(), reshapeLayout.getBufferType(),
+      reshapeLayout.getMemLayout(), reshapeLayout.getDataType(),
+      "_restore_layout");
+
+  auto backPermute = rewriter.create<ttnn::PermuteOp>(
+      reshapeUser.getLoc(), reshapeType, restoredLayout.getResult(),
+      llvm::ArrayRef<int64_t>(backPerm), op.getPadValue());
+
+  rewriter.replaceOp(reshapeUser, backPermute.getResult());
+  rewriter.eraseOp(op);
+  return success();
+}
+
 class PermuteRowMajorAdjusting : public OpRewritePattern<ttnn::PermuteOp> {
 public:
   using OpRewritePattern::OpRewritePattern;
@@ -942,6 +1102,11 @@ public:
     // If the difference is less than 1GB, nothing to do.
     if (tiledVolume - rmVolume < 1LL * 1024LL * 1024LL * 1024LL) {
       return failure();
+    }
+
+    if (!repeatUser &&
+        succeeded(rewriteThinLastDimPermute(op, reshapeUser, rewriter))) {
+      return success();
     }
 
     auto rowMajorLayout =

--- a/test/ttmlir/Transforms/memory_management.mlir
+++ b/test/ttmlir/Transforms/memory_management.mlir
@@ -37,6 +37,9 @@
 #layout_100x50 = #ttnn.ttnn_layout<(d0, d1) -> (d0, d1), <1x1>, memref<4x2x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_5000_t = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x157x!ttcore.tile<32x32, f32>, #dram>, <interleaved>>
 #layout_5000_rm = #ttnn.ttnn_layout<(d0) -> (0, d0), <1x1>, memref<1x5000xf32, #dram>, <interleaved>>
+#layout_ps_in_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0 * 2228224 + d1 * 2228224 + d2 * 1114112 + d3 * 557056 + d4 * 2176 + d5 * 128 + d6, d7), <1x1>, memref<69632x7x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_ps_perm_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0 * 233963520 + d1 * 913920 + d2 * 53760 + d3 * 53760 + d4 * 448 + d5 * 224 + d6, d7), <1x1>, memref<7311360x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+#layout_ps_out_tile = #ttnn.ttnn_layout<(d0, d1, d2, d3, d4) -> (d0 * 1114112 + d1 * 4352 + d2 * 256 + d3, d4), <1x1>, memref<34816x14x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
 
 module {
   // sliceReshape
@@ -245,5 +248,24 @@ module {
     %0 = "ttnn.reshape"(%arg0) <{shape = [5000 : i32]}> : (tensor<100x50xf32, #layout_100x50>) -> tensor<5000xf32, #layout_5000_t>
     %1 = "ttnn.to_tensor_spec"(%0) : (tensor<5000xf32, #layout_5000_t>) -> tensor<5000xf32, #layout_5000_rm>
     return %1 : tensor<5000xf32, #layout_5000_rm>
+  }
+
+  // permute-reshape with a thin last dim: wide dim moved last for the rewrite.
+  // CHECK-LABEL: func.func @permute_reshape_thin_last_dim_wide_row
+  // CHECK: %[[RM_IN:.*]] = "ttnn.to_tensor_spec"(%arg0)
+  // CHECK: %[[PERM:.*]] = "ttnn.permute"(%[[RM_IN]])
+  // CHECK-SAME: permutation = array<i64: 0, 5, 1, 6, 2, 7, 3, 4>
+  // CHECK-SAME: -> tensor<1x17x1x120x2x212x2x256xbf16
+  // CHECK: %[[RESHAPE:.*]] = "ttnn.reshape"(%[[PERM]]) <{shape = [1 : i32, 17 : i32, 240 : i32, 424 : i32, 256 : i32]}>
+  // CHECK-SAME: -> tensor<1x17x240x424x256xbf16
+  // CHECK: %[[RESTORED:.*]] = "ttnn.to_tensor_spec"(%[[RESHAPE]])
+  // CHECK: %[[BACK:.*]] = "ttnn.permute"(%[[RESTORED]])
+  // CHECK-SAME: permutation = array<i64: 0, 4, 1, 2, 3>
+  // CHECK-SAME: -> tensor<1x256x17x240x424xbf16
+  // CHECK: return %[[BACK]]
+  func.func @permute_reshape_thin_last_dim_wide_row(%arg0: tensor<1x1x2x2x256x17x120x212xbf16, #layout_ps_in_tile>) -> tensor<1x256x17x240x424xbf16, #layout_ps_out_tile> {
+    %0 = "ttnn.permute"(%arg0) <{permutation = array<i64: 0, 4, 5, 1, 6, 2, 7, 3>}> : (tensor<1x1x2x2x256x17x120x212xbf16, #layout_ps_in_tile>) -> tensor<1x256x17x1x120x2x212x2xbf16, #layout_ps_perm_tile>
+    %1 = "ttnn.reshape"(%0) <{shape = [1 : i32, 256 : i32, 17 : i32, 240 : i32, 424 : i32]}> : (tensor<1x256x17x1x120x2x212x2xbf16, #layout_ps_perm_tile>) -> tensor<1x256x17x240x424xbf16, #layout_ps_out_tile>
+    return %1 : tensor<1x256x17x240x424xbf16, #layout_ps_out_tile>
   }
 }


### PR DESCRIPTION
## Ticket

https://github.com/tenstorrent/tt-xla/issues/6048

## Problem

`PermuteRowMajorAdjusting` moves a `permute -> reshape` pair to row-major when the tile-padded permute result is much larger than its logical size. This is the right fix when the row-major rows are wide, but it does not reduce memory when the permute result's **last dim is thin** (e.g. 2, the pixel-shuffle case): every row-major row is its own DRAM page, padded to the DRAM alignment (64 B on Blackhole, 32 B on Wormhole), so a 2-element bf16 row still costs 64 B. Observed this case in HunyuanVideo-1.5 VAE decoder. Full analysis, repro and logs: tenstorrent/tt-xla#6048 ([comment](https://github.com/tenstorrent/tt-xla/issues/6048#issuecomment-5588837438)).

Note: the HunyuanVideo-1.5 decoder is no longer blocked on this PR. Its tiled variant, passes on current main without this change, since 256x256 tiles keep every intermediate small [https://github.com/tenstorrent/tt-xla/issues/6048#issuecomment-5599279287](https://github.com/tenstorrent/tt-xla/issues/6048#issuecomment-5599279287). This PR still removes the 16x DRAM blow-up for the non-tiled path, and may help other models whose pixel shuffle produces the same thin-last-dim permute.


## Fix

Extend `PermuteRowMajorAdjusting`: when the permute result's last dim is < 32 elements and the following reshape only merges adjacent dims, move the widest dim the reshape passes through unchanged (the channel dim) to the end before permuting. Rows are then wide, the reshape becomes a free view, and one extra tiled permute restores the dim order:

```
permute(P) -> reshape
=> to_layout(rm) -> permute(P, dim k last) -> reshape -> to_layout(tile) -> permute(dim k back)
```

Pure data movement, bit-exact. Falls back to the existing rewrite when the pattern does not apply. Same approach tt-metal's hand-written VAEs use (channels-last shuffle): Mochi [`depth_to_spacetime`](https://github.com/tenstorrent/tt-metal/blob/d5f9bc4a43b1287523458f1af6a470c6b2adc180/models/tt_dit/models/vae/vae_mochi.py#L868-L905), LTX [`_depth_to_space_bthwc_2x`](https://github.com/tenstorrent/tt-metal/blob/d5f9bc4a43b1287523458f1af6a470c6b2adc180/models/tt_dit/models/upsampler/latent_upsampler_ltx.py#L85-L93).

## Results

Sanity test (`view -> permute -> reshape`, up_blocks[3] shape), DRAM per bank; output matches the CPU reference:

| | before | after |
|---|---|---|
| permute output | +3379 MiB | +211 MiB (= logical size) |
| peak | 3817 MiB | 657 MiB |

Decoder: the `up_blocks[3]` OOM is gone and both pixel-shuffle permutes per block are rewritten. The decoder now advances into `up_blocks[4]`, where it hits a different OOM (f32 replicate-padding temporaries of the full-resolution conv3d) that is unrelated to this pattern, so its end-to-end PCC is not yet measurable.

## Checklist 

- [x] Verify the changes through local testing in QB2 

### Logs

- [sep7_Hunyuan_1_5_decoder_before_fix.log.zip](https://github.com/user-attachments/files/31923370/sep7_Hunyuan_1_5_decoder_dram_save.log.zip)
- [sep8_pixel_shuffle_permute_before_fix.log](https://github.com/user-attachments/files/31991126/sep8_pixel_shuffle_permute.log)
- [sep8_pixel_shuffle_permute_after_fix.log](https://github.com/user-attachments/files/31991124/sep8_pixel_shuffle_permute_after_fix.log)
- [sep8_Hunyuan_1_5_vae_decoder_after_fix.log.zip](https://github.com/user-attachments/files/31991130/sep8_Hunyuan_1_5_vae_decoder_after_fix.log.zip)


