### PR TITLE
[TTML] Add rmsnorm_fw op

### DIFF
--- a/include/ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h
+++ b/include/ttmlir/Dialect/TTNN/Analysis/OpRules/NormalizationRules.h
@@ -58,6 +58,17 @@ struct RmsNormRuleBook : OpRuleBook {
                           bool requiresReshard) const override;
 };
 
+/// TTML RMS norm forward: The backend requires all operands to be tiled and
+/// DRAM-interleaved. It derives the output and optional RMS layouts from the
+/// input.
+struct TTMLRMSNormForwardRuleBook : OpRuleBook {
+  LayoutFilterFn getInputLayoutFilter(unsigned operandIdx) const override;
+  bool shouldExploreReshards() const override;
+  OutputHints
+  getOutputHints(Operation *op,
+                 const std::vector<OpConfig> &legalConfigs) const override;
+};
+
 } // namespace mlir::tt::ttnn
 
 #endif // TTMLIR_DIALECT_TTNN_ANALYSIS_OPRULES_NORMALIZATIONRULES_H

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNOps.td
@@ -2895,6 +2895,42 @@ def TTNN_SDPABackwardOp : TTNN_Op<"sdpa_bw"> {
     let hasVerifier = 1;
 }
 
+def TTNN_RMSNormForwardOp : TTNN_Op<"rmsnorm_fw"> {
+    let summary = "Root mean square normalization forward (ttml).";
+    let description = [{
+      Training-oriented fused RMS normalization forward pass, backed by the
+      ttml metal op `ttml::metal::rmsnorm_fw`. Computes RMS normalization over
+      the last dimension and scales the normalized values by `gamma`:
+      `output = input / rms * gamma`, where
+      `rms = sqrt(mean(input^2) + epsilon)`.
+
+      When `return_intermediates` is set, the per-row `rms` is also returned so
+      the backward pass can reuse it.
+
+      The backing kernel requires `input` and `gamma` to be 4D bfloat16 tensors
+      in tiled, interleaved device memory. The output has the same shape as
+      `input`, while `rms` has the same shape except that its last dimension is
+      one.
+    }];
+
+    let arguments = (ins AnyRankedTensor:$input,
+                         AnyRankedTensor:$gamma,
+                         DefaultValuedAttr<BoolAttr, "true">:$return_intermediates,
+                         DefaultValuedAttr<F32Attr, "1e-06">:$epsilon);
+
+    let results = (outs AnyRankedTensor:$output,
+                        Optional<AnyRankedTensor>:$rms);
+
+    let extraClassDeclaration = [{
+      wa::TTNNOperandsWorkarounds getOperandsWorkarounds() {
+        return wa::TTNNOperandsWorkaroundsFactory::
+            createRMSNormForwardOpOperandsWorkarounds(this->getOperation());
+      }
+    }];
+
+    let hasVerifier = 1;
+}
+
 def TTNN_LayerNormForwardOp : TTNN_Op<"layernorm_fw",
     [SameVariadicResultSize]> {
     let summary = "Layer normalization forward (ttml).";

--- a/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
+++ b/include/ttmlir/Dialect/TTNN/IR/TTNNWorkaroundsPass.h
@@ -399,6 +399,12 @@ public:
   static TTNNOperandsWorkarounds
   createSDPABackwardOpOperandsWorkarounds(Operation *op);
 
+  // Create workarounds for the ttml rmsnorm_fw op: force bf16, tile layout
+  // and DRAM interleaved memory for every operand and result. The backing metal
+  // op (ttml::metal::rmsnorm_fw) TT_FATALs on anything else.
+  static TTNNOperandsWorkarounds
+  createRMSNormForwardOpOperandsWorkarounds(Operation *op);
+
   // Create workarounds for the ttml layernorm_fw op: force bf16, tile layout
   // and DRAM interleaved memory for every operand and result. The backing metal
   // op (ttml::metal::layernorm_fw) TT_FATALs on anything else.

--- a/include/ttmlir/OpModel/TTNN/MetalHeaders.h
+++ b/include/ttmlir/OpModel/TTNN/MetalHeaders.h
@@ -35,6 +35,7 @@ extract_output_tensor(const std::tuple<Tensor, Tensor, Tensor> &result) {
 #include "metal/ops/cross_entropy_bw/cross_entropy_bw.hpp"
 #include "metal/ops/cross_entropy_fw/cross_entropy_fw.hpp"
 #include "metal/ops/layernorm_fw/layernorm_fw.hpp"
+#include "metal/ops/rmsnorm_fw/rmsnorm_fw.hpp"
 #include "metal/ops/sdpa_bw/sdpa_bw.hpp"
 #include "metal/ops/sdpa_fw/sdpa_fw.hpp"
 #include "metal/optimizers/adamw/adamw.hpp"

--- a/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
+++ b/include/ttmlir/OpModel/TTNN/TTNNOpModel.h
@@ -2432,6 +2432,27 @@ struct OpModel<SDPABackwardOp> {
 };
 
 //===----------------------------------------------------------------------===//
+// RMSNormForwardOp
+//===----------------------------------------------------------------------===//
+
+template <>
+struct OpModel<RMSNormForwardOp> {
+  static llvm::Expected<OpConstraints>
+  getOpConstraints(llvm::ArrayRef<int64_t> inputShape,
+                   TTNNLayoutAttr inputLayout,
+                   llvm::ArrayRef<int64_t> gammaShape,
+                   TTNNLayoutAttr gammaLayout, bool returnIntermediates,
+                   llvm::APFloat epsilon, TTNNLayoutAttr outputLayout,
+                   const MockAllocatorState *initialState = nullptr);
+
+  static llvm::Expected<size_t>
+  getOpRuntime(llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+               llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+               bool returnIntermediates, llvm::APFloat epsilon,
+               TTNNLayoutAttr outputLayout);
+};
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp
 //===----------------------------------------------------------------------===//
 

--- a/include/ttmlir/Target/TTNN/operations/ttml.fbs
+++ b/include/ttmlir/Target/TTNN/operations/ttml.fbs
@@ -31,6 +31,15 @@ table SDPAForwardOp {
   intermediates: tt.target.ttnn.TensorRef;
 }
 
+table RMSNormForwardOp {
+  input: tt.target.ttnn.TensorRef;
+  gamma: tt.target.ttnn.TensorRef;
+  return_intermediates: bool = true;
+  epsilon: float = 1e-6;
+  out: tt.target.ttnn.TensorRef;
+  rms: tt.target.ttnn.TensorRef;
+}
+
 table LayerNormForwardOp {
   input: tt.target.ttnn.TensorRef;
   weight: tt.target.ttnn.TensorRef;

--- a/include/ttmlir/Target/TTNN/program.fbs
+++ b/include/ttmlir/Target/TTNN/program.fbs
@@ -134,6 +134,7 @@ union OpType {
   ReduceScatterOp,
   RepeatInterleaveOp,
   RepeatOp,
+  RMSNormForwardOp,
   RMSNormPreAllGatherOp,
   RMSNormOp,
   ReshapeOp,

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1288,6 +1288,71 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
+// RMSNorm forward decomposition pattern
+//===----------------------------------------------------------------------===//
+
+// ttml::metal::rmsnorm_fw only accepts rank-4 tensors. Normalize the
+// composite signature while preserving a valid decomposition fallback.
+namespace {
+struct RMSNormForwardPattern : public OpConversionPattern<ttcore::CompositeOp> {
+public:
+  using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (op.getCompositeName() != "rmsnorm_fw") {
+      return failure();
+    }
+
+    auto isRank4 = [](Value value) {
+      return cast<RankedTensorType>(value.getType()).getRank() == 4;
+    };
+    if (llvm::all_of(adaptor.getInputs(), isRank4) &&
+        llvm::all_of(op.getResults(), isRank4)) {
+      return rewriter.notifyMatchFailure(op, "already 4D");
+    }
+
+    Location loc = op.getLoc();
+    SmallVector<Value> inputs4D;
+    for (Value input : adaptor.getInputs()) {
+      inputs4D.push_back(reshapeToRank4IfNeeded(rewriter, loc, input));
+    }
+
+    SmallVector<Type> resultTypes4D;
+    for (Type type : op.getResultTypes()) {
+      auto tensorType = cast<RankedTensorType>(type);
+      SmallVector<int64_t, 4> shape4D;
+      if (tensorType.getRank() == 4) {
+        shape4D.assign(tensorType.getShape().begin(),
+                       tensorType.getShape().end());
+      } else {
+        shape4D = collapseShapeToRank4(tensorType.getShape());
+      }
+      resultTypes4D.push_back(RankedTensorType::get(
+          shape4D, tensorType.getElementType(), tensorType.getEncoding()));
+    }
+
+    auto decomposition = createRank4DecompositionWrapper(
+        op, TypeRange(inputs4D), resultTypes4D, rewriter);
+    auto rmsNorm4D = rewriter.create<ttcore::CompositeOp>(
+        loc, resultTypes4D, inputs4D, op.getCompositeNameAttr(), decomposition,
+        op.getCompositeAttributesAttr());
+
+    SmallVector<Value> restored;
+    for (auto [result4D, originalType] :
+         llvm::zip(rmsNorm4D.getResults(), op.getResultTypes())) {
+      restored.push_back(
+          reshapeValue(rewriter, loc, result4D,
+                       cast<RankedTensorType>(originalType).getShape()));
+    }
+    rewriter.replaceOp(op, restored);
+    return success();
+  }
+};
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // LayerNorm forward decomposition pattern
 //===----------------------------------------------------------------------===//
 
@@ -2572,6 +2637,7 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<AdamWPattern>(typeConverter, ctx);
   patterns.add<SDPAForwardPattern>(typeConverter, ctx);
   patterns.add<SDPABackwardPattern>(typeConverter, ctx);
+  patterns.add<RMSNormForwardPattern>(typeConverter, ctx);
   patterns.add<LayerNormForwardPattern>(typeConverter, ctx);
   patterns.add<CrossEntropyForwardPattern>(typeConverter, ctx);
   patterns.add<CrossEntropyBackwardPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecomposition.cpp
@@ -1151,157 +1151,22 @@ public:
 } // namespace
 
 //===----------------------------------------------------------------------===//
-// SDPA forward decomposition pattern
+// Rank-4 composite decomposition pattern
 //===----------------------------------------------------------------------===//
 
-// ttml::metal::sdpa_fw only accepts rank-4 (B, H, S, D) tensors. Attention is
-// independent across the leading batch/head dims, so collapse every operand up
-// to 4D and reshape the results back to their original rank.
+// These ttml::metal ops only accept rank-4 tensors. Rehsape every operand to
+// 4D and the results back to their original rank.
 namespace {
-struct SDPAForwardPattern : public OpConversionPattern<ttcore::CompositeOp> {
+struct Rank4CompositePattern : public OpConversionPattern<ttcore::CompositeOp> {
 public:
   using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (op.getCompositeName() != "sdpa_fw") {
-      return failure();
-    }
-
-    auto isRank4 = [](mlir::Value value) {
-      return mlir::cast<RankedTensorType>(value.getType()).getRank() == 4;
-    };
-
-    // Only reshape when some operand/result is not already rank 4; otherwise
-    // this pattern would keep re-matching its own (already 4D) output.
-    if (llvm::all_of(adaptor.getInputs(), isRank4) &&
-        llvm::all_of(op.getResults(), isRank4)) {
-      return rewriter.notifyMatchFailure(op, "already 4D");
-    }
-
-    llvm::SmallVector<mlir::Type> resultTypes4D;
-    for (mlir::Type type : op.getResultTypes()) {
-      auto tensorType = mlir::cast<RankedTensorType>(type);
-      llvm::SmallVector<int64_t, 4> shape4D;
-      if (tensorType.getRank() == 4) {
-        shape4D.assign(tensorType.getShape().begin(),
-                       tensorType.getShape().end());
-      } else {
-        shape4D = collapseShapeToRank4(tensorType.getShape());
-      }
-      resultTypes4D.push_back(RankedTensorType::get(
-          shape4D, tensorType.getElementType(), tensorType.getEncoding()));
-    }
-
-    Location loc = op.getLoc();
-    auto inputs4D = llvm::map_to_vector(
-        adaptor.getInputs(), [&rewriter, loc](mlir::Value value) {
-          return reshapeToRank4IfNeeded(rewriter, loc, value);
-        });
-
-    auto decomposition = createRank4DecompositionWrapper(
-        op, TypeRange(inputs4D), resultTypes4D, rewriter);
-    auto sdpa4D = rewriter.create<ttcore::CompositeOp>(
-        loc, resultTypes4D, inputs4D, op.getCompositeNameAttr(), decomposition,
-        op.getCompositeAttributesAttr());
-
-    llvm::SmallVector<mlir::Value> restored;
-    for (auto [result4D, originalType] :
-         llvm::zip(sdpa4D.getResults(), op.getResultTypes())) {
-      restored.push_back(
-          reshapeValue(rewriter, loc, result4D,
-                       mlir::cast<RankedTensorType>(originalType).getShape()));
-    }
-    rewriter.replaceOp(op, restored);
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// SDPA backward decomposition pattern
-//===----------------------------------------------------------------------===//
-
-// ttml::metal::sdpa_bw only accepts rank-4 (B, H, S, D) tensors. Attention is
-// independent across the leading batch/head dims, so collapse every operand up
-// to 4D and reshape the results back to their original rank.
-namespace {
-struct SDPABackwardPattern : public OpConversionPattern<ttcore::CompositeOp> {
-public:
-  using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (op.getCompositeName() != "sdpa_bw") {
-      return failure();
-    }
-
-    auto isRank4 = [](mlir::Value value) {
-      return mlir::cast<RankedTensorType>(value.getType()).getRank() == 4;
-    };
-
-    // Only reshape when some operand/result is not already rank 4.
-    if (llvm::all_of(adaptor.getInputs(), isRank4) &&
-        llvm::all_of(op->getResults(), isRank4)) {
-      return rewriter.notifyMatchFailure(op, "already 4D");
-    }
-
-    llvm::SmallVector<mlir::Type> resultTypes4D;
-    for (mlir::Type type : op.getResultTypes()) {
-      auto tensorType = mlir::cast<RankedTensorType>(type);
-      llvm::SmallVector<int64_t, 4> shape4D;
-      if (tensorType.getRank() == 4) {
-        shape4D.assign(tensorType.getShape().begin(),
-                       tensorType.getShape().end());
-      } else {
-        shape4D = collapseShapeToRank4(tensorType.getShape());
-      }
-      resultTypes4D.push_back(RankedTensorType::get(
-          shape4D, tensorType.getElementType(), tensorType.getEncoding()));
-    }
-
-    Location loc = op.getLoc();
-    auto inputs4D = llvm::map_to_vector(
-        adaptor.getInputs(), [&rewriter, loc](mlir::Value value) {
-          return reshapeToRank4IfNeeded(rewriter, loc, value);
-        });
-
-    auto decomposition = createRank4DecompositionWrapper(
-        op, TypeRange(inputs4D), resultTypes4D, rewriter);
-    auto sdpa4D = rewriter.create<ttcore::CompositeOp>(
-        loc, resultTypes4D, inputs4D, op.getCompositeNameAttr(), decomposition,
-        op.getCompositeAttributesAttr());
-
-    llvm::SmallVector<mlir::Value> restored;
-    for (auto [result4D, originalType] :
-         llvm::zip(sdpa4D.getResults(), op.getResultTypes())) {
-      restored.push_back(
-          reshapeValue(rewriter, loc, result4D,
-                       mlir::cast<RankedTensorType>(originalType).getShape()));
-    }
-    rewriter.replaceOp(op, restored);
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// RMSNorm forward decomposition pattern
-//===----------------------------------------------------------------------===//
-
-// ttml::metal::rmsnorm_fw only accepts rank-4 tensors. Normalize the
-// composite signature while preserving a valid decomposition fallback.
-namespace {
-struct RMSNormForwardPattern : public OpConversionPattern<ttcore::CompositeOp> {
-public:
-  using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (op.getCompositeName() != "rmsnorm_fw") {
+    StringRef compositeName = op.getCompositeName();
+    if (compositeName != "sdpa_fw" && compositeName != "sdpa_bw" &&
+        compositeName != "rmsnorm_fw" && compositeName != "layernorm_fw") {
       return failure();
     }
 
@@ -1314,10 +1179,10 @@ public:
     }
 
     Location loc = op.getLoc();
-    SmallVector<Value> inputs4D;
-    for (Value input : adaptor.getInputs()) {
-      inputs4D.push_back(reshapeToRank4IfNeeded(rewriter, loc, input));
-    }
+    auto inputs4D =
+        llvm::map_to_vector(adaptor.getInputs(), [&rewriter, loc](Value value) {
+          return reshapeToRank4IfNeeded(rewriter, loc, value);
+        });
 
     SmallVector<Type> resultTypes4D;
     for (Type type : op.getResultTypes()) {
@@ -1335,79 +1200,13 @@ public:
 
     auto decomposition = createRank4DecompositionWrapper(
         op, TypeRange(inputs4D), resultTypes4D, rewriter);
-    auto rmsNorm4D = rewriter.create<ttcore::CompositeOp>(
+    auto composite4D = rewriter.create<ttcore::CompositeOp>(
         loc, resultTypes4D, inputs4D, op.getCompositeNameAttr(), decomposition,
         op.getCompositeAttributesAttr());
 
     SmallVector<Value> restored;
     for (auto [result4D, originalType] :
-         llvm::zip(rmsNorm4D.getResults(), op.getResultTypes())) {
-      restored.push_back(
-          reshapeValue(rewriter, loc, result4D,
-                       cast<RankedTensorType>(originalType).getShape()));
-    }
-    rewriter.replaceOp(op, restored);
-    return success();
-  }
-};
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// LayerNorm forward decomposition pattern
-//===----------------------------------------------------------------------===//
-
-// ttml::metal::layernorm_fw only accepts rank-4 tensors. Normalize the
-// composite signature while preserving a valid decomposition fallback.
-namespace {
-struct LayerNormForwardPattern
-    : public OpConversionPattern<ttcore::CompositeOp> {
-public:
-  using OpConversionPattern<ttcore::CompositeOp>::OpConversionPattern;
-
-  LogicalResult
-  matchAndRewrite(ttcore::CompositeOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    if (op.getCompositeName() != "layernorm_fw") {
-      return failure();
-    }
-
-    auto isRank4 = [](Value value) {
-      return cast<RankedTensorType>(value.getType()).getRank() == 4;
-    };
-    if (llvm::all_of(adaptor.getInputs(), isRank4) &&
-        llvm::all_of(op.getResults(), isRank4)) {
-      return rewriter.notifyMatchFailure(op, "already 4D");
-    }
-
-    Location loc = op.getLoc();
-    SmallVector<Value> inputs4D;
-    for (Value input : adaptor.getInputs()) {
-      inputs4D.push_back(reshapeToRank4IfNeeded(rewriter, loc, input));
-    }
-
-    SmallVector<Type> resultTypes4D;
-    for (Type type : op.getResultTypes()) {
-      auto tensorType = cast<RankedTensorType>(type);
-      SmallVector<int64_t, 4> shape4D;
-      if (tensorType.getRank() == 4) {
-        shape4D.assign(tensorType.getShape().begin(),
-                       tensorType.getShape().end());
-      } else {
-        shape4D = collapseShapeToRank4(tensorType.getShape());
-      }
-      resultTypes4D.push_back(RankedTensorType::get(
-          shape4D, tensorType.getElementType(), tensorType.getEncoding()));
-    }
-
-    auto decomposition = createRank4DecompositionWrapper(
-        op, TypeRange(inputs4D), resultTypes4D, rewriter);
-    auto layerNorm4D = rewriter.create<ttcore::CompositeOp>(
-        loc, resultTypes4D, inputs4D, op.getCompositeNameAttr(), decomposition,
-        op.getCompositeAttributesAttr());
-
-    SmallVector<Value> restored;
-    for (auto [result4D, originalType] :
-         llvm::zip(layerNorm4D.getResults(), op.getResultTypes())) {
+         llvm::zip(composite4D.getResults(), op.getResultTypes())) {
       restored.push_back(
           reshapeValue(rewriter, loc, result4D,
                        cast<RankedTensorType>(originalType).getShape()));
@@ -2635,10 +2434,7 @@ void populateTTIRToTTIRDecompositionPatterns(MLIRContext *ctx,
   patterns.add<BatchNormInferencePattern>(typeConverter, ctx);
   patterns.add<BatchNormTrainingPattern>(typeConverter, ctx);
   patterns.add<AdamWPattern>(typeConverter, ctx);
-  patterns.add<SDPAForwardPattern>(typeConverter, ctx);
-  patterns.add<SDPABackwardPattern>(typeConverter, ctx);
-  patterns.add<RMSNormForwardPattern>(typeConverter, ctx);
-  patterns.add<LayerNormForwardPattern>(typeConverter, ctx);
+  patterns.add<Rank4CompositePattern>(typeConverter, ctx);
   patterns.add<CrossEntropyForwardPattern>(typeConverter, ctx);
   patterns.add<CrossEntropyBackwardPattern>(typeConverter, ctx);
   patterns.add<QuantizeOpPattern>(typeConverter, ctx);

--- a/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
+++ b/lib/Conversion/TTIRToTTIRDecomposition/TTIRToTTIRDecompositionPass.cpp
@@ -121,12 +121,13 @@ struct TTIRToTTIRDecompositionPass
       return op.getParam().getType().getRank() == 4;
     });
 
-    // Decompose SDPA, layer norm, and cross-entropy composites when their
-    // tensor ranks or shapes are unsupported by ttml::metal.
+    // Decompose SDPA, rmsnorm, layernorm, and cross-entropy composites when
+    // their tensor ranks or shapes are unsupported by ttml::metal.
     target.addDynamicallyLegalOp<ttcore::CompositeOp>(
         [&](ttcore::CompositeOp op) {
           if (op.getCompositeName() == "sdpa_fw" ||
               op.getCompositeName() == "sdpa_bw" ||
+              op.getCompositeName() == "rmsnorm_fw" ||
               op.getCompositeName() == "layernorm_fw") {
             bool operandsRank4 = llvm::all_of(op.getInputs(), [&](Value input) {
               return cast<RankedTensorType>(input.getType()).getRank() == 4;

--- a/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
+++ b/lib/Conversion/TTNNToEmitC/TTNNToEmitC.cpp
@@ -3699,6 +3699,76 @@ public:
 } // namespace
 
 //
+// RMSNormForwardOp conversion pattern (emits ::ttml::metal::rmsnorm_fw)
+//
+namespace {
+class RMSNormForwardOpConversionPattern
+    : public TTNNToEmitCBaseOpConversionPattern<
+          mlir::tt::ttnn::RMSNormForwardOp> {
+private:
+  std::string getPrefixSearchPattern() const override {
+    return "ttnn.rmsnorm_fw";
+  }
+  std::string getPrefixSwapPattern() const override {
+    return "ttml::metal::rmsnorm_fw";
+  }
+
+public:
+  using TTNNToEmitCBaseOpConversionPattern<
+      mlir::tt::ttnn::RMSNormForwardOp>::TTNNToEmitCBaseOpConversionPattern;
+  using Adaptor = mlir::tt::ttnn::RMSNormForwardOp::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::RMSNormForwardOp srcOp, Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    ttnn_to_emitc::EmitCTTNNEmitter<mlir::tt::ttnn::RMSNormForwardOp> emitter(
+        srcOp, adaptor, rewriter);
+
+    // Arg order matches ttml::metal::rmsnorm_fw(input, gamma,
+    // return_intermediates, epsilon).
+    llvm::SmallVector<mlir::Attribute> args{
+        emitter.emit(srcOp.getInput()),
+        emitter.emit(srcOp.getGamma()),
+        emitter.emit(srcOp.getReturnIntermediates()),
+        emitter.emit(srcOp.getEpsilon()),
+    };
+
+    using ReturnTy = std::vector<std::optional<::ttnn::Tensor>>;
+    auto rmsNormForwardOp = rewriter.create<emitc::CallOpaqueOp>(
+        srcOp.getLoc(),
+        rewriter.getType<emitc::OpaqueType>(ttnn_to_emitc::TypeNameV<ReturnTy>),
+        convertOpName(srcOp), rewriter.getArrayAttr(args),
+        /*template_args=*/nullptr, adaptor.getOperands());
+
+    auto optionalType = emitc::OpaqueType::get(
+        rewriter.getContext(), ttnn_to_emitc::TypeNameV<ReturnTy::value_type>);
+    auto optionalLValueType = emitc::LValueType::get(optionalType);
+    auto tensorType = rewriter.getType<emitc::OpaqueType>(
+        ttnn_to_emitc::TypeNameV<::ttnn::Tensor>);
+
+    llvm::SmallVector<mlir::Value, 2> results;
+    for (unsigned i = 0; i < srcOp.getNumResults(); ++i) {
+      auto indexOp = rewriter.create<emitc::LiteralOp>(
+          srcOp.getLoc(), rewriter.getIndexType(), std::to_string(i));
+      auto subscriptOp = rewriter.create<emitc::SubscriptOp>(
+          srcOp.getLoc(), optionalLValueType, rmsNormForwardOp.getResult(0),
+          indexOp.getResult());
+      auto loadOp = rewriter.create<emitc::LoadOp>(srcOp.getLoc(), optionalType,
+                                                   subscriptOp.getResult());
+      auto valueOp = rewriter.create<emitc::CallOpaqueOp>(
+          srcOp.getLoc(), tensorType,
+          ttnn_to_emitc::kGetOptionalValueFunctionName, /*args=*/nullptr,
+          /*template_args=*/nullptr, loadOp.getResult());
+      results.push_back(valueOp.getResult(0));
+    }
+
+    rewriter.replaceOp(srcOp, results);
+    return success();
+  }
+};
+} // namespace
+
+//
 // LayerNormForwardOp conversion pattern (emits ::ttml::metal::layernorm_fw)
 //
 namespace {
@@ -6363,22 +6433,22 @@ void populateTTNNToEmitCPatterns(mlir::MLIRContext *ctx,
 
   // Other ops
   //
-  patterns
-      .add<SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
-           DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
-           CumSumOpConversionPattern, CumProdOpConversionPattern,
-           BatchNormInferenceOpConversionPattern, AdamWOpConversionPattern,
-           SDPAForwardOpConversionPattern, SDPABackwardOpConversionPattern,
-           LayerNormForwardOpConversionPattern,
-           CrossEntropyForwardOpConversionPattern,
-           CrossEntropyBackwardOpConversionPattern,
-           BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
-           DitRMSNormUnaryFusedOpConversionPattern,
-           RMSNormPreAllGatherOpConversionPattern,
-           DistributedRMSNormOpConversionPattern, LayerNormOpConversionPattern,
-           LayerNormPreAllGatherOpConversionPattern,
-           LayerNormPostAllGatherOpConversionPattern,
-           GroupNormOpConversionPattern>(typeConverter, ctx);
+  patterns.add<
+      SoftmaxOpConversionPattern, EmbeddingOpConversionPattern,
+      DefaultOpConversionPattern<mlir::tt::ttnn::EmbeddingBackwardOp>,
+      CumSumOpConversionPattern, CumProdOpConversionPattern,
+      BatchNormInferenceOpConversionPattern, AdamWOpConversionPattern,
+      SDPAForwardOpConversionPattern, SDPABackwardOpConversionPattern,
+      RMSNormForwardOpConversionPattern, LayerNormForwardOpConversionPattern,
+      CrossEntropyForwardOpConversionPattern,
+      CrossEntropyBackwardOpConversionPattern,
+      BatchNormTrainingOpConversionPattern, RMSNormOpConversionPattern,
+      DitRMSNormUnaryFusedOpConversionPattern,
+      RMSNormPreAllGatherOpConversionPattern,
+      DistributedRMSNormOpConversionPattern, LayerNormOpConversionPattern,
+      LayerNormPreAllGatherOpConversionPattern,
+      LayerNormPostAllGatherOpConversionPattern, GroupNormOpConversionPattern>(
+      typeConverter, ctx);
 
   // CCL ops
   //

--- a/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
+++ b/lib/Conversion/TTNNToEmitPy/TTNNToEmitPy.cpp
@@ -5616,6 +5616,29 @@ public:
   }
 };
 
+// RMSNormForward conversion pattern.
+//
+// EmitPy lowering for ttnn.rmsnorm_fw is intentionally unsupported. The
+// emitted Python would need to call the low-level ttml::metal::rmsnorm_fw
+// primitive, which tt-train does not expose through its Python bindings.
+// See https://github.com/tenstorrent/tt-mlir/issues/9118.
+class RMSNormForwardOpConversionPattern
+    : public TTNNToEmitPyBaseOpConversionPattern<
+          mlir::tt::ttnn::RMSNormForwardOp> {
+public:
+  using TTNNToEmitPyBaseOpConversionPattern<
+      mlir::tt::ttnn::RMSNormForwardOp>::TTNNToEmitPyBaseOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mlir::tt::ttnn::RMSNormForwardOp srcOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    return rewriter.notifyMatchFailure(
+        srcOp,
+        "EmitPy lowering for ttnn.rmsnorm_fw is not supported: ttml does not "
+        "expose the metal::rmsnorm_fw primitive through its Python bindings.");
+  }
+};
+
 // LayerNormForward conversion pattern.
 //
 // EmitPy lowering for ttnn.layernorm_fw is intentionally unsupported. The
@@ -5961,6 +5984,9 @@ void populateTTNNToEmitPyPatterns(MLIRContext *ctx, RewritePatternSet &patterns,
 
   // SDPABackward: deliberately declines conversion (see comment above).
   patterns.add<SDPABackwardOpConversionPattern>(typeConverter, ctx);
+
+  // Normalization forward ops deliberately decline conversion.
+  patterns.add<RMSNormForwardOpConversionPattern>(typeConverter, ctx);
   patterns.add<LayerNormForwardOpConversionPattern>(typeConverter, ctx);
 
   // CrossEntropyForward: deliberately declines conversion, same reason.

--- a/lib/Dialect/TTNN/Analysis/OpRules/NormalizationRules.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/NormalizationRules.cpp
@@ -103,4 +103,23 @@ LayoutScore RmsNormRuleBook::adjustScore(
   return base;
 }
 
+//===----------------------------------------------------------------------===//
+// TTMLRMSNormForwardRuleBook
+//===----------------------------------------------------------------------===//
+
+LayoutFilterFn TTMLRMSNormForwardRuleBook::getInputLayoutFilter(
+    unsigned /*operandIdx*/) const {
+  return [](TTNNLayoutAttr layout) {
+    return layout_filter_utils::requireTiled(layout) &&
+           layout_filter_utils::requireDRAMInterleaved(layout);
+  };
+}
+
+bool TTMLRMSNormForwardRuleBook::shouldExploreReshards() const { return false; }
+
+OutputHints TTMLRMSNormForwardRuleBook::getOutputHints(
+    Operation * /*op*/, const std::vector<OpConfig> & /*legalConfigs*/) const {
+  return layout_filter_utils::nullHintOnly();
+}
+
 } // namespace mlir::tt::ttnn

--- a/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
+++ b/lib/Dialect/TTNN/Analysis/OpRules/OpRuleBook.cpp
@@ -80,6 +80,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
   static SDPARuleBook sdpa;
   static TTMLSDPAForwardRuleBook ttmlSdpaForward;
   static TTMLSDPABackwardRuleBook ttmlSdpaBackward;
+  static TTMLRMSNormForwardRuleBook ttmlRmsNormForward;
   static TTMLLayerNormForwardRuleBook ttmlLayerNormForward;
   static SDPADecodeRuleBook sdpaDecode;
   static EmbeddingRuleBook embedding;
@@ -122,6 +123,7 @@ const OpRuleBook &getRuleBook(Operation *op) {
     reg(ScaledDotProductAttentionOp::getOperationName(), &sdpa);
     reg(SDPAForwardOp::getOperationName(), &ttmlSdpaForward);
     reg(SDPABackwardOp::getOperationName(), &ttmlSdpaBackward);
+    reg(RMSNormForwardOp::getOperationName(), &ttmlRmsNormForward);
     reg(LayerNormForwardOp::getOperationName(), &ttmlLayerNormForward);
     reg(ScaledDotProductAttentionDecodeOp::getOperationName(), &sdpaDecode);
     reg(PagedScaledDotProductAttentionDecodeOp::getOperationName(),

--- a/lib/Dialect/TTNN/IR/TTNNOps.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNOps.cpp
@@ -4007,6 +4007,60 @@ static ::mlir::LogicalResult verifyTTNNBatchNormOp(OpType op) {
 }
 
 //===----------------------------------------------------------------------===//
+// RMSNormForwardOp
+//===----------------------------------------------------------------------===//
+
+::mlir::LogicalResult mlir::tt::ttnn::RMSNormForwardOp::verify() {
+  RankedTensorType inputType = getInput().getType();
+  RankedTensorType gammaType = getGamma().getType();
+
+  if (inputType.getRank() != 4) {
+    return emitOpError("input must be rank 4 (B, N, S, C)");
+  }
+  if (gammaType.getRank() != 4) {
+    return emitOpError("gamma must be rank 4 (1, 1, 1, C)");
+  }
+
+  int64_t normalizedSize = inputType.getDimSize(3);
+  llvm::SmallVector<int64_t, 4> expectedGammaShape{1, 1, 1, normalizedSize};
+  if (gammaType.getShape() != llvm::ArrayRef<int64_t>(expectedGammaShape)) {
+    return emitOpError("gamma must have shape (1, 1, 1, ")
+           << normalizedSize << ")";
+  }
+
+  RankedTensorType outputType = getOutput().getType();
+  if (outputType.getShape() != inputType.getShape()) {
+    return emitOpError("output must have the same shape as input");
+  }
+
+  mlir::Type elementType = inputType.getElementType();
+  if (gammaType.getElementType() != elementType ||
+      outputType.getElementType() != elementType) {
+    return emitOpError(
+        "input, gamma and output must have the same element type");
+  }
+
+  if (getReturnIntermediates() != static_cast<bool>(getRms())) {
+    return emitOpError("rms result must be present iff "
+                       "return_intermediates is true");
+  }
+
+  if (getRms()) {
+    llvm::SmallVector<int64_t, 4> expectedRmsShape(inputType.getShape());
+    expectedRmsShape.back() = 1;
+    if (getRms().getType().getShape() !=
+        llvm::ArrayRef<int64_t>(expectedRmsShape)) {
+      return emitOpError("rms must have shape (B, N, S, 1)");
+    }
+    if (getRms().getType().getElementType() != elementType) {
+      return emitOpError("rms must have the same element type as input");
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp
 //===----------------------------------------------------------------------===//
 ::mlir::LogicalResult mlir::tt::ttnn::LayerNormForwardOp::verify() {

--- a/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
+++ b/lib/Dialect/TTNN/IR/TTNNWorkaroundsPass.cpp
@@ -1262,6 +1262,36 @@ TTNNOperandsWorkaroundsFactory::createSDPABackwardOpOperandsWorkarounds(
   return operandsWorkaround;
 }
 
+// Create workarounds for the ttml rmsnorm_fw op. The backing metal op
+// (ttml::metal::rmsnorm_fw) requires every tensor it touches to be bf16,
+// tiled and interleaved in DRAM.
+TTNNOperandsWorkarounds
+TTNNOperandsWorkaroundsFactory::createRMSNormForwardOpOperandsWorkarounds(
+    Operation *op) {
+  TTNNOperandWorkarounds tileDramBf16;
+  tileDramBf16.tensorLayoutWorkaround = Layout::Tile;
+  tileDramBf16.tensorBufferTypeWorkaround = BufferType::DRAM;
+  tileDramBf16.tensorMemoryLayoutWorkaround = TensorMemoryLayoutAttr::get(
+      op->getContext(), TensorMemoryLayout::Interleaved);
+  tileDramBf16.tensorDataTypeWorkaround = ttcore::DataType::BFloat16;
+
+  // Input, gamma and output
+  TTNNOperandsWorkarounds operandsWorkaround =
+      TTNNOperandsWorkarounds::createEmptyTTNNOperandsWorkarounds()
+          .addInputOperandWorkaround(tileDramBf16)
+          .addInputOperandWorkaround(tileDramBf16)
+          .addOutputOperandWorkaround(tileDramBf16);
+
+  auto rmsNormForwardOp = cast<RMSNormForwardOp>(op);
+  if (rmsNormForwardOp.getRms()) {
+    // RMS
+    operandsWorkaround =
+        operandsWorkaround.addOutputOperandWorkaround(tileDramBf16);
+  }
+
+  return operandsWorkaround;
+}
+
 // Create workarounds for the ttml layernorm_fw op. The backing metal op
 // (ttml::metal::layernorm_fw) requires every tensor it touches to be bf16,
 // tiled and interleaved in DRAM (see the TT_FATALs in

--- a/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
+++ b/lib/Dialect/TTNN/Interfaces/TTNNOpModelInterface.cpp
@@ -4684,6 +4684,34 @@ SDPABackwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
 }
 
 //===----------------------------------------------------------------------===//
+// RMSNormForwardOp - TTNN Op Model Interface
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<op_model::OpConstraints> RMSNormForwardOp::getOpConstraints(
+    const std::vector<TTNNLayoutAttr> &inputs, const OpConfig &opConfig,
+    std::optional<llvm::ArrayRef<op_model::OpModelAllocationRecord>>
+        liveRecords) {
+  assert(inputs.size() == 2 && "RMSNormForwardOp must have 2 inputs");
+
+  return detail::constraintsDispatch(
+      *this, liveRecords, getInput().getType().getShape(), inputs[0],
+      getGamma().getType().getShape(), inputs[1], getReturnIntermediates(),
+      getEpsilon(), opConfig.outputLayout);
+}
+
+llvm::Expected<size_t>
+RMSNormForwardOp::getOpRuntime(const std::vector<TTNNLayoutAttr> &inputs,
+                               const OpConfig &opConfig) {
+  assert(inputs.size() == 2 && "RMSNormForwardOp must have 2 inputs");
+
+  return opRuntimeCache().getOrCompute(
+      op_model::OpModel<RMSNormForwardOp>::getOpRuntime, *this,
+      getInput().getType().getShape(), inputs[0],
+      getGamma().getType().getShape(), inputs[1], getReturnIntermediates(),
+      getEpsilon(), opConfig.outputLayout);
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp - TTNN Op Model Interface
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNResolveComposites.cpp
@@ -119,6 +119,38 @@ static void registerBuiltinComposites() {
     return;
   }
 
+  registry["rmsnorm_fw"] = CompositeEntry{
+      // Validate
+      [](ttcore::CompositeOp compositeOp,
+         OpBuilder &builder) -> OpValidationResult {
+        TT_assert(compositeOp.getInputs().size() == 2u);
+        auto attrs = compositeOp.getCompositeAttributes();
+        TT_assert(attrs);
+        auto returnIntermediatesAttr =
+            (*attrs).getAs<BoolAttr>("return_intermediates");
+        auto epsilonAttr = (*attrs).getAs<FloatAttr>("epsilon");
+        TT_assert(returnIntermediatesAttr);
+        TT_assert(epsilonAttr);
+
+        SmallVector<Type> resultTypes(compositeOp.getResultTypes());
+        IsolatedIRValidationWrapper validator(compositeOp.getContext());
+        return validator.validateOp<RMSNormForwardOp>(
+            compositeOp.getOperation(), compositeOp.getLoc(), resultTypes,
+            compositeOp.getInputs()[0], compositeOp.getInputs()[1],
+            returnIntermediatesAttr, epsilonAttr);
+      },
+      // Build
+      [](ttcore::CompositeOp compositeOp, OpBuilder &builder) -> Operation * {
+        DictionaryAttr attrs = *compositeOp.getCompositeAttributes();
+        TT_assert(compositeOp.getInputs().size() == 2u);
+        return builder.create<RMSNormForwardOp>(
+            compositeOp.getLoc(), compositeOp.getResultTypes(),
+            compositeOp.getInputs()[0], compositeOp.getInputs()[1],
+            attrs.getAs<BoolAttr>("return_intermediates"),
+            attrs.getAs<FloatAttr>("epsilon"));
+      },
+      /*promotionGuard=*/nullptr};
+
   registry["layernorm_fw"] = CompositeEntry{
       // Validate
       [](ttcore::CompositeOp compositeOp,

--- a/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
+++ b/lib/Dialect/TTNN/Transforms/Workarounds/TTNNWorkaroundsPatterns.cpp
@@ -589,5 +589,10 @@ const std::set<mlir::StringRef>
         // RowMajor input siblings supply its ROW_MAJOR input (tt-metal #46340).
         // SDPABackwardOp is temporarily enabled to restrict the dtype to bf16:
         // https://github.com/tenstorrent/tt-mlir/issues/9233
-        ttnn::SDPABackwardOp::getOperationName()};
+        ttnn::SDPABackwardOp::getOperationName(),
+        // RMSNormForwardOp's workaround is enabled because it sets dtype to
+        // bf16, which optimizer is currently unable to do correctly for a
+        // multi-output op with different output layouts:
+        // https://github.com/tenstorrent/tt-mlir/issues/9295
+        ttnn::RMSNormForwardOp::getOperationName()};
 } // namespace mlir::tt::ttnn

--- a/lib/OpModel/TTNN/TTNNOpModel.cpp
+++ b/lib/OpModel/TTNN/TTNNOpModel.cpp
@@ -9696,6 +9696,71 @@ llvm::Expected<size_t> OpModel<SDPABackwardOp>::getOpRuntime(
 }
 
 //===----------------------------------------------------------------------===//
+// RMSNormForwardOp
+//===----------------------------------------------------------------------===//
+
+llvm::Expected<OpConstraints> OpModel<RMSNormForwardOp>::getOpConstraints(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+    bool returnIntermediates, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout, const MockAllocatorState *initialState) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gammaSpec,
+      detail::convertToTensorSpec(device, gammaShape, gammaLayout));
+
+  std::optional<MockAllocatorState> initialStateOpt =
+      initialState ? std::optional<MockAllocatorState>(*initialState)
+                   : std::nullopt;
+
+  auto rmsNormForwardOpQuery = [=]() {
+    return QUERY_OP_CONSTRAINTS_WITH_STATE(
+        ::ttml::metal::rmsnorm_fw, device, initialStateOpt, inputSpec,
+        gammaSpec, returnIntermediates, epsilon.convertToFloat());
+  };
+
+  return operation::getOpConstraintsWithState(inputLayout.getContext(),
+                                              rmsNormForwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+llvm::Expected<size_t> OpModel<RMSNormForwardOp>::getOpRuntime(
+    llvm::ArrayRef<int64_t> inputShape, TTNNLayoutAttr inputLayout,
+    llvm::ArrayRef<int64_t> gammaShape, TTNNLayoutAttr gammaLayout,
+    bool returnIntermediates, llvm::APFloat epsilon,
+    TTNNLayoutAttr outputLayout) {
+#ifdef TTMLIR_ENABLE_OPMODEL
+  ::tt::tt_metal::distributed::MeshDevice *device =
+      SingletonDeviceContext::getInstance().getDevice();
+
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec inputSpec,
+      detail::convertToTensorSpec(device, inputShape, inputLayout));
+  ASSIGN_OR_RETURN(
+      ::tt::tt_metal::TensorSpec gammaSpec,
+      detail::convertToTensorSpec(device, gammaShape, gammaLayout));
+
+  auto rmsNormForwardOpQuery = [=]() {
+    return QUERY_OP_RUNTIME(::ttml::metal::rmsnorm_fw, device, inputSpec,
+                            gammaSpec, returnIntermediates,
+                            epsilon.convertToFloat());
+  };
+
+  return operation::getOpRuntime(rmsNormForwardOpQuery);
+#else
+  return llvm::createStringError("Not Implemented");
+#endif // TTMLIR_ENABLE_OPMODEL
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/TTNN/TTNNToFlatbuffer.cpp
+++ b/lib/Target/TTNN/TTNNToFlatbuffer.cpp
@@ -1688,6 +1688,26 @@ createOp(FlatbufferObjectCache &cache, SDPAForwardOp op) {
       output, intermediates);
 }
 
+::flatbuffers::Offset<::tt::target::ttnn::RMSNormForwardOp>
+createOp(FlatbufferObjectCache &cache, RMSNormForwardOp op) {
+  auto input = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getInput()));
+  auto gamma = cache.at<::tt::target::ttnn::TensorRef>(
+      getOperandThroughDPSOps(op.getGamma()));
+  auto output = cache.getOrCreateNoSharding(
+      op.getOutput(), tensorValueToFlatbuffer, /*local_shape*/ std::nullopt);
+
+  ::flatbuffers::Offset<::tt::target::ttnn::TensorRef> rms = 0;
+  if (op.getRms()) {
+    rms = cache.getOrCreateNoSharding(op.getRms(), tensorValueToFlatbuffer,
+                                      /*local_shape*/ std::nullopt);
+  }
+
+  return ::tt::target::ttnn::CreateRMSNormForwardOp(
+      *cache.fbb, input, gamma, op.getReturnIntermediates(),
+      op.getEpsilon().convertToFloat(), output, rms);
+}
+
 ::flatbuffers::Offset<::tt::target::ttnn::LayerNormForwardOp>
 createOp(FlatbufferObjectCache &cache, LayerNormForwardOp op) {
   auto input = cache.at<::tt::target::ttnn::TensorRef>(
@@ -5162,6 +5182,11 @@ emitTTNNOperation(FlatbufferObjectCache &cache, Operation *op,
   if (auto sdpaBackwardOp = dyn_cast<SDPABackwardOp>(op); sdpaBackwardOp) {
     return createOperation(cache, createOp(cache, sdpaBackwardOp), debugString,
                            locInfo);
+  }
+  if (auto rmsNormForwardOp = dyn_cast<RMSNormForwardOp>(op);
+      rmsNormForwardOp) {
+    return createOperation(cache, createOp(cache, rmsNormForwardOp),
+                           debugString, locInfo);
   }
   if (auto layerNormForwardOp = dyn_cast<LayerNormForwardOp>(op);
       layerNormForwardOp) {

--- a/runtime/lib/ttnn/operations/ttml/CMakeLists.txt
+++ b/runtime/lib/ttnn/operations/ttml/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 add_library(TTRuntimeTTMLOps STATIC
   adamw.cpp
+  rmsnorm_fw.cpp
   layernorm_fw.cpp
   sdpa_fw.cpp
   sdpa_bw.cpp

--- a/runtime/lib/ttnn/operations/ttml/rmsnorm_fw.cpp
+++ b/runtime/lib/ttnn/operations/ttml/rmsnorm_fw.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "operations/ttml/rmsnorm_fw.h"
+#include "metal/ops/rmsnorm_fw/rmsnorm_fw.hpp"
+
+namespace tt::runtime::ttnn::operations::ttml {
+
+void run(const ::tt::target::ttnn::RMSNormForwardOp *op,
+         ProgramContext &context) {
+  ProgramTensorPool &tensorPool = context.getTensorPool();
+
+  const ::ttnn::Tensor &input =
+      tensorPool.getTTNNTensorAndValidate(op->input());
+  const ::ttnn::Tensor &gamma =
+      tensorPool.getTTNNTensorAndValidate(op->gamma());
+
+  std::vector<std::optional<::ttnn::Tensor>> result = ::ttml::metal::rmsnorm_fw(
+      input, gamma, op->return_intermediates(), op->epsilon());
+
+  LOG_ASSERT(result.size() == 2, "rmsnorm_fw expected 2 results, got {}",
+             result.size());
+  LOG_ASSERT(result.at(0).has_value(), "rmsnorm_fw output was not returned");
+
+  tensorPool.insertTTNNTensorAndValidate(op->out(), result.at(0).value());
+
+  if (op->return_intermediates()) {
+    LOG_ASSERT(result.at(1).has_value(), "rms expected but not returned");
+    tensorPool.insertTTNNTensorAndValidate(op->rms(), result.at(1).value());
+  }
+}
+
+} // namespace tt::runtime::ttnn::operations::ttml

--- a/runtime/lib/ttnn/operations/ttml/rmsnorm_fw.h
+++ b/runtime/lib/ttnn/operations/ttml/rmsnorm_fw.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef RUNTIME_LIB_TTNN_OPERATIONS_TTML_RMSNORM_FW_H
+#define RUNTIME_LIB_TTNN_OPERATIONS_TTML_RMSNORM_FW_H
+
+#include "tt/runtime/detail/ttnn/types/types.h"
+#include "ttmlir/Target/TTNN/program_generated.h"
+
+namespace tt::runtime::ttnn::operations::ttml {
+void run(const ::tt::target::ttnn::RMSNormForwardOp *op,
+         ProgramContext &context);
+} // namespace tt::runtime::ttnn::operations::ttml
+
+#endif // RUNTIME_LIB_TTNN_OPERATIONS_TTML_RMSNORM_FW_H

--- a/runtime/lib/ttnn/program_executor.cpp
+++ b/runtime/lib/ttnn/program_executor.cpp
@@ -130,6 +130,7 @@
 #include "operations/ttml/cross_entropy_bw.h"
 #include "operations/ttml/cross_entropy_fw.h"
 #include "operations/ttml/layernorm_fw.h"
+#include "operations/ttml/rmsnorm_fw.h"
 #include "operations/ttml/sdpa_bw.h"
 #include "operations/ttml/sdpa_fw.h"
 #include "tt/runtime/debug.h"
@@ -656,6 +657,9 @@ void ProgramExecutor::runOperation(const ::tt::target::ttnn::Operation *op) {
   }
   case ::tt::target::ttnn::OpType::SDPABackwardOp: {
     return operations::ttml::run(op->type_as_SDPABackwardOp(), getContext());
+  }
+  case ::tt::target::ttnn::OpType::RMSNormForwardOp: {
+    return operations::ttml::run(op->type_as_RMSNormForwardOp(), getContext());
   }
   case ::tt::target::ttnn::OpType::LayerNormForwardOp: {
     return operations::ttml::run(op->type_as_LayerNormForwardOp(),

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -1610,6 +1610,14 @@ std::vector<tt::runtime::TensorRef> getOpOutputRefs(OpContext opContextHandle) {
     tensorRefs = {op->grad_query(), op->grad_key(), op->grad_value()};
     break;
   }
+  case ::tt::target::ttnn::OpType::RMSNormForwardOp: {
+    auto *op = opContext.type_as_RMSNormForwardOp();
+    tensorRefs = {op->out()};
+    if (op->rms()) {
+      tensorRefs.push_back(op->rms());
+    }
+    break;
+  }
   case ::tt::target::ttnn::OpType::LayerNormForwardOp: {
     auto *op = opContext.type_as_LayerNormForwardOp();
     tensorRefs = {op->out()};
@@ -2022,6 +2030,11 @@ std::vector<tt::runtime::TensorRef> getOpInputRefs(OpContext opContextHandle) {
     if (op->attention_mask()) {
       tensorRefs.push_back(op->attention_mask());
     }
+    break;
+  }
+  case ::tt::target::ttnn::OpType::RMSNormForwardOp: {
+    auto *op = opContext.type_as_RMSNormForwardOp();
+    tensorRefs = {op->input(), op->gamma()};
     break;
   }
   case ::tt::target::ttnn::OpType::LayerNormForwardOp: {

--- a/test/python/golden/test_ttir_ops.py
+++ b/test/python/golden/test_ttir_ops.py
@@ -14,7 +14,7 @@ from builder.base.builder_utils import Operand, Shape, TypeInfo
 from builder.ttir.ttir_builder import TTIRBuilder
 from builder.base.builder_apis import compile_and_execute_ttir, build_module
 from builder.base.builder_enums import *
-from ttmlir.ir import DenseI32ArrayAttr
+from ttmlir.ir import BoolAttr, DenseI32ArrayAttr, DictAttr, FloatAttr, StringAttr
 from test_utils import (
     SkipIf,
     shape_str,
@@ -24,6 +24,59 @@ from test_utils import (
 )
 
 pytestmark = pytest.mark.frontend("ttir")
+
+
+@pytest.mark.parametrize("return_intermediates", [False, True])
+@pytest.mark.parametrize("target", ["ttnn" | SkipIf("sim")])
+def test_rmsnorm_fw_composite(return_intermediates: bool, target: str, request, device):
+    shape = (1, 1, 32, 64)
+    gamma_shape = (1, 1, 1, 64)
+
+    def module(builder: TTIRBuilder):
+        @builder.func([shape, gamma_shape], [torch.bfloat16, torch.bfloat16])
+        def rmsnorm_fw_decomp(
+            input: Operand,
+            gamma: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            if not return_intermediates:
+                return input
+            rms = builder.slice(input, [0, 0, 0, 0], [1, 1, 32, 1])
+            return input, rms
+
+        rmsnorm_fw_decomp.sym_visibility = StringAttr.get("private")
+        builder._nested_funcs.append(rmsnorm_fw_decomp.name.value)
+
+        @builder.func([shape, gamma_shape], [torch.bfloat16, torch.bfloat16])
+        def rmsnorm_fw(
+            input: Operand,
+            gamma: Operand,
+            builder: TTIRBuilder,
+            unit_attrs: Optional[List[str]] = None,
+        ):
+            builder.set_graph_level_check(True)
+            composite_attributes = DictAttr.get(
+                {
+                    "return_intermediates": BoolAttr.get(return_intermediates),
+                    "epsilon": FloatAttr.get_f32(1e-06),
+                }
+            )
+            return builder.composite(
+                "rmsnorm_fw",
+                [input, gamma],
+                decomposition=rmsnorm_fw_decomp,
+                composite_attributes=composite_attributes,
+                unit_attrs=unit_attrs,
+            )
+
+    compile_and_execute_ttir(
+        module,
+        **get_request_kwargs(request),
+        target=target,
+        device=device,
+        pipeline_options=["composite-resolution=force-promote"],
+    )
 
 
 def logical_not(

--- a/test/ttmlir/Dialect/TTIR/rmsnorm_fw/rmsnorm_fw_reshape_test.mlir
+++ b/test/ttmlir/Dialect/TTIR/rmsnorm_fw/rmsnorm_fw_reshape_test.mlir
@@ -1,0 +1,82 @@
+// RUN: ttmlir-opt --ttir-to-ttir-decomposition %s -o %t
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // CHECK-LABEL: func.func @rmsnorm_fw_rank2
+  func.func @rmsnorm_fw_rank2(
+      %input: tensor<128x256xbf16>,
+      %gamma: tensor<256xbf16>) -> tensor<128x256xbf16> {
+    // CHECK-DAG: "ttir.reshape"(%arg0) {{.*}} -> tensor<1x1x128x256xbf16>
+    // CHECK-DAG: "ttir.reshape"(%arg1) {{.*}} -> tensor<1x1x1x256xbf16>
+    // CHECK: "ttcore.composite"
+    // CHECK-SAME: decomposition = @rmsnorm_fw_rank2_decomp_rank4
+    // CHECK-SAME: -> tensor<1x1x128x256xbf16>
+    // CHECK: "ttir.reshape"({{.*}}) {{.*}} -> tensor<128x256xbf16>
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_rank2_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<128x256xbf16>, tensor<256xbf16>)
+          -> tensor<128x256xbf16>
+    return %output : tensor<128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_rank2_decomp(
+      %input: tensor<128x256xbf16>,
+      %gamma: tensor<256xbf16>) -> tensor<128x256xbf16> {
+    return %input : tensor<128x256xbf16>
+  }
+
+  // CHECK-LABEL: func.func @rmsnorm_fw_rank4
+  func.func @rmsnorm_fw_rank4(
+      %input: tensor<2x4x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<2x4x128x256xbf16> {
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: "ttcore.composite"
+    // CHECK-SAME: decomposition = @rmsnorm_fw_rank4_decomp
+    // CHECK-NOT: "ttir.reshape"
+    // CHECK: return
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_rank4_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<2x4x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> tensor<2x4x128x256xbf16>
+    return %output : tensor<2x4x128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_rank4_decomp(
+      %input: tensor<2x4x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<2x4x128x256xbf16> {
+    return %input : tensor<2x4x128x256xbf16>
+  }
+
+  // CHECK-LABEL: func.func @rmsnorm_fw_rank5
+  func.func @rmsnorm_fw_rank5(
+      %input: tensor<2x3x4x128x256xbf16>,
+      %gamma: tensor<256xbf16>) -> tensor<2x3x4x128x256xbf16> {
+    // CHECK: "ttir.reshape"(%arg0) {{.*}} -> tensor<1x24x128x256xbf16>
+    // CHECK: "ttcore.composite"
+    // CHECK-SAME: -> tensor<1x24x128x256xbf16>
+    // CHECK: "ttir.reshape"({{.*}}) {{.*}} -> tensor<2x3x4x128x256xbf16>
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_rank5_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<2x3x4x128x256xbf16>, tensor<256xbf16>)
+          -> tensor<2x3x4x128x256xbf16>
+    return %output : tensor<2x3x4x128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_rank5_decomp(
+      %input: tensor<2x3x4x128x256xbf16>,
+      %gamma: tensor<256xbf16>) -> tensor<2x3x4x128x256xbf16> {
+    return %input : tensor<2x3x4x128x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/rmsnorm_fw_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/rmsnorm_fw_workaround.mlir
@@ -1,0 +1,48 @@
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --canonicalize -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround="ttnn-optimization-level=1" --canonicalize -o %t1 %s
+// RUN: FileCheck %s --check-prefix=OPT1 --input-file=%t1
+
+// At optimization level 0, convert every rmsnorm_fw operand and result to the
+// tiled, DRAM-interleaved bf16 layout required by the backing metal kernel.
+
+module {
+  func.func public @rmsnorm_fw_f32(%input: tensor<1x1x128x256xf32>, %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32> {
+    // CHECK-LABEL: func.func public @rmsnorm_fw_f32
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg0)
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%arg1)
+    // CHECK: %[[OUT_BF16:.*]] = "ttnn.rmsnorm_fw"(%{{[0-9]+}}, %{{[0-9]+}})
+    // CHECK-SAME: -> tensor<1x1x128x256xbf16
+    // CHECK: "ttnn.to_tensor_spec"(%[[OUT_BF16]])
+    // CHECK-SAME: -> tensor<1x1x128x256xf32
+
+    // At optimization level 1 the workaround is skipped.
+    // OPT1-LABEL: func.func public @rmsnorm_fw_f32
+    // OPT1-NOT: ttnn.to_tensor_spec
+    // OPT1: "ttnn.rmsnorm_fw"
+    // OPT1-SAME: -> tensor<1x1x128x256xf32
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{epsilon = 1.000000e-06 : f32, return_intermediates = false}> : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32>
+    return %0 : tensor<1x1x128x256xf32>
+  }
+
+  func.func public @rmsnorm_fw_f32_rms(%input: tensor<1x1x128x256xf32>, %gamma: tensor<1x1x1x256xf32>) -> (tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>) {
+    // CHECK-LABEL: func.func public @rmsnorm_fw_f32_rms
+    // CHECK: %[[OUT_BF16:.*]], %[[RMS_BF16:.*]] = "ttnn.rmsnorm_fw"(%{{[0-9]+}}, %{{[0-9]+}})
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16{{.*}}, tensor<1x1x128x1xbf16
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%[[OUT_BF16]])
+    // CHECK-DAG: "ttnn.to_tensor_spec"(%[[RMS_BF16]])
+    %0, %1 = "ttnn.rmsnorm_fw"(%input, %gamma) <{epsilon = 1.000000e-06 : f32, return_intermediates = true}> : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>) -> (tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>)
+    return %0, %1 : tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>
+  }
+
+  func.func public @rmsnorm_fw_bf16_no_workaround(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // CHECK-LABEL: func.func public @rmsnorm_fw_bf16_no_workaround
+    // CHECK-NOT: ttnn.to_tensor_spec
+    // CHECK: "ttnn.rmsnorm_fw"
+    // CHECK-NOT: ttnn.to_tensor_spec
+    // CHECK: return
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{epsilon = 1.000000e-06 : f32, return_intermediates = false}> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16>
+    return %0 : tensor<1x1x128x256xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/rmsnorm_fw_workaround.mlir
+++ b/test/ttmlir/Dialect/TTNN/Transforms/Workarounds/rmsnorm_fw_workaround.mlir
@@ -1,11 +1,8 @@
 // RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround --canonicalize -o %t %s
 // RUN: FileCheck %s --input-file=%t
 
-// RUN: ttmlir-opt --ttcore-register-device --ttnn-layout --ttnn-workaround="ttnn-optimization-level=1" --canonicalize -o %t1 %s
-// RUN: FileCheck %s --check-prefix=OPT1 --input-file=%t1
-
-// At optimization level 0, convert every rmsnorm_fw operand and result to the
-// tiled, DRAM-interleaved bf16 layout required by the backing metal kernel.
+// Convert every rmsnorm_fw operand and result to the tiled, DRAM-interleaved
+// bf16 layout required by the backing metal kernel.
 
 module {
   func.func public @rmsnorm_fw_f32(%input: tensor<1x1x128x256xf32>, %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32> {
@@ -18,10 +15,6 @@ module {
     // CHECK-SAME: -> tensor<1x1x128x256xf32
 
     // At optimization level 1 the workaround is skipped.
-    // OPT1-LABEL: func.func public @rmsnorm_fw_f32
-    // OPT1-NOT: ttnn.to_tensor_spec
-    // OPT1: "ttnn.rmsnorm_fw"
-    // OPT1-SAME: -> tensor<1x1x128x256xf32
     %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{epsilon = 1.000000e-06 : f32, return_intermediates = false}> : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32>
     return %0 : tensor<1x1x128x256xf32>
   }

--- a/test/ttmlir/Dialect/TTNN/optimizer/rmsnorm_fw_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/rmsnorm_fw_validation.mlir
@@ -1,0 +1,75 @@
+// REQUIRES: opmodel
+// RUN: ttmlir-opt --ttir-to-ttnn-backend-pipeline="optimization-level=2" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // The TTML kernel requires tiled, DRAM-interleaved operands and derives both
+  // output layouts from the input.
+  func.func @rmsnorm_fw(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    // CHECK-DAG: #[[INPUT_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<4x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[GAMMA_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<1x8x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+    // CHECK-DAG: #[[RMS_LAYOUT:ttnn_layout[0-9]*]] = #ttnn.ttnn_layout<{{.*}}memref<4x1x!ttcore.tile<32x32, bf16>, #dram>, <interleaved>>
+
+    // CHECK-LABEL: func.func @rmsnorm_fw(
+    // CHECK-SAME: %[[INPUT:[0-9a-z_]+]]: tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>
+    // CHECK-SAME: %[[GAMMA:[0-9a-z_]+]]: tensor<1x1x1x256xbf16, #[[GAMMA_LAYOUT]]>)
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>, tensor<1x1x128x1xbf16, #[[RMS_LAYOUT]]>)
+    // CHECK: %[[OUTPUT:[0-9a-z_]+]], %[[RMS:[0-9a-z_]+]] = "ttnn.rmsnorm_fw"(%[[INPUT]], %[[GAMMA]])
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>, tensor<1x1x128x1xbf16, #[[RMS_LAYOUT]]>)
+    // CHECK: return %[[OUTPUT]], %[[RMS]]
+    %output, %rms = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_intermediates_decomp,
+        composite_attributes = {
+          return_intermediates = true,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>)
+    return %output, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+
+  // Exercise the bf16 workaround together with OpModel validation while
+  // preserving the f32 function boundary.
+  func.func @rmsnorm_fw_f32(
+      %input: tensor<1x1x128x256xf32>,
+      %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32> {
+    // CHECK-LABEL: func.func @rmsnorm_fw_f32(
+    // CHECK: %[[INPUT_BF16:[0-9a-z_]+]] = "ttnn.typecast"(%{{.*}})
+    // CHECK-SAME: -> tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>
+    // CHECK: %[[GAMMA_BF16:[0-9a-z_]+]] = "ttnn.typecast"(%{{.*}})
+    // CHECK-SAME: -> tensor<1x1x1x256xbf16, #[[GAMMA_LAYOUT]]>
+    // CHECK: %[[OUTPUT_BF16:[0-9a-z_]+]] = "ttnn.rmsnorm_fw"(%[[INPUT_BF16]], %[[GAMMA_BF16]])
+    // CHECK-SAME: -> tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>
+    // CHECK: %[[OUTPUT_F32:[0-9a-z_]+]] = "ttnn.typecast"(%[[OUTPUT_BF16]])
+    // CHECK: return %[[OUTPUT_F32]]
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>)
+          -> tensor<1x1x128x256xf32>
+    return %output : tensor<1x1x128x256xf32>
+  }
+
+  func.func private @rmsnorm_fw_decomp(
+      %input: tensor<1x1x128x256xf32>,
+      %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32> {
+    return %input : tensor<1x1x128x256xf32>
+  }
+
+  func.func private @rmsnorm_fw_intermediates_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    %rms = "ttir.zeros"() <{shape = array<i32: 1, 1, 128, 1>}>
+        : () -> tensor<1x1x128x1xbf16>
+    return %input, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/optimizer/rmsnorm_fw_validation.mlir
+++ b/test/ttmlir/Dialect/TTNN/optimizer/rmsnorm_fw_validation.mlir
@@ -57,10 +57,46 @@ module {
     return %output : tensor<1x1x128x256xf32>
   }
 
+  func.func @rmsnorm_fw_f32_intermediates(
+      %input: tensor<1x1x128x256xf32>,
+      %gamma: tensor<1x1x1x256xf32>)
+      -> (tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>) {
+    // CHECK-LABEL: func.func @rmsnorm_fw_f32_intermediates(
+    // CHECK: %[[INPUT_BF16:[0-9a-z_]+]] = "ttnn.typecast"(%{{.*}})
+    // CHECK-SAME: -> tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>
+    // CHECK: %[[GAMMA_BF16:[0-9a-z_]+]] = "ttnn.typecast"(%{{.*}})
+    // CHECK-SAME: -> tensor<1x1x1x256xbf16, #[[GAMMA_LAYOUT]]>
+    // CHECK: %[[OUTPUT_BF16:[0-9a-z_]+]], %[[RMS_BF16:[0-9a-z_]+]] = "ttnn.rmsnorm_fw"(%[[INPUT_BF16]], %[[GAMMA_BF16]])
+    // CHECK-SAME: -> (tensor<1x1x128x256xbf16, #[[INPUT_LAYOUT]]>, tensor<1x1x128x1xbf16, #[[RMS_LAYOUT]]>)
+    // CHECK-DAG: %[[OUTPUT_F32:[0-9a-z_]+]] = "ttnn.typecast"(%[[OUTPUT_BF16]])
+    // CHECK-DAG: %[[RMS_F32:[0-9a-z_]+]] = "ttnn.typecast"(%[[RMS_BF16]])
+    // CHECK: return %[[OUTPUT_F32]], %[[RMS_F32]]
+    %output, %rms = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_f32_intermediates_decomp,
+        composite_attributes = {
+          return_intermediates = true,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xf32>, tensor<1x1x1x256xf32>)
+          -> (tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>)
+    return %output, %rms
+        : tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>
+  }
+
   func.func private @rmsnorm_fw_decomp(
       %input: tensor<1x1x128x256xf32>,
       %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xf32> {
     return %input : tensor<1x1x128x256xf32>
+  }
+
+  func.func private @rmsnorm_fw_f32_intermediates_decomp(
+      %input: tensor<1x1x128x256xf32>,
+      %gamma: tensor<1x1x1x256xf32>)
+      -> (tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>) {
+    %rms = "ttir.zeros"() <{shape = array<i32: 1, 1, 128, 1>}>
+        : () -> tensor<1x1x128x1xf32>
+    return %input, %rms
+        : tensor<1x1x128x256xf32>, tensor<1x1x128x1xf32>
   }
 
   func.func private @rmsnorm_fw_intermediates_decomp(

--- a/test/ttmlir/Dialect/TTNN/rmsnorm_fw/rmsnorm_fw_invalid.mlir
+++ b/test/ttmlir/Dialect/TTNN/rmsnorm_fw/rmsnorm_fw_invalid.mlir
@@ -1,0 +1,59 @@
+// RUN: ttmlir-opt --split-input-file --verify-diagnostics %s
+
+module {
+  func.func @input_rank(%input: tensor<1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x128x256xbf16> {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op input must be rank 4 (B, N, S, C)}}
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = false}> : (tensor<1x128x256xbf16>, tensor<1x1x1x256xbf16>) -> tensor<1x128x256xbf16>
+    return %0 : tensor<1x128x256xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @gamma_shape(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x2x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op gamma must have shape (1, 1, 1, 256)}}
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = false}> : (tensor<1x1x128x256xbf16>, tensor<1x1x2x256xbf16>) -> tensor<1x1x128x256xbf16>
+    return %0 : tensor<1x1x128x256xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @output_shape(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x64x256xbf16> {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op output must have the same shape as input}}
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = false}> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>) -> tensor<1x1x64x256xbf16>
+    return %0 : tensor<1x1x64x256xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @element_types(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xbf16> {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op input, gamma and output must have the same element type}}
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = false}> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xf32>) -> tensor<1x1x128x256xbf16>
+    return %0 : tensor<1x1x128x256xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @missing_rms(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op rms result must be present iff return_intermediates is true}}
+    %0 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = true}> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16>
+    return %0 : tensor<1x1x128x256xbf16>
+  }
+}
+
+// -----
+
+module {
+  func.func @rms_shape(%input: tensor<1x1x128x256xbf16>, %gamma: tensor<1x1x1x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x64x1xbf16>) {
+    // expected-error @+1 {{'ttnn.rmsnorm_fw' op rms must have shape (B, N, S, 1)}}
+    %0, %1 = "ttnn.rmsnorm_fw"(%input, %gamma) <{return_intermediates = true}> : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>) -> (tensor<1x1x128x256xbf16>, tensor<1x1x64x1xbf16>)
+    return %0, %1 : tensor<1x1x128x256xbf16>, tensor<1x1x64x1xbf16>
+  }
+}

--- a/test/ttmlir/Dialect/TTNN/rmsnorm_fw/simple_rmsnorm_fw.mlir
+++ b/test/ttmlir/Dialect/TTNN/rmsnorm_fw/simple_rmsnorm_fw.mlir
@@ -1,0 +1,54 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-runtime-pipeline="composite-resolution=force-promote" -o %t %s
+// RUN: FileCheck %s --input-file=%t
+
+module {
+  // RMS norm forward without the intermediate RMS tensor.
+  func.func @rmsnorm_fw(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // CHECK: "ttnn.rmsnorm_fw"
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> tensor<1x1x128x256xbf16>
+    return %output : tensor<1x1x128x256xbf16>
+  }
+
+  // RMS norm forward returning the RMS tensor used by the backward pass.
+  func.func @rmsnorm_fw_intermediates(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    // CHECK: "ttnn.rmsnorm_fw"
+    %output, %rms = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_intermediates_decomp,
+        composite_attributes = {
+          return_intermediates = true,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>)
+    return %output, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+
+  func.func private @rmsnorm_fw_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    return %input : tensor<1x1x128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_intermediates_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    %rms = "ttir.zeros"() <{shape = array<i32: 1, 1, 128, 1>}>
+        : () -> tensor<1x1x128x1xbf16>
+    return %input, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+}

--- a/test/ttmlir/EmitC/TTNN/rmsnorm_fw/rmsnorm_fw.mlir
+++ b/test/ttmlir/EmitC/TTNN/rmsnorm_fw/rmsnorm_fw.mlir
@@ -1,0 +1,59 @@
+// RUN: ttmlir-opt --ttir-to-ttnn-common-pipeline="system-desc-path=%system_desc_path% composite-resolution=force-promote" -o %t.mlir %s
+// RUN: ttmlir-opt --ttnn-common-to-emitc-pipeline -o %t2.mlir %t.mlir
+// RUN: ttmlir-translate --mlir-to-cpp %t2.mlir | FileCheck %s
+
+module {
+  // Output only.
+  // CHECK-LABEL: rmsnorm_fw
+  func.func @rmsnorm_fw(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // CHECK: ttml::metal::rmsnorm_fw(
+    // CHECK-COUNT-1: util_get_optional_value(
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> tensor<1x1x128x256xbf16>
+    return %output : tensor<1x1x128x256xbf16>
+  }
+
+  // Output and RMS intermediate.
+  // CHECK-LABEL: rmsnorm_fw_intermediates
+  func.func @rmsnorm_fw_intermediates(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    // CHECK: ttml::metal::rmsnorm_fw(
+    // CHECK-COUNT-2: util_get_optional_value(
+    %output, %rms = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_intermediates_decomp,
+        composite_attributes = {
+          return_intermediates = true,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>)
+    return %output, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+
+  func.func private @rmsnorm_fw_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    return %input : tensor<1x1x128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_intermediates_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>)
+      -> (tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>) {
+    %rms = "ttir.zeros"() <{shape = array<i32: 1, 1, 128, 1>}>
+        : () -> tensor<1x1x128x1xbf16>
+    return %input, %rms
+        : tensor<1x1x128x256xbf16>, tensor<1x1x128x1xbf16>
+  }
+}

--- a/test/ttmlir/EmitPy/rmsnorm_fw/rmsnorm_fw_unsupported.mlir
+++ b/test/ttmlir/EmitPy/rmsnorm_fw/rmsnorm_fw_unsupported.mlir
@@ -1,0 +1,27 @@
+// RUN: not ttmlir-opt --ttir-to-emitpy-pipeline="system-desc-path=%system_desc_path% composite-resolution=force-promote" %s 2>&1 | FileCheck %s
+
+// EmitPy lowering of ttnn.rmsnorm_fw is deliberately unsupported. TTML does
+// not expose the metal::rmsnorm_fw primitive through its Python bindings.
+
+module {
+  func.func @rmsnorm_fw(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    // CHECK: failed to legalize operation 'ttnn.rmsnorm_fw'
+    %output = "ttcore.composite"(%input, %gamma) <{
+        composite_name = "rmsnorm_fw",
+        decomposition = @rmsnorm_fw_decomp,
+        composite_attributes = {
+          return_intermediates = false,
+          epsilon = 1.000000e-06 : f32}}>
+        : (tensor<1x1x128x256xbf16>, tensor<1x1x1x256xbf16>)
+          -> tensor<1x1x128x256xbf16>
+    return %output : tensor<1x1x128x256xbf16>
+  }
+
+  func.func private @rmsnorm_fw_decomp(
+      %input: tensor<1x1x128x256xbf16>,
+      %gamma: tensor<1x1x1x256xbf16>) -> tensor<1x1x128x256xbf16> {
+    return %input : tensor<1x1x128x256xbf16>
+  }
+}

--- a/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
+++ b/test/unittests/OpModel/TTNN/Lib/TestOpModelLib.cpp
@@ -6079,6 +6079,43 @@ TEST_F(OpModelTest, SDPABackwardOp) {
 }
 
 //===----------------------------------------------------------------------===//
+// RMSNormForwardOp Tests
+//===----------------------------------------------------------------------===//
+
+TEST_F(OpModelTest, RMSNormForwardOp) {
+  const llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
+  const llvm::SmallVector<int64_t> gammaShape = {1, 1, 1, 256};
+  const TTNNLayoutAttr inputLayout = CreateTiledLayout(
+      inputShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+  const TTNNLayoutAttr gammaLayout = CreateTiledLayout(
+      gammaShape, BufferType::DRAM, TensorMemoryLayout::Interleaved);
+
+  auto constraintsExp = OpModel<RMSNormForwardOp>::getOpConstraints(
+      inputShape, inputLayout, gammaShape, gammaLayout,
+      /*returnIntermediates=*/true, llvm::APFloat(1e-6f),
+      /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(constraintsExp));
+  EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().tensorL1PeakSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputL1BufferSize, 0);
+  EXPECT_EQ(constraintsExp.get().outputLayouts.size(), 2u);
+
+  auto runtimeExp = OpModel<RMSNormForwardOp>::getOpRuntime(
+      inputShape, inputLayout, gammaShape, gammaLayout,
+      /*returnIntermediates=*/true, llvm::APFloat(1e-6f),
+      /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(runtimeExp));
+  EXPECT_GT(runtimeExp.get(), 0);
+
+  auto outputOnlyConstraintsExp = OpModel<RMSNormForwardOp>::getOpConstraints(
+      inputShape, inputLayout, gammaShape, gammaLayout,
+      /*returnIntermediates=*/false, llvm::APFloat(1e-6f),
+      /*outputLayout=*/TTNNLayoutAttr());
+  ASSERT_TRUE(static_cast<bool>(outputOnlyConstraintsExp));
+  EXPECT_EQ(outputOnlyConstraintsExp.get().outputLayouts.size(), 1u);
+}
+
+//===----------------------------------------------------------------------===//
 // LayerNormForwardOp Tests
 //===----------------------------------------------------------------------===//
 

--- a/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
+++ b/test/unittests/OpModel/TTNN/Op/TestOpModelInterface.cpp
@@ -6449,6 +6449,50 @@ TEST_F(OpModelBase, SDPABackwardOpInterface) {
   }
 }
 
+TEST_F(OpModelBase, RMSNormForwardOpInterface) {
+  llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
+  llvm::SmallVector<int64_t> gammaShape = {1, 1, 1, 256};
+  llvm::SmallVector<int64_t> rmsShape = {1, 1, 128, 1};
+  auto inputLayout = CreateTiledLayout(inputShape, BufferType::DRAM,
+                                       TensorMemoryLayout::Interleaved);
+  auto gammaLayout = CreateTiledLayout(gammaShape, BufferType::DRAM,
+                                       TensorMemoryLayout::Interleaved);
+
+  auto input =
+      createEmptyTensor(inputShape, builder.getBF16Type(), inputLayout);
+  auto gamma =
+      createEmptyTensor(gammaShape, builder.getBF16Type(), gammaLayout);
+  auto outputType =
+      createRankedTensorType(inputShape, builder.getBF16Type(), inputLayout);
+  auto rmsType = createRankedTensorType(rmsShape);
+
+  auto rmsNormForward = builder.create<RMSNormForwardOp>(
+      builder.getUnknownLoc(), TypeRange{outputType, rmsType}, input, gamma,
+      builder.getBoolAttr(true), builder.getF32FloatAttr(1e-6f));
+
+  auto backend = dyn_cast<OpModel>(rmsNormForward.getOperation());
+  ASSERT_TRUE(backend);
+  auto inputLayouts = getInputLayouts(rmsNormForward.getOperation());
+  ASSERT_EQ(inputLayouts.size(), 2u);
+
+  auto constraintsExp = backend.getOpConstraints(inputLayouts, OpConfig());
+  if (constraintsExp) {
+    EXPECT_GT(constraintsExp.get().cbL1PeakSize, 0);
+    ASSERT_EQ(constraintsExp.get().outputLayouts.size(), 2u);
+  } else {
+    FAIL() << "Missing constraints for RMSNormForwardOp; Error="
+           << llvm::toString(constraintsExp.takeError());
+  }
+
+  auto runtimeExp = backend.getOpRuntime(inputLayouts, OpConfig());
+  if (runtimeExp) {
+    EXPECT_GT(runtimeExp.get(), 0);
+  } else {
+    FAIL() << "Error getting runtime for RMSNormForwardOp: "
+           << llvm::toString(runtimeExp.takeError());
+  }
+}
+
 TEST_F(OpModelBase, LayerNormForwardOpInterface) {
   llvm::SmallVector<int64_t> inputShape = {1, 1, 128, 256};
   llvm::SmallVector<int64_t> parameterShape = {1, 1, 1, 256};

--- a/third_party/ttml/CMakeLists.txt
+++ b/third_party/ttml/CMakeLists.txt
@@ -19,6 +19,9 @@ set(TTML_METAL_OP_SRCS
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/layernorm_fw.cpp
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_device_operation.cpp
   ${TTML_SOURCE_DIR}/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/rmsnorm_fw/rmsnorm_fw.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_device_operation.cpp
+  ${TTML_SOURCE_DIR}/metal/ops/rmsnorm_fw/device/rmsnorm_fw_program_factory.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/sdpa_fw.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
   ${TTML_SOURCE_DIR}/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp

--- a/tools/builder/ttir/ttir_builder.py
+++ b/tools/builder/ttir/ttir_builder.py
@@ -170,6 +170,72 @@ class TTIRBuilder(Builder):
 
     # ----- Public Op Generators ----
 
+    ############### ttcore.CompositeOp ###############
+
+    @tag(ttcore.CompositeOp)
+    def composite(
+        self,
+        composite_name: str,
+        operands: Sequence[Operand],
+        decomposition: Union[str, func.FuncOp],
+        loc: Optional[str] = None,
+        unit_attrs: Optional[List[str]] = None,
+        composite_attributes: Optional[DictAttr] = None,
+    ) -> Union[OpResult, Tuple[OpResult, ...]]:
+        if isinstance(decomposition, func.FuncOp):
+            decomposition_func = decomposition
+            decomposition_name = decomposition_func.name.value
+            self._func_name_to_op.setdefault(decomposition_name, decomposition_func)
+        else:
+            decomposition_name = decomposition.removeprefix("@")
+            decomposition_func = self._func_name_to_op.get(decomposition_name)
+            if decomposition_func is None:
+                raise ValueError(
+                    f"Decomposition function {decomposition_name!r} not found on builder."
+                )
+
+        result_types = list(decomposition_func.type.results)
+        operand_goldens = [self._get_golden_tensor(operand) for operand in operands]
+        composite_golden = get_golden_function(ttcore.CompositeOp)
+        golden_output = composite_golden(
+            *operand_goldens,
+            composite_name=composite_name,
+            composite_attributes=composite_attributes,
+            result_types=result_types,
+        )
+
+        attrs: Dict[str, Attribute] = {
+            "composite_name": StringAttr.get(composite_name, self._ctx),
+            "decomposition": FlatSymbolRefAttr.get(decomposition_name, self._ctx),
+        }
+        if composite_attributes is not None:
+            attrs["composite_attributes"] = composite_attributes
+
+        composite_op = Operation.create(
+            name="ttcore.composite",
+            results=result_types,
+            operands=list(operands),
+            attributes=attrs,
+            regions=0,
+            loc=Location.name(loc) if loc is not None else self._get_location(),
+        )
+        if unit_attrs is not None:
+            for attr_name in unit_attrs:
+                composite_op.attributes[attr_name] = UnitAttr.get(self._ctx)
+
+        op_results = list(composite_op.results)
+        golden_outputs = (
+            golden_output if isinstance(golden_output, tuple) else (golden_output,)
+        )
+        if len(golden_outputs) != len(op_results):
+            raise ValueError(
+                "ttcore.composite golden result count does not match op result count."
+            )
+        for op_result, golden in zip(op_results, golden_outputs):
+            self._set_golden_tensor(op_result, golden)
+
+        return op_results[0] if len(op_results) == 1 else tuple(op_results)
+
     ############### ttir.AllToAllOp ###############
 
     @tag(ttir.AllToAllOp)

--- a/tools/golden/mapping.py
+++ b/tools/golden/mapping.py
@@ -6608,6 +6608,35 @@ def stablehlo_convert_golden(
     return input_tensor.to(output_dtype)
 
 
+def ttcore_composite_golden(
+    *operand_tensors: GoldenMapTensor,
+    composite_name=None,
+    composite_attributes=None,
+    result_types=None,
+    **_kwargs,
+) -> GoldenMapTensor:
+    if composite_name == "rmsnorm_fw":
+        attrs = composite_attributes or {}
+        try:
+            epsilon_attr = attrs["epsilon"]
+        except KeyError:
+            epsilon_attr = None
+
+        if not result_types:
+            raise ValueError("ttcore.composite golden requires result types.")
+
+        return rmsnorm_fw_golden(
+            *operand_tensors,
+            epsilon=epsilon_attr,
+            return_intermediates=len(result_types) == 2,
+            output_type_mlir=RankedTensorType(result_types[0]).element_type,
+        )
+
+    raise NotImplementedError(
+        f"No ttcore.composite golden is registered for {composite_name!r}."
+    )
+
+
 def stablehlo_composite_golden(
     *operand_tensors: GoldenMapTensor,
     decomposition_fn=None,
@@ -8807,6 +8836,33 @@ def sdpa_bw_golden(
     return dq.to(query.dtype), dk.to(key.dtype), dv.to(value.dtype)
 
 
+def rmsnorm_fw_golden(
+    input: GoldenMapTensor,
+    gamma: GoldenMapTensor,
+    return_intermediates: bool = True,
+    epsilon: FloatAttr = None,
+    output_type_mlir: Type = None,
+    **kwargs,
+) -> Tuple[GoldenMapTensor, ...]:
+    epsilon = unpack_mlir_attr(epsilon) if epsilon is not None else 1e-06
+
+    x = input.float()
+    rms = torch.sqrt(
+        torch.add(torch.mean(torch.mul(x, x), dim=-1, keepdim=True), epsilon)
+    )
+    output = torch.mul(torch.div(x, rms), gamma.float())
+
+    output_dtype = (
+        mlir_type_to_torch_dtype(output_type_mlir)
+        if output_type_mlir is not None
+        else input.dtype
+    )
+    output = output.to(output_dtype)
+    if return_intermediates:
+        return output, rms.to(output_dtype)
+    return (output,)
+
+
 def layernorm_fw_golden(
     input: GoldenMapTensor,
     weight: GoldenMapTensor,
@@ -9209,6 +9265,8 @@ def debug_region_end_golden(
 
 
 GOLDEN_MAPPINGS: Dict[type, Callable] = {
+    # ----- TTCORE OPS -----
+    ttcore.CompositeOp: ttcore_composite_golden,
     # ----- TTIR OPS -----
     # Elementwise unary operations
     ttir.GetDimensionSizeOp: get_dimension_size_golden,


### PR DESCRIPTION
### Ticket
#9097, closes #9102 

### Problem description
We need this TTML op.

### What's changed
Added `rmsnorm_fw` op as a `ttcore.composite` and TTNN op backed by `ttml::metal::rmsnorm_fw`.

### Checklist
- [x] New/Existing tests provide coverage for changes
