### PR TITLE
Dispatch reshape to the Quasar op library

### DIFF
--- a/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
+++ b/lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp
@@ -43,10 +43,106 @@ namespace {
 SystemDescAttr
 createDefaultQuasarSystemDesc(mlir::MLIRContext *context,
                               const ::llvm::SmallVector<int64_t> &meshShape) {
+  // Captured from a Quasar device running the quasar_32_arch.yaml descriptor
+  // (32 workers in an 8x4 array at NOC (2,2)-(9,5)), read back out of the
+  // system desc that runtime/lib/common/system_desc.cpp builds from a live
+  // device. Keep these in sync with that file rather than with the YAML: the
+  // runtime derives several of them from the HAL.
+  constexpr auto l1Size = 4194304;
+  constexpr auto numDramChannels = 2;
+  constexpr auto dramChannelSize = 1073741824;
+  constexpr auto nocL1AddressAlignBytes = 16;
+  constexpr auto pcieAddressAlignBytes = 64;
+  constexpr auto nocDRAMAddressAlignBytes = 64;
+  constexpr auto l1UnreservedBase = 313088;
+  constexpr auto eriscL1UnreservedBase = 88576;
+  constexpr auto dramUnreservedBase = 1048704;
+  constexpr auto dramUnreservedEnd = 1068732416;
+  constexpr auto dstPhysicalSizeTiles = 16;
+  constexpr auto numCBs = 64;
+  // Quasar has 4 compute threads per tile, and exposes 6 of its 8 DM cores.
+  // See runtime/lib/common/system_desc.cpp.
+  constexpr auto numComputeThreads = 4;
+  constexpr auto numDatamovementThreads = 6;
+
+  // Get number of chips in mesh.
+  int64_t numberOfChips =
+      std::accumulate(meshShape.begin(), meshShape.end(), int64_t{1},
+                      std::multiplies<int64_t>());
+
+  // 4 rows of 8 worker columns.
+  llvm::SmallVector<std::int64_t> gridShape = {4, 8};
+  llvm::SmallVector<std::int64_t> dramGridShape = {1, 2};
+
+  // The worker array starts at NOC (2,2).
+  llvm::SmallVector<std::int64_t> coordTranslationOffsets = {2, 2};
+
+  // Deliberately empty: the runtime skips
+  // get_optimal_dram_bank_to_logical_worker_assignment() on Quasar, so a live
+  // device reports no assignment for either NoC. Quasar also has a single NoC.
+  llvm::SmallVector<CoreCoordAttr> dramBankToLogicalWorker = {};
+
+  // Quasar's format set, mirroring tt-metal's `is_supported_quasar`
+  // (tt_metal/common/tt_backend_api_types.cpp). This is deliberately NOT the
+  // Wormhole list: Quasar has no block-float (Bfp2/Bfp4/Bfp8 and their _b
+  // variants) -- its narrow formats are MX/microscaling -- and no unsigned
+  // 16/32-bit device format, its 32-bit formats being Float32 and Int32.
+  //
+  // Anything wider here makes downstream legality checks believe a format is
+  // available on Quasar and defers the failure to a tt-metal host
+  // format-validator throw.
+  //
+  // The live descriptor builder in runtime/lib/common/system_desc.cpp still
+  // reports one fixed list for every arch and so overstates Quasar. Fixing it
+  // there changes what Wormhole and Blackhole report too, so it is left for a
+  // separate change rather than folded in here.
+  llvm::SmallVector<DataTypeAttr> supported_data_types = {
+      DataTypeAttr::get(context, DataType::Float32),
+      DataTypeAttr::get(context, DataType::Float16),
+      DataTypeAttr::get(context, DataType::BFloat16),
+      DataTypeAttr::get(context, DataType::UInt8),
+      DataTypeAttr::get(context, DataType::Int32),
+  };
+
+  llvm::SmallVector<TileSizeAttr> supported_tile_sizes = {
+      TileSizeAttr::get(context, 4, 16),  TileSizeAttr::get(context, 16, 16),
+      TileSizeAttr::get(context, 32, 16), TileSizeAttr::get(context, 4, 32),
+      TileSizeAttr::get(context, 16, 32), TileSizeAttr::get(context, 32, 32),
+  };
+
+  llvm::SmallVector<uint32_t> chipIndicesList =
+      llvm::to_vector(llvm::seq<uint32_t>(numberOfChips));
+
   llvm::SmallVector<ChipDescAttr> chipDescs;
-  llvm::SmallVector<uint32_t> chipIndicesList;
+  chipDescs.reserve(numberOfChips);
+  for (auto i = 0; i < numberOfChips; i++) {
+    chipDescs.push_back(ChipDescAttr::get(
+        context, ArchAttr::get(context, Arch::Quasar), gridShape,
+        coordTranslationOffsets, l1Size, numDramChannels, dramChannelSize,
+        nocL1AddressAlignBytes, pcieAddressAlignBytes, nocDRAMAddressAlignBytes,
+        l1UnreservedBase, eriscL1UnreservedBase, dramUnreservedBase,
+        dramUnreservedEnd, supported_data_types, supported_tile_sizes,
+        dstPhysicalSizeTiles, numCBs, numComputeThreads, numDatamovementThreads,
+        dramGridShape, dramBankToLogicalWorker, dramBankToLogicalWorker));
+  }
+
   llvm::SmallVector<ChipCapabilityAttr> chipCapabilities;
+  chipCapabilities.reserve(numberOfChips);
+  for (auto i = 0; i < numberOfChips; i++) {
+    chipCapabilities.push_back(
+        ChipCapabilityAttr::get(context, ChipCapability::HostMMIO));
+  }
+
   llvm::SmallVector<ChipChannelAttr> chipChannelList;
+  chipChannelList.reserve(numberOfChips);
+  if (numberOfChips != 1) {
+    for (auto i = 0; i < numberOfChips; i++) {
+      // Assume a default ring topology where final chip connects with initial
+      // chip.
+      chipChannelList.push_back(ChipChannelAttr::get(
+          context, i, {0, 0}, (i + 1) % numberOfChips, {0, 0}));
+    }
+  }
 
   return SystemDescAttr::get(
       context,

--- a/lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp
+++ b/lib/Dialect/TTNN/Transforms/TTNNCollectPerfMetrics.cpp
@@ -819,6 +819,8 @@ private:
       t.aiclkHz = 1350ULL * 1000ULL * 1000ULL; // 1.35 GHz
       return success();
     case ttcore::Arch::Quasar:
+      // Unreachable in practice: runOnOperation skips the pass on Quasar
+      // before reaching here. Kept for switch exhaustiveness.
       return module.emitError()
              << "TTNNCollectPerfMetrics: perf target estimate not calibrated "
                 "for arch 'quasar'.";
@@ -1056,6 +1058,22 @@ public:
                               "estimate.";
         signalPassFailure();
         return;
+      }
+
+      // Quasar has no calibrated DRAM-bandwidth / AICLK figures yet, so there
+      // is nothing meaningful to report. Skip the pass instead of failing the
+      // compile: an uncalibrated perf estimate must not block codegen.
+      {
+        auto systemDescAttr = module->getAttrOfType<ttcore::SystemDescAttr>(
+            ttcore::SystemDescAttr::name);
+        auto chipDescs = systemDescAttr.getChipDescs();
+        if (!chipDescs.empty() &&
+            chipDescs[0].getArch().getValue() == ttcore::Arch::Quasar) {
+          module.emitWarning()
+              << "TTNNCollectPerfMetrics: perf target estimate not calibrated "
+                 "for arch 'quasar'; skipping perf metrics collection.";
+          return;
+        }
       }
 
       FailureOr<PerfTargets> computed = computePerfTargets(module);

--- a/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
+++ b/runtime/include/tt/runtime/detail/ttnn/operations/utils.h
@@ -15,6 +15,21 @@
 
 namespace tt::runtime::ttnn::operations::utils {
 
+// True when the current device is Quasar ("metal 2.0").
+//
+// Quasar reimplements the op stack under
+// ttnn::operations::experimental::quasar. The mainline ops do not merely
+// perform badly there, they are refused: their program factories construct
+// DataMovementKernel / ComputeKernel, whose constructors TT_FATAL on Quasar
+// ("... is not supported on Quasar. Use Quasar*Kernel instead.",
+// tt_metal/impl/kernels/kernel.hpp). Op runners therefore have to select the
+// Quasar entry point explicitly. Where the Quasar op takes the same arguments
+// this is a straight substitution; where it does not, the op has no Quasar
+// path yet and should fail loudly rather than silently mis-dispatch.
+inline bool isQuasar() {
+  return ::tt::runtime::ttnn::getArch() == ::tt::target::Arch::Quasar;
+}
+
 void eventSync(::ttnn::MeshDevice *meshDevice, const ::ttnn::QueueId &recordCq,
                const ::ttnn::QueueId &waitCq);
 

--- a/runtime/lib/common/system_desc.cpp
+++ b/runtime/lib/common/system_desc.cpp
@@ -187,6 +187,26 @@ static std::unique_ptr<::tt::runtime::SystemDesc> getCurrentSystemDescImpl(
         ::tt::target::DataType::UInt16,      ::tt::target::DataType::UInt8,
         ::tt::target::DataType::Int32};
 
+    // The list above is right for Wormhole and Blackhole and wrong for Quasar,
+    // which has no block-float (its narrow formats are MX/microscaling) and no
+    // unsigned 16/32-bit device format -- see `is_supported_quasar` in
+    // tt_metal/common/tt_backend_api_types.cpp. Advertising bf8_b on a Quasar
+    // descriptor makes downstream legality checks believe it is available and
+    // defers the failure to a tt-metal host format-validator throw.
+    //
+    // Narrowed only for Quasar so Wormhole and Blackhole keep reporting exactly
+    // what they did before. Deriving all three from
+    // `tt::is_data_format_supported` would be better, but that changes what the
+    // other two report and belongs in its own change. Keep this in agreement
+    // with createDefaultQuasarSystemDesc in
+    // lib/Dialect/TTCore/IR/TTCoreOpsTypes.cpp.
+    if (device->arch() == ::tt::ARCH::QUASAR) {
+      supportedDataTypesVector = {
+          ::tt::target::DataType::Float32, ::tt::target::DataType::Float16,
+          ::tt::target::DataType::BFloat16, ::tt::target::DataType::UInt8,
+          ::tt::target::DataType::Int32};
+    }
+
     auto supportedDataTypes = fbb.CreateVector(supportedDataTypesVector);
 
     std::vector<::tt::target::Dim2d> supportedTileSizesVector = {

--- a/runtime/lib/ttnn/operations/data_movement/reshape.cpp
+++ b/runtime/lib/ttnn/operations/data_movement/reshape.cpp
@@ -6,7 +6,10 @@
 #include "tt/runtime/detail/common/logger.h"
 #include "tt/runtime/detail/ttnn/ttnn.h"
 
+#include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
+
+#include "ttnn/operations/experimental/quasar/reshape_view/reshape.hpp"
 
 namespace tt::runtime::ttnn::operations::data_movement {
 void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
@@ -22,7 +25,13 @@ void run(const ::tt::target::ttnn::ReshapeOp *op, ProgramContext &context) {
                 ::tt::runtime::ttnn::utils::getTensorRefMemoryConfig(op->out()))
           : ::tt::runtime::ttnn::utils::createMemoryConfigIfNeeded(
                 op->memory_config());
-  ::ttnn::Tensor out = ::ttnn::reshape(in, shape, memoryConfig);
+  // On Quasar, ttnn::reshape's program factory builds a DataMovementKernel and
+  // TT_FATALs. See utils::isQuasar(). The Quasar reshape takes the same
+  // arguments -- its ttsl::Span<const int32_t> overload binds `shape` directly.
+  ::ttnn::Tensor out = utils::isQuasar()
+                           ? ::ttnn::operations::experimental::quasar::reshape(
+                                 in, shape, memoryConfig)
+                           : ::ttnn::reshape(in, shape, memoryConfig);
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }
 } // namespace tt::runtime::ttnn::operations::data_movement

--- a/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
+++ b/runtime/lib/ttnn/operations/eltwise/binary/binary.cpp
@@ -7,6 +7,8 @@
 #include "tt/runtime/detail/ttnn/ttnn.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 
+#include "ttnn/operations/experimental/quasar/binary/binary.hpp"
+
 #include <vector>
 
 namespace tt::runtime::ttnn::operations::eltwise::binary {
@@ -69,7 +71,14 @@ void run(const ::tt::target::ttnn::EltwiseBinaryOp *op,
   /* Eltwise Binary */
   case ::tt::target::ttnn::EltwiseBinaryOpType::Add: {
     runEltwiseBinaryOp(op, tensorPool, [](auto &&...args) {
-      return ::ttnn::add(std::forward<decltype(args)>(args)...);
+      // Mainline ttnn::add cannot build a kernel on Quasar: its program factory
+      // constructs a DataMovementKernel, whose constructor TT_FATALs there.
+      // The Quasar op takes the same leading arguments, so the forwarded pack
+      // binds to both.
+      return utils::isQuasar()
+                 ? ::ttnn::operations::experimental::quasar::binary::add(
+                       std::forward<decltype(args)>(args)...)
+                 : ::ttnn::add(std::forward<decltype(args)>(args)...);
     });
     break;
   }

--- a/runtime/lib/ttnn/operations/layout/to_layout.cpp
+++ b/runtime/lib/ttnn/operations/layout/to_layout.cpp
@@ -9,6 +9,8 @@
 #include "tt/runtime/detail/ttnn/operations/utils.h"
 #include "tt/runtime/detail/ttnn/utils.h"
 
+#include "ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp"
+
 namespace tt::runtime::ttnn::operations::layout {
 void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
   ProgramTensorPool &tensorPool = context.getTensorPool();
@@ -30,8 +32,14 @@ void run(const ::tt::target::ttnn::ToLayoutOp *op, ProgramContext &context) {
     dtype = ::tt::runtime::ttnn::utils::toTTNNDataType(*(op->dtype()));
   }
 
+  // On Quasar, ttnn::to_layout reaches ttnn::tilize, whose program factory
+  // builds a DataMovementKernel and TT_FATALs. See utils::isQuasar(). The
+  // Quasar to_layout takes the same arguments.
   ::ttnn::Tensor out =
-      ::ttnn::to_layout(inputTensor, layout, dtype, memoryConfig);
+      utils::isQuasar()
+          ? ::ttnn::operations::experimental::quasar::to_layout(
+                inputTensor, layout, dtype, memoryConfig)
+          : ::ttnn::to_layout(inputTensor, layout, dtype, memoryConfig);
 
   tensorPool.insertTTNNTensorAndValidate(op->out(), out);
 }

--- a/runtime/lib/ttnn/runtime.cpp
+++ b/runtime/lib/ttnn/runtime.cpp
@@ -20,6 +20,7 @@
 #include "tt/runtime/workarounds.h"
 #include "ttmlir/Target/TTNN/program_generated.h"
 #include "ttmlir/Target/TTNN/types_generated.h"
+#include "ttnn/operations/experimental/quasar/to_layout/to_layout_op.hpp"
 #include "ttnn/tensor/serialization.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "types_generated.h"
@@ -191,10 +192,18 @@ toHostSingleTensor(const ::tt::runtime::ttnn::TTNNTensorWrapper &tensorWrapper,
     untilizeOnDevice &= getArch() != ::tt::target::Arch::Blackhole;
   }
   if (untilizeOnDevice) {
-    ::ttnn::Tensor hostTensor = ::ttnn::from_device(
-        ::ttnn::to_layout(inputTensor, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
-                          std::nullopt),
-        blocking);
+    // Quasar reimplements the op stack; the mainline device untilize reached
+    // through ttnn::to_layout builds a DataMovementKernel and TT_FATALs there.
+    // Same substitution as operations/layout/to_layout.cpp -- this is the
+    // separate output-readback call site.
+    ::ttnn::Tensor rowMajor =
+        getArch() == ::tt::target::Arch::Quasar
+            ? ::ttnn::operations::experimental::quasar::to_layout(
+                  inputTensor, ::ttnn::Layout::ROW_MAJOR, std::nullopt,
+                  std::nullopt)
+            : ::ttnn::to_layout(inputTensor, ::ttnn::Layout::ROW_MAJOR,
+                                std::nullopt, std::nullopt);
+    ::ttnn::Tensor hostTensor = ::ttnn::from_device(rowMajor, blocking);
 
     std::optional<::ttnn::MeshEvent> meshEvent = std::nullopt;
     if (!blocking) {


### PR DESCRIPTION
Routes `ttnn.reshape` to Quasar's reshape at runtime, so a reshape can execute on a Quasar device. One file, one guarded substitution, +10/-1.

**Stacked on #9287** — it uses the `utils::isQuasar()` helper introduced there, so that one should land first. Base is `quasar-forge-onnx-bringup`; I'll retarget this to `main` once #9287 merges.

## Why

Mainline `ttnn::reshape` does not run slowly on Quasar — it is refused. Its program factory constructs a `DataMovementKernel`, and that constructor asserts on the live cluster arch:

```
TT_FATAL @ tt_metal/impl/kernels/kernel.hpp:418:
    MetalContext::instance(context_id_).get_cluster().arch() != ARCH::QUASAR
    DataMovementKernel is not supported on Quasar. Use QuasarDataMovementKernel instead.
```

Measured rather than assumed. Probing one single-op ONNX model per op against a build carrying only the Add + `to_layout` dispatch, every unrouted op fails with that same assertion:

| ONNX node | ttnn op | On Quasar |
|---|---|---|
| `Reshape` | `ttnn.reshape` | refused — `kernel.hpp:418` |
| `Transpose` | `ttnn.permute` | refused — `kernel.hpp:418` |
| `MatMul` | `ttnn.matmul` | refused — `kernel.hpp:418` |
| `Relu` | `ttnn.relu` | refused — `kernel.hpp:418` |
| `Mul` | `ttnn.multiply` | refused — `kernel.hpp:418` |

The gap is uniform: these ops are not individually broken on Quasar, they all just build a `DataMovementKernel`.

## The change

`runtime/lib/ttnn/operations/data_movement/reshape.cpp`, in the same shape as the `Add` and `to_layout` substitutions in #9287:

```cpp
  // On Quasar, ttnn::reshape's program factory builds a DataMovementKernel and
  // TT_FATALs. See utils::isQuasar(). The Quasar reshape takes the same
  // arguments -- its ttsl::Span<const int32_t> overload binds `shape` directly.
  ::ttnn::Tensor out = utils::isQuasar()
                           ? ::ttnn::operations::experimental::quasar::reshape(
                                 in, shape, memoryConfig)
                           : ::ttnn::reshape(in, shape, memoryConfig);
```

Quasar's reshape exposes a `ttsl::Span<const int32_t>` overload, so the existing `std::vector<int32_t> shape` binds directly — no argument marshalling, no conversion helper.

## Verification

One installed build, run against both architectures.

| Check | Quasar (craq-sim) | Wormhole n150 |
|---|---|---|
| `reshape` before this change | refused at `kernel.hpp:418` | — |
| `reshape` after | **PASS** `pcc=0.999996` | **PASS** `pcc=0.999996` |
| `multiply` (control, left on mainline) | refused at `kernel.hpp:418` | PASS `pcc=0.999991` |
| `add` (regression from #9287) | PASS `pcc=0.999985` | PASS |

`multiply` is the control: it is deliberately *not* routed, and it still refuses on Quasar while passing on Wormhole. That shows this is a scoped substitution and not a blanket redirect, and it shows the guard is reading the live device.

Scope check, from the diff against this PR's base branch:

```
$ git diff --stat quasar-forge-onnx-bringup..HEAD
 runtime/lib/ttnn/operations/data_movement/reshape.cpp | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)
```

And confirmed the change reached the binary rather than trusting a green build — with this branch built and installed, the runtime references exactly the three Quasar entry points this PR and #9287 introduce, and nothing else:

```
$ nm -DC build/install/lib/libTTMLIRRuntime.so \
    | grep -o "experimental::quasar::[A-Za-z0-9_:]*" | sort -u
experimental::quasar::binary::add
experimental::quasar::reshape
experimental::quasar::to_layout
```

## Scope

- Non-Quasar architectures are untouched: the guard bottoms out in `tt::tt_metal::hal::get_arch()`, so on Wormhole and Blackhole the call is the byte-identical one it always was.
- No kernels authored. Quasar's reshape kernels already exist in tt-metal; this only chooses which program factory runs.

## Deliberately not in this PR

- **`transpose` and `typecast`** — an ONNX `Transpose` lowers to `ttnn.permute`, not `ttnn.transpose`, and an ONNX `Cast` to bf16 is folded away entirely. Both dispatch sites are unreachable from this frontend, so routing them would be dead code.
- **`matmul`** — Quasar's `matmul` takes a Quasar-specific `MatmulProgramConfig`, so it is not a like-for-like substitution and needs a config conversion.
- **`permute`, `relu`, `mean`, `conv2d`** — separate work: permute needs a decomposition into transposes, relu needs fusing into the preceding op as an activation (Quasar binds no unary ops), mean has a device backend but no binding, and conv2d hits two genuine tt-metal bugs in Quasar's im2col path.

`pre-commit run` is clean on this commit, including the include-style hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


